### PR TITLE
20210914親屬API功能修正

### DIFF
--- a/app/Http/Controllers/Api/ApiController4.php
+++ b/app/Http/Controllers/Api/ApiController4.php
@@ -43,6 +43,11 @@ class ApiController4 extends Controller
         for($i=0;$i<count($people);$i++) {
           $row = DB::table('KIN_DATA')->where('KIN_DATA.c_personid', '=', $people[$i]);
           $row->join('KINSHIP_CODES', 'KINSHIP_CODES.c_kincode', '=', 'KIN_DATA.c_kin_code');
+          //下列判斷是避免循環
+          if($run > 1 ) {
+            $row->whereNotIn('KIN_DATA.c_kin_id', $firstPeople);
+            $row->whereNotIn('KIN_DATA.c_personid', $firstPeople);
+          }
           $row->where('KINSHIP_CODES.c_upstep', '<=', $MAncGen);
           $row->where('KINSHIP_CODES.c_dwnstep', '<=', $MDecGen);
           $row->where('KINSHIP_CODES.c_marstep', '<=', $MColLink);
@@ -88,6 +93,9 @@ class ApiController4 extends Controller
         $MMarLink = $arr['MMarLink']; 
         $MLoop = $arr['MLoop'];
 
+        $debugMode = 0;
+        if(!empty($arr['debugMode'])) { $debugMode = $arr['debugMode']; }
+
         if(!empty($arr['start'])) { 
             if($arr['start'] <= 0) { $start = 0; } // 避免start為負數
             else { $start = $arr['start'] - 1; } // return輸出由1開始, 程式需由0開始.
@@ -129,8 +137,10 @@ class ApiController4 extends Controller
         else {
             $row = $this->relativesLoop($people, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop, $rowArr, $people, $run);
             $total = count($row);
-            //return $row;
         }
+
+        //20210913增加除錯模式的資料輸出
+        if($debugMode) { return $row; }
 
         //預先組合計算用的資料
         foreach ($row as $val) {

--- a/app/Http/Controllers/Api/ApiController4_1.php
+++ b/app/Http/Controllers/Api/ApiController4_1.php
@@ -39,13 +39,22 @@ class ApiController4_1 extends Controller
     protected function relativesLoop($people, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop, $rowArr, $firstPeople, $run) {
         $check = count($firstPeople);
         $c_kin_id = $data = $firstPeopleArr = array();
+        $checkArr = $checkArr2 = array();
         $run = $run + 1;
+        foreach ($rowArr as $checkVal) {
+            array_push($checkArr, $checkVal['c_personid']);
+            array_push($checkArr2, $checkVal['firstId']);
+        }
         //資料庫邏輯
         //把迴圈拿掉，限制$firstPeople只能有一人，改用whereIn可以大幅提升速度。
         if($check > 1) {
           for($i=0;$i<count($people);$i++) {
             $row = DB::table('KIN_DATA')->where('KIN_DATA.c_personid', '=', $people[$i]);
             $row->join('KINSHIP_CODES', 'KINSHIP_CODES.c_kincode', '=', 'KIN_DATA.c_kin_code');
+            //下列三行是避免循環
+            $row->whereNotIn('KIN_DATA.c_kin_id', $checkArr2);
+            $row->whereNotIn('KIN_DATA.c_kin_id',  $checkArr);
+            $row->whereNotIn('KIN_DATA.c_personid', $checkArr);
             //四個參數如果其中一個有值，才進行SQL條件過濾，都為0則略過SQL條件過濾，直接取得親屬關係人id。
             if($MAncGen != 0 || $MDecGen != 0 || $MColLink != 0 || $MMarLink != 0 ) {
                 $row->where('KINSHIP_CODES.c_upstep', '<=', $MAncGen);
@@ -93,6 +102,10 @@ class ApiController4_1 extends Controller
         } else {
             $row = DB::table('KIN_DATA')->whereIn('KIN_DATA.c_personid', $people);
             $row->join('KINSHIP_CODES', 'KINSHIP_CODES.c_kincode', '=', 'KIN_DATA.c_kin_code');
+            //下列三行是避免循環
+            $row->whereNotIn('KIN_DATA.c_kin_id', $checkArr2);
+            $row->whereNotIn('KIN_DATA.c_kin_id',  $checkArr);
+            $row->whereNotIn('KIN_DATA.c_personid', $checkArr);
             //四個參數如果其中一個有值，才進行SQL條件過濾，都為0則略過SQL條件過濾，直接取得親屬關係人id。
             if($MAncGen != 0 || $MDecGen != 0 || $MColLink != 0 || $MMarLink != 0 ) {
                 $row->where('KINSHIP_CODES.c_upstep', '<=', $MAncGen);
@@ -144,10 +157,10 @@ class ApiController4_1 extends Controller
             //$MLoop的作用是生成一些史料不見載的親屬關係
             //$rowArr = $this->relativesLoop($c_kin_id, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop, $rowArr, $firstPeopleArr, $run);
             if($check > 1) {
-                $rowArr = $this->relativesLoop($c_kin_id, 0, 0, 0, 0, $MLoop, $rowArr, $firstPeopleArr, $run);
+                $rowArr = $this->relativesLoop($c_kin_id, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop, $rowArr, $firstPeopleArr, $run);
             }
             else {
-                $rowArr = $this->relativesLoop($c_kin_id, 0, 0, 0, 0, $MLoop, $rowArr, $firstPeople, $run);
+                $rowArr = $this->relativesLoop($c_kin_id, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop, $rowArr, $firstPeople, $run);
             }
             return $rowArr;
         }

--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -67,7 +67,7 @@ class ApiController4_2 extends Controller
       return $s;
     }
 
-    protected function sub_relativesLoop($newdata, $rowArr, $run) {
+    protected function sub_relativesLoop($newdata, $rowArr, $run, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop) {
         //對$newdata執行迴圈
         $cks = '';
         $sub_newdata = array();
@@ -115,13 +115,19 @@ class ApiController4_2 extends Controller
                 $data['c_dwnstep'] = $val->c_dwnstep;
                 $data['c_colstep'] = $val->c_colstep;
                 $data['c_marstep'] = $val->c_marstep;
-                array_push($rowArr, $data);
-                array_push($sub_newdata, $data);
+                //20210913在這裡過濾不符合四參數的親屬。
+                if($data['c_upstep'] <= $MAncGen && $data['c_dwnstep'] <= $MDecGen && $data['c_colstep'] <= $MColLink && $data['c_marstep'] <= $MMarLink) {
+                    array_push($rowArr, $data);
+                    array_push($sub_newdata, $data);
+                }
             }
         }
-        if(!empty($sub_newdata)) {
-        //if(!empty($sub_newdata) && $run < 9) {
-            $rowArr = $this->sub_relativesLoop($sub_newdata, $rowArr, $run);
+        //if(!empty($sub_newdata)) {
+        //if(!empty($sub_newdata) || $run <= $MLoop) {
+        //if($run <= $MLoop) {
+        $MLoop = $MLoop - 1;
+        if($MLoop >= 1) {
+            $rowArr = $this->sub_relativesLoop($sub_newdata, $rowArr, $run, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop);
             return $rowArr;
         }
         else {
@@ -167,8 +173,10 @@ class ApiController4_2 extends Controller
           }
         }
         //這邊判斷$newdata是否有值，有的則繼續遞迴。
-        if(!empty($newdata)) {
-            $rowArr = $this->sub_relativesLoop($newdata, $rowArr, $run); 
+        //if(!empty($newdata)) {
+        $MLoop = $MLoop - 1;
+        if($MLoop >= 1) {
+            $rowArr = $this->sub_relativesLoop($newdata, $rowArr, $run, $MAncGen, $MDecGen, $MColLink, $MMarLink, $MLoop); 
             return $rowArr;
         }
         else {


### PR DESCRIPTION
[query_relatives_1]與[query_relatives_2]沒有「刪掉不符合四參數的親屬」，把程式補上去後，查詢結果up, down, col, mar四列都已符合四參數的設定了。
[query_relatives_1]是原本[query_relatives]的程式修正與優化，原本的[query_relatives]查詢結果已經誤差太大，建議取消使用，比較目前的query_relatives_1與query_relatives_2即可。
a.參考Access的程式邏輯，改寫為Laravel query_relatives_1：迴圈7次為7.36秒
b.與宏甦經理討論DFS(深度優先搜尋)與BFS(廣度優先搜尋)實作 query_relatives_2：迴圈7次為1.79秒