### PR TITLE
20200420根據名稱、存在時間等條件獲取地點API修正

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -161,12 +161,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biogAll = AddrCode::where([
                         ['c_name', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -177,12 +177,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biogAll = AddrCode::where([
                         ['c_name', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -197,12 +197,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biog = AddrCode::where([
                         ['c_name', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -213,12 +213,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biog = AddrCode::where([
                         ['c_name', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {


### PR DESCRIPTION
修改API「根據名稱、存在時間等條件獲取地點」，輸入參數的[startTime 起始時間]與[endTime 結束時間]，依據需求調整。
範例：1368年到2005年間曾經存在的所有地點（包括1368-1643，1644-1911）