### PR TITLE
20210723修改[5.朝代API添加起止年]與[6.罕見字條目無法點擊]

### DIFF
--- a/app/Http/Controllers/Api/ApiController5.php
+++ b/app/Http/Controllers/Api/ApiController5.php
@@ -47,6 +47,11 @@ class ApiController5 extends Controller
         $usePeoplePlace = $arr['usePeoplePlace'];
         $useXy = $arr['useXy'];
         $broad = $arr['broad'];
+        //20210723建安新增指數年查詢
+        $indexYear = $arr['indexYear'];
+        $indexStartTime = $arr['indexStartTime'];
+        $indexEndTime = $arr['indexEndTime'];
+        //新增結束
         if($broad == 1) { $XY = '0.06'; }
         if($broad == 0) { $XY = '0.03'; }
         
@@ -67,6 +72,13 @@ class ApiController5 extends Controller
         if($usePeoplePlace) {
             $row->whereIn('BIOG_ADDR_DATA.c_addr_id', $place);
         }
+
+        //20210723建安新增
+        if($indexYear) {
+            $row->join('BIOG_MAIN', 'ASSOC_DATA.c_personid', '=', 'BIOG_MAIN.c_personid');
+            $row->whereBetween('BIOG_MAIN.c_index_year', array($indexStartTime, $indexEndTime));
+        }
+        //新增結束
 
         if($useXy) {
             $rowOut = $row->get();

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -119,7 +119,7 @@ class BasicInformationAltnamesController extends Controller
         }
         $row = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_alt_name_chn', '=', $addr_l[1]],
+            ['c_alt_name_chn', 'like', '%'.$addr_l[1].'%'],
             ['c_alt_name_type_code', '=', $addr_l[2]],
         ])->first();
         $text_str = null;
@@ -165,7 +165,7 @@ class BasicInformationAltnamesController extends Controller
         }
         DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_alt_name_chn', '=', $addr_l[1]],
+            ['c_alt_name_chn', 'like', '%'.$addr_l[1].'%'],
             ['c_alt_name_type_code', '=', $addr_l[2]],
         ])->update($data);
         $new_alt = $id.'-'.$data['c_alt_name_chn'].'-'.$data['c_alt_name_type_code'];
@@ -173,6 +173,9 @@ class BasicInformationAltnamesController extends Controller
         flash('Update success @ '.Carbon::now(), 'success');
         //20200709引用聯合主鍵保留字弱點防禦函式
         $new_alt = $this->biogMainRepository->unionPKDef($new_alt);
+        //20210715新增錯別字過濾
+        $errWord = array('?', '', '�');
+        $new_alt = str_replace($errWord, '', $new_alt);
         return redirect()->route('basicinformation.altnames.edit', ['id'=>$id, 'addr'=>$new_alt]);
     }
 
@@ -201,14 +204,14 @@ class BasicInformationAltnamesController extends Controller
         }
         $row = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_alt_name_chn', '=', $addr_l[1]],
+            ['c_alt_name_chn', 'like', '%'.$addr_l[1].'%'],
             ['c_alt_name_type_code', '=', $addr_l[2]],
         ])->first();
 
         $this->operationRepository->store(Auth::id(), $id, 4, 'ALTNAME_DATA', $alt, $row);
         DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_alt_name_chn', '=', $addr_l[1]],
+            ['c_alt_name_chn', 'like', '%'.$addr_l[1].'%'],
             ['c_alt_name_type_code', '=', $addr_l[2]],
         ])->delete();
         flash('Delete success @ '.Carbon::now(), 'success');

--- a/app/Repositories/DynastyRepository.php
+++ b/app/Repositories/DynastyRepository.php
@@ -15,6 +15,6 @@ class DynastyRepository
 {
     public function dynasties()
     {
-        return Dynasty::select(['c_dy', 'c_dynasty_chn', 'c_dynasty'])->get();
+        return Dynasty::select(['c_dy', 'c_dynasty_chn', 'c_dynasty', 'c_start', 'c_end'])->get();
     }
 }

--- a/resources/views/biogmains/altname/index.blade.php
+++ b/resources/views/biogmains/altname/index.blade.php
@@ -25,6 +25,9 @@ $value->pivot->c_alt_name = unionPKDef($value->pivot->c_alt_name);
 $value->pivot->c_alt_name_chn = unionPKDef($value->pivot->c_alt_name_chn);
 $c_alt_name_view = unionPKDef_decode_for_convert($value->pivot->c_alt_name);
 $c_alt_name_chn_view = unionPKDef_decode_for_convert($value->pivot->c_alt_name_chn);
+//20210715新增錯別字過濾
+$errWord = array('?', '', '�');
+$value->pivot->c_alt_name_chn = str_replace($errWord, '', $value->pivot->c_alt_name_chn);
 @endphp
                     <tr>
                         <td>{{ $key+1 }}</td>


### PR DESCRIPTION
一、CBDB製作[朝代API添加起止年]
1.修改[朝代API添加起止年]程式位置在[/app/Repositories/DynastyRepository.php]，是錄入系統的表單所使用的API。
2.修改後跟著改變的表單，計有[基本資料]、[官名]。

二、CBDB製作[罕見字條無法點擊]
1.製作[罕見字條無法點擊]的問題修正完成
  a.檢查ALTNAME_DATA資料表結構確認欄位編碼為[utf8mb4_general_ci]。
  b.從資料抽樣取得頻繁出現的錯別字，共計三組。
  c.增加錯別字過濾的函式，讓錯別字不會隨著聯合主鍵一起傳遞到controller程式。
  d.修改controller程式的SQL語句，以王開(384614)為例，比較前後版本的SQL查詢語法。
    原本：SELECT * FROM `ALTNAME_DATA` WHERE `c_personid` = 384614 AND `c_alt_name_chn` = '元???' AND `c_alt_name_type_code` = 4 
    修改：SELECT * FROM `ALTNAME_DATA` WHERE `c_personid` = 384614 AND `c_alt_name_chn` LIKE '%元%' AND `c_alt_name_type_code` = 4
  e.修改後的SQL語句可以解決大多數的[罕見字條無法點擊]，但有些例外，則**需要從資料庫修改**，
    舉例來說，[`c_personid` = 384614 AND `c_alt_name_chn` LIKE '%元%']恰好有兩筆，程式無法判別，這兩筆的欄位值除了c_alt_name_chn其他都完全一樣，聯合主鍵不易辨認。
![王開(384614)的別名，條件相同的情況恰好有兩筆。](https://user-images.githubusercontent.com/6869447/126731630-2b117ea3-f476-414f-9264-2d32d6dca155.PNG)
(圖說：王開(384614)的別名，條件相同的情況恰好有兩筆。)

![錯別字範例1](https://user-images.githubusercontent.com/6869447/126731637-b70d2ae9-9be4-476c-b581-8c2f1e9d4ca4.PNG)
(圖說：錯別字範例1)

![錯別字範例2](https://user-images.githubusercontent.com/6869447/126731647-e2414cfe-0fe7-4245-a89c-273e9a0bcd6b.PNG)
(圖說：錯別字範例2)

![錯別字範例3](https://user-images.githubusercontent.com/6869447/126731651-700c0016-49be-4530-ae75-d259f6ca299b.PNG)
(圖說：錯別字範例3)


三、CBDB製作[查詢人物社會關係API添加指數年相關條件]
1.修改【十三、查詢人物社會關係】的API添加上與指數年相關的條件。（https://github.com/cbdb-project/cbdb-online-main-server/blob/develop/API.md）
2.功能修改完成，查詢條件增加indexYear，indexStartTime，indexEndTime。