### PR TITLE
20240710修正The reverse kinship code issue

### DIFF
--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -115,6 +115,13 @@ class BasicInformationKinshipController extends Controller
         }
         $data = $this->biogMainRepository->kinshipUpdateById($request, $id, $id_);
         $id_ = $id."-".$data['c_kin_id']."-".$data['c_kin_code'];
+        if($data['err'] == 0) {
+             flash('對應的親屬資料更新失敗，請從對應的親屬人物修改。', 'error');
+        }
+        elseif($data['err'] > 1) {
+             flash('對應的親屬資料有多筆重複，請從對應的親屬人物修改。', 'error');
+        }
+        else {}
         flash('Update success @ '.Carbon::now(), 'success');
         return redirect()->route('basicinformation.kinship.edit', ['id'=>$id, 'id_'=>$id_]);
     }


### PR DESCRIPTION
1.git創建branch issues267-patch1，處理需求〔The reverse kinship code issue #267〕。
2.檢測CBDB資料庫的KIN_DATA資料表，KIN_DATA資料表的primary key已經有做資料組合與檢查。
3.程式修正〔對應親屬人物〕的查詢方式，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢。
4.資料更新之前，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢，提前做一次〔對應親屬人物〕的查詢，檢查資料庫是否有0筆資料或多筆資料，並回應給使用者提示訊息。
5.主要修正kinshipUpdateById()與kinshipDeleteById()，已經依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2做正確的查詢。
6.測試〔親屬〕介面的新增、修改、刪除、查詢，功能正常與資料正確。