### PR TITLE
修改親屬pair code一對多的錄入

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -344,8 +344,12 @@ class ApiController extends Controller
     {
         $kin_code = $request->kin_code;
         $person_id = $request->person_id;
-        $data = KinshipCode::find($kin_code);
-        $res = KinshipCode::find([$data->c_kin_pair2, $data->c_kin_pair1]);
+        //20201026修改成對親屬關係的選項
+        $res = KinshipCode::where('c_kin_pair1', '=', $kin_code)->orWhere('c_kin_pair2', '=', $kin_code)->orderBy('c_pick_sorting', 'desc')->get();
+        if(count($res) == 0) {
+            $data = KinshipCode::find($kin_code);
+            $res = KinshipCode::find([$data->c_kin_pair2, $data->c_kin_pair1]);
+        }
         return $res;
     }
 

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -131,7 +131,7 @@
                 <div class="form-group">
                     <label for="c_assoc_count" class="col-sm-2 control-label">關係次數(c_assoc_count)</label>
                     <div class="col-sm-10">
-                        <input type="text" class="form-control" name="c_assoc_count">
+                        <input type="text" class="form-control" name="c_assoc_count" value="1">
                         此欄位僅適用於書信 : 當無法以標題及日期區分多次信件時 , 則僅建「一筆」社會關係 , 並將信件總數填於此欄 . 請填阿拉伯數字
                     </div>
                 </div>
@@ -147,7 +147,7 @@
                     <label for="" class="col-sm-2 control-label">社會關係發生地</label>
                     <div class="col-sm-10">
                         <select class="form-control c_addr_id" name="c_addr_id">
-                            <option value="0" selected="selected"></option>
+                            <option value="0" selected="selected">0 [Unknown] [未詳]  ~ </option>
                         </select>
                     </div>
                 </div>

--- a/resources/views/biogmains/kinship/create.blade.php
+++ b/resources/views/biogmains/kinship/create.blade.php
@@ -56,10 +56,10 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">成对亲属关系</label>
+                    <label for="" class="col-sm-2 control-label">成對親屬關係</label>
                     <div class="col-sm-10">
                         <select class="form-control c_kinship_pair" name="c_kinship_pair">
-                            <option value="0">无对应亲属关系</option>
+                            <option value="0">無對應親屬關係</option>
                         </select>
                     </div>
                 </div>
@@ -155,7 +155,8 @@
 
                     item = data[i];
                     // console.log(item);
-                    $(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
                 }
             });
 

--- a/resources/views/biogmains/kinship/edit.blade.php
+++ b/resources/views/biogmains/kinship/edit.blade.php
@@ -65,7 +65,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">成对亲属关系</label>
+                    <label for="" class="col-sm-2 control-label">成對親屬關係</label>
                     <div class="col-sm-10">
                         <select class="form-control c_kinship_pair" name="c_kinship_pair">
                             @if($res['kinpair_str'])
@@ -181,7 +181,8 @@
                 for (let i=data.length-1; i>-1; i--){
                     item = data[i];
                     // console.log(item);
-                    $(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
                 }
             });
 


### PR DESCRIPTION
問題本體回覆：
1.直接用c_kincode的值查c_kin_pair1與c_kin_pair2，再輸出列印至成對親屬的下拉式選單，選項的排序在資料表已有值儲存（KINSHIP_CODES資料表的c_pick_sorting欄位），依照值排序。
例如：
點選[親屬關係]選取為[父]，[成對親屬關係]輸出選項為[子、女、次子、三子、七子......]等相關選項。

2.如果用c_kincode的值查c_kin_pair1與c_kin_pair2，查詢不到資料，則以c_kincode該筆資料的c_kin_pair1與c_kin_pair2輸出。
例如：
點選[親屬關係]選取為[三子]，[成對親屬關係]輸出選項為[父、母]等相關選項。

相關問題 1回覆：
1.評估資料是一個人物的親屬關係對應另一個人物的親屬關係，在親屬資料表是儲存兩筆，也就是說，選項雖為一對多，但資料儲存的結構維持一筆對應一筆，刪除的程式，是會搜尋對應的人物一起刪除兩筆。
2.除了查詢原本聯合主鍵的[person id] + 親戚姓名(c_kin_id) + 親屬關係(c_kin_code)]與出處(c_source)，再加上兩個欄位的資訊：c_created_date 和 c_modified_date。
這樣做的第一個 assumption 是：自動建立的反向關係一定是建立正向關係的瞬間建立的，所以兩者應該是同一天建立的。第二個 assumption 是：同一天根據同一個 source 建立同一個人兩筆重覆的資料（如子和第三子）幾率非常非常的低。所以這樣來設置刪除的條件基本能確保萬無一失。

相關問題 2回應：
1.「成對親屬關係」的資料呈現，是我在抓取錯誤欄位的資料作為呈現（我把兩個欄位的資料呈現都抓到「親屬關係」的值），所以才會兩個都是[父]。但是資料庫中儲存的值是正確的，只有呈現錯誤。
（新增時的資料輸入是正確的，只有開啟編輯畫面時的資料呈現錯誤，所以目前為止輸入的資料都會正確。）
2.在前台顯示正確的數據，已將 c_status_code 替換成 c_kincode，前端可以正確呈現與修改親屬關係。

相關問題 3回應：
修改簡體中文為正體中文。
