### PR TITLE
20240701 Modify the [create] Function in Basic Information Page

### DIFF
--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -406,7 +406,10 @@
 
             </div>
             <div class="btn-group pull-right">
-                <a href="../../basicinformation/{{$basicinformation->c_personid}}/saveas" class="btn btn-success" style="margin-right:40px;">Create</a>
+                <a href="../../basicinformation/{{$basicinformation->c_personid}}/Duplicate_Collateral_Info" class="btn btn-success" style="margin-right:40px;">Duplicate Collateral Info</a>
+            </div>
+            <div class="btn-group pull-right">
+                <a href="../../basicinformation/{{$basicinformation->c_personid}}/saveas" class="btn btn-success" style="margin-right:40px;">Duplicate Basic Info</a>
             </div>
             <form id="delete-form" action="{{ route('basicinformation.destroy', ['id' => $basicinformation->c_personid]) }}" method="POST" style="display: none;">
                 {{ method_field('DELETE') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::resource('basicinformation', 'BasicInformationController', ['name' => [
     'index' => 'basicinformation.index',
 ]]);
 Route::get('basicinformation/{id}/saveas', 'BasicInformationController@saveas');
+Route::get('basicinformation/{id}/Duplicate_Collateral_Info', 'BasicInformationController@Duplicate_Collateral_Info');
 Route::get('basicinformation/{id}/offices/{cpk}/saveas', 'BasicInformationOfficesController@saveas');
 
 Route::resource('basicinformation.addresses', 'BasicInformationAddressesController');


### PR DESCRIPTION
1.依據需求github issues 265，製作「Duplicate Collateral Info 」功能。
2.按鍵功能需要創建人物的六種對應資訊
＊地址 BIOG_ADDR_DATA
＊出處 BIOG_SOURCE_DATA
＊親屬 KIN_DATA
　備註：特別需要小心，在這裡除了以 c_personid 複製親屬關係以外，還要透過 c_kin_id 複製成對的親屬關係。（例如 A 是 B 的父親，B 是 A 的孩子。親屬關係需要成對複製）
＊社會關係 ASSOC_DATA
　備註：特別需要小心：
　1) 這裡除了以 c_personid 複製社會關係以外，還要透過 c_assoc_id 複製成對的社會關係。（例如 A 是 B 的老師，B 是 A 的學生。社會關係需要成對複製）。
　2) ASSOC_DATA 設計人物關係的欄位還有 c_kin_id, c_kin_code, c_assoc_kin_id, c_assoc_kin_code, c_tertiary_personid, c_tertiary_type_notes. 這些欄位資訊的內容比較複雜。在複製的時候，把這些欄位的值設置為 0 或者 null(c_tertiary_type_notes 是 text 欄位，所以將c_tertiary_type_notes欄位預設值設置為 null。
＊社交機構 BIOG_INST_DATA
＊社會區分 STATUS_DATA
3.逐筆檢測「Duplicate Collateral Info 」功能創建的每一筆資料，在〔最近編輯列表〕的連結功能均有效，連結表單均可以正常編輯。
