### PR TITLE
20210309修改socialinstcode API輸出

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -258,13 +258,32 @@ class ApiController extends Controller
         return $data;
     }
 
-    /*20210205新增的API，提供社交機構(social_institution)查詢，20210304修改。*/
+    /*20210205新增的API，提供社交機構(social_institution)查詢，20210309修改。*/
     public function socialinstcode(Request $request)
     {
-        $data = SocialInstCode::where('c_inst_code', 'like', '%'.$request->q.'%')->paginate(20);
-        $data->appends(['q' => $request->q])->links();
+        $temp = explode("-", $request->q);
+        $c_inst_code = $temp[0];
+        if(!empty($temp[1])) {
+            $c_inst_name_code = $temp[1];
+        }
+        else {
+            $c_inst_name_code = '';
+        }
+
+        if($c_inst_name_code != '') {
+            $data = SocialInstCode::where([
+                ['c_inst_code', '=', $c_inst_code],
+                ['c_inst_name_code', '=', $c_inst_name_code],
+            ])->paginate(20);
+        }
+        else {
+            $data = SocialInstCode::where('c_inst_code', 'like', '%'.$c_inst_code.'%')->paginate(20);
+        }
+
+        $data->appends(['q' => $c_inst_code])->links();
         foreach($data as $item){
-            $item['id'] = $item->c_inst_code;
+            //修改$item['id']，改變這組API回傳的值。
+            $item['id'] = $item->c_inst_code .'-'. $item->c_inst_name_code;
             if($item['id'] === 0) $item['id'] = -999;
             $name_hz = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_hz;
             $name_py = SocialInst::where('c_inst_name_code', $item->c_inst_name_code)->first()->c_inst_name_py;

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -81,6 +81,24 @@ class BasicInformationAssocController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        $temp = explode("-", $request->c_inst_code);
+        $c_inst_code = $temp[0];
+        if(!empty($temp[1])) {
+            $c_inst_name_code = $temp[1];
+        }
+        else {
+            $c_inst_name_code = '';
+        }
+
+        if($c_inst_name_code != '') {
+            $request->c_inst_code = $c_inst_code;
+            $request->c_inst_name_code = $c_inst_name_code;
+            $request->merge(['c_inst_code' => $c_inst_code]);
+            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        }
+        //return $request;
+        //修改結束
         $data = $this->biogMainRepository->assocStoreById($request, $id);
         $_id = $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'];
         flash('Store success @ '.Carbon::now(), 'success');
@@ -133,6 +151,24 @@ class BasicInformationAssocController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        $temp = explode("-", $request->c_inst_code);
+        $c_inst_code = $temp[0];
+        if(!empty($temp[1])) {
+            $c_inst_name_code = $temp[1];
+        }
+        else {
+            $c_inst_name_code = '';
+        }
+
+        if($c_inst_name_code != '') {
+            $request->c_inst_code = $c_inst_code;
+            $request->c_inst_name_code = $c_inst_name_code;
+            $request->merge(['c_inst_code' => $c_inst_code]);
+            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        }
+        //return $request;
+        //修改結束
         $data = $this->biogMainRepository->assocUpdateById($request, $id_, $id);
         $id_ = $id."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'];
         flash('Update success @ '.Carbon::now(), 'success');

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -48,7 +48,7 @@ class ModifiedController extends Controller
             elseif(!empty($resource_id = $listsArr['data'][$x]['resource_id']) && !empty($resource = $listsArr['data'][$x]['resource'])) {
                 switch ($resource) {
                     case "OFFICE_CODES":
-                        if(count(OfficeCode::find($resource_id))) {
+                        if(count((Array)OfficeCode::find($resource_id))) {
                             $arr3 = OfficeCode::find($resource_id)->toArray();
                         }
                         break;

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -40,7 +40,7 @@ class OperationsController extends Controller
             elseif(!empty($resource_id = $listsArr['data'][$x]['resource_id']) && !empty($resource = $listsArr['data'][$x]['resource'])) {
                 switch ($resource) {
                     case "OFFICE_CODES":
-                        if(count(OfficeCode::find($resource_id))) {
+                        if(count((Array)OfficeCode::find($resource_id))) {
                             $arr3 = OfficeCode::find($resource_id)->toArray();
                         }
                         break;

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -974,7 +974,11 @@ class BiogMainRepository
             //20210204進行改寫
             //$text_ = SocialInst::find($row->c_inst_code);
             //$inst_code = $text_->c_inst_name_code." ".$text_->c_inst_name_hz." ".$text_->c_inst_name_py;
-            $text_ = SocialInstCode::find($row->c_inst_code);
+            //$text_ = SocialInstCode::find($row->c_inst_code);
+            $text_ = SocialInstCode::where([
+                ['c_inst_code', '=', $row->c_inst_code],
+                ['c_inst_name_code', '=', $row->c_inst_name_code],
+            ])->first();
             $name_hz = SocialInst::where('c_inst_name_code', $text_->c_inst_name_code)->first()->c_inst_name_hz;
             $name_py = SocialInst::where('c_inst_name_code', $text_->c_inst_name_code)->first()->c_inst_name_py;
             $res = SocialInstAddr::where('c_inst_code', $text_->c_inst_code)->first();
@@ -1042,7 +1046,7 @@ class BiogMainRepository
         $data = array_except($data, ['_method', '_token', 'c_assocship_pair']);
         $data['c_assoc_intercalary'] = (int)($data['c_assoc_intercalary']);
         //20210204增加儲存c_inst_name_code
-        $data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
+        //$data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
         //新增結束
         $data = (new ToolsRepository)->timestamp($data);
         DB::table('ASSOC_DATA')->where([
@@ -1081,7 +1085,7 @@ class BiogMainRepository
         $data['tts_sysno'] = DB::table('ASSOC_DATA')->max('tts_sysno') + 1;
         $data['c_assoc_intercalary'] = (int)($data['c_assoc_intercalary']);
         //20210204增加儲存c_inst_name_code
-        $data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
+        //$data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
         //新增結束
         $data = (new ToolsRepository)->timestamp($data, True);
         DB::table('ASSOC_DATA')->insert($data);

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -10,6 +10,7 @@
 $row->c_text_title = unionPKDef($row->c_text_title);
 $row->c_notes = unionPKDef($row->c_notes);
 @endphp
+
             <form action="{{ route('basicinformation.assoc.update', [$id, $row->c_personid."-".$row->c_assoc_code."-".$row->c_assoc_id."-".$row->c_kin_code."-".$row->c_kin_id."-".$row->c_assoc_kin_code."-".$row->c_assoc_kin_id."-".$row->c_text_title]) }}" class="form-horizontal" method="post">
                 {{ method_field('PATCH') }}
                 {{ csrf_field() }}
@@ -181,10 +182,12 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">社交機構(social_institution)</label>
+                    <input name="c_inst_name_code" type="hidden">
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
                             @if($res['inst_code'])
-                                <option value="{{ $row->c_inst_code }}" selected="selected">{{ $res['inst_code'] }}</option>
+                                <option value="{{ $row->c_inst_code.'-'.$row->c_inst_name_code }}" selected="selected">{{ $res['inst_code'] }}</option>
+
                             @endif
                         </select>
                     </div>


### PR DESCRIPTION
1.宏甦經理回報，需修正兩處程式，一起更新至github。
cbdb_input/app/Http/Controllers/OperationsController.php line43
修改：count((Array)OfficeCode::find($resource_id))

cbdb_input/app/Http/Controllers/ModifiedController.php line51
修改：if(count((Array)OfficeCode::find($resource_id))) {

2.(c_inst_code)3885重複值需要兼容，修改socialinstcode API輸出，初步規劃與製作。
- a.表單input變造，原本讀入與儲存為A值，修改為A-B值，有create(檢查後不需修改)與edit(需修改)兩個表單。
- b.search API(/api/select/search/socialinstcode)修改，原讀取A值(c_inst_code)改為A(c_inst_code)-B(c_inst_name_code)值，輸出結果也要一起修改。(修改$item['id']，改變這組API回傳的值。)
- c.controller修改$request，A值(c_inst_code)欄位取得時，拆解後分別存入A(c_inst_code)、B(c_inst_name_code)欄。
- d.調整BiogMainRepository.php的assocById()、assocStoreById()、assocUpdateById()，三個函式的資料處理。
- e.資料錄入測試，確認ASSOC_DATA儲存的資料正確並成對。