### PR TITLE
20210304[社會關係界面異動]程式修正

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -258,6 +258,7 @@ class ApiController extends Controller
         return $data;
     }
 
+    /*20210205新增的API，提供社交機構(social_institution)查詢，20210304修改。*/
     public function socialinstcode(Request $request)
     {
         $data = SocialInstCode::where('c_inst_code', 'like', '%'.$request->q.'%')->paginate(20);
@@ -268,7 +269,7 @@ class ApiController extends Controller
             $name_hz = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_hz;
             $name_py = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_py;
             $res = SocialInstAddr::where('c_inst_code', $item->c_inst_code)->first();
-            if(count($res) == 0 ) $addr = "未詳";
+            if(count((array)$res) == 0 ) $addr = "未詳";
             else {
                 $addr = AddressCode::where('c_addr_id', $res->c_inst_addr_id)->first()->c_name_chn;
             }
@@ -376,7 +377,7 @@ class ApiController extends Controller
         $person_id = $request->person_id;
         //20201026修改成對親屬關係的選項
         $res = KinshipCode::where('c_kin_pair1', '=', $kin_code)->orWhere('c_kin_pair2', '=', $kin_code)->orderBy('c_pick_sorting', 'desc')->get();
-        if(count($res) == 0) {
+        if(count((array)$res) == 0) {
             $data = KinshipCode::find($kin_code);
             $res = KinshipCode::find([$data->c_kin_pair2, $data->c_kin_pair1]);
         }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -978,7 +978,7 @@ class BiogMainRepository
             $name_hz = SocialInst::where('c_inst_name_code', $text_->c_inst_name_code)->first()->c_inst_name_hz;
             $name_py = SocialInst::where('c_inst_name_code', $text_->c_inst_name_code)->first()->c_inst_name_py;
             $res = SocialInstAddr::where('c_inst_code', $text_->c_inst_code)->first();
-            if(count($res) == 0 ) $addr = "未詳";
+            if(count((array)$res) == 0 ) $addr = "未詳";
             else {
                 $addr = AddressCode::where('c_addr_id', $res->c_inst_addr_id)->first()->c_name_chn;
             }

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -152,7 +152,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">社交機構代碼(c_inst_code)</label>
+                    <label for="" class="col-sm-2 control-label">社交機構(social_institution)</label>
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
                             <option value="0" selected="selected">0 [Unknown] [未詳] </option>

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -180,7 +180,7 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">社交機構代碼(c_inst_code)</label>
+                    <label for="" class="col-sm-2 control-label">社交機構(social_institution)</label>
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
                             @if($res['inst_code'])


### PR DESCRIPTION
1.社會關係label改名為[社交機構(social_institution)]。
2.count((array)object)的修改
線上伺服器的 PHP 版本是 7.3，count 對於 non-countable objects 的寫法在 7.2 以前可以是 count(object)，而現在只能是 count((array)object)。
