### PR TITLE
修正 /codes/ADDR_CODES 等頁面因記憶體使用超過 128MB 而導致的 500 錯誤 

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -34,21 +34,40 @@ class CodesController extends Controller
 
     public function show($table_name)
     {
-        try{
-//            $data = DB::table($table_name)->paginate(1000);
-            $data = DB::table($table_name)->get();
-            $thead = array();
-            $count = 0;
-            foreach($data[0] as $key => $value){
-                if ($count >2){
-//                    break;
+        try {
+            $perPage = config('codes.per_page', 20);
+            $query = DB::table($table_name);
+            $data = $query->paginate($perPage);
+
+            $firstRow = $data->first();
+            $thead = [];
+            if ($firstRow) {
+                $count = 0;
+                foreach ($firstRow as $key => $value) {
+                    if ($count > 2) {
+                        break;
+                    }
+
+                    if (
+                        str_contains($key, 'name') ||
+                        str_contains($key, 'desc') ||
+                        str_contains($key, 'code') ||
+                        str_contains($key, 'id') ||
+                        str_contains($key, 'sequence') ||
+                        str_contains($key, 'chn') ||
+                        str_contains($key, 'dy')
+                    ) {
+                        $thead[] = $key;
+                        $count++;
+                    }
                 }
-                if(str_contains($key, 'name') or str_contains($key, 'desc') or str_contains($key, 'code') or str_contains($key, 'id') or str_contains($key, 'sequence') or str_contains($key, 'chn') or str_contains($key, 'dy')){
-                    array_push($thead, $key);
-                    $count++;
+
+                if (empty($thead)) {
+                    $thead = array_keys((array) $firstRow);
                 }
+            } else {
+                $thead = Schema::getColumnListing($table_name);
             }
-//                dd($data);
             return view('codes.show', [
                 'page_title' => 'Codes',
                 'page_description' => $table_name,
@@ -56,7 +75,8 @@ class CodesController extends Controller
                 'archer' => "<li class='active'>".$table_name."</li>",
                 'q' => $table_name,
                 'thead' => $thead,
-                'data' => $data]);
+                'data' => $data,
+            ]);
         }catch (\PDOException $e){
             flash('找不到该数据表', 'warning');
             return redirect()->back();

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -50,10 +50,10 @@ class CodesController extends Controller
             }
 //                dd($data);
             return view('codes.show', [
-                'page_title' => $table_name,
+                'page_title' => 'Codes',
                 'page_description' => $table_name,
                 'page_url' => '/codes',
-                'archer' => "<li><a href=''>".$table_name."</a></li>",
+                'archer' => "<li class='active'>".$table_name."</li>",
                 'q' => $table_name,
                 'thead' => $thead,
                 'data' => $data]);

--- a/resources/views/codes/show.blade.php
+++ b/resources/views/codes/show.blade.php
@@ -12,7 +12,7 @@
         </div>
         <!-- /.box-header -->
         <div class="box-body">
-            <table id="example1" class="table table-bordered table-striped">
+            <table class="table table-bordered table-striped table-condensed">
                 <thead>
                 <tr>
                     @foreach ($thead as $item)
@@ -22,12 +22,12 @@
                 </tr>
                 </thead>
                 <tbody>
-                @foreach ($data as $item)
+                @forelse ($data as $item)
                     <tr>
                         @php($count = 0)
                         @php($sum = 0)
                         @php($id_ = '')
-                        @foreach($item as $key=>$value)
+                        @foreach((array)$item as $key => $value)
                             @if($count > count($thead)-1)
                                 @break
                             @endif
@@ -58,7 +58,11 @@
                             </form>
                         </td>
                     </tr>
-                @endforeach
+                @empty
+                    <tr>
+                        <td colspan="{{ count($thead) + 1 }}" class="text-center text-muted">沒有資料</td>
+                    </tr>
+                @endforelse
                 </tbody>
                 <tfoot>
                 <tr>
@@ -69,209 +73,9 @@
                 </tr>
                 </tfoot>
             </table>
-            {{--<div class="pull-right">{{ $data->links() }}</div>--}}
+            <div class="pull-right">{{ $data->links() }}</div>
         </div>
         <!-- /.box-body -->
     </div>
     <!-- /.box -->
-@endsection
-@section('js')
-    <script>
-        (function(window, document, undefined){
-
-            let factory = function( $, DataTable ) {
-                "use strict";
-
-
-                /* Set the defaults for DataTables initialisation */
-                $.extend( true, DataTable.defaults, {
-                    dom:
-                    "<'row'<'col-sm-6'l><'col-sm-6'f>>" +
-                    "<'row'<'col-sm-12'tr>>" +
-                    "<'row'<'col-sm-5'i><'col-sm-7'p>>",
-                    renderer: 'bootstrap'
-                } );
-
-
-                /* Default class modification */
-                $.extend( DataTable.ext.classes, {
-                    sWrapper:      "dataTables_wrapper form-inline dt-bootstrap",
-                    sFilterInput:  "form-control input-sm",
-                    sLengthSelect: "form-control input-sm"
-                } );
-
-
-                /* Bootstrap paging button renderer */
-                DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, buttons, page, pages ) {
-                    let api     = new DataTable.Api( settings );
-                    let classes = settings.oClasses;
-                    let lang    = settings.oLanguage.oPaginate;
-                    let btnDisplay, btnClass, counter=0;
-
-                    let attach = function( container, buttons ) {
-                        let i, ien, node, button;
-                        let clickHandler = function ( e ) {
-                            e.preventDefault();
-                            if ( !$(e.currentTarget).hasClass('disabled') ) {
-                                api.page( e.data.action ).draw( false );
-                            }
-                        };
-
-                        for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
-                            button = buttons[i];
-
-                            if ( $.isArray( button ) ) {
-                                attach( container, button );
-                            }
-                            else {
-                                btnDisplay = '';
-                                btnClass = '';
-
-                                switch ( button ) {
-                                    case 'ellipsis':
-                                        btnDisplay = '&hellip;';
-                                        btnClass = 'disabled';
-                                        break;
-
-                                    case 'first':
-                                        btnDisplay = lang.sFirst;
-                                        btnClass = button + (page > 0 ?
-                                            '' : ' disabled');
-                                        break;
-
-                                    case 'previous':
-                                        btnDisplay = lang.sPrevious;
-                                        btnClass = button + (page > 0 ?
-                                            '' : ' disabled');
-                                        break;
-
-                                    case 'next':
-                                        btnDisplay = lang.sNext;
-                                        btnClass = button + (page < pages-1 ?
-                                            '' : ' disabled');
-                                        break;
-
-                                    case 'last':
-                                        btnDisplay = lang.sLast;
-                                        btnClass = button + (page < pages-1 ?
-                                            '' : ' disabled');
-                                        break;
-
-                                    default:
-                                        btnDisplay = button + 1;
-                                        btnClass = page === button ?
-                                            'active' : '';
-                                        break;
-                                }
-
-                                if ( btnDisplay ) {
-                                    node = $('<li>', {
-                                        'class': classes.sPageButton+' '+btnClass,
-                                        'id': idx === 0 && typeof button === 'string' ?
-                                            settings.sTableId +'_'+ button :
-                                            null
-                                    } )
-                                        .append( $('<a>', {
-                                                'href': '#',
-                                                'aria-controls': settings.sTableId,
-                                                'data-dt-idx': counter,
-                                                'tabindex': settings.iTabIndex
-                                            } )
-                                                .html( btnDisplay )
-                                        )
-                                        .appendTo( container );
-
-                                    settings.oApi._fnBindAction(
-                                        node, {action: button}, clickHandler
-                                    );
-
-                                    counter++;
-                                }
-                            }
-                        }
-                    };
-
-                    // IE9 throws an 'unknown error' if document.activeElement is used
-                    // inside an iframe or frame.
-                    let activeEl;
-
-                    try {
-                        // Because this approach is destroying and recreating the paging
-                        // elements, focus is lost on the select button which is bad for
-                        // accessibility. So we want to restore focus once the draw has
-                        // completed
-                        activeEl = $(document.activeElement).data('dt-idx');
-                    }
-                    catch (e) {}
-
-                    attach(
-                        $(host).empty().html('<ul class="pagination"/>').children('ul'),
-                        buttons
-                    );
-
-                    if ( activeEl ) {
-                        $(host).find( '[data-dt-idx='+activeEl+']' ).focus();
-                    }
-                };
-
-
-                /*
-                 * TableTools Bootstrap compatibility
-                 * Required TableTools 2.1+
-                 */
-                if ( DataTable.TableTools ) {
-                    // Set the classes that TableTools uses to something suitable for Bootstrap
-                    $.extend( true, DataTable.TableTools.classes, {
-                        "container": "DTTT btn-group",
-                        "buttons": {
-                            "normal": "btn btn-default",
-                            "disabled": "disabled"
-                        },
-                        "collection": {
-                            "container": "DTTT_dropdown dropdown-menu",
-                            "buttons": {
-                                "normal": "",
-                                "disabled": "disabled"
-                            }
-                        },
-                        "print": {
-                            "info": "DTTT_print_info"
-                        },
-                        "select": {
-                            "row": "active"
-                        }
-                    } );
-
-                    // Have the collection use a bootstrap compatible drop down
-                    $.extend( true, DataTable.TableTools.DEFAULTS.oTags, {
-                        "collection": {
-                            "container": "ul",
-                            "button": "li",
-                            "liner": "a"
-                        }
-                    } );
-                }
-
-            }; // /factory
-
-
-// Define as an AMD module if possible
-            if ( typeof define === 'function' && define.amd ) {
-                define( ['jquery', 'datatables'], factory );
-            }
-            else if ( typeof exports === 'object' ) {
-                // Node/CommonJS
-                factory( require('jquery'), require('datatables') );
-            }
-            else if ( jQuery ) {
-                // Otherwise simply initialise as normal, stopping multiple evaluation
-                factory( jQuery, jQuery.fn.dataTable );
-            }
-
-
-        })(window, document);
-        $(function () {
-            $("#example1").DataTable();
-        });
-    </script>
 @endsection


### PR DESCRIPTION
目前，下列幾個 Codes 頁面無法正常載入，會出現 500 錯誤，且無 Laravel 預設渲染的錯誤頁面：

- https://input.cbdb.fas.harvard.edu/codes/ADDR_CODES
- https://input.cbdb.fas.harvard.edu/codes/OFFICE_CODES
- https://input.cbdb.fas.harvard.edu/codes/TEXT_CODES

經排查發現，產生 500 錯誤的原因為載入頁面所使用的記憶體容量超過 128MB 閾值，導致崩潰。具體原因是，載入資料庫內容未採用分頁（參見 https://github.com/cbdb-project/cbdb-online-main-server/commit/99d948f83c070e524546b12a0b74fa25d7c65afc#diff-b9ab348f6391c394d8a226d848b2cea64343b88f62d4a6f986cb87f35e4a7891R39）。

解決方法是將分頁的正確邏輯寫回，並對頁面渲染做相應修改。
每頁暫時設定成 20 筆記錄，與 /addrcodes 實作相同。

修改後上述三個頁面正常，可自由翻頁。

<img width="1445" height="932" alt="image" src="https://github.com/user-attachments/assets/17a31f29-b53a-41a2-b1b7-daa53aace04c" />
<img width="1447" height="878" alt="image" src="https://github.com/user-attachments/assets/e29e10d6-2914-4002-bed2-b8c674c42533" />
<img width="1430" height="871" alt="image" src="https://github.com/user-attachments/assets/5a7845f2-8f78-42d2-bd07-1449542d1e9e" />
