### PR TITLE
20211015[關於親屬關係API修改的建議]與[Addresses查詢的問題的修正]

### DIFF
--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -190,7 +190,7 @@ class ApiController4_2 extends Controller
         $arr = json_decode($json, true);
         $people = $mCircleArr = $data = $dataV = $rowArr = array();
         $k_addr_id_Arr = array();
-        $mCircle = $MAncGen = $MDecGen = $MColLink = $MMarLink = $MLoop = $run = $start = $list = 0;
+        $mCircle = $MAncGen = $MDecGen = $MColLink = $MMarLink = $MLoop = $outputSchema = $run = $start = $list = 0;
         
         $people = $arr['people'];
         $mCircle = $arr['mCircle']; 
@@ -199,6 +199,8 @@ class ApiController4_2 extends Controller
         $MColLink = $arr['MColLink'];
         $MMarLink = $arr['MMarLink']; 
         $MLoop = $arr['MLoop'];
+        //20211015增加outputSchema，1代表對返回的數據進行彙整，使每個人物都能指向查詢式提交的“中心人物”。0 代表直接返回數據庫中的人物關係，不做彙整。
+        if(!empty($arr['outputSchema'])) { $outputSchema = $arr['outputSchema']; }
 
         $debugMode = 0;
         if(!empty($arr['debugMode'])) { $debugMode = $arr['debugMode']; }
@@ -371,6 +373,16 @@ class ApiController4_2 extends Controller
 
             $data_val['xy_count'] = $answer[$k_addr_id.'-'.$KAddrCode->c_name_chn]; 
             $data_val['Notes'] = $val['c_notes'];
+
+            //增列判斷$outputSchema值的輸出欄位
+            if($outputSchema == 1) {
+                $c_kinrel_simplified = $c_kinrel = '';
+                $c_kinrel_simplified = str_replace('-', '', $val['c_kinrel_simplified']);
+                $c_kinrel = KinshipCode::where('c_kinrel_simplified', '=', $c_kinrel_simplified)->first();
+                $data_val['rId_c_kinrel_chn'] = !empty($c_kinrel) ? $c_kinrel->c_kinrel_chn : '';
+                $data_val['c_kinrel_simplified'] = $c_kinrel_simplified;
+                $data_val['c_kinrel_simplified_ori'] = $val['c_kinrel_simplified'];
+            }
 
             array_push($data, $data_val);
         }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -34,6 +34,7 @@ use App\SocialInstAddr;
 //20210625建安修改
 use App\AddrCode;
 use App\BiogAddrCode;
+use App\AddrBelong;
 //修改結束
 
 
@@ -1381,9 +1382,26 @@ class BiogMainRepository
 
     protected function addr_str($id)
     {
+        /*20211015遮除，不使用[ADDRESSES]表，改以[ADDR_CODES]和[ADDR_BELONGS_DATA]查得資料。*/
+        /*
         $row = AddressCode::find($id);
         $belongs = $row->belongs1_Name." ".$row->belongs2_Name." ".$row->belongs3_Name." ".$row->belongs4_Name." ".$row->belongs5_Name;
         return $row->c_addr_id.' '.$row->c_name.' '.$row->c_name_chn.' '.trim($belongs);
+        */
+        $row = AddrCode::find($id);
+        $belongs = "";
+        $originalText = $row->c_addr_id." ".$row->c_name." ".$row->c_name_chn." ".trim($belongs)." ".$row->c_firstyear."~".$row->c_lastyear;
+        $add = "";
+        $dy = AddrBelong::where('c_addr_id', $row->c_addr_id)->value('c_belongs_to');
+        $dy2 = AddrCode::where('c_addr_id', $dy)->value('c_name_chn');
+        if($dy == null) {
+            $dy = 0; $add = "";
+        }
+        else {
+            $dy2 = AddrCode::where('c_addr_id', $dy)->value('c_name_chn');
+            $add = "[[".$dy." ".$dy2."]]";
+        }
+        return $originalText." ".$add;
     }
 
     protected function insertAddr(Array $c_addr, $_id, $_postingid, $_officeid)


### PR DESCRIPTION
本次修改：

1.「查詢式中加入一個變數: outputSchema。它的取值為 0 或 1」，1代表對返回的數據進行彙整，使每個人物都能指向查詢式提交的“中心人物”。0 代表直接返回數據庫中的人物關係，不做彙整。

2.「關於Addresses查詢的問題的修正」，追蹤原因，在於edit.blade.php使用$this->biogMainRepository->officeById($office)回傳的資料，在officeById()這個環節有誤。
biogMainRepository物件的1382行使用了addr_str($id)進行資料的查詢並回傳字串，需要改寫這一段，不使用[ADDRESSES]表，改以[ADDR_CODES]和[ADDR_BELONGS_DATA]查得資料。
