### PR TITLE
20211122多筆著作版本表錄入修改

### DIFF
--- a/app/Http/Controllers/TextInstanceDataController.php
+++ b/app/Http/Controllers/TextInstanceDataController.php
@@ -72,6 +72,8 @@ class TextInstanceDataController extends Controller
             flash('c_textid 未填或已存在 '.Carbon::now(), 'error');
             return redirect()->back();
         }
+        //20211117增加用戶名和保存時間自動填寫
+        $data = $this->toolRepository->timestamp($data, True); //新增
         $flight = TextInstanceData::create($data);
         $this->operationRepository->store(Auth::id(), '', 1, 'TEXT_INSTANCE_DATA', $data['c_textid']."-".$data['c_text_edition_id']."-".$data['c_text_instance_id'], $data);
         flash('Create success @ '.Carbon::now(), 'success');

--- a/app/Repositories/TextInstanceDataRepository.php
+++ b/app/Repositories/TextInstanceDataRepository.php
@@ -42,6 +42,8 @@ class TextInstanceDataRepository{
     {
         $data = $request->all();
         $data = array_except($data, ['_method', '_token']);
+        //20211117增加用戶名和保存時間自動填寫
+        $data = (new ToolsRepository)->timestamp($data); //更新
         //$altcode = TextInstanceData::find($id);
         $id_l = explode("-", $id);
         $altcode = TextInstanceData::where([

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -45639,6 +45639,14 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     props: [],
@@ -45775,7 +45783,15 @@ var render = function() {
           return _c("tr", [
             _c("td", [_vm._v(_vm._s(item.c_textid))]),
             _vm._v(" "),
+            _c("td", [_vm._v(_vm._s(item.c_text_edition_id))]),
+            _vm._v(" "),
+            _c("td", [_vm._v(_vm._s(item.c_text_instance_id))]),
+            _vm._v(" "),
             _c("td", [_vm._v(_vm._s(item.c_instance_title_chn))]),
+            _vm._v(" "),
+            _c("td", [_vm._v(_vm._s(item.c_publisher))]),
+            _vm._v(" "),
+            _c("td", [_vm._v(_vm._s(item.c_print))]),
             _vm._v(" "),
             _c("td", [_vm._v(_vm._s(item.c_instance_title))]),
             _vm._v(" "),
@@ -45968,7 +45984,15 @@ var staticRenderFns = [
       _c("tr", [
         _c("th", [_vm._v("c_textid")]),
         _vm._v(" "),
+        _c("th", [_vm._v("c_text_edition_id")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("c_text_instance_id")]),
+        _vm._v(" "),
         _c("th", [_vm._v("c_instance_title_chn")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("c_publisher")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("c_print")]),
         _vm._v(" "),
         _c("th", [_vm._v("c_instance_title")]),
         _vm._v(" "),

--- a/resources/assets/js/components/TextInstanceDataList.vue
+++ b/resources/assets/js/components/TextInstanceDataList.vue
@@ -16,7 +16,11 @@
             <thead>
             <tr>
                 <th>c_textid</th>
+                <th>c_text_edition_id</th>
+                <th>c_text_instance_id</th>
                 <th>c_instance_title_chn</th>
+                <th>c_publisher</th>
+                <th>c_print</th>
                 <th>c_instance_title</th>
                 <th>操作</th>
             </tr>
@@ -24,7 +28,11 @@
             <tbody>
             <tr v-for="item in names.data">
                 <td>{{item.c_textid}}</td>
+                <td>{{item.c_text_edition_id}}</td>
+                <td>{{item.c_text_instance_id}}</td>
                 <td>{{item.c_instance_title_chn}}</td>
+                <td>{{item.c_publisher}}</td>
+                <td>{{item.c_print}}</td>
                 <td>{{item.c_instance_title}}</td>
                 <td>
                     <div class="btn-group">


### PR DESCRIPTION
申請合併至develop，本次更新需要執行npm run dev。

1.「著作版本表」的查詢界面上添加 c_text_edition_id, c_text_instance_id, c_publisher, c_print 這四列。（功能完成）
2.在「著作版本表」編輯界面的 c_textid 旁邊添加一個「Load Data」按鈕. 錄入者點 Load Data 之後可以從 TEXT_CODES 中，
用 c_textid 查到對應的 c_title_chn 自動填入 c_instance_title_chn，
用 c_textid 查到對應的 c_title 自動填入 c_instance_title。（尚未完成，這個表單剛好是Vue + laravel，資料的傳遞尚未測試出適合的方法，研究中。）
3.增加「著作版本表」的錄入者四列資訊（資訊創建者用戶名，資訊創建時間、資訊修改者用戶名，資訊修改時間），
並由系統自動填寫：c_created_by, c_created_date, c_modified_by, c_modified_date.（功能完成）

