### PR TITLE
改善操作記錄比對與 modal 顯示為表格

### DIFF
--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -79,7 +79,10 @@ class CrowdsourcingController extends Controller
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
                 //將比對後的結果存回至resource_original欄位
-                $lists[$x]['resource_original'] = $ans;
+                $lists[$x]->setAttribute('resource_diff', $ans);
+            }
+            else {
+                $lists[$x]->setAttribute('resource_diff', null);
             }
         }
         return view('crowdsourcing.index', ['lists' => $lists,

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -75,8 +75,9 @@ class ModifiedController extends Controller
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至resource_original欄位
-                $lists[$x]['resource_original'] = $ans;
+                $lists[$x]->setAttribute('resource_diff', $ans);
+            } else {
+                $lists[$x]->setAttribute('resource_diff', null);
             }
         }
         return view('modified.index', ['lists' => $lists,

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -111,8 +111,9 @@ class OperationsController extends Controller
                 $arr1 = json_decode($arr1, true);
                 $arr2 = json_decode($arr2, true);
                 $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至resource_original欄位
-                $lists[$x]['resource_original'] = $ans;
+                $lists[$x]->setAttribute('resource_diff', $ans);
+            } else {
+                $lists[$x]->setAttribute('resource_diff', null);
             }
         }
         //echo "<pre><code>";

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -51,50 +51,76 @@ class OperationRepository
 
     public function getArrDiff($arr1, $arr2, $arr3)
     {
-        //進行陣列雜訊的濾除
-        //if(!is_array($arr1) || !is_array($arr2) || !is_array($arr3)) { return ""; }
-	//20251001Compare 功能有時無法顯示修改內容修改
-	if(!is_array($arr1)) return "";  // arr1 必須有修改後資料才 diff
-	$arr2 = is_array($arr2) ? $arr2 : [];
-	$arr3 = is_array($arr3) ? $arr3 : [];
+        //20251001Compare 功能有時無法顯示修改內容修改
+        if (!is_array($arr1)) {
+            return null;  // 沒有修改後資料就不產生比對結果
+        }
 
-        $NewArr1ture = array();
-        $NewArr2ture = array();
-        $NewArr3ture = array();
-        $NewArr1 = array_diff_assoc($arr1, $arr2);
-        $NewArr2 = array_diff_assoc($arr2, $arr1);
-        $NewArr3 = array_diff_assoc($arr1, $arr3);
-        $data = "<br/><p>[修改後]</p>";
-        foreach($NewArr1 as $key => $value){
-            if($key == "_method" || $key == "_token") {
+        $arr2 = is_array($arr2) ? $arr2 : [];
+        $arr3 = is_array($arr3) ? $arr3 : [];
+
+        $formatValue = function ($value) {
+            if (is_array($value) || is_object($value)) {
+                return json_encode($value, JSON_UNESCAPED_UNICODE);
+            }
+            if ($value === null) {
+                return '(null)';
+            }
+            if (is_bool($value)) {
+                return $value ? 'true' : 'false';
+            }
+            return (string)$value;
+        };
+
+        $normalize = function ($value) {
+            if (is_array($value) || is_object($value)) {
+                return json_encode($value);
+            }
+            if ($value === null) {
+                return '';
+            }
+            if (is_bool($value)) {
+                return $value ? '1' : '0';
+            }
+            return trim((string)$value);
+        };
+
+        $valuesEqual = function ($left, $right) use ($normalize) {
+            return $normalize($left) === $normalize($right);
+        };
+
+        $ignoredKeys = ['_method', '_token'];
+        $keys = array_keys($arr1);
+        $rows = [];
+
+        foreach ($keys as $key) {
+            if (in_array($key, $ignoredKeys, true)) {
                 continue;
             }
-            else {
-                $NewArr1ture[$key] = $value;
-                $data .= "欄位：".$key."  內容：".$value."<br/>";
-            }
-        }
-        $data .= "<br/><p>[原本的]</p>";
-        foreach($NewArr1ture as $key => $value){
-            $NewArr2ture[$key] = $value;
-            $data .= "欄位：".$key."  內容：".$NewArr2[$key]."<br/>";
-        }
-        $data .= "<br/><p>[實時比對]</p>";
-        $check = 0;
-        foreach($NewArr3 as $key => $value){
-            if($key == "_method" || $key == "_token") {
+
+            $afterRaw = array_key_exists($key, $arr1) ? $arr1[$key] : null;
+            $beforeRaw = array_key_exists($key, $arr2) ? $arr2[$key] : null;
+
+            if ($valuesEqual($afterRaw, $beforeRaw)) {
                 continue;
             }
-            else {
-                if(!empty($arr3[$key])) {
-                    $NewArr3ture[$key] = $value;
-                    $data .= "欄位：".$key."  內容：".$arr3[$key]."<br/>";
-                    $check++;
-                }
-            }
+
+            $currentExists = array_key_exists($key, $arr3);
+            $currentRaw = $currentExists ? $arr3[$key] : null;
+
+            $rows[] = [
+                'field' => $key,
+                'before' => $formatValue($beforeRaw),
+                'after' => $formatValue($afterRaw),
+                'current' => $currentExists ? $formatValue($currentRaw) : '(未取得)',
+                'matches_current' => $currentExists && $normalize($afterRaw) === $normalize($currentRaw),
+                'matches_before' => $currentExists && $normalize($beforeRaw) === $normalize($currentRaw),
+            ];
         }
-        if(empty($check)) { $data .= "資料與[修改後]完全一致"; }
-        //雜訊濾除結束
-        return $data;
+
+        if (empty($rows)) {
+            return null;
+        }
+        return ['rows' => $rows];
     }
 }

--- a/resources/views/components/diff-table.blade.php
+++ b/resources/views/components/diff-table.blade.php
@@ -1,0 +1,45 @@
+@php
+    $diff = $diff ?? null;
+@endphp
+
+@if (is_array($diff))
+    @php
+        $rows = $diff['rows'] ?? [];
+        $note = $diff['note'] ?? null;
+    @endphp
+    @if (!empty($rows))
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th>欄位</th>
+                        <th>原本的</th>
+                        <th>修改後</th>
+                        <th>目前資料</th>
+                    </tr>
+                </thead>
+                <tbody>
+                   @foreach ($rows as $row)
+                       @php
+                            $afterMatchesCurrent = !empty($row['matches_current']);
+                            $beforeMatchesCurrent = !empty($row['matches_before']);
+                            $currentClass = $afterMatchesCurrent ? 'success' : ($beforeMatchesCurrent ? 'info' : '');
+                       @endphp
+                       <tr>
+                           <td>{{ $row['field'] }}</td>
+                            <td class="{{ $beforeMatchesCurrent ? 'info' : '' }}">{{ $row['before'] }}</td>
+                            <td class="{{ $afterMatchesCurrent ? 'success' : '' }}">{{ $row['after'] }}</td>
+                            <td class="{{ $currentClass }}">{{ $row['current'] ?? '(未取得)' }}</td>
+                       </tr>
+                   @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <p class="text-muted small">沒有比對紀錄</p>
+    @endif
+@elseif (is_string($diff) && trim($diff) !== '')
+    {!! $diff !!}
+@else
+    <p class="text-muted small">沒有比對紀錄</p>
+@endif

--- a/resources/views/components/key-value-table.blade.php
+++ b/resources/views/components/key-value-table.blade.php
@@ -1,0 +1,58 @@
+@php
+    $dataset = $data ?? null;
+
+    $formatValue = function ($value) {
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE);
+        }
+        if ($value === null) {
+            return '(null)';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        return (string) $value;
+    };
+@endphp
+
+@if (is_array($dataset))
+    @php
+        $rows = [];
+        foreach ($dataset as $key => $value) {
+            if (in_array($key, ['_method', '_token'], true)) {
+                continue;
+            }
+            $rows[] = [
+                'field' => $key,
+                'value' => $formatValue($value),
+            ];
+        }
+    @endphp
+
+    @if (empty($rows))
+        <p class="text-muted small">沒有資料</p>
+    @else
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th>欄位</th>
+                        <th>內容</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($rows as $row)
+                        <tr>
+                            <td>{{ $row['field'] }}</td>
+                            <td>{{ $row['value'] }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+@elseif (is_string($dataset) && trim($dataset) !== '')
+    <pre>{{ $dataset }}</pre>
+@else
+    <p class="text-muted small">沒有資料</p>
+@endif

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -28,12 +28,57 @@
                         <tr>
 
                             <td>{{ $item->resource }}</td>
+                            @php
+                                $diffSource = $item->resource_diff ?? $item->resource_original;
+                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
+                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $resourceDataParsed = json_decode($item->resource_data, true);
+                                if (!is_array($resourceDataParsed)) {
+                                    $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;
+                                }
+                            @endphp
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ empty($item->resource_original) ? 'disabled' : '' }}>
+                                    {{ $hasDiffContent ? '' : 'disabled' }}>
                                     compare
                                 </button>                                
+
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">resource_data</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        @include('components.key-value-table', ['data' => $resourceDataParsed])
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">compare</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        <div>
+                                        @include('components.diff-table', ['diff' => $diffSource])
+                                        </div>
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
@@ -48,50 +93,6 @@
                                 @endif
                             </td>
                         </tr>
-                        <!--Start-->
-                        <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">resource_data</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
-                              </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
-                        <!--Start-->
-                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">compare</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <div>
-                                @if (!empty($item->resource_original))
-                                    欄位比對的結果：<br/>
-                                    {!! $item->resource_original !!}
-                                @else
-                                    沒有比對紀錄
-                                @endif
-                                </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
                     @endforeach
                 </tbody>
             </table>

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -93,12 +93,57 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
 /edit">{{ $item->biogmain->c_name_chn.' '.$item->biogmain->c_name }}</a>
                             </td>
                             <td>{{ $item->resource }}</td>
+                            @php
+                                $diffSource = $item->resource_diff ?? $item->resource_original;
+                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
+                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $resourceDataParsed = json_decode($item->resource_data, true);
+                                if (!is_array($resourceDataParsed)) {
+                                    $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;
+                                }
+                            @endphp
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ empty($item->resource_original) ? 'disabled' : '' }}>
+                                    {{ $hasDiffContent ? '' : 'disabled' }}>
                                     compare
                                 </button>
+
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">resource_data</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        @include('components.key-value-table', ['data' => $resourceDataParsed])
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">compare</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        <div>
+                                        @include('components.diff-table', ['diff' => $diffSource])
+                                        </div>
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
@@ -107,51 +152,6 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                             <td>{{ $item->updated_at }}</td>
                             <td>{{ $item->crowdsourcing_status }}</td>
                         </tr>
-                        <!--Start-->
-                        <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">resource_data</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
-                              </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
-                        <!--Start-->
-                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">compare</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <div>
-                                @if (!empty($item->resource_original))
-                                    欄位比對的結果：<br/>
-                                    {!! $item->resource_original !!}
-                                @else
-                                    沒有比對紀錄
-                                @endif
-                                </div>
-                              </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
                     @endforeach
                 </tbody>
             </table>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -88,63 +88,63 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
 /edit">{{ $item->biogmain->c_name_chn.' '.$item->biogmain->c_name }}</a>
                             </td>
                             <td>{{ $item->resource }}</td>
+                            @php
+                                $diffSource = $item->resource_diff ?? $item->resource_original;
+                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
+                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $resourceDataParsed = json_decode($item->resource_data, true);
+                                if (!is_array($resourceDataParsed)) {
+                                    $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;
+                                }
+                            @endphp
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ empty($item->resource_original) ? 'disabled' : '' }}>
+                                    {{ $hasDiffContent ? '' : 'disabled' }}>
                                     compare
                                 </button>
+
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">resource_data</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        @include('components.key-value-table', ['data' => $resourceDataParsed])
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                  <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
+                                    <div class="modal-content">
+                                      <div class="modal-header">
+                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        <h4 class="modal-title">compare</h4>
+                                      </div>
+                                      <div class="modal-body" style="word-break: break-all;">
+                                        <div>
+                                        @include('components.diff-table', ['diff' => $diffSource])
+                                        </div>
+                                      </div>
+                                      <div class="modal-footer">
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
                             </td>
                             <td>{{ $item->resource_id }}</td>
                             <td>{{ $item->op_type }}</td>
                             <td>{{ $item->user->name }}</td>
                             <td>{{ $item->updated_at }}</td>
                         </tr>
-                        <!--Start-->
-                        <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-              e                 <h4 class="modal-title">resource_data</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <textarea rows="16" cols="90">{{ $item->resource_data }}</textarea>
-                              </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
-                        <!--Start-->
-                        <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
-                          <div class="modal-dialog">
-                            <!-- Modal content-->
-                            <div class="modal-content">
-                              <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                <h4 class="modal-title">compare</h4>
-                              </div>
-                              <div class="modal-body" style="word-break: break-all;">
-                                <div>
-                                @if (!empty($item->resource_original))
-                                    欄位比對的結果：<br/>
-                                    {!! $item->resource_original !!}
-                                @else
-                                    沒有比對紀錄
-                                @endif
-                                </div>
-                              </div>
-                              <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!--End-->
                     @endforeach
                 </tbody>
 


### PR DESCRIPTION
Resource Data now shows as:
<img width="640" height="917" alt="image" src="https://github.com/user-attachments/assets/8d214c4b-fc83-4a38-ba3c-c9e47abfc654" />

(Removed "_method" and "_token" from being displayed)

Compare now shows as:
<img width="1393" height="276" alt="image" src="https://github.com/user-attachments/assets/d20eb51a-e2c3-45fe-ae8a-8ded78a27f6a" />

<img width="1389" height="378" alt="image" src="https://github.com/user-attachments/assets/368aebbc-1cbe-47d9-b680-c0bde334c967" />
