### PR TITLE
20210705「社會關係」介面修改

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -405,7 +405,8 @@ class ApiController extends Controller
         $person_id = $request->person_id;
         //20201026修改成對親屬關係的選項
         $res = KinshipCode::where('c_kin_pair1', '=', $kin_code)->orWhere('c_kin_pair2', '=', $kin_code)->orderBy('c_pick_sorting', 'desc')->get();
-        if(count((array)$res) == 0) {
+        $res_arr = json_decode($res, true);
+        if(count((array)$res_arr) == 0) {
             $data = KinshipCode::find($kin_code);
             $res = KinshipCode::find([$data->c_kin_pair2, $data->c_kin_pair1]);
         }

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -23,7 +23,7 @@
                     <label for="" class="col-sm-2 control-label">親屬關係人</label>
                     <div class="col-sm-1">關係</div>
                     <div class="col-sm-3">
-                        <select class="form-control c_kin_code" name="c_kin_code">
+                        <select class="form-control c_kin_code" name="c_kin_code" onchange="kinship_pair()">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
@@ -53,7 +53,7 @@
                     <label for="" class="col-sm-2 control-label">社會關係人親屬</label>
                     <div class="col-sm-1">關係</div>
                     <div class="col-sm-3">
-                        <select class="form-control c_assoc_kin_code" name="c_assoc_kin_code">
+                        <select class="form-control c_assoc_kin_code" name="c_assoc_kin_code" onchange="assoc_kinship_pair()">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
@@ -136,9 +136,23 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">社會關係指證人</label>
+                    <label for="" class="col-sm-2 control-label">社會關係中介人(tertiary_personid)</label>
                     <div class="col-sm-10">
                         <select class="form-control biog" name="c_tertiary_personid">
+                            <option value="0" selected="selected"></option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">社會關係中介類型(tertiary_type)</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" name="c_tertiary_type_notes" value="">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">社會關係指證人</label>
+                    <div class="col-sm-10">
+                        <select class="form-control biog" name="c_assoc_claimer_id">
                             <option value="0" selected="selected"></option>
                         </select>
                     </div>
@@ -186,6 +200,22 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">成對親屬關係</label>
+                    <div class="col-sm-10">
+                        <select class="form-control c_kinship_pair" name="c_kinship_pair">
+                            <option value="0">無對應親屬關係</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">成對社會關係人的親屬關係</label>
+                    <div class="col-sm-10">
+                        <select class="form-control c_assoc_kinship_pair" name="c_assoc_kinship_pair">
+                            <option value="0">無對應親屬關係</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
                         <button type="submit" class="btn btn-default">Submit</button>
                     </div>
@@ -201,7 +231,9 @@
         $(".select2").select2();
         $(".biog").select2(options('biog'));
         $(".c_kin_code").select2(options('kincode'));
+        $(".c_kinship_pair").select2();
         $(".c_assoc_kin_code").select2(options('kincode'));
+        $(".c_assoc_kinship_pair").select2();
         $(".c_assoc_code").select2(options('assoccode'));
         $(".c_addr_id").select2(options('addr'));
         $(".c_inst_code").select2(options('socialinstcode'));
@@ -280,6 +312,56 @@
                     item = data[i];
                     // console.log(item);
                     $(".c_assocship_pair").append(new Option(item['c_assoc_code'] + ' ' + item['c_assoc_desc_chn'] + ' ' + item['c_assoc_desc'], item['c_assoc_code'], false, true));
+                }
+            });
+
+        }
+ 
+        function kinship_pair(){
+            let c_kin_code = $('.c_kin_code').val();
+            let c_kin_id = $('.c_kin_id').val();
+            // console.log(c_kin_id, c_kin_code);
+            // if (c_kin_id == 0 || c_kin_id == -999) {return}
+            let data = [{
+                id: 0,
+                text: '请选择对应亲属关系'
+            }];
+            // $(".c_kinship_pair").val(null).trigger("change");
+            // console.log($(".c_kinship_pair").val());
+            $.get('/api/select/search/kinpair', {kin_code: c_kin_code, person_id: c_kin_id}, function (data, textStatus){
+                //返回的 data 可以是 xmlDoc, jsonObj, html, text, 等等.
+                // console.log(data);
+                for (let i=data.length-1; i>-1; i--){
+
+                    item = data[i];
+                    // console.log(item);
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
+                }
+            });
+
+        }
+
+        function assoc_kinship_pair(){
+            let c_assoc_kin_code = $('.c_assoc_kin_code').val();
+            let c_assoc_kin_id = $('.c_assoc_kin_id').val();
+            // console.log(c_kin_id, c_kin_code);
+            // if (c_kin_id == 0 || c_kin_id == -999) {return}
+            let data = [{
+                id: 0,
+                text: '请选择对应亲属关系'
+            }];
+            // $(".c_kinship_pair").val(null).trigger("change");
+            // console.log($(".c_kinship_pair").val());
+            $.get('/api/select/search/kinpair', {kin_code: c_assoc_kin_code, person_id: c_assoc_kin_id}, function (data, textStatus){
+                //返回的 data 可以是 xmlDoc, jsonObj, html, text, 等等.
+                // console.log(data);
+                for (let i=data.length-1; i>-1; i--){
+
+                    item = data[i];
+                    // console.log(item);
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_assoc_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
                 }
             });
 

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -30,7 +30,7 @@ $row->c_notes = unionPKDef($row->c_notes);
                     <label for="" class="col-sm-2 control-label">親屬關係人</label>
                     <div class="col-sm-1">關係</div>
                     <div class="col-sm-3">
-                        <select class="form-control c_kin_code" name="c_kin_code">
+                        <select class="form-control c_kin_code" name="c_kin_code" onchange="kinship_pair()">
                             @if($res['kin_code'])
                                 <option value="{{ $row->c_kin_code }}" selected="selected">{{ $res['kin_code'] }}</option>
                             @endif
@@ -68,7 +68,7 @@ $row->c_notes = unionPKDef($row->c_notes);
                     <label for="" class="col-sm-2 control-label">社會關係人親屬</label>
                     <div class="col-sm-1">關係</div>
                     <div class="col-sm-3">
-                        <select class="form-control c_assoc_kin_code" name="c_assoc_kin_code">
+                        <select class="form-control c_assoc_kin_code" name="c_assoc_kin_code" onchange="assoc_kinship_pair()">
                             @if($res['assoc_kin_code'])
                                 <option value="{{ $row->c_assoc_kin_code }}" selected="selected">{{ $res['assoc_kin_code'] }}</option>
                             @endif
@@ -161,11 +161,27 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="" class="col-sm-2 control-label">社會關係指證人</label>
+                    <label for="" class="col-sm-2 control-label">社會關係中介人(tertiary_personid)</label>
                     <div class="col-sm-10">
                         <select class="form-control biog" name="c_tertiary_personid">
                             @if($res['tertiary_personid'])
                                 <option value="{{ $row->c_tertiary_personid }}" selected="selected">{{ $res['tertiary_personid'] }}</option>
+                            @endif
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">社會關係中介類型(tertiary_type)</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" name="c_tertiary_type_notes" value="{{ $row->c_tertiary_type_notes }}">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">社會關係指證人</label>
+                    <div class="col-sm-10">
+                        <select class="form-control biog" name="c_assoc_claimer_id">
+                            @if($res['assoc_claimer_id'])
+                                <option value="{{ $row->c_assoc_claimer_id }}" selected="selected">{{ $res['assoc_claimer_id'] }}</option>
                             @endif
                         </select>
                     </div>
@@ -221,6 +237,28 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">成對親屬關係</label>
+                    <div class="col-sm-10">
+                        <select class="form-control c_kinship_pair" name="c_kinship_pair">
+                            @if($res['kinship_pair'])
+                                <option value="{{ $res['kinship_pair'] }}" selected="selected">{{ $res['kinship_pair'] }}</option>
+                            @endif
+                                <option value="0">無對應親屬關係</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">成對社會關係人的親屬關係</label>
+                    <div class="col-sm-10">
+                        <select class="form-control c_assoc_kinship_pair" name="c_assoc_kinship_pair">
+                            @if($res['assoc_kinship_pair'])
+                                <option value="{{ $res['assoc_kinship_pair'] }}" selected="selected">{{ $res['assoc_kinship_pair'] }}</option>
+                            @endif
+                                <option value="0">無對應親屬關係</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
                     <label for="" class="col-sm-2 control-label">建檔</label>
                     <div class="col-sm-10">
                         <input type="text" name="" class="form-control"
@@ -252,13 +290,17 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
         $(".select2").select2();
         $(".biog").select2(options('biog'));
         $(".c_kin_code").select2(options('kincode'));
+        $(".c_kinship_pair").select2();
         $(".c_assoc_kin_code").select2(options('kincode'));
+        $(".c_assoc_kinship_pair").select2();
         $(".c_assoc_code").select2(options('assoccode'));
         $(".c_addr_id").select2(options('addr'));
         $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_source").select2(options('text'));
         $(".c_assocship_pair").select2();
         assocship_pair();
+        //kinship_pair();
+        //assoc_kinship_pair();
 
         function formatRepo (repo) {
             if (repo.loading) {
@@ -331,6 +373,55 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                     item = data[i];
                     // console.log(item);
                     $(".c_assocship_pair").append(new Option(item['c_assoc_code'] + ' ' + item['c_assoc_desc_chn'] + ' ' + item['c_assoc_desc'], item['c_assoc_code'], false, true));
+                }
+            });
+
+        }
+
+        function kinship_pair(){
+            let c_kin_code = $('.c_kin_code').val();
+            let c_kin_id = $('.c_kin_id').val();
+            // console.log(c_kin_id, c_kin_code);
+            // if (c_kin_id == 0 || c_kin_id == -999) {return}
+            let data = [{
+                id: 0,
+                text: '请选择对应亲属关系'
+            }];
+            // $(".c_kinship_pair").val(null).trigger("change");
+            // console.log($(".c_kinship_pair").val());
+            $.get('/api/select/search/kinpair', {kin_code: c_kin_code, person_id: c_kin_id}, function (data, textStatus){
+                //返回的 data 可以是 xmlDoc, jsonObj, html, text, 等等.
+                // console.log(data);
+                for (let i=data.length-1; i>-1; i--){
+                    item = data[i];
+                    // console.log(item);
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
+                }
+            });
+
+        }
+
+        function assoc_kinship_pair(){
+            let c_assoc_kin_code = $('.c_assoc_kin_code').val();
+            let c_assoc_kin_id = $('.c_assoc_kin_id').val();
+            // console.log(c_kin_id, c_kin_code);
+            // if (c_kin_id == 0 || c_kin_id == -999) {return}
+            let data = [{
+                id: 0,
+                text: '请选择对应亲属关系'
+            }];
+            // $(".c_kinship_pair").val(null).trigger("change");
+            // console.log($(".c_kinship_pair").val());
+            $.get('/api/select/search/kinpair', {kin_code: c_assoc_kin_code, person_id: c_assoc_kin_id}, function (data, textStatus){
+                //返回的 data 可以是 xmlDoc, jsonObj, html, text, 等等.
+                // console.log(data);
+                for (let i=data.length-1; i>-1; i--){
+
+                    item = data[i];
+                    // console.log(item);
+                    //$(".c_kinship_pair").append(new Option(item['c_kinrel'] + ' ' + item['c_kinrel_chn'], item['c_kincode'], false, true));
+                    $(".c_assoc_kinship_pair").append(new Option(item['c_kincode'] + ' ' + item['c_kinrel_chn'] + ' ' + item['c_kinrel'], item['c_kincode'], false, true));
                 }
             });
 


### PR DESCRIPTION
需求4「社會關係」介面的「親屬關係人」說明：

1.製作「社會關係」介面的「親屬關係人」的資料儲存邏輯。
a.[新增]：自動依據親屬的關係值，在對象資料儲存相對的關係值（排序依據KINSHIP_CODES的c_pick_sorting desc）
  說明：選取(125)兄，「成對親屬關係」可查得(126)弟。
  舉例：
  「社會關係」新增一筆A君資料時，與A君有[社會關係]的B君，也會自動創建一筆B君的資料。
  A君與B君的「社會關係」中，[親屬關係]如有設定B君，兩筆資料都會有B君，原本B君的[親屬關係]如果設定為[兄]，則兩筆資料都是[兄]，現在修改為「成對親屬關係」，A君的「社會關係」對B君[親屬關係]是[兄]，B君的「社會關係」對A君親屬關係是[弟]。（可於下拉式選單再次修改，選取對應親屬關係。）
b.[修改]：在這個階段，如果修改[親屬關係]（無論A君或是B君），依據使用者選取的值儲存[親屬關係]欄位，「成對親屬關係」的資料的也會自動儲存至ASSOC_DATA的對應資料。
  舉例：
　A君的「社會關係」對B君[親屬關係]是[兄]，B君的「社會關係」對A君[親屬關係]可能是[妹]，以使用者選取的資料儲存。
　之前的版本會將兩筆「社會關係」的[親屬關係]一起儲存[妹]，改用「成對親屬關係」調整這個功能，其他的欄位還是保持兩筆「社會關係」資料同步的情況。
c.[刪除]
  檢測刪除功能，依照聯合主鍵的各項值進行檢測，確認功能正常。
2.主要修改BiogMainRepository.php，因為此項修改將改變原本ASSOC_DATA資料儲存的邏輯，所以詳加說明。
3.依照上述同樣的概念，製作「成對社會關係人的親屬關係」功能。

----------------------------------------------

需求8「一對多親屬關係無法正常顯示」的程式修正說明：

檢測親屬關係查詢不到時，會回傳空的[物件]。

PHP 7對於count()的限制要求只能計算[陣列]的總數，在回傳的的資料，如果宣告(array)[物件]會無效，

增加一行$res_arr = json_decode($res, true);，確保物件先轉換為陣列，再進行count()判別總數。

另外，同一支程式的300行使用if(count((array)$res) == 0 )，由於$res可以使用laravel的first()，如無資料會回傳null，就不會有空物件的情況發生，所以不需增加陣列轉換$res_arr = json_decode($res, true);

總結：
使用laravel的get()取得全部資料，找到會回傳object，找不到也會回傳object。
使用laravel的first()取得第一筆資料，找到會回傳object，找不到會回傳null。
舉例：if(count((array)null) == 0) { 成立 }

----------------------------------------------

需求9「添加「社會關係中介人」欄位」說明：

「中介人」和「指證人」的儲存欄位需修改對應。
a.「社會關係中介人(tertiary_personid)」 >>> ASSOC_DATA.c_tertiary_personid
b.「社會關係指證人」 >>> ASSOC_DATA.c_assoc_claimer_id