### PR TITLE
20211116多筆地址從屬資訊錄入功能修正

### DIFF
--- a/app/Http/Controllers/AddrBelongsDataController.php
+++ b/app/Http/Controllers/AddrBelongsDataController.php
@@ -66,8 +66,8 @@ class AddrBelongsDataController extends Controller
             return redirect()->back();
         }
         $data = $request->all();
-        if ($data['c_addr_id'] == null or $data['c_addr_id'] == 0 or AddrBelongsData::where('c_addr_id', $data['c_addr_id'])->get()->isEmpty()){
-            flash('c_addr_id 未填或已存在 '.Carbon::now(), 'error');
+        if ($data['c_addr_id'] == null or $data['c_addr_id'] == 0){
+            flash('c_addr_id 未填 '.Carbon::now(), 'error');
             return redirect()->back();
         }
         $flight = AddrBelongsData::create($data);


### PR DESCRIPTION
新建地址從屬資訊的時候，會辨認填寫表單的[c_addr_id等於null]或是[c_addr_id等於0]或是[填寫的c_addr_id不存在於ADDR_BELONGS_DATA資料表]，而阻擋寫入資料庫。

[填寫的c_addr_id不存在於ADDR_BELONGS_DATA資料表]這個規則應刪除，修正這一段程式。
