### PR TITLE
20210804修正[閏]月顯示故障與入仕API朝代查詢

### DIFF
--- a/app/Http/Controllers/Api/ApiController3.php
+++ b/app/Http/Controllers/Api/ApiController3.php
@@ -92,8 +92,8 @@ class ApiController3 extends Controller
             elseif($dateType == 'dynasty') {
                 //$row->join('BIOG_MAIN', 'ENTRY_DATA.c_personid', '=', 'BIOG_MAIN.c_personid');
                 $row->join('DYNASTIES', 'BIOG_MAIN.c_dy', '=', 'DYNASTIES.c_dy');
-                $row->where('DYNASTIES.c_start', '>=', $dynStart);
-                $row->where('DYNASTIES.c_end', '<=', $dynEnd);
+                $row->where('DYNASTIES.c_dy', '>=', $dynStart);
+                $row->where('DYNASTIES.c_dy', '<=', $dynEnd);
             }
             else {}
         }

--- a/resources/views/biogmains/addresses/edit.blade.php
+++ b/resources/views/biogmains/addresses/edit.blade.php
@@ -58,9 +58,9 @@
                         <label for="">閏</label>
                         <select name="c_fy_intercalary" class="form-control select2" name="c_natal">
                             <option disabled value="">请选择</option>
-                            <option value="0" {{ ord($row->c_fy_intercalary) == 0? 'selected': '' }}>0-否
+                            <option value="0" {{ $row->c_fy_intercalary == 0? 'selected': '' }}>0-否
                             </option>
-                            <option value="1" {{ ord($row->c_fy_intercalary) == 1? 'selected': '' }}>1-是
+                            <option value="1" {{ $row->c_fy_intercalary == 1? 'selected': '' }}>1-是
                             </option>
                         </select>
                     </div>

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -184,9 +184,9 @@
                         <label for="">閏</label>
                         <select name="c_by_intercalary" class="form-control select2">
                             <option disabled value="">请选择</option>
-                            <option value="0" {{ ord($basicinformation->c_by_intercalary) == 0? 'selected': '' }}>0-否
+                            <option value="0" {{ $basicinformation->c_by_intercalary == 0? 'selected': '' }}>0-否
                             </option>
-                            <option value="1" {{ ord($basicinformation->c_by_intercalary) == 1? 'selected': '' }}>1-是
+                            <option value="1" {{ $basicinformation->c_by_intercalary == 1? 'selected': '' }}>1-是
                             </option>
                         </select>
                     </div>
@@ -223,9 +223,9 @@
                         <label for="">閏</label>
                         <select name="c_dy_intercalary" class="form-control select2">
                             <option disabled value="">请选择</option>
-                            <option value="0" {{ ord($basicinformation->c_dy_intercalary) == 0? 'selected': '' }}>0-否
+                            <option value="0" {{ $basicinformation->c_dy_intercalary == 0? 'selected': '' }}>0-否
                             </option>
-                            <option value="1" {{ ord($basicinformation->c_dy_intercalary) == 1? 'selected': '' }}>1-是
+                            <option value="1" {{ $basicinformation->c_dy_intercalary == 1? 'selected': '' }}>1-是
                             </option>
                         </select>
                     </div>

--- a/resources/views/biogmains/offices/edit.blade.php
+++ b/resources/views/biogmains/offices/edit.blade.php
@@ -106,9 +106,9 @@
                         <label for="">閏</label>
                         <select name="c_fy_intercalary" class="form-control select2" name="c_natal">
                             <option disabled value="">请选择</option>
-                            <option value="0" {{ ord($row->c_fy_intercalary) == 0? 'selected': '' }}>0-否
+                            <option value="0" {{ $row->c_fy_intercalary == 0? 'selected': '' }}>0-否
                             </option>
-                            <option value="1" {{ ord($row->c_fy_intercalary) == 1? 'selected': '' }}>1-是
+                            <option value="1" {{ $row->c_fy_intercalary == 1? 'selected': '' }}>1-是
                             </option>
                         </select>
                     </div>


### PR DESCRIPTION
1.檢測發現，前輩誤用ord函式判別[閏]月的值，盤點受到影響的有[人物][地址][官名]，未受到影響的有[事件][社會關係]。
![誤用ord函式](https://user-images.githubusercontent.com/6869447/128145590-1c6777f6-3abb-4c04-8fd7-e9ae96052ea1.PNG)
（誤用ord函式）

![正確判別](https://user-images.githubusercontent.com/6869447/128145617-ba81068f-bc42-4fec-815e-bd6946fe5515.PNG)
（正確判別）

![閏月的顯示問題，前輩使用ord沒有生效。](https://user-images.githubusercontent.com/6869447/128145658-43f6d0a8-c408-4c1e-b679-183339b11a15.PNG)
（閏月的顯示問題，前輩使用ord沒有生效。）

![閏的正確寫法](https://user-images.githubusercontent.com/6869447/128145691-f72a75d8-365d-40b7-bc9d-c52b26e6f06f.PNG)
（閏的正確寫法）

![盤點ord的影響範圍](https://user-images.githubusercontent.com/6869447/128145739-7c66ea93-da05-4c04-8c0e-00defc689afd.png)
（盤點ord的影響範圍）

![盤點 閏 的標籤](https://user-images.githubusercontent.com/6869447/128145767-8a0c445a-1ad2-4b27-94fb-dd6fcd2d7b6d.PNG)
（盤點[閏]的標籤）


2.入仕API查詢的[朝代起訖]，之前是去判斷DYNASTIES資料表中，c_start與c_end欄位的值，修改為判斷c_dy的值即可。
![目前的程式邏輯](https://user-images.githubusercontent.com/6869447/128145829-5dd7ff00-1651-4163-a3ee-e8c6cf9923bf.png)
