### PR TITLE
20200427[根據名稱、存在時間等條件獲取地點]API修正，新增[根據官職中英文名獲取官職列表]與[根據入仕途徑中英文名獲取入仕途徑列表]API

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -161,12 +161,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biogAll = AddrCode::where([
                         ['c_name', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -177,12 +177,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biogAll = AddrCode::where([
                         ['c_name', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -197,12 +197,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biog = AddrCode::where([
                         ['c_name', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', 'like', '%'.$name.'%'],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {
@@ -213,12 +213,12 @@ class ApiController extends Controller
                 if($startTime && $endTime) {
                     $biog = AddrCode::where([
                         ['c_name', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->orWhere([
                         ['c_name_chn', '=', $name],
-                        ['c_firstyear', '=', $startTime],
-                        ['c_lastyear', '=', $endTime],
+                        ['c_firstyear', '>=', $startTime],
+                        ['c_lastyear', '<=', $endTime],
                         ])->get();
                 }
                 else {

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,5 +151,9 @@ Route::group(['prefix' => '/place_list'], function (){
 Route::group(['prefix' => '/place_belongs_to'], function (){
     Route::match(['get', 'post'], '/', 'Api\ApiController@place_belongs_to');
 });
-
-
+Route::group(['prefix' => '/office_list_by_name'], function (){
+    Route::match(['get', 'post'], '/', 'Api\ApiController@office_list_by_name');
+});
+Route::group(['prefix' => '/entry_list_by_name'], function (){
+    Route::match(['get', 'post'], '/', 'Api\ApiController@entry_list_by_name');
+});


### PR DESCRIPTION
修改第3組API「根據名稱、存在時間等條件獲取地點」，輸入參數的[startTime 起始時間]與[endTime 結束時間]，依據需求調整。
說明：1399年到1980年間曾經存在的所有地點（只要資料起訖日期的部分，有在1399-1980的範圍，例如：1368-1990，一率回傳。）
範例：/api/place_list?name=廣州&accurate=1&startTime=1399&endTime=1980&start=1&list=50

第5組API「根據官職中英文名獲取官職列表」
範例：/api/office_list_by_name?pName=尚書省工部&start=2&list=2&accurate=0

第6組API「根據入仕途徑中英文名獲取入仕途徑列表」
範例：/api/entry_list_by_name?eName=生員&start=1&list=2&accurate=0