### PR TITLE
20211020[社會機構的編輯bug修正]、[親屬關係API修正]與[官名頁面的社交機構欄位]

### DIFF
--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -271,40 +271,44 @@ class ApiController4_2 extends Controller
         
         //組合輸出資料
         foreach ($row as $val) {
-            $FirstBiogMain = BiogMain::where('c_personid', '=', $val['firstId'])->first();
-            $data_val['rId'] = $val['firstId'];
-            $data_val['rName'] = $FirstBiogMain->c_name;
-            $data_val['rNameChn'] = $FirstBiogMain->c_name_chn;
-            $BiogMain = BiogMain::where('c_personid', '=', $val['c_personid'])->first();
-            if($BiogMain) {
+            if($outputSchema == 1) {
+              $FirstBiogMain = BiogMain::where('c_personid', '=', $val['firstId'])->first();
+              $data_val['rId'] = $val['firstId'];
+              $data_val['rName'] = $FirstBiogMain->c_name;
+              $data_val['rNameChn'] = $FirstBiogMain->c_name_chn;
+            }
+            if($outputSchema == 0) {
+              $BiogMain = BiogMain::where('c_personid', '=', $val['c_personid'])->first();
+              if($BiogMain) {
                 $data_val['pId'] = $val['c_personid'];
                 $data_val['pName'] = $BiogMain->c_name;
                 $data_val['pNameChn'] = $BiogMain->c_name_chn;
-            }
-            else {
+              }
+              else {
                 $data_val['pId'] = $val['c_personid'];
                 $data_val['pName'] = '';
                 $data_val['pNameChn'] = '';
-            }
-            //這裡是查詢人物的[地址]BIOG_ADDR_DATA
-            $c_addr_type = $c_addr_id = 0;
-            $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->whereIn('c_addr_type', [1, 16, 6, 4, 2, 13, 14, 17])->first();
-            if(!$BiogAddr) {
+              }
+              //這裡是查詢人物的[地址]BIOG_ADDR_DATA
+              $c_addr_type = $c_addr_id = 0;
+              $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->whereIn('c_addr_type', [1, 16, 6, 4, 2, 13, 14, 17])->first();
+              if(!$BiogAddr) {
                 $BiogAddr = BiogAddr::where('c_personid', '=', $val['c_personid'])->first();
-            }
-            if($BiogAddr) {
+              }
+              if($BiogAddr) {
                 $c_addr_type = $BiogAddr->c_addr_type;
                 $c_addr_id = $BiogAddr->c_addr_id;
+              }
+              $BiogAddrCode = BiogAddrCode::where('c_addr_type', '=', $c_addr_type)->first(); 
+              $data_val['pAddrID'] = $c_addr_id;
+              $data_val['pAddrType'] = $BiogAddrCode->c_addr_desc;
+              $data_val['pAddrTypeChn'] = $BiogAddrCode->c_addr_desc_chn;
+              $AddrCode = AddrCode::where('c_addr_id', '=', $c_addr_id)->first();
+              $data_val['pAddrName'] = $AddrCode->c_name;
+              $data_val['pAddrNameChn'] = $AddrCode->c_name_chn;
+              $data_val['pX'] = $AddrCode->x_coord;
+              $data_val['pY'] = $AddrCode->y_coord;
             }
-            $BiogAddrCode = BiogAddrCode::where('c_addr_type', '=', $c_addr_type)->first(); 
-            $data_val['pAddrID'] = $c_addr_id;
-            $data_val['pAddrType'] = $BiogAddrCode->c_addr_desc;
-            $data_val['pAddrTypeChn'] = $BiogAddrCode->c_addr_desc_chn;
-            $AddrCode = AddrCode::where('c_addr_id', '=', $c_addr_id)->first();
-            $data_val['pAddrName'] = $AddrCode->c_name;
-            $data_val['pAddrNameChn'] = $AddrCode->c_name_chn;
-            $data_val['pX'] = $AddrCode->x_coord;
-            $data_val['pY'] = $AddrCode->y_coord;
 
             $KinBiogMain = BiogMain::where('c_personid', '=', $val['c_kin_id'])->first();
             if($KinBiogMain) {
@@ -321,8 +325,12 @@ class ApiController4_2 extends Controller
                 $data_val['Sex'] = '';
                 $data_val['IndexYear'] = '';
             }
+
             $KinshipCode = KinshipCode::where('c_kincode', '=', $val['c_kin_code'])->first();
-            $data_val['pkinship'] = $KinshipCode->c_kinrel_chn;
+
+            if($outputSchema == 0) {
+              $data_val['pkinship'] = $KinshipCode->c_kinrel_chn;
+            }
 
             $rKinshipCodeNum = 0;
             $rKinship = DB::table('KIN_DATA')->where('c_personid', '=', $val['firstId'])->where('c_kin_id', '=', $val['c_kin_id'])->get();
@@ -331,8 +339,13 @@ class ApiController4_2 extends Controller
                     $rKinshipCodeNum = $val2->c_kin_code;
                 }
             }
+
             $rKinshipCode = KinshipCode::where('c_kincode', '=', $rKinshipCodeNum)->first();
-            $data_val['rKinship'] = $rKinshipCode->c_kinrel_chn;
+
+            if($outputSchema == 1) {
+              $data_val['rKinship'] = $rKinshipCode->c_kinrel_chn;
+            }
+
             $data_val['up'] = $KinshipCode->c_upstep;
             $data_val['down'] = $KinshipCode->c_dwnstep;
             $data_val['col'] = $KinshipCode->c_colstep;
@@ -368,8 +381,12 @@ class ApiController4_2 extends Controller
                 $r_addr_id = $RBiogAddr->c_addr_id;
             }
             $RAddrCode = AddrCode::where('c_addr_id', '=', $r_addr_id)->first();
-            $data_val['pDistance'] = $this->getdizhi($KAddrCode->x_coord, $KAddrCode->y_coord, $AddrCode->x_coord, $AddrCode->y_coord);
-            $data_val['rDistance'] = $this->getdizhi($KAddrCode->x_coord, $KAddrCode->y_coord, $RAddrCode->x_coord, $RAddrCode->y_coord);
+            if($outputSchema == 0) {
+              $data_val['pDistance'] = $this->getdizhi($KAddrCode->x_coord, $KAddrCode->y_coord, $AddrCode->x_coord, $AddrCode->y_coord);
+            }
+            if($outputSchema == 1) {
+              $data_val['rDistance'] = $this->getdizhi($KAddrCode->x_coord, $KAddrCode->y_coord, $RAddrCode->x_coord, $RAddrCode->y_coord);
+            }
 
             $data_val['xy_count'] = $answer[$k_addr_id.'-'.$KAddrCode->c_name_chn]; 
             $data_val['Notes'] = $val['c_notes'];

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -78,6 +78,26 @@ class BasicInformationOfficesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        //20211020在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        //20211020修正$c_inst_name_code預設為0
+        $temp = explode("-", $request->c_inst_code);
+        $c_inst_code = $temp[0];
+        if(!empty($temp[1])) {
+            $c_inst_name_code = $temp[1];
+        }
+        else {
+            $c_inst_code = '0';
+            $c_inst_name_code = '0';
+        }
+
+        if($c_inst_name_code != '') {
+            $request->c_inst_code = $c_inst_code;
+            $request->c_inst_name_code = $c_inst_name_code;
+            $request->merge(['c_inst_code' => $c_inst_code]);
+            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        }
+        //return $request;
+        //修改結束
         $_id = $this->biogMainRepository->officeStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
         return redirect()->route('basicinformation.offices.edit', ['id' => $id, 'office' => $_id]);
@@ -127,6 +147,26 @@ class BasicInformationOfficesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        //20211020在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
+        //20211020修正$c_inst_name_code預設為0
+        $temp = explode("-", $request->c_inst_code);
+        $c_inst_code = $temp[0];
+        if(!empty($temp[1])) {
+            $c_inst_name_code = $temp[1];
+        }
+        else {
+            $c_inst_code = '0';
+            $c_inst_name_code = '0';
+        }
+
+        if($c_inst_name_code != '') {
+            $request->c_inst_code = $c_inst_code;
+            $request->c_inst_name_code = $c_inst_name_code;
+            $request->merge(['c_inst_code' => $c_inst_code]);
+            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        }
+        //return $request;
+        //修改結束
         $id_ = $this->biogMainRepository->officeUpdateById($request, $id_, $id);
         flash('Update success @ '.Carbon::now(), 'success');
         return redirect()->route('basicinformation.offices.edit', ['id' => $id, 'office' => $id_]);

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -164,13 +164,17 @@ class BasicInformationSocialInstController extends Controller
             $data['c_inst_name_code'] = $c_inst_name_code;
         }
         //return $request;
-        //修改結束
+        //修改結束 //20211020修改增加c_bi_begin_year與c_bi_end_year
         $addr_l = explode("-", $id_);
+        if($addr_l[1] == '') {$addr_l[1] = NULL; }
+        if($addr_l[2] == '') {$addr_l[2] = NULL; }
         DB::table('BIOG_INST_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_bi_role_code', '=', $addr_l[1]],
+            ['c_bi_begin_year', '=', $addr_l[1]],
+            ['c_bi_end_year', '=', $addr_l[2]],
+            ['c_bi_role_code', '=', $addr_l[3]],
         ])->update($data);
-        $newid = $id.'-'.$data['c_bi_role_code'];
+        $newid = $id.'-'.$data['c_bi_begin_year'].'-'.$data['c_bi_end_year'].'-'.$data['c_bi_role_code'];
         $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_INST_DATA', $newid, $data);
         flash('Update success @ '.Carbon::now(), 'success');
         return redirect()->route('basicinformation.socialinst.edit', ['id'=>$id, 'id_'=>$newid]);
@@ -197,13 +201,17 @@ class BasicInformationSocialInstController extends Controller
         $addr_l = explode("-", $id_);
         $row = DB::table('BIOG_INST_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_bi_role_code', '=', $addr_l[1]],
+            ['c_bi_begin_year', '=', $addr_l[1]],
+            ['c_bi_end_year', '=', $addr_l[2]],
+            ['c_bi_role_code', '=', $addr_l[3]],
         ])->first();
 
         $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', $id_, $row);
         DB::table('BIOG_INST_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
-            ['c_bi_role_code', '=', $addr_l[1]],
+            ['c_bi_begin_year', '=', $addr_l[1]],
+            ['c_bi_end_year', '=', $addr_l[2]],
+            ['c_bi_role_code', '=', $addr_l[3]],
         ])->delete();
         flash('Delete success @ '.Carbon::now(), 'success');
         return redirect()->route('basicinformation.socialinst.index', ['id' => $id]);

--- a/resources/views/biogmains/offices/create.blade.php
+++ b/resources/views/biogmains/offices/create.blade.php
@@ -29,7 +29,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="c_inst_code" class="col-sm-2 control-label">社交機構代碼(c_inst_code)</label>
+                    <label for="c_inst_code" class="col-sm-2 control-label">社交機構(social_institution)</label>
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
                             <option value="0">0 unknown 未详</option>
@@ -205,7 +205,7 @@
         $(".select2").select2();
         $(".c_office_id").select2(options('office'));
         $(".c_source").select2(options('text'));
-        $(".c_inst_code").select2(options('socialinst'));
+        $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_addr").select2(options('addr'));
 
         function formatRepo (repo) {

--- a/resources/views/biogmains/offices/edit.blade.php
+++ b/resources/views/biogmains/offices/edit.blade.php
@@ -41,11 +41,12 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="c_office_id" class="col-sm-2 control-label">社交機構代碼(c_inst_code)</label>
+                    <label for="c_office_id" class="col-sm-2 control-label">社交機構(social_institution)</label>
+                    <input name="c_inst_name_code" type="hidden">
                     <div class="col-sm-10">
                         <select class="form-control c_inst_code" name="c_inst_code">
                             @if($res['posting_str'])
-                            <option value="{{ $row->c_inst_code }}" selected="selected">{{ $res['posting_str'] }}</option>
+                            <option value="{{ $row->c_inst_code.'-'.$row->c_inst_name_code }}" selected="selected">{{ $res['posting_str'] }}</option>
                             @endif
                         </select>
                     </div>
@@ -228,7 +229,7 @@
         $(".select2").select2();
         $(".c_office_id").select2(options('office'));
         $(".c_source").select2(options('text'));
-        $(".c_inst_code").select2(options('socialinst'));
+        $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_addr").select2(options('addr'));
 
         function formatRepo (repo) {

--- a/resources/views/biogmains/socialinst/edit.blade.php
+++ b/resources/views/biogmains/socialinst/edit.blade.php
@@ -5,7 +5,7 @@
         <div class="panel-heading">社交機構 SocialInst</div>
         <div class="panel-body">
             <div class="panel-body">
-            <form action="{{ route('basicinformation.socialinst.update', [$id, '_id' => $row->c_personid.'-'.$row->c_bi_role_code]) }}" class="form-horizontal" method="post">
+            <form action="{{ route('basicinformation.socialinst.update', [$id, '_id' => $row->c_personid.'-'.$row->c_bi_begin_year.'-'.$row->c_bi_end_year.'-'.$row->c_bi_role_code]) }}" class="form-horizontal" method="post">
                 {{ method_field('PATCH') }}
                 {{ csrf_field() }}
                 <div class="form-group">

--- a/resources/views/biogmains/socialinst/index.blade.php
+++ b/resources/views/biogmains/socialinst/index.blade.php
@@ -29,7 +29,7 @@
                         <td>{{ $value->pivot->c_bi_end_year }}</td>
                         <td>
                             <div class="btn-group">
-                                @php($id_ = $value->pivot->c_personid."-".$value->pivot->c_bi_role_code)
+                                @php($id_ = $value->pivot->c_personid."-".$value->pivot->c_bi_begin_year."-".$value->pivot->c_bi_end_year."-".$value->pivot->c_bi_role_code)
                                 <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.socialinst.edit', ['id' => $basicinformation->c_personid, 'id_' => $id_]) }}">edit</a>
                                 <a href=""
                                    onclick="


### PR DESCRIPTION
一、處理CBDB團隊回報[社會機構]的編輯bug。
1.[社會機構]的編輯bug是因為聯合主鍵原本採取「person id + 社交機構角色(c_bi_role_code)」，人物34344曾國藩的兩筆社交機構，聯合主鍵恰好都為34344-18，所以出現編輯bug。
  因社交機構(social_institution)整合c_inst_code與c_inst_name_code，不易使用在聯合主鍵，所以增加[始年]與[終年]，目前聯合主鍵為「person id + 始年(c_bi_begin_year) + 終年(c_bi_end_year) +社交機構角色(c_bi_role_code)」，這樣程式就可以索引到正確的資料了。

二、處理CBDB[20211016關於親屬關係API修改的建議]的需求
1.依據討論內容，修正["outputSchema":1]與["outputSchema":0]的輸出資料。

三、處理CBDB issues136-patch6「官名」頁面的社交機構欄位，改以[社交機構新錄入方式的全面應用]。
1.修改create與edit的「官名」介面，改為社交機構(social_institution)欄位，並處理欄位的儲存值。