### PR TITLE
20230612移除c_secondary_source_author表單欄位，共計24隻程式。

### DIFF
--- a/resources/views/biogmains/addresses/create.blade.php
+++ b/resources/views/biogmains/addresses/create.blade.php
@@ -124,10 +124,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/addresses/edit.blade.php
+++ b/resources/views/biogmains/addresses/edit.blade.php
@@ -131,10 +131,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/altname/create.blade.php
+++ b/resources/views/biogmains/altname/create.blade.php
@@ -44,10 +44,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author " class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/altname/edit.blade.php
+++ b/resources/views/biogmains/altname/edit.blade.php
@@ -62,10 +62,6 @@ $row->c_alt_name = unionPKDef_decode_for_convert($row->c_alt_name);
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author " class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/assoc/create.blade.php
+++ b/resources/views/biogmains/assoc/create.blade.php
@@ -186,10 +186,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">成对社会关系</label>

--- a/resources/views/biogmains/assoc/edit.blade.php
+++ b/resources/views/biogmains/assoc/edit.blade.php
@@ -225,10 +225,6 @@ $row->c_text_title = unionPKDef_decode_for_convert($row->c_text_title);
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="" class="col-sm-2 control-label">成对社会关系</label>

--- a/resources/views/biogmains/entries/create.blade.php
+++ b/resources/views/biogmains/entries/create.blade.php
@@ -143,10 +143,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(notes)</label>

--- a/resources/views/biogmains/entries/edit.blade.php
+++ b/resources/views/biogmains/entries/edit.blade.php
@@ -163,10 +163,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(notes)</label>

--- a/resources/views/biogmains/events/create.blade.php
+++ b/resources/views/biogmains/events/create.blade.php
@@ -93,10 +93,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">大事件</label>

--- a/resources/views/biogmains/events/edit.blade.php
+++ b/resources/views/biogmains/events/edit.blade.php
@@ -107,10 +107,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_event" class="col-sm-2 control-label">大事件</label>

--- a/resources/views/biogmains/kinship/create.blade.php
+++ b/resources/views/biogmains/kinship/create.blade.php
@@ -42,10 +42,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/kinship/edit.blade.php
+++ b/resources/views/biogmains/kinship/edit.blade.php
@@ -53,10 +53,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/offices/create.blade.php
+++ b/resources/views/biogmains/offices/create.blade.php
@@ -57,10 +57,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_firstyear" class="col-sm-2 control-label">始年(firstyear)</label>

--- a/resources/views/biogmains/offices/edit.blade.php
+++ b/resources/views/biogmains/offices/edit.blade.php
@@ -82,10 +82,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_firstyear" class="col-sm-2 control-label">始年(firstyear)</label>

--- a/resources/views/biogmains/possession/create.blade.php
+++ b/resources/views/biogmains/possession/create.blade.php
@@ -87,10 +87,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/possession/edit.blade.php
+++ b/resources/views/biogmains/possession/edit.blade.php
@@ -96,10 +96,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/socialinst/create.blade.php
+++ b/resources/views/biogmains/socialinst/create.blade.php
@@ -76,10 +76,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/socialinst/edit.blade.php
+++ b/resources/views/biogmains/socialinst/edit.blade.php
@@ -85,10 +85,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/sources/create.blade.php
+++ b/resources/views/biogmains/sources/create.blade.php
@@ -25,10 +25,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="0">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/sources/edit.blade.php
+++ b/resources/views/biogmains/sources/edit.blade.php
@@ -37,10 +37,6 @@ $row->c_pages = unionPKDef_decode_for_convert($row->c_pages);
 @endphp
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/statuses/create.blade.php
+++ b/resources/views/biogmains/statuses/create.blade.php
@@ -83,10 +83,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/statuses/edit.blade.php
+++ b/resources/views/biogmains/statuses/edit.blade.php
@@ -90,10 +90,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/texts/create.blade.php
+++ b/resources/views/biogmains/texts/create.blade.php
@@ -40,10 +40,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>

--- a/resources/views/biogmains/texts/edit.blade.php
+++ b/resources/views/biogmains/texts/edit.blade.php
@@ -47,10 +47,6 @@
                     <div class="col-sm-4">
                         <input type="text" class="form-control" name="c_pages" value="{{ $row->c_pages }}">
                     </div>
-                    <label for="c_secondary_source_author" class="col-sm-2 control-label">二手文獻的原作者</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" name="c_secondary_source_author" value="{{ $row->c_secondary_source_author }}">
-                    </div>
                 </div>
                 <div class="form-group">
                     <label for="c_notes" class="col-sm-2 control-label">注(c_notes)</label>


### PR DESCRIPTION
1.盤點html/resources/，c_secondary_source_author存在於24隻程式，共計有48處。
2.檢查routes/、app/、Repositories/、Controllers/、Api/位置，沒有c_secondary_source_author相關程式碼。
申請合併至develop，請檢視，謝謝您。