### PR TITLE
20210315[社會關係的錄入介面與API修改]與[social_institution_codes錄入表單的修改]

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -259,6 +259,7 @@ class ApiController extends Controller
     }
 
     /*20210205新增的API，提供社交機構(social_institution)查詢，20210309修改。*/
+    /*20210315新增漢字與英文對SOCIAL_INSTITUTION_NAME_CODES的檢索。*/
     public function socialinstcode(Request $request)
     {
         $temp = explode("-", $request->q);
@@ -275,6 +276,14 @@ class ApiController extends Controller
                 ['c_inst_code', '=', $c_inst_code],
                 ['c_inst_name_code', '=', $c_inst_name_code],
             ])->paginate(20);
+        }
+        elseif(is_string($c_inst_code) && !is_numeric($c_inst_code) && !empty($c_inst_code)) {
+            $data_ori = DB::table('SOCIAL_INSTITUTION_NAME_CODES')->select('c_inst_name_code')->where('c_inst_name_hz', 'like', '%'.$c_inst_code.'%')->orWhere('c_inst_name_py', 'like', '%'.$c_inst_code.'%')->get();
+            $data_arr = array();
+            foreach($data_ori as $value) {
+                array_push($data_arr, $value->c_inst_name_code);
+            }
+            $data = SocialInstCode::whereIn('c_inst_name_code', $data_arr)->paginate(20);
         }
         else {
             $data = SocialInstCode::where('c_inst_code', 'like', '%'.$c_inst_code.'%')->paginate(20);

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -82,13 +82,15 @@ class BasicInformationAssocController extends Controller
             return redirect()->back();
         }
         //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        //20210315修正$c_inst_name_code預設為0
         $temp = explode("-", $request->c_inst_code);
         $c_inst_code = $temp[0];
         if(!empty($temp[1])) {
             $c_inst_name_code = $temp[1];
         }
         else {
-            $c_inst_name_code = '';
+            $c_inst_code = '0';
+            $c_inst_name_code = '0';
         }
 
         if($c_inst_name_code != '') {
@@ -152,13 +154,15 @@ class BasicInformationAssocController extends Controller
             return redirect()->back();
         }
         //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        //20210315修正$c_inst_name_code預設為0
         $temp = explode("-", $request->c_inst_code);
         $c_inst_code = $temp[0];
         if(!empty($temp[1])) {
             $c_inst_name_code = $temp[1];
         }
         else {
-            $c_inst_name_code = '';
+            $c_inst_code = '0';
+            $c_inst_name_code = '0';
         }
 
         if($c_inst_name_code != '') {

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -107,12 +107,15 @@ class CodesController extends Controller
         return redirect()->route('codes.show', ['table_name' => $table_name]);
     }
 
+    //20210315增加table_name等於SOCIAL_INSTITUTION_CODES的例外判斷式，將預設遮除的第1個欄位呈現。
     public function create($table_name)
     {
 //        dd($table_name);
         $data = Schema::getColumnListing($table_name);
         $id_ = $data[0];
-        $data = array_splice($data, 1);
+        if($table_name != 'SOCIAL_INSTITUTION_CODES') {
+            $data = array_splice($data, 1);
+        }
         $id = DB::table($table_name)->max($id_) + 1;
         return view('codes.create',[
             'page_title' => 'Codes',
@@ -123,6 +126,7 @@ class CodesController extends Controller
             'id' => $id, 'table' => $table_name]);
     }
 
+    //20210315增加table_name等於SOCIAL_INSTITUTION_CODES的例外判斷式，將預設自動增加的$id遮除。
     public function store(Request $request, $table_name)
     {
         if (!Auth::check()) {
@@ -136,8 +140,14 @@ class CodesController extends Controller
         $data = $request->all();
         $data = array_except($data, ['_token']);
         $id_ = $this->getIdName($table_name);
-        $id = DB::table($table_name)->max($id_) + 1;
-        $data[$id_] = $id;
+        if($table_name != 'SOCIAL_INSTITUTION_CODES') {
+            $id = DB::table($table_name)->max($id_) + 1;
+            $data[$id_] = $id;
+        }
+        else {
+            //當資料表等於SOCIAL_INSTITUTION_CODES，$id從表單取值。
+            $id = $data[$id_];
+        }
         DB::table($table_name)->insert($data);
         flash('Store success @ '.Carbon::now(), 'success');
         return redirect()->route('codes.edit', ['table_name' => $table_name, 'id' => $id]);

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -155,7 +155,7 @@
                     <label for="" class="col-sm-2 control-label">社交機構(social_institution)</label>
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
-                            <option value="0" selected="selected">0 [Unknown] [未詳] </option>
+                            <option value="0-0" selected="selected">0 [Unknown] [未詳] </option>
                         </select>
                     </div>
                 </div>

--- a/resources/views/codes/create.blade.php
+++ b/resources/views/codes/create.blade.php
@@ -12,8 +12,11 @@
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
                             <div class="col-sm-10">
-                                <input type="text" name="{{ $key }}" class="form-control"
-                                       >
+                                <input type="text" name="{{ $key }}" class="form-control" 
+                                @if($table == 'SOCIAL_INSTITUTION_CODES' && $key == 'c_inst_name_code')
+                                    value="{{ $id }}"
+                                @endif
+                                >
                             </div>
                         </div>
                     @endforeach


### PR DESCRIPTION
社會關係的錄入介面當「社交機構為0」的程式修復，使用者檢索[社交機構]的時候，目前只能錄入 c_inst_code，將增列漢字的檢索。

功能已經修改完成，請宏甦經理檢視，謝謝您。

－－－－－－－－－－－－－－－－－－－－－－－－－－－

原本codes相關資料表的設計說明：

前輩之前是將codes的新增表單第一欄(通常為primary key)移除，新增的表單都看不到第一欄，在後端自動將序號+1，儲存進入資料庫。

資料新增後，進入編輯的表單，就可以看到全部的欄位了。

－－－－－－－－－－－－－－－－－－－－－－－－－－－

這次[codes/social_institution_codes錄入表單修改]的需求，程式修改說明：

主要修改：app/Http/Controllers/CodesController.php

次要修改：resources/views/codes/create.blade.php

前輩之前是特地將第一欄(通常為primary key)移除，我這邊增加[SOCIAL_INSTITUTION_CODES]的例外判斷式，讓需求中提到的效果呈現出來。

錄入表單的填寫，因為[SOCIAL_INSTITUTION_CODES]資料表的欄位連動設定，[c_inst_name_code]、[c_inst_type_code]、[c_source]需要與其他資料表的資料連動，這三欄需要有正確的值，資料才可以建立。（請參考[錄入的範例.PNG]）

但是刪除功能，會將[c_inst_name_code]序號相同的資料都刪除，例如[錄入的範例.PNG]建立的2505，原本資料表的2505也會被一起刪除。

－－－－－－－－－－－－－－－－－－－－－－－－－－－－

我嘗試找尋解決的方法，發現到[社會機構編碼表]的功能，能解決這個問題，請參考。

(網址請變更)/socialinstitutioncodes/create

我先保留codes的修改，與[社會機構編碼表]的功能比較，提供給宏甦經理評估，是否考慮將codes修改回原本的流程呢？^^