### PR TITLE
20191029assoc聯合主鍵的擴充修改

### DIFF
--- a/app/BiogMain.php
+++ b/app/BiogMain.php
@@ -148,7 +148,7 @@ class BiogMain extends Model
 
     public function assoc()
     {
-        return $this->belongsToMany('App\AssocCode', 'ASSOC_DATA', 'c_personid', 'c_assoc_code')->withPivot('tts_sysno', 'c_assoc_id');
+        return $this->belongsToMany('App\AssocCode', 'ASSOC_DATA', 'c_personid', 'c_assoc_code')->withPivot('tts_sysno', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title');
     }
 
     public function assoc_name()

--- a/app/Http/Controllers/AddrCodesController.php
+++ b/app/Http/Controllers/AddrCodesController.php
@@ -32,7 +32,7 @@ class AddrCodesController extends Controller
      */
     public function index()
     {
-        return view('addrcodes.index', ['page_title' => 'Addr Codes', 'page_description' => '地址编码表(ADDR_CODES)', 'codes' => session('codes')]);
+        return view('addrcodes.index', ['page_title' => 'Addr Codes', 'page_description' => '地址編碼表(ADDR_CODES)', 'codes' => session('codes')]);
     }
 
     /**
@@ -43,7 +43,7 @@ class AddrCodesController extends Controller
     public function create()
     {
         $temp_id = AddrCode::max('c_addr_id') + 1;
-        return view('addrcodes.create', ['page_title' => 'Addr Codes', 'page_description' => '地址编码表(ADDR_CODES)', 'temp_id' => $temp_id]);
+        return view('addrcodes.create', ['page_title' => 'Addr Codes', 'page_description' => '地址編碼表(ADDR_CODES)', 'temp_id' => $temp_id]);
     }
 
     /**
@@ -93,7 +93,7 @@ class AddrCodesController extends Controller
     public function edit($id)
     {
         $data = $this->addrcoderepository->byId($id);
-        return view('addrcodes.edit', ['page_title' => 'Addr Codes', 'page_description' => '地址编码表(ADDR_CODES)', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('addrcodes.edit', ['page_title' => 'Addr Codes', 'page_description' => '地址編碼表(ADDR_CODES)', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/AddressCodesController.php
+++ b/app/Http/Controllers/AddressCodesController.php
@@ -45,7 +45,7 @@ class AddressCodesController extends Controller
      */
     public function index()
     {
-        return view('addresscodes.index', ['page_title' => 'Address Codes', 'page_description' => '地址编码表(ADDRESSES)', 'codes' => session('codes')]);
+        return view('addresscodes.index', ['page_title' => 'Address Codes', 'page_description' => '地址編碼表(ADDRESSES)', 'codes' => session('codes')]);
     }
 
     /**
@@ -56,7 +56,7 @@ class AddressCodesController extends Controller
     public function create()
     {
         $temp_id = AddressCode::max('c_addr_id') + 1;
-        return view('addresscodes.create', ['page_title' => 'Address Codes', 'page_description' => '地址编码表(ADDRESSES)', 'temp_id' => $temp_id]);
+        return view('addresscodes.create', ['page_title' => 'Address Codes', 'page_description' => '地址編碼表(ADDRESSES)', 'temp_id' => $temp_id]);
     }
 
     /**
@@ -106,7 +106,7 @@ class AddressCodesController extends Controller
     public function edit($id)
     {
         $data = $this->addrcodeRepository->byId($id);
-        return view('addresscodes.edit', ['page_title' => 'Address Codes', 'page_description' => '地址编码表(ADDRESSES)', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('addresscodes.edit', ['page_title' => 'Address Codes', 'page_description' => '地址編碼表(ADDRESSES)', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/AltnameCodesController.php
+++ b/app/Http/Controllers/AltnameCodesController.php
@@ -23,7 +23,7 @@ class AltnameCodesController extends Controller
      */
     public function index()
     {
-        return view('altnamecodes.index', ['page_title' => 'Altname Codes', 'page_description' => '别名编码表', 'codes' => session('codes')]);
+        return view('altnamecodes.index', ['page_title' => 'Altname Codes', 'page_description' => '別名編碼表', 'codes' => session('codes')]);
     }
 
     /**
@@ -67,7 +67,7 @@ class AltnameCodesController extends Controller
     public function edit($id)
     {
         $data = $this->altcodeRepository->byId($id);
-        return view('altnamecodes.edit', ['page_title' => 'Altname Codes', 'page_description' => '别名编码表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('altnamecodes.edit', ['page_title' => 'Altname Codes', 'page_description' => '別名編碼表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -86,7 +86,7 @@ class OperationsController extends Controller
         $operation->c_personid = $c_personid;
         $operation->resource_id = $c_personid;
         $operation->resource_data = $x;
-        $operation->biog = $ori;
+        $operation->resource_original = $ori;
         $operation->user_id = $token; //這邊要規劃由token取值.
         $operation->crowdsourcing_status = 2;
         $operation->op_type = 3;
@@ -117,7 +117,7 @@ class OperationsController extends Controller
         $operation->c_personid = $c_personid;
         $operation->resource_id = $c_personid;
         $operation->resource_data = $biog;
-        $operation->biog = $ori;
+        $operation->resource_original = $ori;
         $operation->user_id = $token; //這邊要規劃由token取值.
         $operation->crowdsourcing_status = 2;
         $operation->op_type = 4;

--- a/app/Http/Controllers/AppointCodesController.php
+++ b/app/Http/Controllers/AppointCodesController.php
@@ -21,7 +21,7 @@ class AppointCodesController extends Controller
      */
     public function index()
     {
-        return view('appointcodes.index', ['page_title' => 'Appointment Type Codes', 'page_description' => '任命编码表', 'codes' => session('codes')]);
+        return view('appointcodes.index', ['page_title' => 'Appointment Type Codes', 'page_description' => '任命類型編碼表', 'codes' => session('codes')]);
     }
 
     /**
@@ -65,7 +65,7 @@ class AppointCodesController extends Controller
     public function edit($id)
     {
         $data = $this->appcoderepository->byId($id);
-        return view('appointcodes.edit', ['page_title' => 'Appointment Type Codes', 'page_description' => '任命类型编码表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('appointcodes.edit', ['page_title' => 'Appointment Type Codes', 'page_description' => '任命類型編碼表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -67,7 +67,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -155,7 +155,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -192,7 +192,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -113,8 +113,11 @@ class BasicInformationAddressesController extends Controller
      */
     public function edit($id, $addr)
     {
-
+        $addr = str_replace("--","-minus",$addr);
         $addr_l = explode("-", $addr);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
 //        dd($addr_l);
         $row = DB::table('BIOG_ADDR_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
@@ -166,7 +169,11 @@ class BasicInformationAddressesController extends Controller
 
         $data = array_except($data, ['_method', '_token']);
         $data = $this->toolsRepository->timestamp($data);
+        $addr = str_replace("--","-minus",$addr);
         $addr_l = explode("-", $addr);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
         DB::table('BIOG_ADDR_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_addr_id', '=', $addr_l[1]],
@@ -196,7 +203,11 @@ class BasicInformationAddressesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        $addr = str_replace("--","-minus",$addr);
         $addr_l = explode("-", $addr);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('BIOG_ADDR_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_addr_id', '=', $addr_l[1]],

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -108,7 +108,11 @@ class BasicInformationAltnamesController extends Controller
      */
     public function edit($id, $alt)
     {
+        $alt = str_replace("--","-minus",$alt);
         $addr_l = explode("-", $alt);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_alt_name_chn', '=', $addr_l[1]],
@@ -148,7 +152,11 @@ class BasicInformationAltnamesController extends Controller
         $data = $request->all();
         $data = array_except($data, ['_method', '_token']);
         $data = $this->toolsRepository->timestamp($data);
+        $alt = str_replace("--","-minus",$alt);
         $addr_l = explode("-", $alt);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
         DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_alt_name_chn', '=', $addr_l[1]],
@@ -176,7 +184,11 @@ class BasicInformationAltnamesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        $alt = str_replace("--","-minus",$alt);
         $addr_l = explode("-", $alt);
+        foreach($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_alt_name_chn', '=', $addr_l[1]],

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -66,7 +66,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -141,7 +141,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -172,7 +172,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -82,8 +82,11 @@ class BasicInformationAssocController extends Controller
             return redirect()->back();
         }
         $data = $this->biogMainRepository->assocStoreById($request, $id);
-        $_id = $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id'];
+        $_id = $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'];
         flash('Store success @ '.Carbon::now(), 'success');
+        //20191029對於c_text_title欄位內含斜線所做的字串重組
+        $_id = str_replace("/","(slash)",$_id);
+        //end
         return redirect()->route('basicinformation.assoc.edit', ['id' => $id, '_id' => $_id]);
     }
 
@@ -132,8 +135,11 @@ class BasicInformationAssocController extends Controller
             return redirect()->back();
         }
         $data = $this->biogMainRepository->assocUpdateById($request, $id_, $id);
-        $id_ = $id."-".$data['c_assoc_code']."-".$data['c_assoc_id'];
+        $id_ = $id."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'];
         flash('Update success @ '.Carbon::now(), 'success');
+        //20191029對於c_text_title欄位內含斜線所做的字串重組
+        $id_ = str_replace("/","(slash)",$id_);
+        //end
         return redirect()->route('basicinformation.assoc.edit', ['id'=>$id, 'id_'=>$id_]);
     }
 

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -77,7 +77,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -127,7 +127,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -149,7 +149,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -58,7 +58,7 @@ class BasicInformationController extends Controller
      */
     public function index()
     {
-        return view('biogmains.basicinformation.index', ['page_title' => 'Basicinformation', 'page_description' => '编辑人物基本信息']);
+        return view('biogmains.basicinformation.index', ['page_title' => 'Basicinformation', 'page_description' => '編輯人物基本信息']);
     }
 
     /**

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -176,7 +176,11 @@ class BasicInformationEntriesController extends Controller
         $data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         //新增結束
+        $id_ = str_replace("--","-minus",$id_);
         $addr_a = explode("-", $id_);
+        foreach($addr_a as $key => $value) {
+            $addr_a[$key] = str_replace("minus","-",$value);
+        }
         DB::table('ENTRY_DATA')->where([
             ['c_personid', '=', $addr_a[0]],
             ['c_entry_code', '=', $addr_a[1]],
@@ -213,7 +217,11 @@ class BasicInformationEntriesController extends Controller
         }
         //建安修改20191112
         //$this->biogMainRepository->entryDeleteById($id_, $id);
+        $id_ = str_replace("--","-minus",$id_);
         $addr_a = explode("-", $id_);
+        foreach($addr_a as $key => $value) {
+            $addr_a[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ENTRY_DATA')->where([
             ['c_personid', '=', $addr_a[0]],
             ['c_entry_code', '=', $addr_a[1]],

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -66,7 +66,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -155,7 +155,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -207,7 +207,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -58,7 +58,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -107,7 +107,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -128,7 +128,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -59,7 +59,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -109,7 +109,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -131,7 +131,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -74,7 +74,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -123,7 +123,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -139,7 +139,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -197,7 +197,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -58,7 +58,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -109,7 +109,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -130,7 +130,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -66,7 +66,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -115,7 +115,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -152,7 +152,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -58,7 +58,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -109,7 +109,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -131,7 +131,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -58,7 +58,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -108,7 +108,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -130,7 +130,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -68,7 +68,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -131,7 +131,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -163,7 +163,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -27,7 +27,7 @@ class CodesController extends Controller
         $data = $this->codesrepostory->codes();
         return view('codes.index',[
             'page_title' => 'Codes',
-            'page_description' => '编码表',
+            'page_description' => '代碼表',
             'page_url' => '/codes',
             'data' => $data]);
     }

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -7,6 +7,7 @@ use App\BiogMain;
 use App\Operation;
 use App\Repositories\ToolsRepository;
 use App\Repositories\OperationRepository;
+use App\Repositories\BiogMainRepository;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -17,11 +18,13 @@ class CrowdsourcingController extends Controller
 {
     protected $operationRepository;
     protected $toolRepository;
+    protected $biogMainRepository;
 
-    public function __construct(ToolsRepository $toolsRepository,OperationRepository $operationRepository)
+    public function __construct(ToolsRepository $toolsRepository,OperationRepository $operationRepository,BiogMainRepository $biogMainRepository)
     {
         $this->toolRepository  = $toolsRepository;
         $this->operationRepository = $operationRepository;
+        $this->biogMainRepository = $biogMainRepository;
     }
 
     public function store()
@@ -32,6 +35,21 @@ class CrowdsourcingController extends Controller
     public function index()
     {
         $lists = Operation::where('crowdsourcing_status', '!=' , 0)->orderBy('created_at', 'desc')->limit(100)->paginate(20);
+        //將物件轉為陣列進行陣列比對
+        $listsArr = $this->operationRepository->objectToArray($lists);
+        $all = count($listsArr['data']);
+        for($x=0;$x<$all;$x++) {
+            $arr1 = $listsArr['data'][$x]['resource_data'];
+            $arr2 = $listsArr['data'][$x]['biog'];
+            if(!empty($arr2)) {
+                //將json轉換為陣列進行比對
+                $arr1 = json_decode($arr1, true);
+                $arr2 = json_decode($arr2, true);
+                $ans = $this->operationRepository->getArrDiff($arr1, $arr2);
+                //將比對後的結果存回至biog欄位
+                $lists[$x]['biog'] = $ans;
+            }
+        }
         return view('crowdsourcing.index', ['lists' => $lists,
             'page_title' => 'Crowdsourcing', 'page_description' => '最近眾包錄入紀錄',
             'page_url' => '/crowdsourcing'
@@ -56,34 +74,72 @@ class CrowdsourcingController extends Controller
         $rate = $data[0]['rate'];
         $rate = $rate+1;
         $resource = $data[0]['resource'];
+        $op_type = $data[0]['op_type'];
+        $c_personid = $data[0]['c_personid'];
         $data = $data[0]['resource_data'];
         $data = json_decode($data,true);
         $updated_at = Carbon::now()->format('YmdHis');
 
         //資料對應處理
-        switch ($resource) {
-            case "BIOG_MAIN":
-                $new_id = BiogMain::max('c_personid') + 1;
-                $new_ttsid = BiogMain::max('tts_sysno') + 1;
-                $data['c_personid'] = $new_id;
-                $data['tts_sysno'] = $new_ttsid;
-                $data = $this->toolRepository->timestamp($data); //建檔資訊
+        if($op_type == 1) { //新增資料
+            switch ($resource) {
+                case "BIOG_MAIN":
+                    $new_id = BiogMain::max('c_personid') + 1;
+                    $new_ttsid = BiogMain::max('tts_sysno') + 1;
+                    $data['c_personid'] = $new_id;
+                    $data['tts_sysno'] = $new_ttsid;
+                    $data = $this->toolRepository->timestamp($data); //建檔資訊
 
-                //$errorMsg = "您提供的JSON格式不符合，請refect這筆紀錄。";
-                //App::abort(403, $errorMsg);
+                    //$errorMsg = "您提供的JSON格式不符合，請refect這筆紀錄。";
+                    //App::abort(403, $errorMsg);
 
-
-                $message = BiogMain::create($data);
-                if($message == true) {
+                    $message = BiogMain::create($data);
+                    if($message == true) {
+                        DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at));
+                        $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, $resource, $data['c_personid'], $data);
+                        flash('Create success @ '.Carbon::now(), 'success');
+                    }
+                    break;
+                default:
+                    DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 4, 'rate' => $rate, 'updated_at' => $updated_at));
+                    flash('Create error @ '.Carbon::now(), 'danger');
+                    break;
+            }
+        }
+        elseif($op_type == 3){ //修改資料
+            switch ($resource) {
+                case "BIOG_MAIN":
+                    //眾包用戶經由錄入介面所儲存的json，是經過biogMainRepository->updateById整理過後的完整json，所以可以直接呼叫後儲存即可。
+                    $ori = $this->biogMainRepository->byPersonId($c_personid);
+                    $biog = BiogMain::find($c_personid);
+                    $biog->update($data);
                     DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at));
-                    $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, $resource, $data['c_personid'], $data);
-                    flash('Create success @ '.Carbon::now(), 'success');
-                }
-                break;
-            default:
-                DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 4, 'rate' => $rate, 'updated_at' => $updated_at));
-                flash('Create error @ '.Carbon::now(), 'danger');
-                break;
+                    $this->operationRepository->store(Auth::id(), $c_personid, 3, $resource, $c_personid, $data, $ori);
+                    flash('Update success @ '.Carbon::now(), 'success');
+                    break;
+                default:
+                    DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 4, 'rate' => $rate, 'updated_at' => $updated_at));
+                    flash('Update error @ '.Carbon::now(), 'danger');
+                    break;
+            }
+        }
+        elseif($op_type == 4){ //刪除資料
+            switch ($resource) {
+                case "BIOG_MAIN":
+                    //眾包用戶經由錄入介面所儲存的json，是經過biogMainRepository->updateById整理過後的完整json，所以>可以直接呼叫後儲存即可。
+                    $ori = $this->biogMainRepository->byPersonId($c_personid);
+                    $biog = BiogMain::find($c_personid);
+                    $biog->update($data);
+                    DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at));
+                    $this->operationRepository->store(Auth::id(), $c_personid, 4, $resource, $c_personid, $data, $ori);
+                    flash('Delete success @ '.Carbon::now(), 'success');
+                    break;
+                default:
+                    DB::table('operations')->where('id', $id)->update(array('crowdsourcing_status' => 4, 'rate' => $rate, 'updated_at' => $updated_at));
+                    flash('Update error @ '.Carbon::now(), 'danger');
+                    break;
+            }
+        
         }
         return redirect()->route('crowdsourcing.index');
     }

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -39,13 +39,16 @@ class CrowdsourcingController extends Controller
         $listsArr = $this->operationRepository->objectToArray($lists);
         $all = count($listsArr['data']);
         for($x=0;$x<$all;$x++) {
+            $c_personid = '';
+            $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['biog'];
+            if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2);
+                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
                 //將比對後的結果存回至biog欄位
                 $lists[$x]['biog'] = $ans;
             }

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -42,15 +42,15 @@ class CrowdsourcingController extends Controller
             $c_personid = '';
             $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
-            $arr2 = $listsArr['data'][$x]['biog'];
+            $arr2 = $listsArr['data'][$x]['resource_original'];
             if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至biog欄位
-                $lists[$x]['biog'] = $ans;
+                //將比對後的結果存回至resource_original欄位
+                $lists[$x]['resource_original'] = $ans;
             }
         }
         return view('crowdsourcing.index', ['lists' => $lists,

--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -24,7 +24,7 @@ class ManagementController extends Controller
             return redirect('/home');
         }
         $data = User::all()->where('confirmation_token', '!=', '-')->where('remember_token', '!=', '-')->where('password', '!=', '-');
-        return view('manage.index',['data' => $data, 'page_title' => 'Management', 'page_description' => '审核用户']);
+        return view('manage.index',['data' => $data, 'page_title' => 'Management', 'page_description' => '管理用戶']);
     }
 
     /**

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -39,15 +39,15 @@ class ModifiedController extends Controller
             $c_personid = '';
             $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
-            $arr2 = $listsArr['data'][$x]['biog'];
+            $arr2 = $listsArr['data'][$x]['resource_original'];
             if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至biog欄位
-                $lists[$x]['biog'] = $ans;
+                //將比對後的結果存回至resource_original欄位
+                $lists[$x]['resource_original'] = $ans;
             }
         }
         return view('modified.index', ['lists' => $lists,

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -36,13 +36,16 @@ class ModifiedController extends Controller
         $listsArr = $this->operationRepository->objectToArray($lists);
         $all = count($listsArr['data']);
         for($x=0;$x<$all;$x++) {
+            $c_personid = '';
+            $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['biog'];
+            if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2);
+                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
                 //將比對後的結果存回至biog欄位
                 $lists[$x]['biog'] = $ans;
             }

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -32,6 +32,21 @@ class ModifiedController extends Controller
     public function index()
     {
         $lists = Operation::whereIn('crowdsourcing_status', array(0,1))->orderBy('updated_at', 'desc')->limit(100)->paginate(20);
+        //將物件轉為陣列進行陣列比對
+        $listsArr = $this->operationRepository->objectToArray($lists);
+        $all = count($listsArr['data']);
+        for($x=0;$x<$all;$x++) {
+            $arr1 = $listsArr['data'][$x]['resource_data'];
+            $arr2 = $listsArr['data'][$x]['biog'];
+            if(!empty($arr2)) {
+                //將json轉換為陣列進行比對
+                $arr1 = json_decode($arr1, true);
+                $arr2 = json_decode($arr2, true);
+                $ans = $this->operationRepository->getArrDiff($arr1, $arr2);
+                //將比對後的結果存回至biog欄位
+                $lists[$x]['biog'] = $ans;
+            }
+        }
         return view('modified.index', ['lists' => $lists,
             'page_title' => 'Modified', 'page_description' => '最近修改紀錄',
             'page_url' => '/modified'

--- a/app/Http/Controllers/OfficeCodesController.php
+++ b/app/Http/Controllers/OfficeCodesController.php
@@ -32,7 +32,7 @@ class OfficeCodesController extends Controller
      */
     public function index()
     {
-        return view('officecodes.index', ['page_title' => 'Office Codes', 'page_description' => '任官编码表', 'codes' => session('codes')]);
+        return view('officecodes.index', ['page_title' => 'Office Codes', 'page_description' => '任官編碼表', 'codes' => session('codes')]);
     }
 
     /**
@@ -43,7 +43,7 @@ class OfficeCodesController extends Controller
     public function create()
     {
         $temp_id = OfficeCode::max('c_office_id') + 1;
-        return view('officecodes.create', ['page_title' => 'Office Codes', 'page_description' => '任官编码表', 'temp_id' => $temp_id]);
+        return view('officecodes.create', ['page_title' => 'Office Codes', 'page_description' => '任官編碼表', 'temp_id' => $temp_id]);
     }
 
     /**
@@ -93,7 +93,7 @@ class OfficeCodesController extends Controller
     public function edit($id)
     {
         $data = $this->officecoderepository->byId($id);
-        return view('officecodes.edit', ['page_title' => 'Office Codes', 'page_description' => '任官编码表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('officecodes.edit', ['page_title' => 'Office Codes', 'page_description' => '任官編碼表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -42,7 +42,7 @@ class OperationsController extends Controller
         //print_r($lists[0]['biog']); //成功
         //echo "</code></pre>";
         return view('operations.index', ['lists' => $lists,
-            'page_title' => 'NewUpdate', 'page_description' => '最近编辑列表',
+            'page_title' => 'NewUpdate', 'page_description' => '最近編輯列表',
             'page_url' => '/operations'
         ]);
     }

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Operation;
+use App\BiogMain;
 use App\Repositories\OperationRepository;
 use Illuminate\Http\Request;
 
@@ -27,13 +28,16 @@ class OperationsController extends Controller
         $listsArr = $this->operationRepository->objectToArray($lists);
         $all = count($listsArr['data']);
         for($x=0;$x<$all;$x++) {
+            $c_personid = '';
+            $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['biog'];
+            if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2);
+                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
                 //將比對後的結果存回至biog欄位
                 $lists[$x]['biog'] = $ans;
             }

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -31,19 +31,19 @@ class OperationsController extends Controller
             $c_personid = '';
             $arr3 = array();
             $arr1 = $listsArr['data'][$x]['resource_data'];
-            $arr2 = $listsArr['data'][$x]['biog'];
+            $arr2 = $listsArr['data'][$x]['resource_original'];
             if(!empty($c_personid = $listsArr['data'][$x]['c_personid'])) { $arr3 = BiogMain::find($c_personid)->toArray(); }
             if(!empty($arr2)) {
                 //將json轉換為陣列進行比對
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至biog欄位
-                $lists[$x]['biog'] = $ans;
+                //將比對後的結果存回至resource_original欄位
+                $lists[$x]['resource_original'] = $ans;
             }
         }
         //echo "<pre><code>";
-        //print_r($lists[0]['biog']); //成功
+        //print_r($lists[0]['resource_original']); //成功
         //echo "</code></pre>";
         return view('operations.index', ['lists' => $lists,
             'page_title' => 'NewUpdate', 'page_description' => '最近編輯列表',

--- a/app/Http/Controllers/SocialInstitutionCodesController.php
+++ b/app/Http/Controllers/SocialInstitutionCodesController.php
@@ -32,7 +32,7 @@ class SocialInstitutionCodesController extends Controller
      */
     public function index()
     {
-        return view('socialinstitutioncodes.index', ['page_title' => 'Social Institution Codes', 'page_description' => '社会机构编码表', 'codes' => session('codes')]);
+        return view('socialinstitutioncodes.index', ['page_title' => 'Social Institution Codes', 'page_description' => '社會機構編碼表', 'codes' => session('codes')]);
     }
 
     /**
@@ -43,7 +43,7 @@ class SocialInstitutionCodesController extends Controller
     public function create()
     {
         $temp_id = SocialInstitutionCode::max('c_inst_name_code') + 1;
-        return view('socialinstitutioncodes.create', ['page_title' => 'Social Institution Codes', 'page_description' => '社会机构编码表', 'temp_id' => $temp_id]);
+        return view('socialinstitutioncodes.create', ['page_title' => 'Social Institution Codes', 'page_description' => '社會機構編碼表', 'temp_id' => $temp_id]);
     }
 
     /**
@@ -94,7 +94,7 @@ class SocialInstitutionCodesController extends Controller
     public function edit($id)
     {
         $data = $this->socialinstitutioncoderepository->byUnionId($id);
-        return view('socialinstitutioncodes.edit', ['page_title' => 'Social Institution Codes', 'page_description' => '社会机构编码表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('socialinstitutioncodes.edit', ['page_title' => 'Social Institution Codes', 'page_description' => '社會機構編碼表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Http/Controllers/TextCodesController.php
+++ b/app/Http/Controllers/TextCodesController.php
@@ -31,7 +31,7 @@ class TextCodesController extends Controller
      */
     public function index()
     {
-        return view('textcodes.index', ['page_title' => 'Text Codes', 'page_description' => '著作编码表', 'codes' => session('codes')]);
+        return view('textcodes.index', ['page_title' => 'Text Codes', 'page_description' => '著作編碼表', 'codes' => session('codes')]);
     }
 
     /**
@@ -42,7 +42,7 @@ class TextCodesController extends Controller
     public function create()
     {
         $temp_id = TextCode::max('c_textid') + 1;
-        return view('textcodes.create', ['page_title' => 'Text Codes', 'page_description' => '著作编码表', 'temp_id' => $temp_id]);
+        return view('textcodes.create', ['page_title' => 'Text Codes', 'page_description' => '著作編碼表', 'temp_id' => $temp_id]);
     
     }
 
@@ -93,7 +93,7 @@ class TextCodesController extends Controller
     public function edit($id)
     {
         $data = $this->textcoderepository->byId($id);
-        return view('textcodes.edit', ['page_title' => 'Text Codes', 'page_description' => '著作编码表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
+        return view('textcodes.edit', ['page_title' => 'Text Codes', 'page_description' => '著作編碼表', 'id' => $id, 'row' => $data, 'codes' => session('codes')]);
     }
 
     /**

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -319,7 +319,11 @@ class BiogMainRepository
     {
         //建安修改20181109
         //$row = DB::table('ENTRY_DATA')->where('tts_sysno', $id)->first();
+        $id = str_replace("--","-minus",$id);
         $addr_a = explode("-", $id);
+        foreach($addr_a as $key => $value) {
+            $addr_a[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ENTRY_DATA')->where([
             ['c_personid', '=', $addr_a[0]],
             ['c_entry_code', '=', $addr_a[1]],
@@ -443,7 +447,11 @@ class BiogMainRepository
 
     public function statuseById($id)
     {
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('STATUS_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_sequence', '=', $temp_l[1]],
@@ -465,7 +473,11 @@ class BiogMainRepository
 
     public function statuseUpdateById(Request $request, $id, $c_personid)
     {
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('STATUS_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_sequence', '=', $temp_l[1]],
@@ -502,7 +514,11 @@ class BiogMainRepository
 
     public function statuseDeleteById($id, $c_personid)
     {
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('STATUS_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_sequence', '=', $temp_l[1]],
@@ -519,10 +535,10 @@ class BiogMainRepository
 
     public function kinshipById($id)
     {
-        $id = str_replace("--","-負",$id);
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
         foreach($temp_l as $key => $value) {
-            $temp_l[$key] = str_replace("負","-",$value);
+            $temp_l[$key] = str_replace("minus","-",$value);
         }
 
         $row = DB::table('KIN_DATA')->where([
@@ -558,10 +574,10 @@ class BiogMainRepository
 
     public function kinshipUpdateById(Request $request, $id, $id_)
     {
-        $id_ = str_replace("--","-負",$id_);
+        $id_ = str_replace("--","-minus",$id_);
         $temp_l = explode("-", $id_);
         foreach($temp_l as $key => $value) {
-            $temp_l[$key] = str_replace("負","-",$value);
+            $temp_l[$key] = str_replace("minus","-",$value);
         }
 
         $row = DB::table('KIN_DATA')->where([
@@ -626,10 +642,10 @@ class BiogMainRepository
     public function kinshipDeleteById($id, $id_)
     {
         $operationRepository = new OperationRepository();
-        $id = str_replace("--","-負",$id);
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
         foreach($temp_l as $key => $value) {
-            $temp_l[$key] = str_replace("負","-",$value);
+            $temp_l[$key] = str_replace("minus","-",$value);
         }
 
         $row = DB::table('KIN_DATA')->where([
@@ -826,7 +842,11 @@ class BiogMainRepository
 
     public function assocById($id)
     {
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
@@ -890,7 +910,11 @@ class BiogMainRepository
 
     public function assocUpdateById(Request $request, $id, $c_personid)
     {
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
@@ -953,7 +977,11 @@ class BiogMainRepository
         //20190118筆記, 修改這邊的刪除功能.
         //$row = DB::table('ASSOC_DATA')->where('tts_sysno', $id)->first();
         //DB::table('ASSOC_DATA')->where('tts_sysno', $row->tts_sysno)->delete();
+        $id = str_replace("--","-minus",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("minus","-",$value);
+        }
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -150,8 +150,16 @@ class BiogMainRepository
         $data['c_dy_intercalary'] = (int)($data['c_dy_intercalary']);
         $data = (new ToolsRepository)->timestamp($data);
         $biogbasicinformation = BiogMain::find($id);
-        $biogbasicinformation->update($data);
-        (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data);
+        $ori = $this->byPersonId($id);
+        //20190531判別是否為眾包用戶
+        if (Auth::user()->is_admin == 2) {
+            (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori, 2);
+        }
+        else {
+            $biogbasicinformation->update($data);
+            (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori);
+        }
+        //20190531修改結束
     }
 
     /**

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -843,14 +843,33 @@ class BiogMainRepository
     public function assocById($id)
     {
         $id = str_replace("--","-minus",$id);
+        //20191029對於c_text_title欄位內含斜線所做的字串重組
+        $id = str_replace("(slash)","/",$id);
+        //end
         $temp_l = explode("-", $id);
         foreach($temp_l as $key => $value) {
             $temp_l[$key] = str_replace("minus","-",$value);
         }
+        //20191028防止c_text_title欄位內含負號所做的字串重組
+        $new_c_text_title = '';
+        if(!empty($temp_l[8])) {
+            for($i=7; $i<count($temp_l); $i++) {
+                if(empty($new_c_text_title)) { $new_c_text_title .= $temp_l[$i]; }
+                else { $new_c_text_title .= "-".$temp_l[$i]; }
+            }
+            $temp_l[7] = $new_c_text_title;
+        }
+        
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
             ['c_assoc_id', '=', $temp_l[2]],
+            //20191028進行聯合主鍵的擴充修改
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $temp_l[7]],
         ])->first();
         //$row = DB::table('ASSOC_DATA')->where('tts_sysno', $id)->first();
         $text_str = null;
@@ -911,14 +930,34 @@ class BiogMainRepository
     public function assocUpdateById(Request $request, $id, $c_personid)
     {
         $id = str_replace("--","-minus",$id);
+        //20191029對於c_text_title欄位內含斜線所做的字串重組
+        $id = str_replace("(slash)","/",$id);
+        //end
         $temp_l = explode("-", $id);
         foreach($temp_l as $key => $value) {
             $temp_l[$key] = str_replace("minus","-",$value);
         }
+        //20191028防止c_text_title欄位內含負號所做的字串重組
+        $new_c_text_title = '';
+        if(!empty($temp_l[8])) {
+            for($i=7; $i<count($temp_l); $i++) {
+                if(empty($new_c_text_title)) { $new_c_text_title .= $temp_l[$i]; }
+                else { $new_c_text_title .= "-".$temp_l[$i]; }
+            }
+            $temp_l[7] = $new_c_text_title;
+        }
+        //end
+
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
             ['c_assoc_id', '=', $temp_l[2]],
+            //20191028進行聯合主鍵的擴充修改
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $temp_l[7]],
         ])->first();
         $data = $request->all();
         $data = $this->formatSelect($data);
@@ -934,10 +973,16 @@ class BiogMainRepository
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
             ['c_assoc_id', '=', $temp_l[2]],
+            //20191028進行聯合主鍵的擴充修改
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $temp_l[7]],
         ])->update($data);
         $ori_data = $data;
         $data['c_personid'] = $c_personid;
-        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id'], $data);
+        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'], $data);
         $data['c_assoc_code'] = $assoc_pair;
         $data['c_personid'] = $assoc_id;
         $data = array_except($data, ['c_assoc_id']);
@@ -962,7 +1007,7 @@ class BiogMainRepository
         $data = (new ToolsRepository)->timestamp($data, True);
         DB::table('ASSOC_DATA')->insert($data);
         $ori_Data = $data;
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id'], $data);
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'], $data);
         $data['tts_sysno'] += 1;
         $data['c_assoc_code'] = $assoc_pair;
         $data['c_personid'] = $data['c_assoc_id'];
@@ -978,14 +1023,33 @@ class BiogMainRepository
         //$row = DB::table('ASSOC_DATA')->where('tts_sysno', $id)->first();
         //DB::table('ASSOC_DATA')->where('tts_sysno', $row->tts_sysno)->delete();
         $id = str_replace("--","-minus",$id);
+        //20191029對於c_text_title欄位內含斜線所做的字串重組
+        $id = str_replace("(slash)","/",$id);
+        //end
         $temp_l = explode("-", $id);
         foreach($temp_l as $key => $value) {
             $temp_l[$key] = str_replace("minus","-",$value);
+        }        
+        //20191028防止c_text_title欄位內含負號所做的字串重組
+        $new_c_text_title = '';
+        if(!empty($temp_l[8])) {
+            for($i=7; $i<count($temp_l); $i++) {
+                if(empty($new_c_text_title)) { $new_c_text_title .= $temp_l[$i]; }
+                else { $new_c_text_title .= "-".$temp_l[$i]; }
+            }
+            $temp_l[7] = $new_c_text_title;
         }
+
         $row = DB::table('ASSOC_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
             ['c_assoc_id', '=', $temp_l[2]],
+            //20191028進行聯合主鍵的擴充修改
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $temp_l[7]],
         ])->first();
         $row2 = DB::table('ASSOC_DATA')->where([
             ['c_personid',$row->c_assoc_id],
@@ -996,6 +1060,12 @@ class BiogMainRepository
             ['c_personid', '=', $temp_l[0]],
             ['c_assoc_code', '=', $temp_l[1]],
             ['c_assoc_id', '=', $temp_l[2]],
+            //20191028進行聯合主鍵的擴充修改
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $temp_l[7]],
         ])->delete();
         (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ASSOC_DATA', $id, $row);
         DB::table('ASSOC_DATA')->where([

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -519,7 +519,12 @@ class BiogMainRepository
 
     public function kinshipById($id)
     {
+        $id = str_replace("--","-負",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("負","-",$value);
+        }
+
         $row = DB::table('KIN_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_kin_id', '=', $temp_l[1]],
@@ -553,7 +558,12 @@ class BiogMainRepository
 
     public function kinshipUpdateById(Request $request, $id, $id_)
     {
+        $id_ = str_replace("--","-負",$id_);
         $temp_l = explode("-", $id_);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("負","-",$value);
+        }
+
         $row = DB::table('KIN_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_kin_id', '=', $temp_l[1]],
@@ -567,6 +577,7 @@ class BiogMainRepository
         $old_kin_id = $row->c_kin_id;
         $data = array_except($data, ['_token', '_method', 'c_kinship_pair']);
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
+        $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository)->timestamp($data);
 //        dump($data);
@@ -615,7 +626,12 @@ class BiogMainRepository
     public function kinshipDeleteById($id, $id_)
     {
         $operationRepository = new OperationRepository();
+        $id = str_replace("--","-負",$id);
         $temp_l = explode("-", $id);
+        foreach($temp_l as $key => $value) {
+            $temp_l[$key] = str_replace("負","-",$value);
+        }
+
         $row = DB::table('KIN_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_kin_id', '=', $temp_l[1]],

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -194,7 +194,22 @@ class BiogMainRepository
         $text = null;
         if($row->c_textid || $row->c_textid === 0) {
             $text_ = TextCode::find($row->c_textid);
-            $text = $text_->c_textid." ".$text_->c_title." ".$text_->c_title_chn;
+            //進行查詢資訊的擴充
+            $c_bibl_cat_code = $text_->c_bibl_cat_code;
+            $x1 = DB::table('TEXT_BIBLCAT_CODE_TYPE_REL')->select('c_text_cat_type_id')->where('c_text_cat_code', $c_bibl_cat_code)->get();
+            foreach($x1 as $object) {
+                $ans1[0] = $object->c_text_cat_type_id;
+            }
+            for($j=0; $j<=3; $j++) {
+                $x[$j] = $this->searchTextSub($ans1[$j]);
+                foreach($x[$j] as $object) {
+                    $ans1[$j+1] = $object->c_text_cat_type_parent_id;
+                    $ans2[$j+1] = $object->c_text_cat_type_desc_chn;
+                }
+            }
+            $word = $ans2[1]."/".$ans2[2]."/".$ans2[3];
+            $text = $text_->c_textid." ".$text_->c_title." ".$text_->c_title_chn." ".$word;
+            //$text = $text_->c_textid." ".$text_->c_title." ".$text_->c_title_chn;
 
         }
         $text_str = null;
@@ -203,6 +218,11 @@ class BiogMainRepository
             $text_str = $text_->c_textid." ".$text_->c_title." ".$text_->c_title_chn;
         }
         return ['row' => $row, 'text' => $text, 'text_str' => $text_str];
+    }
+
+    public function searchTextSub($request){
+        $data = DB::table('TEXT_BIBLCAT_TYPES')->select('c_text_cat_type_parent_id', 'c_text_cat_type_desc_chn')->where('c_text_cat_type_id', $request)->get();
+        return $data;
     }
 
     public function textUpdateById( )

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -38,7 +38,7 @@ class OperationRepository
         $operation->resource = $resource;
         $operation->resource_id = $resource_id;
         $operation->resource_data = json_encode($resource_data);
-        if(!empty($ori)) $operation->biog = json_encode($ori);
+        if(!empty($ori)) $operation->resource_original = json_encode($ori);
         if($crowdsourcing_status != 0) $operation->crowdsourcing_status = $crowdsourcing_status;
         $operation->save();
     }

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -20,9 +20,16 @@ class OperationRepository
      * @param string $resource 修改表明
      * @param int $resource_id 修改数据ID
      * @param array $resource_data 数据
+     * @param array $ori 数据
+     * @param int $crowdsourcing_status 0.專業用戶修改紀錄 
+     *                                  1.crowdsourcing記錄並已插入數據庫 
+     *                                  2.crowdsourcing記錄還沒有被處理 
+     *                                  3.crowdsourcing記錄reject 
+     *                                  4.crowdsourcing處理失敗
      * @return mixed
      */
-    public function store($user_id, $c_personid, $op_type, $resource, $resource_id, $resource_data)
+
+    public function store($user_id, $c_personid, $op_type, $resource, $resource_id, $resource_data, $ori='', $crowdsourcing_status=0)
     {
         $operation = new Operation();
         $operation->user_id = $user_id;
@@ -31,7 +38,41 @@ class OperationRepository
         $operation->resource = $resource;
         $operation->resource_id = $resource_id;
         $operation->resource_data = json_encode($resource_data);
+        if(!empty($ori)) $operation->biog = json_encode($ori);
+        if($crowdsourcing_status != 0) $operation->crowdsourcing_status = $crowdsourcing_status;
         $operation->save();
     }
 
+    public function objectToArray($object)
+    {
+        //先編碼成json字串，再解碼成陣列
+        return json_decode(json_encode($object), true);
+    }
+
+    public function getArrDiff($arr1, $arr2)
+    {
+        //進行陣列雜訊的濾除
+        if(!is_array($arr1) || !is_array($arr2)) { return ""; }
+        $NewArr1ture = array();
+        $NewArr2ture = array();
+        $NewArr1 = array_diff_assoc($arr1, $arr2);
+        $NewArr2 = array_diff_assoc($arr2, $arr1);
+        $data = "<br/><p>[修改後]</p>";
+        foreach($NewArr1 as $key => $value){
+            if($key == "_method" || $key == "_token") {
+                continue;
+            }
+            else {
+                $NewArr1ture[$key] = $value;
+                $data .= "欄位：".$key."  內容：".$value."<br/>";
+            }
+        }
+        $data .= "<br/><p>[原本的]</p>";
+        foreach($NewArr1ture as $key => $value){
+            $NewArr2ture[$key] = $value;
+            $data .= "欄位：".$key."  內容：".$NewArr2[$key]."<br/>";
+        }
+        //雜訊濾除結束
+        return $data;
+    }
 }

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -49,14 +49,16 @@ class OperationRepository
         return json_decode(json_encode($object), true);
     }
 
-    public function getArrDiff($arr1, $arr2)
+    public function getArrDiff($arr1, $arr2, $arr3)
     {
         //進行陣列雜訊的濾除
         if(!is_array($arr1) || !is_array($arr2)) { return ""; }
         $NewArr1ture = array();
         $NewArr2ture = array();
+        $NewArr3ture = array();
         $NewArr1 = array_diff_assoc($arr1, $arr2);
         $NewArr2 = array_diff_assoc($arr2, $arr1);
+        $NewArr3 = array_diff_assoc($arr1, $arr3);
         $data = "<br/><p>[修改後]</p>";
         foreach($NewArr1 as $key => $value){
             if($key == "_method" || $key == "_token") {
@@ -71,6 +73,18 @@ class OperationRepository
         foreach($NewArr1ture as $key => $value){
             $NewArr2ture[$key] = $value;
             $data .= "欄位：".$key."  內容：".$NewArr2[$key]."<br/>";
+        }
+        $data .= "<br/><p>[實時比對]</p>";
+        foreach($NewArr3 as $key => $value){
+            if($key == "_method" || $key == "_token") {
+                continue;
+            }
+            else {
+                if(!empty($arr3[$key])) {
+                    $NewArr3ture[$key] = $value;
+                    $data .= "欄位：".$key."  內容：".$arr3[$key]."<br/>";
+                }
+            }
         }
         //雜訊濾除結束
         return $data;

--- a/database/migrations/2017_09_17_202402_create_operations_table.php
+++ b/database/migrations/2017_09_17_202402_create_operations_table.php
@@ -21,7 +21,7 @@ class CreateOperationsTable extends Migration
             $table->string('resource');
             $table->string('resource_id');
             $table->json('resource_data');
-            $table->json('biog')->nullable();
+            $table->json('resource_original')->nullable();
             $table->timestamps();
             $table->smallInteger('crowdsourcing_status')->comment('0.專業用戶修改紀錄 1.crowdsourcing記錄並已插入數據庫 2.crowdsourcing記錄還沒有被處理 3.crowdsourcing記錄reject 4.crowdsourcing處理失敗');
             $table->smallInteger('rate')->comment('記錄處理次數');

--- a/resources/views/addrcodes/create.blade.php
+++ b/resources/views/addrcodes/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDR_CODES)</div>
+        <div class="panel-heading">地址編碼表(ADDR_CODES)</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="{{ route('addrcodes.store') }}" class="form-horizontal" method="post">

--- a/resources/views/addrcodes/edit.blade.php
+++ b/resources/views/addrcodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDR_CODES)</div>
+        <div class="panel-heading">地址編碼表(ADDR_CODES)</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/addrcodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/addrcodes/index.blade.php
+++ b/resources/views/addrcodes/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDR_CODES)</div>
+        <div class="panel-heading">地址編碼表(ADDR_CODES)</div>
         <div class="panel-body">
             <a href="{{ route('addrcodes.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="panel-body">

--- a/resources/views/addresscodes/create.blade.php
+++ b/resources/views/addresscodes/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDRESSES)</div>
+        <div class="panel-heading">地址編碼表(ADDRESSES)</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="{{ route('addresscodes.store') }}" class="form-horizontal" method="post">

--- a/resources/views/addresscodes/edit.blade.php
+++ b/resources/views/addresscodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDRESSES)</div>
+        <div class="panel-heading">地址編碼表(ADDRESSES)</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/addresscodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/addresscodes/index.blade.php
+++ b/resources/views/addresscodes/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">地址编码表(ADDRESSES)</div>
+        <div class="panel-heading">地址編碼表(ADDRESSES)</div>
         <div class="panel-body">
             <a href="{{ route('addresscodes.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="panel-body">

--- a/resources/views/altnamecodes/edit.blade.php
+++ b/resources/views/altnamecodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">别名编码表</div>
+        <div class="panel-heading">別名編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/altnamecodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/altnamecodes/index.blade.php
+++ b/resources/views/altnamecodes/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">别名编码表</div>
+        <div class="panel-heading">別名編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <altname-code-list></altname-code-list>

--- a/resources/views/appointcodes/edit.blade.php
+++ b/resources/views/appointcodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">任命类型编码表</div>
+        <div class="panel-heading">任命類型編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/appointcodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/appointcodes/index.blade.php
+++ b/resources/views/appointcodes/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     <div class="panel panel-default">
-        <div class="panel-heading">任命类型编码表</div>
+        <div class="panel-heading">任命類型編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <appoint-code-list></appoint-code-list>

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -5,7 +5,10 @@
         <div class="panel-heading">社會關係</div>
         <div class="panel-body">
             <div class="panel-body">
-            <form action="{{ route('basicinformation.assoc.update', [$id, $row->c_personid."-".$row->c_assoc_code."-".$row->c_assoc_id]) }}" class="form-horizontal" method="post">
+@php
+$row->c_text_title = str_replace("/","(slash)",$row->c_text_title);
+@endphp
+            <form action="{{ route('basicinformation.assoc.update', [$id, $row->c_personid."-".$row->c_assoc_code."-".$row->c_assoc_id."-".$row->c_kin_code."-".$row->c_kin_id."-".$row->c_assoc_kin_code."-".$row->c_assoc_kin_id."-".$row->c_text_title]) }}" class="form-horizontal" method="post">
                 {{ method_field('PATCH') }}
                 {{ csrf_field() }}
                 <div class="form-group">
@@ -138,6 +141,9 @@
                 <div class="form-group">
                     <label for="c_text_title" class="col-sm-2 control-label">作品標題</label>
                     <div class="col-sm-10">
+@php
+$row->c_text_title = str_replace("(slash)","/",$row->c_text_title);
+@endphp
                         <input type="text" class="form-control" name="c_text_title" value="{{ $row->c_text_title }}">
                     </div>
                 </div>

--- a/resources/views/biogmains/assoc/index.blade.php
+++ b/resources/views/biogmains/assoc/index.blade.php
@@ -34,13 +34,16 @@
                             @endif
                         <td>
                             <div class="btn-group">
-                                <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.assoc.edit', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id]) }}">edit</a>
+                            @php
+                            $value->pivot->c_text_title = str_replace("/","(slash)",$value->pivot->c_text_title);
+                            @endphp
+                                <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.assoc.edit', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id."-".$value->pivot->c_kin_code."-".$value->pivot->c_kin_id."-".$value->pivot->c_assoc_kin_code."-".$value->pivot->c_assoc_kin_id."-".$value->pivot->c_text_title]) }}">edit</a>
                                 <a href=""
                                    onclick="
                                            let msg = '您真的确定要删除吗？\n\n请确认！';
                                            if (confirm(msg)===true){
                                                event.preventDefault();
-                                               document.getElementById('delete-form-{{ $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id }}').submit();
+                                               document.getElementById('delete-form-{{ $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id."-".$value->pivot->c_kin_code."-".$value->pivot->c_kin_id."-".$value->pivot->c_assoc_kin_code."-".$value->pivot->c_assoc_kin_id."-".$value->pivot->c_text_title }}').submit();
                                            }else{
                                                 return false;
                                            }
@@ -48,7 +51,7 @@
                                    class="btn btn-sm btn-danger">delete</a>
 
                             </div>
-                            <form id="delete-form-{{ $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id }}" action="{{ route('basicinformation.assoc.destroy', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id]) }}" method="POST" style="display: none;">
+                            <form id="delete-form-{{ $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id."-".$value->pivot->c_kin_code."-".$value->pivot->c_kin_id."-".$value->pivot->c_assoc_kin_code."-".$value->pivot->c_assoc_kin_id."-".$value->pivot->c_text_title }}" action="{{ route('basicinformation.assoc.destroy', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_personid."-".$value->pivot->c_assoc_code."-".$value->pivot->c_assoc_id."-".$value->pivot->c_kin_code."-".$value->pivot->c_kin_id."-".$value->pivot->c_assoc_kin_code."-".$value->pivot->c_assoc_kin_id."-".$value->pivot->c_text_title]) }}" method="POST" style="display: none;">
                                 {{ method_field('DELETE') }}
                                 {{ csrf_field() }}
                             </form>

--- a/resources/views/biogmains/basicinformation/index.blade.php
+++ b/resources/views/biogmains/basicinformation/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">人名查询</div>
+        <div class="panel-heading">人名查詢</div>
         <div class="panel-body">
             <a href="{{ route('basicinformation.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="clearfix"></div>

--- a/resources/views/codes/index.blade.php
+++ b/resources/views/codes/index.blade.php
@@ -4,7 +4,7 @@
     <!-- SELECT2 EXAMPLE -->
     <div class="box box-default">
         <div class="box-header with-border">
-            <h3 class="box-title">编码表</h3>
+            <h3 class="box-title">代碼表</h3>
 
             <div class="box-tools pull-right">
                 <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-minus"></i></button>

--- a/resources/views/codes/show.blade.php
+++ b/resources/views/codes/show.blade.php
@@ -4,7 +4,7 @@
 
     <div class="box">
         <div class="box-header">
-            <h3 class="box-title">编码表</h3>
+            <h3 class="box-title">代碼表</h3>
 
             <div class="box-tools pull-right">
                 <a class="btn btn-default" href="/codes/{{ $q }}/create">新增</a>

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -75,9 +75,9 @@
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <div>
-                                @if (!empty($item->biog))
+                                @if (!empty($item->resource_original))
                                     欄位比對的結果：<br/>
-                                    {!! $item->biog !!}
+                                    {!! $item->resource_original !!}
                                 @else
                                     沒有比對紀錄
                                 @endif

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -30,6 +30,7 @@
                             <td>{{ $item->resource }}</td>
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}">compare</button>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
@@ -38,7 +39,7 @@
                             <td>{{ $item->created_at }}</td>
                             <td>{{ $item->crowdsourcing_status }}</td>
                             <td>
-                                @if($item->crowdsourcing_status == 2)
+                                @if($item->crowdsourcing_status == 2 and Auth::check() and Auth::user()->is_admin == 1)
                                 <a href="../../crowdsourcing/{{$item->id}}/confirm" type="button" class="btn btn-success">confirm</a>　
                                 <a href="../../crowdsourcing/{{$item->id}}/reject" type="button" class="btn btn-danger">reject</a>
                                 @endif
@@ -51,16 +52,37 @@
                             <div class="modal-content">
                               <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">resource_data </h4>
+                                <h4 class="modal-title">resource_data</h4>
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
                               </div>
                               <div class="modal-footer">
-                                <!--temporarily
-                                <a href="" type="button" class="btn btn-success">Confirm</a>
-                                <a href="" type="button" class="btn btn-danger">Reject</a>
-                                -->
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <!--End-->
+                        <!--Start-->
+                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                          <div class="modal-dialog">
+                            <!-- Modal content-->
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                <h4 class="modal-title">compare</h4>
+                              </div>
+                              <div class="modal-body" style="word-break: break-all;">
+                                <div>
+                                @if (!empty($item->biog))
+                                    欄位比對的結果：<br/>
+                                    {!! $item->biog !!}
+                                @else
+                                    沒有比對紀錄
+                                @endif
+                                </div>
+                              <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                               </div>
                             </div>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -38,27 +38,27 @@
             <li class="header">MAIN NAVIGATION</li>
             <!-- Optionally, you can add icons to the links -->
             {{--<li class="{{ $page_title == 'Dashboard' ? 'active' : '' }}"><a href="/home"><i class="fa fa-dashboard"></i> <span>控制面板</span></a></li>--}}
-            <li class="{{ $page_title == 'Basicinformation' ? 'active' : '' }}"><a href="{{ route('basicinformation.index') }}"><i class="ion ion-ios-people-outline"></i> <span>个人基本信息</span></a></li>
-            <li class="{{ $page_title == 'NewUpdate' ? 'active' : '' }}"><a href="{{ route('operations.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近编辑列表</span></a></li>
+            <li class="{{ $page_title == 'Basicinformation' ? 'active' : '' }}"><a href="{{ route('basicinformation.index') }}"><i class="ion ion-ios-people-outline"></i> <span>個人基本信息</span></a></li>
+            <li class="{{ $page_title == 'NewUpdate' ? 'active' : '' }}"><a href="{{ route('operations.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近編輯列表</span></a></li>
             <li class="{{ $page_title == 'Crowdsourcing' ? 'active' : '' }}"><a href="{{ route('crowdsourcing.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近眾包錄入記錄</span></a></li>
             <li class="{{ $page_title == 'Modified' ? 'active' : '' }}"><a href="{{ route('modified.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近修改記錄</span></a></li>
 
             <li class="header">CODES</li>
-            <li class="{{ $page_title == 'Codes' ? 'active' : '' }}"><a href="/codes"><i class="fa fa-database"></i> <span>Codes</span></a></li>
+            <li class="{{ $page_title == 'Codes' ? 'active' : '' }}"><a href="/codes"><i class="fa fa-database"></i> <span>代碼表(CODES TABLES)</span></a></li>
             {{--<li class="{{ $page_title == 'ADDR_CODES' ? 'active' : '' }}"><a href="/codes/ADDR_CODES"><i class="fa fa-database"></i> <span>ADDR_CODES</span></a></li>--}}
             {{--<li class="{{ $page_title == 'ALTNAME_CODES' ? 'active' : '' }}"><a href="/codes/ALTNAME_CODES"><i class="fa fa-database"></i> <span>ALTNAME_CODES</span></a></li>--}}
-            <li class="{{ $page_title == 'Address Codes' ? 'active' : '' }}"><a href="{{ route('addresscodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址编码表(ADDRESSES)</span></a></li>
-            <li class="{{ $page_title == 'Altname Codes' ? 'active' : '' }}"><a href="{{ route('altnamecodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>别名编码表</span></a></li>
-            <li class="{{ $page_title == 'Appointment Type Codes' ? 'active' : '' }}"><a href="{{ route('appointcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>任命类型编码表</span></a></li>
-            <li class="{{ $page_title == 'Text Codes' ? 'active' : '' }}"><a href="{{ route('textcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>著作编码表</span></a></li>
-            <li class="{{ $page_title == 'Addrbelongsdata Type Codes' ? 'active' : '' }}"><a href="{{ route('addrbelongsdata.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址从属表</span></a></li>
-            <li class="{{ $page_title == 'Addr Codes' ? 'active' : '' }}"><a href="{{ route('addrcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址编码表(ADDR_CODES)</span></a></li>
-            <li class="{{ $page_title == 'Office Codes' ? 'active' : '' }}"><a href="{{ route('officecodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>任官编码表</span></a></li>
-            <li class="{{ $page_title == 'Social Institution Codes' ? 'active' : '' }}"><a href="{{ route('socialinstitutioncodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>社会机构编码表</span></a></li>
+            <li class="{{ $page_title == 'Address Codes' ? 'active' : '' }}"><a href="{{ route('addresscodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址編碼表(ADDRESSES)</span></a></li>
+            <li class="{{ $page_title == 'Altname Codes' ? 'active' : '' }}"><a href="{{ route('altnamecodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>別名編碼表</span></a></li>
+            <li class="{{ $page_title == 'Appointment Type Codes' ? 'active' : '' }}"><a href="{{ route('appointcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>任命類型編碼表</span></a></li>
+            <li class="{{ $page_title == 'Text Codes' ? 'active' : '' }}"><a href="{{ route('textcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>著作編碼表</span></a></li>
+            <li class="{{ $page_title == 'Addrbelongsdata Type Codes' ? 'active' : '' }}"><a href="{{ route('addrbelongsdata.index') }}"><i class="ion ion-ios-people-outline"></i> <span>著作從屬表</span></a></li>
+            <li class="{{ $page_title == 'Addr Codes' ? 'active' : '' }}"><a href="{{ route('addrcodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址編碼表(ADDR_CODES)</span></a></li>
+            <li class="{{ $page_title == 'Office Codes' ? 'active' : '' }}"><a href="{{ route('officecodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>任官編碼表</span></a></li>
+            <li class="{{ $page_title == 'Social Institution Codes' ? 'active' : '' }}"><a href="{{ route('socialinstitutioncodes.index') }}"><i class="ion ion-ios-people-outline"></i> <span>社會機構編碼表</span></a></li>
 
             @if(Auth::check() and Auth::user()->is_admin == 1)
                 <li class="header">Management</li>
-                <li class="{{ $page_title == 'Management' ? 'active' : '' }}"><a href="{{ route('manage.index') }}"><i class="ion ion-ios-people-outline"></i> <span>管理用户</span></a></li>
+                <li class="{{ $page_title == 'Management' ? 'active' : '' }}"><a href="{{ route('manage.index') }}"><i class="ion ion-ios-people-outline"></i> <span>管理用戶</span></a></li>
             @endif
         </ul>
         <!-- /.sidebar-menu -->

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -83,6 +83,7 @@ else {
                             <td>{{ $item->resource }}</td>
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}">compare</button>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
@@ -98,16 +99,38 @@ else {
                             <div class="modal-content">
                               <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">resource_data </h4>
+                                <h4 class="modal-title">resource_data</h4>
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
                               </div>
                               <div class="modal-footer">
-                                <!--temporarily
-                                <a href="" type="button" class="btn btn-success">Confirm</a>
-                                <a href="" type="button" class="btn btn-danger">Reject</a>
-                                -->
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <!--End-->
+                        <!--Start-->
+                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                          <div class="modal-dialog">
+                            <!-- Modal content-->
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                <h4 class="modal-title">compare</h4>
+                              </div>
+                              <div class="modal-body" style="word-break: break-all;">
+                                <div>
+                                @if (!empty($item->biog))
+                                    欄位比對的結果：<br/>
+                                    {!! $item->biog !!}
+                                @else
+                                    沒有比對紀錄
+                                @endif
+                                </div>
+                              </div>
+                              <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                               </div>
                             </div>

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -122,9 +122,9 @@ else {
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <div>
-                                @if (!empty($item->biog))
+                                @if (!empty($item->resource_original))
                                     欄位比對的結果：<br/>
-                                    {!! $item->biog !!}
+                                    {!! $item->resource_original !!}
                                 @else
                                     沒有比對紀錄
                                 @endif

--- a/resources/views/officecodes/create.blade.php
+++ b/resources/views/officecodes/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">任官编码表</div>
+        <div class="panel-heading">任官編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="{{ route('officecodes.store') }}" class="form-horizontal" method="post">

--- a/resources/views/officecodes/edit.blade.php
+++ b/resources/views/officecodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">任官编码表</div>
+        <div class="panel-heading">任官編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/officecodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/officecodes/index.blade.php
+++ b/resources/views/officecodes/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     <div class="panel panel-default">
-        <div class="panel-heading">任官编码表</div>
+        <div class="panel-heading">任官編碼表</div>
         <div class="panel-body">
             <a href="{{ route('officecodes.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="panel-body">

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -79,6 +79,7 @@ else {
                             <td>{{ $item->resource }}</td>
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}">compare</button>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
@@ -92,16 +93,38 @@ else {
                             <div class="modal-content">
                               <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">resource_data </h4>
+                                <h4 class="modal-title">resource_data</h4>
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
                               </div>
                               <div class="modal-footer">
-                                <!--temporarily
-                                <a href="" type="button" class="btn btn-success">Confirm</a>
-                                <a href="" type="button" class="btn btn-danger">Reject</a>
-                                -->
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <!--End-->
+                        <!--Start-->
+                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                          <div class="modal-dialog">
+                            <!-- Modal content-->
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                <h4 class="modal-title">compare</h4>
+                              </div>
+                              <div class="modal-body" style="word-break: break-all;">
+                                <div>
+                                @if (!empty($item->biog))
+                                    欄位比對的結果：<br/>
+                                    {!! $item->biog !!}
+                                @else
+                                    沒有比對紀錄
+                                @endif
+                                </div>
+                              </div>
+                              <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                               </div>
                             </div>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -116,9 +116,9 @@ else {
                               </div>
                               <div class="modal-body" style="word-break: break-all;">
                                 <div>
-                                @if (!empty($item->biog))
+                                @if (!empty($item->resource_original))
                                     欄位比對的結果：<br/>
-                                    {!! $item->biog !!}
+                                    {!! $item->resource_original !!}
                                 @else
                                     沒有比對紀錄
                                 @endif

--- a/resources/views/socialinstitutioncodes/create.blade.php
+++ b/resources/views/socialinstitutioncodes/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">社会机构编码表</div>
+        <div class="panel-heading">社會機構編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="{{ route('socialinstitutioncodes.store') }}" class="form-horizontal" method="post">

--- a/resources/views/socialinstitutioncodes/edit.blade.php
+++ b/resources/views/socialinstitutioncodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">社会机构编码表</div>
+        <div class="panel-heading">社會機構編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/socialinstitutioncodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/socialinstitutioncodes/index.blade.php
+++ b/resources/views/socialinstitutioncodes/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     <div class="panel panel-default">
-        <div class="panel-heading">社会机构编码表</div>
+        <div class="panel-heading">社會機構編碼表</div>
         <div class="panel-body">
             <a href="{{ route('socialinstitutioncodes.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="panel-body">

--- a/resources/views/textcodes/create.blade.php
+++ b/resources/views/textcodes/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">著作编码表</div>
+        <div class="panel-heading">著作編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="{{ route('textcodes.store') }}" class="form-horizontal" method="post">

--- a/resources/views/textcodes/edit.blade.php
+++ b/resources/views/textcodes/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     <div class="panel panel-default">
-        <div class="panel-heading">著作编码表</div>
+        <div class="panel-heading">著作編碼表</div>
         <div class="panel-body">
             <div class="panel-body">
                 <form action="/textcodes/{{ $id }}" class="form-horizontal" method="post">

--- a/resources/views/textcodes/index.blade.php
+++ b/resources/views/textcodes/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     <div class="panel panel-default">
-        <div class="panel-heading">著作编码表</div>
+        <div class="panel-heading">著作編碼表</div>
         <div class="panel-body">
             <a href="{{ route('textcodes.create') }}" class="pull-right btn btn-default">新增</a>
             <div class="panel-body">

--- a/routes/api.php
+++ b/routes/api.php
@@ -124,4 +124,6 @@ Route::group(['prefix' => 'v1'], function (){
 Route::group(['prefix' => 'operations'], function (){
     Route::match(['get', 'post'], 'token', 'Api\OperationsController@token');
     Route::post('add', 'Api\OperationsController@add');
+    Route::post('update', 'Api\OperationsController@update');
+    Route::post('delete', 'Api\OperationsController@del');
 });


### PR DESCRIPTION
20191029assoc聯合主鍵的擴充修改
1.檢測[社會關係查詢]的bug回報，聯合主鍵需由3個欄位擴充至8個，才能符合所有使用情境。
2.修改聯合主鍵的組成程式，抓取相關欄位，c_text_title欄位的資料，有儲存許多的符號，例如括弧、斜線與負號，進行判斷後組合為聯合主鍵。
3.測試新的聯合主鍵組合，可以符合使用者回報的[社會關係查詢]使用情境。