### PR TITLE
20210205完成社會關係界面異動，新增[二手文獻的原作者]欄位。

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -258,6 +258,36 @@ class ApiController extends Controller
         return $data;
     }
 
+    public function socialinstcode(Request $request)
+    {
+        $data = SocialInstCode::where('c_inst_code', 'like', '%'.$request->q.'%')->paginate(20);
+        $data->appends(['q' => $request->q])->links();
+        foreach($data as $item){
+            $item['id'] = $item->c_inst_code;
+            if($item['id'] === 0) $item['id'] = -999;
+            $name_hz = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_hz;
+            $name_py = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_py;
+            $res = SocialInstAddr::where('c_inst_code', $item->c_inst_code)->first();
+            if(count($res) == 0 ) $addr = "未詳";
+            else {
+                $addr = AddressCode::where('c_addr_id', $res->c_inst_addr_id)->first()->c_name_chn;
+            }
+            $dy = $item->c_inst_begin_year;
+            $dy2 = $item->c_inst_floruit_dy;
+            $dy3 = $item->c_inst_end_year;
+            $dy4 = $item->c_inst_last_known_year;
+            if($name_hz == null) $name_hz = "未詳";
+            if($name_py == null) $name_py = "未詳";
+            if($addr == null) $addr = "未詳";
+            if($dy == null) $dy = "未詳";
+            if($dy2 == null) $dy2 = "未詳";
+            if($dy3 == null) $dy3 = "未詳";
+            if($dy4 == null) $dy4 = "未詳";
+            $item['text'] = $item->c_inst_code." (社交機構代碼)-".$name_hz." ".$name_py."(社交機構名稱)-".$item->c_inst_name_code."(社交機構名稱代碼)-".$addr."(地址)-".$dy."(起年)-".$dy2."(最早見諸文獻年)-".$dy3."(訖年)-".$dy4."(最晚見諸文獻年)";
+        }
+        return $data;
+    }
+
     public function searchEntry(Request $request)
     {
         $data = EntryCode::where('c_entry_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_entry_desc', 'like', '%'.$request->q.'%')->orWhere('c_entry_code', $request->q)->paginate(20);

--- a/resources/views/biogmains/addresses/create.blade.php
+++ b/resources/views/biogmains/addresses/create.blade.php
@@ -113,14 +113,20 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
 
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/addresses/edit.blade.php
+++ b/resources/views/biogmains/addresses/edit.blade.php
@@ -123,9 +123,15 @@
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/altname/create.blade.php
+++ b/resources/views/biogmains/altname/create.blade.php
@@ -33,14 +33,20 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
 
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author " class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/altname/edit.blade.php
+++ b/resources/views/biogmains/altname/edit.blade.php
@@ -47,16 +47,22 @@ $row->c_alt_name = unionPKDef_decode_for_convert($row->c_alt_name);
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($text_str)
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $text_str }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author " class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -147,7 +147,7 @@
                     <label for="" class="col-sm-2 control-label">社會關係發生地</label>
                     <div class="col-sm-10">
                         <select class="form-control c_addr_id" name="c_addr_id">
-                            <option value="0" selected="selected">0 [Unknown] [未詳]  ~ </option>
+                            <option value="0" selected="selected">0 [Unknown] [未詳] </option>
                         </select>
                     </div>
                 </div>
@@ -155,20 +155,26 @@
                     <label for="" class="col-sm-2 control-label">社交機構代碼(c_inst_code)</label>
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
-                            <option value="0" selected="selected"></option>
+                            <option value="0" selected="selected">0 [Unknown] [未詳] </option>
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">
@@ -198,7 +204,7 @@
         $(".c_assoc_kin_code").select2(options('kincode'));
         $(".c_assoc_code").select2(options('assoccode'));
         $(".c_addr_id").select2(options('addr'));
-        $(".c_inst_code").select2(options('socialinst'));
+        $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_source").select2(options('text'));
         $(".c_assocship_pair").select2();
 

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -191,16 +191,22 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">
@@ -246,7 +252,7 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
         $(".c_assoc_kin_code").select2(options('kincode'));
         $(".c_assoc_code").select2(options('assoccode'));
         $(".c_addr_id").select2(options('addr'));
-        $(".c_inst_code").select2(options('socialinst'));
+        $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_source").select2(options('text'));
         $(".c_assocship_pair").select2();
         assocship_pair();

--- a/resources/views/biogmains/entries/create.blade.php
+++ b/resources/views/biogmains/entries/create.blade.php
@@ -140,14 +140,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/entries/edit.blade.php
+++ b/resources/views/biogmains/entries/edit.blade.php
@@ -157,16 +157,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/events/create.blade.php
+++ b/resources/views/biogmains/events/create.blade.php
@@ -82,14 +82,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/events/edit.blade.php
+++ b/resources/views/biogmains/events/edit.blade.php
@@ -92,16 +92,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/kinship/create.blade.php
+++ b/resources/views/biogmains/kinship/create.blade.php
@@ -31,14 +31,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected">0 未详</option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/kinship/edit.blade.php
+++ b/resources/views/biogmains/kinship/edit.blade.php
@@ -38,16 +38,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/offices/create.blade.php
+++ b/resources/views/biogmains/offices/create.blade.php
@@ -46,14 +46,20 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected>0 Weizhi 未知</option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/offices/edit.blade.php
+++ b/resources/views/biogmains/offices/edit.blade.php
@@ -66,16 +66,22 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/possession/create.blade.php
+++ b/resources/views/biogmains/possession/create.blade.php
@@ -76,14 +76,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/possession/edit.blade.php
+++ b/resources/views/biogmains/possession/edit.blade.php
@@ -81,16 +81,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/socialinst/create.blade.php
+++ b/resources/views/biogmains/socialinst/create.blade.php
@@ -65,14 +65,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/socialinst/edit.blade.php
+++ b/resources/views/biogmains/socialinst/edit.blade.php
@@ -68,16 +68,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/sources/create.blade.php
+++ b/resources/views/biogmains/sources/create.blade.php
@@ -15,13 +15,19 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_textid" required>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="0">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/sources/edit.blade.php
+++ b/resources/views/biogmains/sources/edit.blade.php
@@ -21,19 +21,25 @@ $row->c_pages = unionPKDef($row->c_pages);
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_textid" required>
                             @if($res['text_str'])
                                 <option value="{{ $row->c_textid }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
 @php
 $row->c_pages = unionPKDef_decode_for_convert($row->c_pages);
 @endphp
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/statuses/create.blade.php
+++ b/resources/views/biogmains/statuses/create.blade.php
@@ -72,14 +72,20 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/statuses/edit.blade.php
+++ b/resources/views/biogmains/statuses/edit.blade.php
@@ -75,16 +75,22 @@
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/texts/create.blade.php
+++ b/resources/views/biogmains/texts/create.blade.php
@@ -29,14 +29,20 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
 
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
                     </div>
                 </div>
                 <div class="form-group">

--- a/resources/views/biogmains/texts/edit.blade.php
+++ b/resources/views/biogmains/texts/edit.blade.php
@@ -32,16 +32,22 @@
                 </div>
                 <div class="form-group">
                     <label for="c_source" class="col-sm-2 control-label">出處(c_source)</label>
-                    <div class="col-sm-5">
+                    <div class="col-sm-10">
                         <select class="form-control c_source" name="c_source">
                             @if($res['text_str'])
                                 <option value="{{ $row->c_source }}" selected="selected">{{ $res['text_str'] }}</option>
                             @endif
                         </select>
                     </div>
+                </div>
+                <div class="form-group">
                     <label for="c_pages" class="col-sm-2 control-label">頁數/條目</label>
-                    <div class="col-sm-3">
+                    <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
+                    </div>
+                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
+                    <div class="col-sm-4">
+                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
                     </div>
                 </div>
                 <div class="form-group">

--- a/routes/api.php
+++ b/routes/api.php
@@ -97,6 +97,7 @@ Route::group(['prefix' => 'select'], function (){
     Route::get('search/office', 'ApiController@searchOffice');
     Route::get('search/socialinst', 'ApiController@socialinst');
     Route::get('search/socialinstaddr', 'ApiController@socialinstaddr');
+    Route::get('search/socialinstcode', 'ApiController@socialinstcode');
     Route::get('search/entry', 'ApiController@searchEntry');
     Route::get('search/kincode', 'ApiController@searchKincode');
     Route::get('search/assoccode', 'ApiController@searchAssoccode');


### PR DESCRIPTION
說明：

a.新增[二手文獻的原作者]欄位至12項（altname_data（別名）、assoc_data（社會關係）...等）錄入表單。

b.將需求修改為：不添加一個新的  [c_inst_name_code] 錄入，而是把「社會關係」表單中的「社交機構代碼(c_inst_code)」改名為 「社交機構(social_institution)」，學者在錄入的時候，只要錄入一次，就能同時寫入 ASSOC_DATA 表的 [c_inst_code] 和 [c_inst_name_code] 兩個欄位。

製作步驟：

b-1.新增一組下拉式選單的 [socialinstcode] API，依據 [SOCIAL_INSTITUTION_CODES] 資料表組合資料，輸出內容為「社交機構代碼 - 社交機構名稱 - 社會機構名稱代碼 - 地址 - 起年 - 最早見諸文獻年 - 訖年 - 最晚見諸文獻年」

b-2.在[社會關係錄入界面]儲存社交機構代碼(c_inst_code)的選項後，程式自動依據 [SOCIAL_INSTITUTION_CODES] 資料表中， [c_inst_code] 對應的 [c_inst_name_code]，自動將值儲存至 [ASSOC_DATA] 資料表的 [c_inst_name_code] 欄位。

總結：

新增[二手文獻的原作者]欄位後，12項（altname_data（別名）、assoc_data（社會關係）...等）錄入表單的CRUD已經測試過，均測試正常，請宏甦經理先測試a項的功能是否正確。

b項的功能請測試是否符合需求？如果有需要調整的地方請跟我說，如果OK，請宏甦經理規劃需修改與調整的錄入表單，我們將在後續的issues進行這個項目。