### PR TITLE
20211111「人名查詢」界面新增[號]與[指數年]。

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -43676,6 +43676,10 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     props: ['user'],
@@ -43871,6 +43875,19 @@ var render = function() {
                     target: "_blank"
                   }
                 },
+                [_vm._v(_vm._s(item.c_index_year))]
+              )
+            ]),
+            _vm._v(" "),
+            _c("td", [
+              _c(
+                "a",
+                {
+                  attrs: {
+                    href: "/basicinformation/" + item.c_personid + "/edit",
+                    target: "_blank"
+                  }
+                },
                 [_vm._v(_vm._s(item.ADDR_c_name_chn))]
               )
             ]),
@@ -43884,7 +43901,20 @@ var render = function() {
                     target: "_blank"
                   }
                 },
-                [_vm._v(_vm._s(item.c_alt_name_chn))]
+                [_vm._v(_vm._s(item.c_alt_name_chn_zi))]
+              )
+            ]),
+            _vm._v(" "),
+            _c("td", [
+              _c(
+                "a",
+                {
+                  attrs: {
+                    href: "/basicinformation/" + item.c_personid + "/edit",
+                    target: "_blank"
+                  }
+                },
+                [_vm._v(_vm._s(item.c_alt_name_chn_hao))]
               )
             ])
           ])
@@ -43985,9 +44015,13 @@ var staticRenderFns = [
         _vm._v(" "),
         _c("th", [_vm._v("dynasty")]),
         _vm._v(" "),
+        _c("th", [_vm._v("index year")]),
+        _vm._v(" "),
         _c("th", [_vm._v("index address")]),
         _vm._v(" "),
-        _c("th", [_vm._v("zi")])
+        _c("th", [_vm._v("zi")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("hao")])
       ])
     ])
   }

--- a/resources/assets/js/components/NameList.vue
+++ b/resources/assets/js/components/NameList.vue
@@ -19,8 +19,10 @@
                 <th>c_name_chn</th>
                 <th>c_name</th>
                 <th>dynasty</th>
+                <th>index year</th>
                 <th>index address</th>
                 <th>zi</th>
+                <th>hao</th>
             </tr>
             </thead>
             <tbody>
@@ -29,8 +31,10 @@
                     <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_name_chn}}</a></td>
                     <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_name}}</a></td>
                     <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_dynasty_chn}}</a></td>
+                    <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_index_year}}</a></td>
                     <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.ADDR_c_name_chn}}</a></td>
-                    <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_alt_name_chn}}</a></td>
+                    <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_alt_name_chn_zi}}</a></td>
+                    <td><a v-bind:href="'/basicinformation/'+item.c_personid+'/edit'" target="_blank">{{item.c_alt_name_chn_hao}}</a></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
1.需求：
  a.從當前的結果看，號也很重要，需添加[hao]這一列，查詢[hao]的時候，限定[ALTNAME_DATA]表中 [c_alt_name_type_code]列的值是[5]，同樣如果有多個號，隨機取一個即可。
  [c_alt_name_type_code值等於4]：字
  [c_alt_name_type_code值等於5]：室名、別號
  b.此外，需在「人名查詢」界面中添加一列[index year]。
  [指數年index year：BIOG_MAIN.c_index_year欄位]
2.製作：
  a.resources/assets/js/components/NameList.vue
  b.app/Repositories/BiogMainRepository.php
3.本次更新需要執行npm run dev。