### PR TITLE
20251020 修正breadcrumb中第二級標題Codes的名稱

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -53,7 +53,7 @@ class CodesController extends Controller
                 'page_title' => 'Codes',
                 'page_description' => $table_name,
                 'page_url' => '/codes',
-                'archer' => "<li class='active'>".$table_name."</li>",
+                'archer' => "<li class='active'>".htmlspecialchars($table_name, ENT_QUOTES, 'UTF-8')."</li>",
                 'q' => $table_name,
                 'thead' => $thead,
                 'data' => $data]);

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -50,10 +50,10 @@ class CodesController extends Controller
             }
 //                dd($data);
             return view('codes.show', [
-                'page_title' => $table_name,
+                'page_title' => 'Codes',
                 'page_description' => $table_name,
                 'page_url' => '/codes',
-                'archer' => "<li><a href=''>".$table_name."</a></li>",
+                'archer' => "<li class='active'>".$table_name."</li>",
                 'q' => $table_name,
                 'thead' => $thead,
                 'data' => $data]);


### PR DESCRIPTION
原始的

<img width="406" height="212" alt="image" src="https://github.com/user-attachments/assets/57bb4b1a-6646-4575-bbdc-7d910f7840b4" />

修改後

<img width="366" height="121" alt="image" src="https://github.com/user-attachments/assets/c059d601-a567-435c-b7a6-e52995e44c08" />
