### PR TITLE
20210805[地址]錄入表單與[查詢除授記錄API]修改

### DIFF
--- a/app/Http/Controllers/Api/ApiController2.php
+++ b/app/Http/Controllers/Api/ApiController2.php
@@ -37,14 +37,18 @@ class ApiController2 extends Controller
         $json = $request['RequestPlayload'];
         $arr = json_decode($json, true);
         $office = $officePlace = $peoplePlace = $data = $useXyArr = array();
-        $useOfficePlace = $usePeoplePlace = $indexYear = $indexStartTime = $indexEndTime = $useXy = $start = $list = 0;
+        $useOfficePlace = $usePeoplePlace = $indexYear = $useDate = $indexStartTime = $indexEndTime = $dateType = $dynStart = $dynEnd = $useXy = $start = $list = 0;
         
         $office = $arr['office'];
         $officePlace = $arr['officePlace'];
         $peoplePlace = $arr['peoplePlace'];
         $useOfficePlace = $arr['useOfficePlace'];
         $usePeoplePlace = $arr['usePeoplePlace']; 
-        $indexYear = $arr['indexYear']; 
+        //$indexYear = $arr['indexYear']; 
+        $useDate = $arr['useDate'];
+        $dateType = $arr['dateType'];
+        $dynStart = $arr['dynStart'];
+        $dynEnd = $arr['dynEnd'];
         $indexStartTime = $arr['indexStartTime']; 
         $indexEndTime = $arr['indexEndTime']; 
         $useXy = $arr['useXy']; 
@@ -54,6 +58,7 @@ class ApiController2 extends Controller
         
         $row = DB::table('POSTED_TO_OFFICE_DATA')->whereIn('POSTED_TO_OFFICE_DATA.c_office_id', $office);
         $row->join('POSTED_TO_ADDR_DATA', 'POSTED_TO_OFFICE_DATA.c_posting_id', '=', 'POSTED_TO_ADDR_DATA.c_posting_id');
+        $row->join('BIOG_MAIN', 'POSTED_TO_OFFICE_DATA.c_personid', '=', 'BIOG_MAIN.c_personid');
 
         if($useOfficePlace) {
             $row->whereIn('c_addr_id', $officePlace);
@@ -63,9 +68,23 @@ class ApiController2 extends Controller
             $row->join('BIOG_ADDR_DATA', 'POSTED_TO_ADDR_DATA.c_personid', '=', 'BIOG_ADDR_DATA.c_personid');
             $row->whereIn('BIOG_ADDR_DATA.c_addr_id', $peoplePlace);
         }
+        /*
         if($indexYear) {
             $row->join('BIOG_MAIN', 'POSTED_TO_OFFICE_DATA.c_personid', '=', 'BIOG_MAIN.c_personid');
             $row->whereBetween('BIOG_MAIN.c_index_year', array($indexStartTime, $indexEndTime));
+        }
+        */
+        if($useDate) {
+            if($dateType == 'index') {
+                $row->where('BIOG_MAIN.c_index_year', '>=', $dateStartTime);
+                $row->where('BIOG_MAIN.c_index_year', '<=', $dateEndTime);
+            }
+            elseif($dateType == 'dynasty') {
+                $row->join('DYNASTIES', 'BIOG_MAIN.c_dy', '=', 'DYNASTIES.c_dy');
+                $row->where('DYNASTIES.c_dy', '>=', $dynStart);
+                $row->where('DYNASTIES.c_dy', '<=', $dynEnd);
+            }
+            else {}
         }
         if($useXy) {
             $rowOut = $row->get();
@@ -103,6 +122,7 @@ WHERE (((ADDR_CODES.x_coord)>=(ADDR_CODES_1.x_coord-0.03) And (ADDR_CODES.x_coor
         if($list) {
             $row = $row->slice($start, $list);
         }
+        //return $row;
 
         foreach ($row as $val) {
             $BiogMain = $BiogAddr = $BiogAddrCode = $AddrCode = $AddrCode_office = $office = $POSTED_TO_ADDR_DATA = $c_addr_type = $c_addr_id = 0;

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\AddressCode;
+use App\AddrCode;
+use App\AddrBelong;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
@@ -127,8 +129,24 @@ class BasicInformationAddressesController extends Controller
         ])->first();
         $addr_str = null;
         if($row->c_addr_id || $row->c_addr_id === 0){
-            $addr_ = AddressCode::find($row->c_addr_id);
-            $addr_str = $addr_->c_addr_id." ".$addr_->c_name." ".$addr_->c_name_chn." ".$addr_->c_firstyear."~".$addr_->c_lastyear;
+            //20210805修改「地址」中利用 ADDRESSES 表和 ADDR_CODES 表
+            //$addr_ = AddressCode::find($row->c_addr_id);
+            //$addr_str = $addr_->c_addr_id." ".$addr_->c_name." ".$addr_->c_name_chn." ".$addr_->c_firstyear."~".$addr_->c_lastyear;
+            $item = AddrCode::find($row->c_addr_id);
+            $belongs = "";
+            $originalText = $item->c_addr_id." ".$item->c_name." ".$item->c_name_chn." ".trim($belongs)." ".$item->c_firstyear."~".$item->c_lastyear;
+            $add = "";
+            $dy = AddrBelong::where('c_addr_id', $item->c_addr_id)->value('c_belongs_to');
+            $dy2 = AddrCode::where('c_addr_id', $dy)->value('c_name_chn');
+            if($dy == null) {
+                $dy = 0; $add = "";
+            }
+            else {
+                $dy2 = AddrCode::where('c_addr_id', $dy)->value('c_name_chn');
+                $add = "[[".$dy." ".$dy2."]]";
+            }
+            $addr_str = $originalText." ".$add;
+            //修改結束
         }
         $text_str = null;
 //        dd($row->c_source);


### PR DESCRIPTION
回報「issues_144「地址」中利用 ADDRESSES 表和 ADDR_CODES 表的討論」已經完成，已經在[地址]的錄入表單，使用物件 ADDR_CODES 和 ADDR_BELONGS_DATA 組出來（和下方的邏輯一致），而完全不使用 ADDRESSES 這張表。

1.AddrBelong對應ADDR_BELONGS_DATA資料表
2.AddrCode物件對應ADDR_CODES資料表

另外，本次更新也完成了「【社区版查询系统】关于API中“八、查詢除授記錄”的修改事宜」，
這次的dateType、dynStart與dynEnd邏輯都與前次相同。