### PR TITLE
20240328刪除 tts_sysno 欄位

### DIFF
--- a/app/BiogMain.php
+++ b/app/BiogMain.php
@@ -84,7 +84,7 @@ class BiogMain extends Model
 
     public function addresses()
     {
-        return $this->belongsToMany('App\AddressCode', 'BIOG_ADDR_DATA', 'c_personid', 'c_addr_id')->withPivot('c_addr_type', 'c_firstyear', 'c_lastyear', 'c_sequence', 'tts_sysno');
+        return $this->belongsToMany('App\AddressCode', 'BIOG_ADDR_DATA', 'c_personid', 'c_addr_id')->withPivot('c_addr_type', 'c_firstyear', 'c_lastyear', 'c_sequence');
     }
 
     public function addresses_type()
@@ -99,12 +99,12 @@ class BiogMain extends Model
 
     public function altnames()
     {
-        return $this->belongsToMany('App\AltnameCode', 'ALTNAME_DATA', 'c_personid', 'c_alt_name_type_code')->withPivot('c_alt_name', 'c_alt_name_chn', 'tts_sysno', 'c_alt_name_type_code', 'c_sequence')->orderBy(DB::raw('ISNULL(c_sequence), c_sequence'), 'ASC');
+        return $this->belongsToMany('App\AltnameCode', 'ALTNAME_DATA', 'c_personid', 'c_alt_name_type_code')->withPivot('c_alt_name', 'c_alt_name_chn', 'c_alt_name_type_code', 'c_sequence')->orderBy(DB::raw('ISNULL(c_sequence), c_sequence'), 'ASC');
     }
 
     public function texts()
     {
-        return $this->belongsToMany('App\TextCode', 'BIOG_TEXT_DATA', 'c_personid', 'c_textid')->withPivot('tts_sysno', 'c_textid', 'c_role_id');
+        return $this->belongsToMany('App\TextCode', 'BIOG_TEXT_DATA', 'c_personid', 'c_textid')->withPivot('c_textid', 'c_role_id');
     }
 
     public function texts_role()
@@ -114,7 +114,7 @@ class BiogMain extends Model
 
     public function offices()
     {
-        return $this->belongsToMany('App\OfficeCode', 'POSTED_TO_OFFICE_DATA', 'c_personid', 'c_office_id')->withPivot('c_sequence', 'c_posting_id', 'c_firstyear', 'c_lastyear', 'tts_sysno')->orderBy('c_sequence');
+        return $this->belongsToMany('App\OfficeCode', 'POSTED_TO_OFFICE_DATA', 'c_personid', 'c_office_id')->withPivot('c_sequence', 'c_posting_id', 'c_firstyear', 'c_lastyear')->orderBy('c_sequence');
     }
 
     public function offices_addr()
@@ -124,22 +124,22 @@ class BiogMain extends Model
 
     public function entries()
     {
-        return $this->belongsToMany('App\EntryCode', 'ENTRY_DATA', 'c_personid', 'c_entry_code')->withPivot('c_sequence', 'tts_sysno', 'c_kin_code', 'c_kin_id', 'c_assoc_code', 'c_assoc_id', 'c_year', 'c_inst_code', 'c_inst_name_code')->orderBy('c_sequence');
+        return $this->belongsToMany('App\EntryCode', 'ENTRY_DATA', 'c_personid', 'c_entry_code')->withPivot('c_sequence', 'c_kin_code', 'c_kin_id', 'c_assoc_code', 'c_assoc_id', 'c_year', 'c_inst_code', 'c_inst_name_code')->orderBy('c_sequence');
     }
 
     public function statuses()
     {
-        return $this->belongsToMany('App\StatusCode', 'STATUS_DATA', 'c_personid', 'c_status_code')->withPivot('c_sequence', 'c_lastyear', 'c_firstyear', 'tts_sysno')->orderBy('c_sequence');
+        return $this->belongsToMany('App\StatusCode', 'STATUS_DATA', 'c_personid', 'c_status_code')->withPivot('c_sequence', 'c_lastyear', 'c_firstyear')->orderBy('c_sequence');
     }
 
     public function events()
     {
-        return $this->belongsToMany('App\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence', 'tts_sysno')->orderBy('c_sequence');
+        return $this->belongsToMany('App\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence')->orderBy('c_sequence');
     }
 
     public function kinship()
     {
-        return $this->belongsToMany('App\KinshipCode', 'KIN_DATA', 'c_personid', 'c_kin_code')->withPivot('tts_sysno', 'c_personid', 'c_kin_id', 'c_kin_code');
+        return $this->belongsToMany('App\KinshipCode', 'KIN_DATA', 'c_personid', 'c_kin_code')->withPivot('c_personid', 'c_kin_id', 'c_kin_code');
     }
 
     public function kinship_name()
@@ -149,7 +149,7 @@ class BiogMain extends Model
 
     public function assoc()
     {
-        return $this->belongsToMany('App\AssocCode', 'ASSOC_DATA', 'c_personid', 'c_assoc_code')->withPivot('tts_sysno', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title');
+        return $this->belongsToMany('App\AssocCode', 'ASSOC_DATA', 'c_personid', 'c_assoc_code')->withPivot('c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title');
     }
 
     public function assoc_name()
@@ -165,10 +165,6 @@ class BiogMain extends Model
     public function inst()
     {
         return $this->belongsToMany('App\BiogInstCode', 'BIOG_INST_DATA', 'c_personid', 'c_bi_role_code')->withPivot('c_bi_begin_year', 'c_bi_end_year', 'c_inst_code', 'c_inst_name_code');
-        //建安修改20211022
-        //return $this->belongsToMany('App\BiogInstCode', 'BIOG_INST_DATA', 'c_personid', 'c_bi_role_code')->withPivot('c_bi_begin_year', 'c_bi_end_year');
-        //建安修改20181113
-        //return $this->belongsToMany('App\BiogInstCode', 'BIOG_INST_DATA', 'c_personid', 'c_bi_role_code')->withPivot('c_bi_begin_year', 'c_bi_end_year', 'tts_sysno');
     }
 
     public function inst_name(){

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -101,7 +101,8 @@ class BasicInformationController extends Controller
             return redirect()->back();
         }
 //        $data['c_personid'] = BiogMain::max('c_personid') + 1;
-        $data['tts_sysno'] = BiogMain::max('tts_sysno') + 1;
+        #20240328移除tts_sysno
+        #$data['tts_sysno'] = BiogMain::max('tts_sysno') + 1;
         $data = $this->toolRepository->timestamp($data, True);
         //20190531判別是否為眾包用戶
         if (Auth::user()->is_admin == 2) {
@@ -196,9 +197,11 @@ class BasicInformationController extends Controller
         //如果沒有使用toArray(), 需搭配save()儲存, 則會儲存物件本身, 就無法另存.
         $data = BiogMain::find($id)->toArray();
         $new_id = BiogMain::max('c_personid') + 1;
-        $new_ttsid = BiogMain::max('tts_sysno') + 1;
+        #20240328移除tts_sysno
+        #$new_ttsid = BiogMain::max('tts_sysno') + 1;
         $data['c_personid'] = $new_id;
-        $data['tts_sysno'] = $new_ttsid;
+        #20240328移除tts_sysno
+        #$data['tts_sysno'] = $new_ttsid;
         $data = $this->toolRepository->timestamp($data, True); //建檔資訊
         $data['c_modified_by'] = $data['c_modified_date'] = '';
         $flight = BiogMain::create($data);

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -86,7 +86,7 @@ class BasicInformationEventsController extends Controller
      */
     public function edit($id, $id_)
     {
-        $res = $this->biogMainRepository->eventById($id_);
+        $res = $this->biogMainRepository->eventById($id.'-'.$id_);
         return view('biogmains.events.edit', ['id' => $id, 'row' => $res['row'], 'res' => $res,
             'page_title' => 'Basicinformation', 'page_description' => '基本信息表 事件',
             'page_url' => '/basicinformation/'.$id.'/events',
@@ -111,9 +111,9 @@ class BasicInformationEventsController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        $this->biogMainRepository->eventUpdateById($request, $id, $id_);
+        $_id = $this->biogMainRepository->eventUpdateById($request, $id, $id_);
         flash('Update success @ '.Carbon::now(), 'success');
-        return redirect()->route('basicinformation.events.edit', ['id'=>$id, 'id_'=>$id_]);
+        return redirect()->route('basicinformation.events.edit', ['id' => $id, '_id' => $_id]);
     }
 
     /**

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -551,6 +551,7 @@ class BiogMainRepository
 
     public function entryUpdateById(Request $request, $id, $c_personid)
     {
+        #20240328移除tts_sysno，檢查此函式未被BasicInformationEntriesController.php使用
         $data = $request->all();
         $data = array_except($data, ['_method', '_token']);
         $data['c_entry_code'] = $data['c_entry_code'] == -999 ? '0' : $data['c_entry_code'];
@@ -566,7 +567,7 @@ class BiogMainRepository
 
     public function entryStoreById(Request $request, $id)
     {
-        //建安修改20181109
+        #20240328移除tts_sysno，檢查此函式未被BasicInformationEntriesController.php使用
         $data = $request->all();
         $data = array_except($data, ['_token']);
         $data['tts_sysno'] = DB::table('ENTRY_DATA')->max('tts_sysno') + 1;
@@ -589,6 +590,7 @@ class BiogMainRepository
 
     public function entryDeleteById($id, $c_personid)
     {
+        #20240328移除tts_sysno，檢查此函式未被BasicInformationEntriesController.php使用
         $row = DB::table('ENTRY_DATA')->where('tts_sysno', $id)->first();
         DB::table('ENTRY_DATA')->where('tts_sysno', $id)->delete();
         (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ENTRY_DATA', $id, $row);
@@ -651,7 +653,8 @@ class BiogMainRepository
     {
         $data = $request->all();
         $data = array_except($data, ['_token']);
-        $data['tts_sysno'] = DB::table('STATUS_DATA')->max('tts_sysno') + 1;
+        #20240328移除tts_sysno
+        #$data['tts_sysno'] = DB::table('STATUS_DATA')->max('tts_sysno') + 1;
         $data['c_personid'] = $id;
         $data['c_status_code'] = $data['c_status_code'] == -999 ? '0' : $data['c_status_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
@@ -773,8 +776,9 @@ class BiogMainRepository
         $data = $request->all();
         $kin_pair = $data['c_kinship_pair'];
         $data = array_except($data, ['_token', 'c_kinship_pair']);
-        $data['tts_sysno'] = DB::table('KIN_DATA')->max('tts_sysno') + 1;
-        $tts = $data['tts_sysno'];
+        #20240328移除tts_sysno
+        #$data['tts_sysno'] = DB::table('KIN_DATA')->max('tts_sysno') + 1;
+        #$tts = $data['tts_sysno'];
         $data['c_personid'] = $id;
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
@@ -783,7 +787,7 @@ class BiogMainRepository
         DB::table('KIN_DATA')->insert($data);
         $ori_Data = $data;
         (new OperationRepository())->store(Auth::id(), $id, 1, 'KIN_DATA', $data['c_personid']."-".$data['c_kin_id']."-".$data['c_kin_code'], $data);
-        $data['tts_sysno'] += 1;
+        #$data['tts_sysno'] += 1;
         $data['c_kin_code'] = $kin_pair;
         $data['c_personid'] = $data['c_kin_id'];
         $data['c_kin_id'] = $id;
@@ -949,6 +953,7 @@ class BiogMainRepository
 
     public function socialInstUpdateById(Request $request, $id_, $c_personid)
     {
+        #20240328移除tts_sysno，檢查此函式未被BasicInformationSocialInstController.php使用
         $data = $request->all();
         $data = array_except($data, ['_method', '_token']);
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
@@ -981,7 +986,9 @@ class BiogMainRepository
 
     public function eventById($id)
     {
-        $row = DB::table('EVENTS_DATA')->where('tts_sysno', $id)->first();
+        #20240328移除tts_sysno
+        $id_arr = explode("-", $id);
+        $row = DB::table('EVENTS_DATA')->where('c_personid', $id_arr[0])->where('c_sequence', $id_arr[1])->first();
         $text_str = null;
         if($row->c_source || $row->c_source === 0) {
             $text_ = TextCode::find($row->c_source);
@@ -1011,8 +1018,10 @@ class BiogMainRepository
         $data = array_except($data, ['_method', '_token', 'c_addr_id']);
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository)->timestamp($data);
-        DB::table('EVENTS_DATA')->where('tts_sysno',$id_)->update($data);
+        #20240328移除tts_sysno
+        DB::table('EVENTS_DATA')->where('c_personid',$id)->where('c_sequence',$id_)->update($data);
         (new OperationRepository())->store(Auth::id(), $id, 3, 'EVENTS_DATA', $id_, $data);
+        return $data['c_sequence'];
     }
 
     public function eventStoreById(Request $request, $id)
@@ -1023,18 +1032,21 @@ class BiogMainRepository
         $data['c_event_record_id'] = DB::table('EVENTS_DATA')->max('c_event_record_id') + 1;
         $this->insertAddrEvent($data['c_addr_id'], $data['c_event_record_id'], $id);
         $data = array_except($data, ['_token', 'c_addr_id']);
-        $data['tts_sysno'] = DB::table('EVENTS_DATA')->max('tts_sysno') + 1;
+        #20240328移除tts_sysno
+        #$data['tts_sysno'] = DB::table('EVENTS_DATA')->max('tts_sysno') + 1;
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository)->timestamp($data, True);
         DB::table('EVENTS_DATA')->insert($data);
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', $data['tts_sysno'], $data);
-        return $data['tts_sysno'];
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', $data['c_sequence'], $data);
+        #20240328移除tts_sysno
+        #return $data['tts_sysno'];
+        return $data['c_sequence'];
     }
 
     public function eventDeleteById($id, $c_personid)
     {
-        $row = DB::table('EVENTS_DATA')->where('tts_sysno', $id)->first();
-        DB::table('EVENTS_DATA')->where('tts_sysno', $id)->delete();
+        $row = DB::table('EVENTS_DATA')->where('c_personid',$c_personid)->where('c_sequence',$id)->first();
+        DB::table('EVENTS_DATA')->where('c_personid',$c_personid)->where('c_sequence',$id)->delete();
         DB::table('EVENTS_ADDR')->where('c_event_record_id', $row->c_event_record_id)->delete();
         (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'EVENTS_DATA', $id, $row);
     }
@@ -1270,7 +1282,7 @@ class BiogMainRepository
         $assoc_kin_pair = $data['c_assoc_kinship_pair'];
         $data['c_personid'] = $id;
         $data = array_except($data, ['_token', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
-        $data['tts_sysno'] = DB::table('ASSOC_DATA')->max('tts_sysno') + 1;
+        #$data['tts_sysno'] = DB::table('ASSOC_DATA')->max('tts_sysno') + 1;
         $data['c_assoc_intercalary'] = (int)($data['c_assoc_intercalary']);
         //20210204增加儲存c_inst_name_code
         //$data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
@@ -1279,7 +1291,7 @@ class BiogMainRepository
         DB::table('ASSOC_DATA')->insert($data);
         $ori_Data = $data;
         (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$data['c_text_title'], $data);
-        $data['tts_sysno'] += 1;
+        #$data['tts_sysno'] += 1;
         $data['c_assoc_code'] = $assoc_pair;
         $data['c_personid'] = $data['c_assoc_id'];
         $data['c_assoc_id'] = $id;

--- a/resources/views/biogmains/events/edit.blade.php
+++ b/resources/views/biogmains/events/edit.blade.php
@@ -5,7 +5,7 @@
         <div class="panel-heading">事件 Event</div>
         <div class="panel-body">
             <div class="panel-body">
-            <form action="{{ route('basicinformation.events.update', [$id, $row->tts_sysno]) }}" class="form-horizontal" method="post">
+            <form action="{{ route('basicinformation.events.update', [$id, $row->c_sequence]) }}" class="form-horizontal" method="post">
                 {{ method_field('PATCH') }}
                 {{ csrf_field() }}
                 <input type="text" class="hidden" name="c_event_record_id" value="{{ $row->c_event_record_id }}">

--- a/resources/views/biogmains/events/index.blade.php
+++ b/resources/views/biogmains/events/index.blade.php
@@ -25,13 +25,13 @@
                         <td>{{ $value->c_event_name_chn }}</td>
                         <td>
                             <div class="btn-group">
-                                <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.events.edit', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->tts_sysno]) }}">edit</a>
+                                <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.events.edit', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_sequence]) }}">edit</a>
                                 <a href=""
                                    onclick="
                                            let msg = '您真的确定要删除吗？\n\n请确认！';
                                            if (confirm(msg)===true){
                                                event.preventDefault();
-                                               document.getElementById('delete-form-{{ $value->pivot->tts_sysno }}').submit();
+                                               document.getElementById('delete-form-{{ $value->pivot->c_sequence }}').submit();
                                            }else{
                                                return false;
                                            }
@@ -39,7 +39,7 @@
                                    class="btn btn-sm btn-danger">delete</a>
 
                             </div>
-                            <form id="delete-form-{{ $value->pivot->tts_sysno }}" action="{{ route('basicinformation.events.destroy', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->tts_sysno]) }}" method="POST" style="display: none;">
+                            <form id="delete-form-{{ $value->pivot->c_sequence }}" action="{{ route('basicinformation.events.destroy', ['id' => $basicinformation->c_personid, 'id_' => $value->pivot->c_sequence]) }}" method="POST" style="display: none;">
                                 {{ method_field('DELETE') }}
                                 {{ csrf_field() }}
                             </form>


### PR DESCRIPTION
資料庫刪除 tts_sysno 欄位，程式在之前已經陸續捨棄 tts_sysno 欄位值的使用，雖未使用，但延續著之前的程式脈絡，依舊有儲存 tts_sysno 欄位值，本次資料庫刪除 tts_sysno 欄位，將相關程式儲存 tts_sysno 欄位值的行為移除，恢復相關頁面增刪改查（CRUD）的功能正常。