### PR TITLE
20250321 Appointment 表重構

### DIFF
--- a/app/AppointmentTypeCode.php
+++ b/app/AppointmentTypeCode.php
@@ -11,8 +11,11 @@ class AppointmentTypeCode extends Model
      *
      * @var string
      */
-    protected $table = 'APPOINTMENT_TYPE_CODES';
-    protected $primaryKey = 'c_appt_type_code';
+    #20250321依據Appointment表重構，修改為存取APPOINTMENT_CODES表
+    #protected $table = 'APPOINTMENT_TYPE_CODES';
+    #protected $primaryKey = 'c_appt_type_code';
+    protected $table = 'APPOINTMENT_CODES';
+    protected $primaryKey = 'c_appt_code';
 
     /**
      * 该模型是否被自动维护时间戳

--- a/app/Http/Controllers/Api/ApiController2.php
+++ b/app/Http/Controllers/Api/ApiController2.php
@@ -178,9 +178,13 @@ WHERE (((ADDR_CODES.x_coord)>=(ADDR_CODES_1.x_coord-0.03) And (ADDR_CODES.x_coor
             $data_val['office_xy_count'] = $POSTED_TO_ADDR_DATA; // 數字 職官地址數
             $data_val['PostingID'] = $val->c_appt_type_code; // 數字 除授記錄
             if($val->c_appt_type_code != null) {
-                $c_appt_type_code = DB::table('APPOINTMENT_TYPE_CODES')->where('c_appt_type_code', '=', $val->c_appt_type_code)->first();
-                $c_appt_type_desc = $c_appt_type_code->c_appt_type_desc;
-                $c_appt_type_desc_chn = $c_appt_type_code->c_appt_type_desc_chn;
+                #20250321依據Appointment表重構，修改為存取APPOINTMENT_CODES表
+                #$c_appt_type_code = DB::table('APPOINTMENT_TYPE_CODES')->where('c_appt_type_code', '=', $val->c_appt_type_code)->first();
+                #$c_appt_type_desc = $c_appt_type_code->c_appt_type_desc;
+                #$c_appt_type_desc_chn = $c_appt_type_code->c_appt_type_desc_chn;
+                $c_appt_type_code = DB::table('APPOINTMENT_CODES')->where('c_appt_code', '=', $val->c_appt_type_code)->first();
+                $c_appt_type_desc = $c_appt_type_code->c_appt_desc;
+                $c_appt_type_desc_chn = $c_appt_type_code->c_appt_desc_chn;
             }
             else { $c_appt_type_desc = $c_appt_type_desc_chn = ''; }
             $data_val['ApptType'] = $c_appt_type_desc; // 字符串 除授類型，英文

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -140,7 +140,9 @@ class ApiController extends Controller
 
     public function appttype()
     {
-        return DB::table('APPOINTMENT_TYPE_CODES')->get();
+        #20250321依據Appointment表重構，修改為存取APPOINTMENT_CODES表
+        #return DB::table('APPOINTMENT_TYPE_CODES')->get();
+        return DB::table('APPOINTMENT_CODES')->select(['c_appt_code', 'c_appt_desc_chn', 'c_appt_desc', 'c_appt_desc_chn_alt', 'c_appt_desc_alt'])->get(); 
     }
 
     public function assumeoffice()


### PR DESCRIPTION
確認需求，盤點使用APPOINTMENT_TYPE_CODES相關的程式，主要的源頭有三組，其他都是被動的使用AppointmentTypeCode物件程式，不需要修改。

	app/AppointmentTypeCode.php：protected $table = 'APPOINTMENT_TYPE_CODES';
說明：將系統比喻為車子，這個程式可以比喻為輪子，存取資料表直接輸出的AppointmentTypeCode物件程式。

	app/Http/Controllers/Api/ApiController2.php：$c_appt_type_code = DB::table('APPOINTMENT_TYPE_CODES')->where('c_appt_type_code', '=', $val->c_appt_type_code)->first();
說明：這是查詢除授記錄（Office Postings）的query_office_postings API，裡面有一段是輸出除授資料。（不影響其他程式）
 
修改後的測試URL，確認[除授類型]資料輸出正常：
[https://input.cbdb.fas.harvard.edu/api/query_office_postings?RequestPayload={"office":[129,134,299],"useOfficePlace":0,"officePlace":[],"usePeoplePlace":1,"peoplePlace":[2928,10522,12553,13947,13949],"indexYear":1,"indexStartTime":960,"indexEndTime":1250,"entry":[36],"usePeoplePlace":0,"peoplePlace":[],"locationType":"peAddr","useDate":1,"dateType":"entry","dateStartTime":1368,"dateEndTime":1644,"useXy":1,"dynStart":0,"dynEnd":1800,"start":77,"list":1}](https://input.cbdb.fas.harvard.edu/api/query_office_postings?RequestPayload=%7b%22office%22:%5b129,134,299%5d,%22useOfficePlace%22:0,%22officePlace%22:%5b%5d,%22usePeoplePlace%22:1,%22peoplePlace%22:%5b2928,10522,12553,13947,13949%5d,%22indexYear%22:1,%22indexStartTime%22:960,%22indexEndTime%22:1250,%22entry%22:%5b36%5d,%22usePeoplePlace%22:0,%22peoplePlace%22:%5b%5d,%22locationType%22:%22peAddr%22,%22useDate%22:1,%22dateType%22:%22entry%22,%22dateStartTime%22:1368,%22dateEndTime%22:1644,%22useXy%22:1,%22dynStart%22:0,%22dynEnd%22:1800,%22start%22:77,%22list%22:1%7d)
 
	app/Http/Controllers/ApiController.php：return DB::table('APPOINTMENT_TYPE_CODES')->get();
這是表單使用的下拉式選單，是「直接讀取APPOINTMENT_TYPE_CODES資料表後，直接輸出，數字0.1.2.3.4代表APPOINTMENT_TYPE_CODES資料表的c_appt_type_code欄位值。」（僅影響使用這個下拉式選單的表單，以及儲存值。）

以上報告，程式已經推送到github的issues293-patch1，申請合併至develop，請您檢視，謝謝。