### PR TITLE
20210830[拼音檢索時以字為單位]與[親屬關係API修正]

### DIFF
--- a/app/Http/Controllers/Api/ApiController4.php
+++ b/app/Http/Controllers/Api/ApiController4.php
@@ -158,9 +158,16 @@ class ApiController4 extends Controller
             $data_val['rName'] = $FirstBiogMain->c_name;
             $data_val['rNameChn'] = $FirstBiogMain->c_name_chn;
             $BiogMain = BiogMain::where('c_personid', '=', $val['c_personid'])->first();
-            $data_val['pId'] = $val['c_personid'];
-            $data_val['pName'] = $BiogMain->c_name;
-            $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            if($BiogMain) {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = $BiogMain->c_name;
+                $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            }
+            else {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = '';
+                $data_val['pNameChn'] = '';
+            }
             //這裡是查詢人物的[地址]BIOG_ADDR_DATA
             $c_addr_type = $c_addr_id = 0;
             $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->whereIn('c_addr_type', [1, 16, 6, 4, 2, 13, 14, 17])->first();
@@ -182,11 +189,20 @@ class ApiController4 extends Controller
             $data_val['pY'] = $AddrCode->y_coord;
 
             $KinBiogMain = BiogMain::where('c_personid', '=', $val['c_kin_id'])->first();
-            $data_val['Id'] = $val['c_kin_id'];
-            $data_val['Name'] = $KinBiogMain->c_name;
-            $data_val['NameChn'] = $KinBiogMain->c_name_chn;
-            $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
-            $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            if($KinBiogMain) {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = $KinBiogMain->c_name;
+                $data_val['NameChn'] = $KinBiogMain->c_name_chn;
+                $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
+                $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            }
+            else {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = '';
+                $data_val['NameChn'] = '';
+                $data_val['Sex'] = '';
+                $data_val['IndexYear'] = '';
+            }
             $KinshipCode = KinshipCode::where('c_kincode', '=', $val['c_kin_code'])->first();
             $data_val['pkinship'] = $KinshipCode->c_kinrel_chn;
 

--- a/app/Http/Controllers/Api/ApiController4_1.php
+++ b/app/Http/Controllers/Api/ApiController4_1.php
@@ -255,9 +255,16 @@ class ApiController4_1 extends Controller
             $data_val['rName'] = $FirstBiogMain->c_name;
             $data_val['rNameChn'] = $FirstBiogMain->c_name_chn;
             $BiogMain = BiogMain::where('c_personid', '=', $val['c_personid'])->first();
-            $data_val['pId'] = $val['c_personid'];
-            $data_val['pName'] = $BiogMain->c_name;
-            $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            if($BiogMain) {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = $BiogMain->c_name;
+                $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            }
+            else {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = '';
+                $data_val['pNameChn'] = '';
+            }
             //這裡是查詢人物的[地址]BIOG_ADDR_DATA
             $c_addr_type = $c_addr_id = 0;
             $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->whereIn('c_addr_type', [1, 16, 6, 4, 2, 13, 14, 17])->first();
@@ -279,11 +286,20 @@ class ApiController4_1 extends Controller
             $data_val['pY'] = $AddrCode->y_coord;
 
             $KinBiogMain = BiogMain::where('c_personid', '=', $val['c_kin_id'])->first();
-            $data_val['Id'] = $val['c_kin_id'];
-            $data_val['Name'] = $KinBiogMain->c_name;
-            $data_val['NameChn'] = $KinBiogMain->c_name_chn;
-            $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
-            $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            if($KinBiogMain) {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = $KinBiogMain->c_name;
+                $data_val['NameChn'] = $KinBiogMain->c_name_chn;
+                $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
+                $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            }
+            else {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = '';
+                $data_val['NameChn'] = '';
+                $data_val['Sex'] = '';
+                $data_val['IndexYear'] = '';
+            }
             $KinshipCode = KinshipCode::where('c_kincode', '=', $val['c_kin_code'])->first();
 
             //pkinship親屬關係

--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -266,9 +266,16 @@ class ApiController4_2 extends Controller
             $data_val['rName'] = $FirstBiogMain->c_name;
             $data_val['rNameChn'] = $FirstBiogMain->c_name_chn;
             $BiogMain = BiogMain::where('c_personid', '=', $val['c_personid'])->first();
-            $data_val['pId'] = $val['c_personid'];
-            $data_val['pName'] = $BiogMain->c_name;
-            $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            if($BiogMain) {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = $BiogMain->c_name;
+                $data_val['pNameChn'] = $BiogMain->c_name_chn;
+            }
+            else {
+                $data_val['pId'] = $val['c_personid'];
+                $data_val['pName'] = '';
+                $data_val['pNameChn'] = '';
+            }
             //這裡是查詢人物的[地址]BIOG_ADDR_DATA
             $c_addr_type = $c_addr_id = 0;
             $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->whereIn('c_addr_type', [1, 16, 6, 4, 2, 13, 14, 17])->first();
@@ -290,11 +297,20 @@ class ApiController4_2 extends Controller
             $data_val['pY'] = $AddrCode->y_coord;
 
             $KinBiogMain = BiogMain::where('c_personid', '=', $val['c_kin_id'])->first();
-            $data_val['Id'] = $val['c_kin_id'];
-            $data_val['Name'] = $KinBiogMain->c_name;
-            $data_val['NameChn'] = $KinBiogMain->c_name_chn;
-            $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
-            $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            if($KinBiogMain) {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = $KinBiogMain->c_name;
+                $data_val['NameChn'] = $KinBiogMain->c_name_chn;
+                $data_val['Sex'] = $KinBiogMain->c_female ? '1-女' : '0-男';
+                $data_val['IndexYear'] = $KinBiogMain->c_index_year;
+            }
+            else {
+                $data_val['Id'] = $val['c_kin_id'];
+                $data_val['Name'] = '';
+                $data_val['NameChn'] = '';
+                $data_val['Sex'] = '';
+                $data_val['IndexYear'] = '';
+            }
             $KinshipCode = KinshipCode::where('c_kincode', '=', $val['c_kin_code'])->first();
             $data_val['pkinship'] = $KinshipCode->c_kinrel_chn;
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -221,7 +221,17 @@ class BiogMainRepository
         if (!$request->q){
             return BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])->paginate($num);
         }
-        $names = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])->where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_personid', $request->q)->paginate($num);
+        //20210827修改拼音檢索時以字為單位
+        //$names = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])->where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_personid', $request->q)->paginate($num);
+        $names = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])
+            ->where('c_name_chn', 'like', '%'.$request->q.'%')
+            ->orWhere('c_name', 'like', ''.$request->q.'')
+            ->orWhere('c_surname', 'like', ''.$request->q.'')
+            ->orWhere('c_mingzi', 'like', ''.$request->q.'')
+            ->orWhere('c_personid', $request->q)
+            ->orderByRaw("FIELD(c_surname, '$request->q') DESC")
+            ->orderBy('c_personid', 'ASC')
+            ->paginate($num);
         $names->appends(['q' => $request->q])->links();
         return $names;
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,7 +22,7 @@ Route::middleware('auth:api')->get(/**
 });
 
 Route::group([], function () {
-    Route::post('name', function (Request $request)    {
+    Route::match(['get', 'post'], 'name', function (Request $request) {
         return \App\Repositories\BiogMainRepository::namesByQuery($request);
     });
 


### PR DESCRIPTION
一、CBDB功能製作[拼音檢索時以字為單位]
1.研讀了 Michael 教授提供的程式碼，以Laravel的ORM架構製作，調整[查詢人物]的功能，
  運用[c_name]、[c_surname]、[c_mingzi]查詢英文姓名，排序以[c_personid]asc與FIELD(c_surname, q)desc，製作英文姓氏優先排序的需求。
2.測試檢索 1) hao yixing/Hao Yixing 或者 2) yixing/Yixing 或者 3) hao/Hao，才可以精準檢索到[郝懿行]，檢索 hao yi 則會查得[c_name]為 hao yi 的人物。

二、CBDB檢修[親屬關係API]，並以同一組Query測試三組API的效能。
1.以同一組查詢條件測試三組API
  Query：{"people":["1499"],"mCircle":0,"MAncGen":3,"MDecGen":1,"MColLink":1,"MMarLink":1,"MLoop":7,"start":0,"list":65535,"debugMode":0}
  硬體參考：CPU 8 核心 2.6 GHz，記憶體 16 G。
  a.原本的邏輯，已經優化過程式效能 query_relatives：迴圈6次為60秒，迴圈7次會出現反應時間過長。
  b.參考Access的程式邏輯，改寫為Laravel query_relatives_1：迴圈7次為24.29秒
  c.與宏甦經理討論DFS(深度優先搜尋)與BFS(廣度優先搜尋)實作 query_relatives_2：迴圈7次為3.40秒
  目前三組API已經獨立創建路由，並更新至GitHub，陳諾經理可以切換這三組API使用。
  範例：網域名稱/api/query_relatives_2?RequestPlayload={"people":["1499"],"mCircle":0,"MAncGen":3,"MDecGen":1,"MColLink":1,"MMarLink":1,"MLoop":7,"start":0,"list":65535,"debugMode":0}