### PR TITLE
20251021 新增人物合併預覽與檢驗流程

### DIFF
--- a/MERGE.md
+++ b/MERGE.md
@@ -1,0 +1,39 @@
+# MERGE 工具說明
+
+本專案提供 `/merge-preview` 介面，協助管理員在刪除或合併人物記錄前進行全面檢視與驗證。本頁面由 `MergePreviewController` 與 `resources/views/manage/merge-preview.blade.php` 驅動，僅對 `is_admin == 1` 的使用者開放。
+
+## 功能摘要
+
+- **基礎資訊對比**  
+  輸入保留 (`from` 或 `primary_id`) 與合併來源 (`to` 或 `secondary_id`) 的人物 ID 後，介面會顯示雙方姓名、朝代與性別等欄位，並模擬合併後 (`merged_person`) 的欄位值。姓名差異會以紅色標示並出現警告，提醒管理員需要人工再確認。
+
+- **欄位差異表**  
+  `BIOG_MAIN` 全欄位會以表格呈現「保留人物值 / 合併來源值 / 合併後預覽」，同時標示出所有差異與最終更新的欄位。`c_notes` 會依序寫入「保留人物備註」「來源人物備註」與一行 `[merged #ID1 and #ID2 on YYYYMMDD with reason] 合併理由` 的記錄（若缺少其中一個 ID 則僅顯示存在的 ID）；`c_modified_by` 與 `c_modified_date` 則使用當前登入者與今日日期。
+
+- **相關資料預覽**  
+  額外列出 `ALTNAME_DATA`（別名）與 `KIN_DATA`（親屬）之筆數與內容摘要，並將 `KinID` 連結到對應的人物編輯頁面。頁面也會顯示 `ASSOC_DATA` 對四個欄位（`c_personid`、`c_kin_id`、`c_assoc_id`、`c_assoc_kin_id`）的資料、以及其它會受影響的資料表（如 `BIOG_ADDR_DATA`、`ENTRY_DATA`、`EVENTS_DATA` 等）在保留與來源人物的筆數與前 20 筆 JSON 摘要，以協助評估合併範圍。
+
+- **SQL 操作預覽**  
+  工具會產生兩段 SQL 交易：
+  1. 第一段 `START TRANSACTION` 會執行欄位更新、將所有關聯欄位的 `c_personid` 由來源 ID 改為保留 ID、然後列出 `SELECT COUNT(*)` 供確認各表已無來源 ID 資料，最後刪除 `BIOG_MAIN` 的來源記錄並 `COMMIT`。  
+  2. 如果使用者勾選「將較大 ID 自動合併至較小 ID（合併後會進行一次 ID 移動）」，在第一段完成後會再開啟第二段交易，將資料最終調整到較小的 ID（包含所有關聯表與 `BIOG_MAIN` 主鍵），最後再 `COMMIT`。
+  SQL 區塊僅供人工審閱與複製執行；實際寫入仍需由管理員於資料庫中逐步確認。
+
+- **複製連結**  
+  「複製連結」按鈕會根據目前輸入的 ID、`merge_to_min` 勾選狀態與合併理由即時生成 URL，格式如：
+  ```
+  /merge-preview?from=100388&to=339737&merge_to_min=false&reason=...
+  ```
+  方便與其他審核者分享。
+
+## 欄位補充
+
+- `merge_to_min=true` 或勾選「將較大 ID 自動合併至較小 ID」時，頁面僅模擬欄位值，實際 SQL 仍會先以原 ID 順序合併，並在第一段交易完成後另行執行「轉至最小 ID」的交易，避免前端邏輯自動交換 ID。
+- `merge_reason` 欄位會被寫入 `c_notes`、用於複製連結與提示文字，請在此描述合併依據、史料證據或分析方法。
+- 如果 `ALTNAME`、`KIN` 或 `ASSOC` 等表在合併前有待人工比對的差異，管理員可以利用 JSON 摘要快速檢視各欄位，必要時手動調整資料並重新預覽。
+
+## 注意事項
+
+1. 此工具僅提供預覽與 SQL 示例，實際執行資料庫操作前務必確認各項 `SELECT COUNT(*)` 結果為 0，再進行刪除或轉移。
+2. 若遇到姓名 (`c_name` / `c_name_chn`) 不一致，頁面仍會顯示 SQL，但會以紅字與警告提醒使用者檢視是否為同一人物。
+3. 頁面只列出前 20 筆相關資料摘要；若資料量龐大，應在資料庫中進一步查詢驗證。

--- a/app/Http/Controllers/MergePreviewController.php
+++ b/app/Http/Controllers/MergePreviewController.php
@@ -1,0 +1,640 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\BiogMain;
+use App\Dynasty;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
+use Carbon\Carbon;
+
+class MergePreviewController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(Request $request)
+    {
+        if (Auth::user()->is_admin != 1) {
+            flash('該用戶沒有權限，請聯絡管理員。', 'error');
+            return redirect('/home');
+        }
+
+        $preview = null;
+        if ($request->isMethod('post')) {
+            $autoArrange = $request->has('auto_arrange');
+        } else {
+            $autoParam = $request->input('merge_to_min', null);
+            if (is_null($autoParam)) {
+                $autoArrange = true;
+            } else {
+                if (is_string($autoParam)) {
+                    $autoArrange = !in_array(strtolower($autoParam), ['0', 'false', 'no'], true);
+                } else {
+                    $autoArrange = (bool)$autoParam;
+                }
+            }
+        }
+        $primaryRaw = $request->filled('primary_id') ? $request->input('primary_id') : $request->input('from', '');
+        $secondaryRaw = $request->filled('secondary_id') ? $request->input('secondary_id') : $request->input('to', '');
+        $reasonRaw = $request->filled('merge_reason') ? $request->input('merge_reason') : $request->input('reason', '');
+
+        $primaryInput = trim((string)$primaryRaw);
+        $secondaryInput = trim((string)$secondaryRaw);
+        $mergeReason = trim((string)$reasonRaw);
+
+        $shouldPreview = ($primaryInput !== '' && $secondaryInput !== '') &&
+            (
+                $request->isMethod('post')
+                || $request->query->has('primary_id')
+                || $request->query->has('secondary_id')
+                || $request->query->has('from')
+                || $request->query->has('to')
+            );
+
+        if ($shouldPreview) {
+            $originalPrimary = $primaryInput;
+            $originalSecondary = $secondaryInput;
+
+            $primary = $primaryInput;
+            $secondary = $secondaryInput;
+            $minTargetId = $autoArrange ? min($primaryInput, $secondaryInput) : null;
+
+        $primarySummary = $this->buildPersonSummary($primary, $mergeReason);
+        $secondarySummary = $this->buildPersonSummary($secondary, $mergeReason);
+
+            $mergedResult = $this->calculateMergedPerson($primarySummary, $secondarySummary, $mergeReason);
+            $secondaryDetails = $this->loadSecondaryDetails($secondarySummary);
+            $primaryDetails = $this->loadSecondaryDetails($primarySummary);
+            $primaryCounts = $this->buildTableSummaries($primarySummary);
+            $secondaryCounts = $this->buildTableSummaries($secondarySummary);
+
+            $mergeBlocked = $this->shouldBlockMerge($primarySummary, $secondarySummary);
+
+            $preview = [
+                'primary_id' => $primary,
+                'secondary_id' => $secondary,
+                'auto_arrange' => $autoArrange,
+                'primary_person' => $primarySummary,
+                'secondary_person' => $secondarySummary,
+                'merged_person' => $mergedResult['values'],
+                'merged_updates' => $mergedResult['updates'],
+                'name_match' => $this->compareName($primarySummary, $secondarySummary),
+                'dynasty_match' => $this->compareDynasty($primarySummary, $secondarySummary),
+                'gender_match' => $this->compareGender($primarySummary, $secondarySummary),
+                'altname_details_primary' => $primaryDetails['altname'],
+                'altname_details_secondary' => $secondaryDetails['altname'],
+                'kin_details_primary' => $primaryDetails['kin'],
+                'kin_details_secondary' => $secondaryDetails['kin'],
+                'assoc_details_primary' => $primaryDetails['assoc'],
+                'assoc_details_secondary' => $secondaryDetails['assoc'],
+                'other_details_primary' => $primaryDetails['other'],
+                'other_details_secondary' => $secondaryDetails['other'],
+                'table_counts_primary' => $primaryCounts,
+                'table_counts_secondary' => $secondaryCounts,
+                'sql_preview' => $this->buildSqlPreview($primary, $secondary, $mergedResult['updates'], $autoArrange, $minTargetId),
+                'merge_reason' => $mergeReason,
+                'biog_columns' => $this->getBiogColumns(),
+                'share_url' => $this->buildShareUrl($request, $originalPrimary, $originalSecondary, $autoArrange, $mergeReason),
+                'merge_blocked' => $mergeBlocked,
+                'notes' => $mergeBlocked ? '姓名資訊不一致，請重新確認後再合併。' : '此區為示意合併結果，實作時將整合人物欄位。',
+                'auto_min_target' => $minTargetId,
+            ];
+        }
+
+        return view('manage.merge-preview', [
+            'page_title' => 'MergePreview',
+            'page_description' => '人物記錄合併預覽',
+            'page_url' => '/merge-preview',
+            'preview' => $preview,
+            'auto_arrange' => $autoArrange,
+            'merge_reason' => $mergeReason,
+            'form_primary' => $primaryInput,
+            'form_secondary' => $secondaryInput,
+            'merge_blocked' => $preview['merge_blocked'] ?? false,
+        ]);
+    }
+
+    protected function buildPersonSummary($personId, $mergeReason = '')
+    {
+        if ($personId === '') {
+            return [
+                'exists' => false,
+                'id' => null,
+                'name_chn' => null,
+                'name' => null,
+                'dynasty_code' => null,
+                'dynasty_name' => null,
+                'gender_code' => null,
+                'gender_label' => null,
+            ];
+        }
+
+        $person = BiogMain::find($personId);
+        if (!$person) {
+            return [
+                'exists' => false,
+                'id' => $personId,
+                'name_chn' => null,
+                'name' => null,
+                'dynasty_code' => null,
+                'dynasty_name' => null,
+                'attributes' => [],
+                'gender_code' => null,
+                'gender_label' => null,
+            ];
+        }
+
+        $dynastyName = null;
+        if (!empty($person->c_dy)) {
+            $dynasty = Dynasty::find($person->c_dy);
+            if ($dynasty) {
+                $dynastyName = $dynasty->c_dynasty_chn ?: $dynasty->c_dynasty_name;
+            }
+        }
+
+        $genderCode = is_null($person->c_female) || $person->c_female === '' ? null : (int)$person->c_female;
+
+        return [
+            'exists' => true,
+            'id' => $person->c_personid,
+            'name_chn' => $person->c_name_chn,
+            'name' => $person->c_name,
+            'dynasty_code' => $person->c_dy,
+            'dynasty_name' => $dynastyName,
+            'attributes' => $person->getAttributes(),
+            'gender_code' => $genderCode,
+            'gender_label' => $this->formatGenderLabel($genderCode),
+        ];
+    }
+
+    protected function compareDynasty(array $primary, array $secondary)
+    {
+        if (!$primary['exists'] || !$secondary['exists']) {
+            return 'unknown';
+        }
+
+        if ($primary['dynasty_code'] === $secondary['dynasty_code']) {
+            return 'same';
+        }
+
+        return 'different';
+    }
+
+    protected function compareName(array $primary, array $secondary)
+    {
+        if (!$primary['exists'] || !$secondary['exists']) {
+            return 'unknown';
+        }
+
+        $primaryName = $primary['name'] ?? null;
+        $primaryNameChn = $primary['name_chn'] ?? null;
+        $secondaryName = $secondary['name'] ?? null;
+        $secondaryNameChn = $secondary['name_chn'] ?? null;
+
+        $primaryHasName = $this->normalizeName($primaryName) !== '' || $this->normalizeName($primaryNameChn) !== '';
+        $secondaryHasName = $this->normalizeName($secondaryName) !== '' || $this->normalizeName($secondaryNameChn) !== '';
+
+        if (!$primaryHasName || !$secondaryHasName) {
+            return 'unknown';
+        }
+
+        $different = $this->namesDiffer($primaryName, $secondaryName) || $this->namesDiffer($primaryNameChn, $secondaryNameChn);
+
+        return $different ? 'different' : 'same';
+    }
+
+    protected function compareGender(array $primary, array $secondary)
+    {
+        if (!$primary['exists'] || !$secondary['exists']) {
+            return 'unknown';
+        }
+
+        $primaryGender = $primary['gender_code'];
+        $secondaryGender = $secondary['gender_code'];
+
+        if ($primaryGender === null || $secondaryGender === null) {
+            return 'unknown';
+        }
+
+        return ((int)$primaryGender === (int)$secondaryGender) ? 'same' : 'different';
+    }
+
+    protected function formatGenderLabel($genderCode)
+    {
+        if ($genderCode === null) {
+            return '未詳';
+        }
+
+        $value = (int)$genderCode;
+        if ($value === 0) {
+            return '0-男';
+        }
+        if ($value === 1) {
+            return '1-女';
+        }
+
+        return (string)$genderCode;
+    }
+
+    protected function buildSqlPreview($primary, $secondary, array $mergedUpdates, $autoArrange, $minTargetId = null)
+    {
+        $statements = [];
+        $statements[] = 'START TRANSACTION;';
+
+        if (!empty($mergedUpdates)) {
+            $setParts = [];
+            foreach ($mergedUpdates as $field => $value) {
+                $setParts[] = sprintf('%s = %s', $field, $this->formatSqlValue($value));
+            }
+            if (!empty($setParts)) {
+                $statements[] = sprintf(
+                    'UPDATE BIOG_MAIN SET %s WHERE c_personid = %s;',
+                    implode(', ', $setParts),
+                    $primary
+                );
+            }
+        }
+
+        $map = [
+            'ALTNAME_DATA' => ['c_personid'],
+            'ASSOC_DATA' => ['c_personid', 'c_kin_id', 'c_assoc_id', 'c_assoc_kin_id'],
+            'BIOG_ADDR_DATA' => ['c_personid'],
+            'BIOG_INST_DATA' => ['c_personid'],
+            'BIOG_SOURCE_DATA' => ['c_personid'],
+            'BIOG_TEXT_DATA' => ['c_personid'],
+            'ENTRY_DATA' => ['c_personid'],
+            'EVENTS_DATA' => ['c_personid'],
+            'KIN_DATA' => ['c_personid', 'c_kin_id'],
+            'POSSESSION_DATA' => ['c_personid'],
+            'POSTED_TO_ADDR_DATA' => ['c_personid'],
+            'POSTING_DATA' => ['c_personid'],
+            'POSTED_TO_OFFICE_DATA' => ['c_personid'],
+            'STATUS_DATA' => ['c_personid'],
+        ];
+
+        foreach ($map as $table => $columns) {
+            foreach ($columns as $column) {
+                $statements[] = sprintf(
+                    'UPDATE %s SET %s = %s WHERE %s = %s;',
+                    $table,
+                    $column,
+                    $primary,
+                    $column,
+                    $secondary
+                );
+            }
+        }
+
+        $statements[] = '-- 確認以下查詢結果皆為 0 後，再刪除來源人物資料';
+        foreach ($map as $table => $columns) {
+            foreach ($columns as $column) {
+                $statements[] = sprintf(
+                    'SELECT COUNT(*) AS remaining_%s_%s FROM %s WHERE %s = %s;',
+                    $table,
+                    $column,
+                    $table,
+                    $column,
+                    $secondary
+                );
+            }
+        }
+
+        $statements[] = 'DELETE FROM BIOG_MAIN WHERE c_personid = '.$secondary.';';
+        $statements[] = 'COMMIT;';
+
+        if ($autoArrange && $minTargetId !== null && $primary !== $minTargetId) {
+            $statements[] = 'START TRANSACTION;';
+            $statements[] = sprintf('-- 調整至較小 ID %s', $minTargetId);
+            foreach ($map as $table => $columns) {
+                foreach ($columns as $column) {
+                    $statements[] = sprintf(
+                        'UPDATE %s SET %s = %s WHERE %s = %s;',
+                        $table,
+                        $column,
+                        $minTargetId,
+                        $column,
+                        $primary
+                    );
+                }
+            }
+            $statements[] = sprintf('UPDATE BIOG_MAIN SET c_personid = %s WHERE c_personid = %s;', $minTargetId, $primary);
+            $statements[] = 'COMMIT;';
+        }
+
+        return $statements;
+    }
+
+    protected function buildShareUrl(Request $request, $originalPrimary, $originalSecondary, $autoArrange, $reason)
+    {
+        $params = [
+            'from' => $originalPrimary,
+            'to' => $originalSecondary,
+        ];
+        $params['merge_to_min'] = $autoArrange ? 'true' : 'false';
+        if ($reason !== '') {
+            $params['reason'] = $reason;
+        }
+
+        return $request->url().'?'.http_build_query($params);
+    }
+
+    protected function getBiogColumns()
+    {
+        static $columns = null;
+        if ($columns === null) {
+            try {
+                $columns = Schema::getColumnListing('BIOG_MAIN');
+            } catch (\Throwable $e) {
+                $columns = [];
+            }
+        }
+        return $columns;
+    }
+
+    protected function calculateMergedPerson(array $primary, array $secondary, $mergeReason)
+    {
+        if (!$secondary['exists']) {
+            return [
+                'values' => [],
+                'updates' => [],
+            ];
+        }
+
+        $primaryAttributes = $primary['attributes'] ?? [];
+        $secondaryAttributes = $secondary['attributes'] ?? [];
+
+        // 模擬更新後的狀態：以保留人物的非空值覆寫次要人物
+        $result = $secondaryAttributes;
+        foreach ($primaryAttributes as $key => $value) {
+            if (!is_null($value) && $value !== '') {
+                $result[$key] = $value;
+            }
+        }
+
+        // c_personid 最終會取保留人物
+        if (isset($primaryAttributes['c_personid'])) {
+            $result['c_personid'] = $primaryAttributes['c_personid'];
+        }
+
+        // 更新操作者與日期
+        $currentDate = Carbon::now()->format('Ymd');
+        $result['c_modified_by'] = Auth::check() ? (Auth::user()->name ?? Auth::user()->email ?? 'admin') : 'admin';
+        $result['c_modified_date'] = $currentDate;
+
+        $primaryNotes = isset($primaryAttributes['c_notes']) ? trim((string)$primaryAttributes['c_notes']) : '';
+        $secondaryNotes = isset($secondaryAttributes['c_notes']) ? trim((string)$secondaryAttributes['c_notes']) : '';
+        $notesLines = [];
+        if ($primaryNotes !== '') {
+            $notesLines[] = $primaryNotes;
+        }
+        if ($secondaryNotes !== '') {
+            $notesLines[] = $secondaryNotes;
+        }
+        $mergedSourceId = $secondaryAttributes['c_personid'] ?? ($secondary['id'] ?? null);
+        $primaryPersonId = $primaryAttributes['c_personid'] ?? ($primary['id'] ?? null);
+        $idSegments = [];
+        if (!is_null($primaryPersonId) && $primaryPersonId !== '') {
+            $idSegments[] = '#'.$primaryPersonId;
+        }
+        if (!is_null($mergedSourceId) && $mergedSourceId !== '') {
+            $idSegments[] = '#'.$mergedSourceId;
+        }
+        $mergeTag = '[merged';
+        if (!empty($idSegments)) {
+            $mergeTag .= ' '.implode(' and ', $idSegments);
+        }
+        $mergeTag .= ' on '.$currentDate.' with reason]';
+        $reasonText = trim((string)$mergeReason);
+        if ($reasonText !== '') {
+            $mergeTag .= ' '.$reasonText;
+        }
+        $notesLines[] = $mergeTag;
+        $result['c_notes'] = implode("\n", $notesLines);
+
+        $updates = [];
+        foreach ($result as $field => $value) {
+            if ($field === 'c_personid') {
+                continue;
+            }
+            $original = $primaryAttributes[$field] ?? null;
+            // normalise empty string vs null
+            if ($original instanceof \DateTimeInterface) {
+                $original = $original->format('Y-m-d H:i:s');
+            }
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d H:i:s');
+            }
+            if ($original !== $value) {
+                $updates[$field] = $value;
+            }
+        }
+
+        return [
+            'values' => $result,
+            'updates' => $updates,
+        ];
+    }
+
+    protected function formatSqlValue($value)
+    {
+        if (is_null($value)) {
+            return 'NULL';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_numeric($value) && !is_string($value)) {
+            return (string)$value;
+        }
+
+        $string = (string)$value;
+        $escaped = str_replace("'", "''", $string);
+        return "'".$escaped."'";
+    }
+
+    protected function loadSecondaryDetails(array $summary)
+    {
+        if (!$summary['exists']) {
+            return ['altname' => [], 'kin' => [], 'assoc' => [], 'other' => []];
+        }
+
+        $personId = $summary['id'];
+
+        $altNames = \DB::table('ALTNAME_DATA')
+            ->select(
+                'ALTNAME_DATA.c_personid',
+                'ALTNAME_DATA.c_sequence',
+                'ALTNAME_DATA.c_alt_name_type_code',
+                'ALTNAME_DATA.c_alt_name_chn',
+                'ALTNAME_DATA.c_alt_name',
+                'ALTNAME_DATA.c_notes',
+                'ALTNAME_CODES.c_name_type_desc_chn as alt_type_label_chn',
+                'ALTNAME_CODES.c_name_type_desc as alt_type_label'
+            )
+            ->leftJoin('ALTNAME_CODES', 'ALTNAME_CODES.c_name_type_code', '=', 'ALTNAME_DATA.c_alt_name_type_code')
+            ->where('ALTNAME_DATA.c_personid', $personId)
+            ->orderBy('c_sequence')
+            ->limit(20)
+            ->get();
+
+        $kin = \DB::table('KIN_DATA')
+            ->select(
+                'KIN_DATA.c_personid',
+                'KIN_DATA.c_kin_id',
+                'KIN_DATA.c_kin_code',
+                'KIN_DATA.c_notes',
+                'KINSHIP_CODES.c_kinrel_chn as kinship_label_chn',
+                'KINSHIP_CODES.c_kinrel as kinship_label',
+                'BIOG_MAIN.c_name_chn as kin_name_chn',
+                'BIOG_MAIN.c_name as kin_name'
+            )
+            ->leftJoin('KINSHIP_CODES', 'KINSHIP_CODES.c_kincode', '=', 'KIN_DATA.c_kin_code')
+            ->leftJoin('BIOG_MAIN', 'BIOG_MAIN.c_personid', '=', 'KIN_DATA.c_kin_id')
+            ->where('KIN_DATA.c_personid', $personId)
+            ->limit(20)
+            ->get();
+
+        $assocColumns = [
+            'c_personid' => 'c_personid',
+            'c_kin_id' => 'c_kin_id',
+            'c_assoc_id' => 'c_assoc_id',
+            'c_assoc_kin_id' => 'c_assoc_kin_id',
+        ];
+        $assocDetails = [];
+        foreach ($assocColumns as $key => $column) {
+            $assocDetails[$key] = \DB::table('ASSOC_DATA')
+                ->select('c_personid', 'c_assoc_id', 'c_kin_id', 'c_assoc_kin_id', 'c_notes')
+                ->where($column, $personId)
+                ->limit(20)
+                ->get();
+        }
+
+        $otherConfigs = [
+            'BIOG_ADDR_DATA' => ['column' => 'c_personid'],
+            'BIOG_INST_DATA' => ['column' => 'c_personid'],
+            'BIOG_SOURCE_DATA' => ['column' => 'c_personid'],
+            'BIOG_TEXT_DATA' => ['column' => 'c_personid'],
+            'ENTRY_DATA' => ['column' => 'c_personid'],
+            'EVENTS_DATA' => ['column' => 'c_personid'],
+            'POSSESSION_DATA' => ['column' => 'c_personid'],
+            'STATUS_DATA' => ['column' => 'c_personid'],
+            'POSTED_TO_ADDR_DATA' => ['column' => 'c_personid'],
+            'POSTING_DATA' => ['column' => 'c_personid'],
+            'POSTED_TO_OFFICE_DATA' => ['column' => 'c_personid'],
+        ];
+        $otherDetails = [];
+        foreach ($otherConfigs as $table => $info) {
+            $otherDetails[$table] = \DB::table($table)
+                ->where($info['column'], $personId)
+                ->limit(20)
+                ->get();
+        }
+
+        return [
+            'altname' => $altNames,
+            'kin' => $kin,
+            'assoc' => $assocDetails,
+            'other' => $otherDetails,
+        ];
+    }
+
+    protected function buildTableSummaries(array $summary)
+    {
+        if (!$summary['exists']) {
+            return [
+                'assoc' => ['c_personid' => 0, 'c_kin_id' => 0, 'c_assoc_id' => 0, 'c_assoc_kin_id' => 0],
+                'biog_addr' => 0,
+                'biog_inst' => 0,
+                'biog_source' => 0,
+                'biog_text' => 0,
+                'entry' => 0,
+                'events' => 0,
+                'possession' => 0,
+                'status' => 0,
+                'posted_to_addr' => 0,
+                'posting' => 0,
+                'posted_to_office' => 0,
+            ];
+        }
+
+        $id = $summary['id'];
+
+        $assocCounts = [
+            'c_personid' => \DB::table('ASSOC_DATA')->where('c_personid', $id)->count(),
+            'c_kin_id' => \DB::table('ASSOC_DATA')->where('c_kin_id', $id)->count(),
+            'c_assoc_id' => \DB::table('ASSOC_DATA')->where('c_assoc_id', $id)->count(),
+            'c_assoc_kin_id' => \DB::table('ASSOC_DATA')->where('c_assoc_kin_id', $id)->count(),
+        ];
+
+        $simpleTables = [
+            'biog_addr' => ['table' => 'BIOG_ADDR_DATA', 'column' => 'c_personid'],
+            'biog_inst' => ['table' => 'BIOG_INST_DATA', 'column' => 'c_personid'],
+            'biog_source' => ['table' => 'BIOG_SOURCE_DATA', 'column' => 'c_personid'],
+            'biog_text' => ['table' => 'BIOG_TEXT_DATA', 'column' => 'c_personid'],
+            'entry' => ['table' => 'ENTRY_DATA', 'column' => 'c_personid'],
+            'events' => ['table' => 'EVENTS_DATA', 'column' => 'c_personid'],
+            'possession' => ['table' => 'POSSESSION_DATA', 'column' => 'c_personid'],
+            'status' => ['table' => 'STATUS_DATA', 'column' => 'c_personid'],
+            'posted_to_addr' => ['table' => 'POSTED_TO_ADDR_DATA', 'column' => 'c_personid'],
+            'posting' => ['table' => 'POSTING_DATA', 'column' => 'c_personid'],
+            'posted_to_office' => ['table' => 'POSTED_TO_OFFICE_DATA', 'column' => 'c_personid'],
+        ];
+
+        $counts = [
+            'assoc' => $assocCounts,
+        ];
+
+        foreach ($simpleTables as $key => $info) {
+            $counts[$key] = \DB::table($info['table'])->where($info['column'], $id)->count();
+        }
+
+        return $counts;
+    }
+
+    protected function shouldBlockMerge(array $primary, array $secondary)
+    {
+        if (!$primary['exists'] || !$secondary['exists']) {
+            return false;
+        }
+
+        $nameDiff = $this->namesDiffer($primary['name'], $secondary['name']);
+        $nameChnDiff = $this->namesDiffer($primary['name_chn'], $secondary['name_chn']);
+
+        return $nameDiff || $nameChnDiff;
+    }
+
+    protected function namesDiffer($a, $b)
+    {
+        $normA = $this->normalizeName($a);
+        $normB = $this->normalizeName($b);
+
+        if ($normA === '' && $normB === '') {
+            return false;
+        }
+
+        return $normA !== $normB;
+    }
+
+    protected function normalizeName($value)
+    {
+        if ($value === null) {
+            return '';
+        }
+        $trimmed = trim((string)$value);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($trimmed, 'UTF-8');
+        }
+
+        return strtolower($trimmed);
+    }
+}

--- a/app/Http/Controllers/MergePreviewController.php
+++ b/app/Http/Controllers/MergePreviewController.php
@@ -61,7 +61,7 @@ class MergePreviewController extends Controller
 
             $primary = $primaryInput;
             $secondary = $secondaryInput;
-            $minTargetId = $autoArrange ? min($primaryInput, $secondaryInput) : null;
+            $minTargetId = $autoArrange ? min((int)$primaryInput, (int)$secondaryInput) : null;
 
         $primarySummary = $this->buildPersonSummary($primary, $mergeReason);
         $secondarySummary = $this->buildPersonSummary($secondary, $mergeReason);

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -170,6 +170,7 @@ desired effect
 <!-- Scripts -->
 <script src="{{ mix('js/app.js') }}"></script>
 @yield('js')
+@stack('scripts')
 <script>
     $('#flash-overlay-modal').modal();
 </script>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -59,6 +59,7 @@
 
             @if(Auth::check() and Auth::user()->is_admin == 1)
                 <li class="header">Management</li>
+                <li class="{{ $page_title == 'MergePreview' ? 'active' : '' }}"><a href="{{ route('merge-preview.index') }}"><i class="ion ion-shuffle"></i> <span>人物記錄合併</span></a></li>
                 <li class="{{ $page_title == 'Management' ? 'active' : '' }}"><a href="{{ route('manage.index') }}"><i class="ion ion-ios-people-outline"></i> <span>管理用戶</span></a></li>
             @endif
         </ul>

--- a/resources/views/manage/merge-preview.blade.php
+++ b/resources/views/manage/merge-preview.blade.php
@@ -1,0 +1,598 @@
+@extends('layouts.dashboard')
+
+@section('content')
+    <div class="panel panel-default">
+        <div class="panel-heading">人物記錄合併</div>
+        <div class="panel-body">
+            <form method="post" action="{{ route('merge-preview.index') }}" class="form-horizontal">
+                {{ csrf_field() }}
+                <div class="form-group">
+                    <label for="primary_id" class="col-sm-2 control-label">主要人物 ID</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" id="primary_id" name="primary_id" value="{{ old('primary_id', $form_primary ?? (isset($preview['primary_id']) ? $preview['primary_id'] : '')) }}" placeholder="輸入保留的 c_personid">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="secondary_id" class="col-sm-2 control-label">次要人物 ID</label>
+                    <div class="col-sm-10">
+                        <input type="text" class="form-control" id="secondary_id" name="secondary_id" value="{{ old('secondary_id', $form_secondary ?? (isset($preview['secondary_id']) ? $preview['secondary_id'] : '')) }}" placeholder="輸入要合併進來的 c_personid">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="merge_reason" class="col-sm-2 control-label">合併理由</label>
+                    <div class="col-sm-10">
+                        <textarea class="form-control" id="merge_reason" name="merge_reason" rows="3" placeholder="簡要解釋合併理由，如史料證據與分析方法">{{ old('merge_reason', isset($preview['merge_reason']) ? $preview['merge_reason'] : ($merge_reason ?? '')) }}</textarea>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        @php
+                            $autoCheckedOld = old('auto_arrange');
+                            if (is_null($autoCheckedOld)) {
+                                if (isset($auto_arrange)) {
+                                    $autoChecked = $auto_arrange;
+                                } else {
+                                    $autoChecked = true;
+                                }
+                            } else {
+                                $autoChecked = (bool)$autoCheckedOld;
+                            }
+                        @endphp
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="auto_arrange" value="1" {{ $autoChecked ? 'checked' : '' }}>
+                                將較大 ID 自動合併至較小 ID（合併後會進行一次 ID 移動）
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <button type="submit" class="btn btn-primary" id="preview-button">預覽合併結果</button>
+                        <button type="button" class="btn btn-default" id="copy_merge_link" data-base="{{ route('merge-preview.index') }}">複製連結</button>
+                    </div>
+                </div>
+            </form>
+
+            @if(!empty($preview))
+                <hr>
+                <h4>合併結果預覽</h4>
+                @if(!empty($merge_blocked))
+                    <div class="alert alert-danger">
+                        <strong>無法進行合併：</strong> 保留與來源人物的姓名資訊不同，請先人工確認後再動作。
+                    </div>
+                @endif
+                <div class="row">
+                    <div class="col-md-6">
+                        <h5>保留人物</h5>
+                        <table class="table table-bordered table-condensed">
+                            <tr>
+                                <th>ID</th>
+                                <td>
+                                    @if($preview['primary_person']['exists'])
+                                        <a href="{{ url('basicinformation/'.$preview['primary_id'].'/edit') }}" target="_blank">{{ $preview['primary_id'] }}</a>
+                                    @else
+                                        {{ $preview['primary_id'] }}
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>姓名</th>
+                                <td>
+                                    @if($preview['primary_person']['exists'])
+                                        {{ $preview['primary_person']['name_chn'] }} ({{ $preview['primary_person']['name'] }})
+                                    @else
+                                        <span class="text-danger">查無資料</span>
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>性別</th>
+                                <td class="{{ $preview['gender_match'] === 'different' ? 'text-danger' : '' }}">
+                                    @if($preview['primary_person']['exists'])
+                                        {{ $preview['primary_person']['gender_label'] ?? '未詳' }}
+                                    @else
+                                        —
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>朝代</th>
+                                <td>
+                                    @if($preview['primary_person']['exists'])
+                                        {{ $preview['primary_person']['dynasty_name'] ?? '未詳' }}
+                                    @else
+                                        —
+                                    @endif
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="col-md-6">
+                        <h5>合併來源</h5>
+                        <table class="table table-bordered table-condensed">
+                            <tr>
+                                <th>ID</th>
+                                <td>
+                                    @if($preview['secondary_person']['exists'])
+                                        <a href="{{ url('basicinformation/'.$preview['secondary_id'].'/edit') }}" target="_blank">{{ $preview['secondary_id'] }}</a>
+                                    @else
+                                        {{ $preview['secondary_id'] }}
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>姓名</th>
+                                <td>
+                    @if($preview['secondary_person']['exists'])
+                        {{ $preview['secondary_person']['name_chn'] }} ({{ $preview['secondary_person']['name'] }})
+                    @else
+                        <span class="text-danger">查無資料</span>
+                    @endif
+                </td>
+            </tr>
+            <tr>
+                <th>朝代</th>
+                <td>
+                    @if($preview['secondary_person']['exists'])
+                        {{ $preview['secondary_person']['dynasty_name'] ?? '未詳' }}
+                    @else
+                        —
+                    @endif
+                </td>
+            </tr>
+            <tr>
+                <th>性別</th>
+                <td class="{{ $preview['gender_match'] === 'different' ? 'text-danger' : '' }}">
+                    @if($preview['secondary_person']['exists'])
+                        {{ $preview['secondary_person']['gender_label'] ?? '未詳' }}
+                    @else
+                        —
+                    @endif
+                </td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+                @php
+                    $statusLabels = [
+                        'same' => '一致',
+                        'different' => '不同',
+                        'unknown' => '無法判斷',
+                    ];
+                    $statusClasses = [
+                        'same' => 'text-success',
+                        'different' => 'text-warning',
+                        'unknown' => 'text-muted',
+                    ];
+                    $basicComparisons = [
+                        [
+                            'label' => '姓名',
+                            'status' => $preview['name_match'] ?? 'unknown',
+                            'messages' => [
+                                'different' => '兩筆人物的姓名資訊不同，請再次確認合併關係。',
+                                'unknown' => '至少一筆人物缺少姓名資料，無法比較姓名是否一致。',
+                            ],
+                        ],
+                        [
+                            'label' => '性別',
+                            'status' => $preview['gender_match'] ?? 'unknown',
+                            'messages' => [
+                                'different' => '兩筆人物的性別不同，請再次確認合併關係。',
+                                'unknown' => '無法判斷性別（其中至少一筆找不到人物資料或未填性別）。',
+                            ],
+                        ],
+                        [
+                            'label' => '朝代',
+                            'status' => $preview['dynasty_match'] ?? 'unknown',
+                            'messages' => [
+                                'different' => '兩筆人物的朝代不同，請再次確認合併關係。',
+                                'unknown' => '無法判斷朝代（其中至少一筆找不到人物資料）。',
+                            ],
+                        ],
+                    ];
+                    $basicParts = [];
+                    $basicWarnings = [];
+                    foreach ($basicComparisons as $item) {
+                        $status = $item['status'];
+                        $label = $item['label'];
+                        $class = $statusClasses[$status] ?? '';
+                        $statusText = $statusLabels[$status] ?? $status;
+                        $basicParts[] = sprintf('%s：<span class="%s">%s</span>', $label, $class, $statusText);
+                        if (!empty($item['messages'][$status] ?? '')) {
+                            $basicWarnings[] = $item['messages'][$status];
+                        }
+                    }
+                @endphp
+                <div class="alert alert-info">
+                    <strong>人物比對：</strong>
+                    {!! implode('，', $basicParts) !!}
+                    @if(!empty($basicWarnings))
+                        <div class="small" style="margin-top: 8px;">
+                            @foreach($basicWarnings as $warning)
+                                <div class="text-warning">{{ $warning }}</div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+
+                @if(!empty($preview['merge_reason']))
+                    <div class="alert alert-warning">
+                        <strong>合併理由：</strong> {{ $preview['merge_reason'] }}
+                    </div>
+                @endif
+
+                <h5>合併策略</h5>
+                <p>{{ $preview['auto_arrange'] ? '已自動調整順序（大 ID 合併至小 ID）' : '依照輸入順序合併' }}</p>
+
+                <h5>人物欄位比對</h5>
+                @php
+                    $columns = $preview['biog_columns'] ?? [];
+                    $primaryAttrs = $preview['primary_person']['attributes'] ?? [];
+                    $secondaryAttrs = $preview['secondary_person']['attributes'] ?? [];
+                    $mergedAttrs = $preview['merged_person'] ?? [];
+                    $mergedUpdates = $preview['merged_updates'] ?? [];
+                @endphp
+                @if(!empty($columns))
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-condensed table-striped">
+                            <thead>
+                                <tr>
+                                    <th>欄位</th>
+                                    <th>保留人物值</th>
+                                    <th>合併來源值</th>
+                                    <th>合併後值（預覽）</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($columns as $column)
+                                    @php
+                                        $primaryVal = $primaryAttrs[$column] ?? null;
+                                        $secondaryVal = $secondaryAttrs[$column] ?? null;
+                                        $mergedVal = $mergedAttrs[$column] ?? ($secondaryVal ?? $primaryVal);
+                                        $diff = ($primaryVal != $secondaryVal) || ($mergedVal != $secondaryVal) || array_key_exists($column, $mergedUpdates);
+                                    @endphp
+                                    <tr class="{{ $diff ? 'warning' : '' }}">
+                                        <td>{{ $column }}</td>
+                                        <td class="{{ ($column === 'c_name' || $column === 'c_name_chn') && $primaryVal != $secondaryVal ? 'text-danger' : '' }}">{{ is_null($primaryVal) ? 'NULL' : $primaryVal }}</td>
+                                        <td class="{{ ($column === 'c_name' || $column === 'c_name_chn') && $primaryVal != $secondaryVal ? 'text-danger' : '' }}">{{ is_null($secondaryVal) ? 'NULL' : $secondaryVal }}</td>
+                                        <td>{{ is_null($mergedVal) ? 'NULL' : $mergedVal }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @else
+                    <p class="text-muted">無法取得 BIOG_MAIN 欄位列表。</p>
+                @endif
+
+                <h5>其他相關資料預覽</h5>
+                <div class="row">
+                    <div class="col-md-12">
+                        @php
+                            $altPrimaryCount = count($preview['altname_details_primary']);
+                            $altSecondaryCount = count($preview['altname_details_secondary']);
+                        @endphp
+                        <h6>別名（ALTNAME_DATA）</h6>
+                        @if($altPrimaryCount || $altSecondaryCount)
+                            <table class="table table-bordered table-condensed table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>欄位</th>
+                                        <th>保留人物 ({{ $preview['primary_id'] ?? '-' }}) — {{ $altPrimaryCount }} 筆</th>
+                                        <th>合併來源 ({{ $preview['secondary_id'] ?? '-' }}) — {{ $altSecondaryCount }} 筆</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>內容摘要</th>
+                                        <td>
+                                            @forelse($preview['altname_details_primary'] as $item)
+                                                <div>
+                                                    @php
+                                                        $altName = $item->c_alt_name_chn ?: $item->c_alt_name ?: '(無)';
+                                                        $altTypeLabel = $item->alt_type_label_chn ?: $item->alt_type_label;
+                                                        $sequence = $item->c_sequence !== null ? $item->c_sequence : '—';
+                                                    @endphp
+                                                    Seq {{ $sequence }} — {{ $altName }}
+                                                    (code {{ $item->c_alt_name_type_code }}
+                                                    @if(!empty($altTypeLabel))
+                                                        — {{ $altTypeLabel }}
+                                                    @endif
+                                                    )
+                                                    <code style="display:block; white-space: pre-wrap; word-break: break-all;" class="text-muted">{{ json_encode((array)$item, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code>
+                                                </div>
+                                            @empty
+                                                <div class="text-muted">無資料</div>
+                                            @endforelse
+                                        </td>
+                                        <td>
+                                            @forelse($preview['altname_details_secondary'] as $item)
+                                                <div>
+                                                    @php
+                                                        $altName = $item->c_alt_name_chn ?: $item->c_alt_name ?: '(無)';
+                                                        $altTypeLabel = $item->alt_type_label_chn ?: $item->alt_type_label;
+                                                        $sequence = $item->c_sequence !== null ? $item->c_sequence : '—';
+                                                    @endphp
+                                                    Seq {{ $sequence }} — {{ $altName }}
+                                                    (code {{ $item->c_alt_name_type_code }}
+                                                    @if(!empty($altTypeLabel))
+                                                        — {{ $altTypeLabel }}
+                                                    @endif
+                                                    )
+                                                    <code style="display:block; white-space: pre-wrap; word-break: break-all;" class="text-muted">{{ json_encode((array)$item, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code>
+                                                </div>
+                                            @empty
+                                                <div class="text-muted">無資料</div>
+                                            @endforelse
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        @else
+                            <p class="text-muted">無別名資料。</p>
+                        @endif
+                    </div>
+                </div>
+                <div class="row" style="margin-top: 15px;">
+                    <div class="col-md-12">
+                        <h6>親屬（KIN_DATA）</h6>
+                        @php
+                            $kinPrimaryCount = count($preview['kin_details_primary']);
+                            $kinSecondaryCount = count($preview['kin_details_secondary']);
+                        @endphp
+                        @if($kinPrimaryCount || $kinSecondaryCount)
+                            <table class="table table-bordered table-condensed table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>欄位</th>
+                                        <th>保留人物 ({{ $preview['primary_id'] ?? '-' }}) — {{ $kinPrimaryCount }} 筆</th>
+                                        <th>合併來源 ({{ $preview['secondary_id'] ?? '-' }}) — {{ $kinSecondaryCount }} 筆</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>內容摘要</th>
+                                        <td>
+                                            @forelse($preview['kin_details_primary'] as $item)
+                                                <div>
+                                                    @php
+                                                        $kinName = $item->kin_name_chn ?: $item->kin_name;
+                                                        $kinCodeLabel = $item->kinship_label_chn ?: $item->kinship_label;
+                                                    @endphp
+                                                    KinID <a href="{{ url('basicinformation/' . $item->c_kin_id . '/edit') }}" target="_blank">{{ $item->c_kin_id }}</a>
+                                                    @if(!empty($kinName))
+                                                        — {{ $kinName }}
+                                                    @endif
+                                                    (code {{ $item->c_kin_code }}
+                                                    @if(!empty($kinCodeLabel))
+                                                        — {{ $kinCodeLabel }}
+                                                    @endif
+                                                    )
+                                                    <code style="display:block; white-space: pre-wrap; word-break: break-all;" class="text-muted">{{ json_encode((array)$item, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code>
+                                                </div>
+                                            @empty
+                                                <div class="text-muted">無資料</div>
+                                            @endforelse
+                                        </td>
+                                        <td>
+                                            @forelse($preview['kin_details_secondary'] as $item)
+                                                <div>
+                                                    @php
+                                                        $kinName = $item->kin_name_chn ?: $item->kin_name;
+                                                        $kinCodeLabel = $item->kinship_label_chn ?: $item->kinship_label;
+                                                    @endphp
+                                                    KinID <a href="{{ url('basicinformation/' . $item->c_kin_id . '/edit') }}" target="_blank">{{ $item->c_kin_id }}</a>
+                                                    @if(!empty($kinName))
+                                                        — {{ $kinName }}
+                                                    @endif
+                                                    (code {{ $item->c_kin_code }}
+                                                    @if(!empty($kinCodeLabel))
+                                                        — {{ $kinCodeLabel }}
+                                                    @endif
+                                                    )
+                                                    <code style="display:block; white-space: pre-wrap; word-break: break-all;" class="text-muted">{{ json_encode((array)$item, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code>
+                                                </div>
+                                            @empty
+                                                <div class="text-muted">無資料</div>
+                                            @endforelse
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        @else
+                            <p class="text-muted">無親屬資料。</p>
+                        @endif
+                    </div>
+                </div>
+                <div class="row" style="margin-top: 15px;">
+                    <div class="col-md-12">
+                        <h6>ASSOC_DATA 關聯概況</h6>
+                        @php
+                            $assocPrimary = $preview['table_counts_primary']['assoc'] ?? [];
+                            $assocSecondary = $preview['table_counts_secondary']['assoc'] ?? [];
+                            $assocDetailsPrimary = $preview['assoc_details_primary'] ?? [];
+                            $assocDetailsSecondary = $preview['assoc_details_secondary'] ?? [];
+                            $assocColumns = [
+                                'c_personid' => 'c_personid = 人物 ID',
+                                'c_kin_id' => 'c_kin_id = 親屬人物 ID',
+                                'c_assoc_id' => 'c_assoc_id = 關聯人物 ID',
+                                'c_assoc_kin_id' => 'c_assoc_kin_id = 關聯親屬 ID',
+                            ];
+                        @endphp
+                        @foreach($assocColumns as $key => $label)
+                            @php
+                                $primaryCount = $assocPrimary[$key] ?? 0;
+                                $secondaryCount = $assocSecondary[$key] ?? 0;
+                                $primaryRows = collect($assocDetailsPrimary[$key] ?? []);
+                                $secondaryRows = collect($assocDetailsSecondary[$key] ?? []);
+                            @endphp
+                            <div class="table-responsive" style="margin-top: 10px;">
+                                <div class="small text-muted" style="margin-bottom: 4px;">欄位：{{ $label }} — 保留 {{ $primaryCount }} 筆 / 來源 {{ $secondaryCount }} 筆</div>
+                                <table class="table table-bordered table-condensed table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>內容</th>
+                                            <th>保留人物 ({{ $preview['primary_id'] ?? '-' }})</th>
+                                            <th>合併來源 ({{ $preview['secondary_id'] ?? '-' }})</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <th>內容摘要</th>
+                                            <td>
+                                                @if($primaryRows->count())
+                                                    <ul class="list-unstyled small" style="word-break: break-all;">
+                                                        @foreach($primaryRows as $row)
+                                                            <li><code style="white-space: pre-wrap; word-break: break-all;">{{ json_encode((array)$row, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code></li>
+                                                        @endforeach
+                                                    </ul>
+                                                @else
+                                                    <div class="text-muted">無資料</div>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if($secondaryRows->count())
+                                                    <ul class="list-unstyled small" style="word-break: break-all;">
+                                                        @foreach($secondaryRows as $row)
+                                                            <li><code style="white-space: pre-wrap; word-break: break-all;">{{ json_encode((array)$row, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code></li>
+                                                        @endforeach
+                                                    </ul>
+                                                @else
+                                                    <div class="text-muted">無資料</div>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+                @php
+                    $tableMap = [
+                        'biog_addr' => 'BIOG_ADDR_DATA',
+                        'biog_inst' => 'BIOG_INST_DATA',
+                        'biog_source' => 'BIOG_SOURCE_DATA',
+                        'biog_text' => 'BIOG_TEXT_DATA',
+                        'entry' => 'ENTRY_DATA',
+                        'events' => 'EVENTS_DATA',
+                        'possession' => 'POSSESSION_DATA',
+                        'status' => 'STATUS_DATA',
+                        'posted_to_addr' => 'POSTED_TO_ADDR_DATA',
+                        'posting' => 'POSTING_DATA',
+                        'posted_to_office' => 'POSTED_TO_OFFICE_DATA',
+                    ];
+                    $countsPrimary = $preview['table_counts_primary'] ?? [];
+                    $countsSecondary = $preview['table_counts_secondary'] ?? [];
+                @endphp
+                @foreach($tableMap as $key => $label)
+                    @php
+                        $primaryCount = $countsPrimary[$key] ?? 0;
+                        $secondaryCount = $countsSecondary[$key] ?? 0;
+                        $primaryRows = collect($preview['other_details_primary'][$label] ?? []);
+                        $secondaryRows = collect($preview['other_details_secondary'][$label] ?? []);
+                    @endphp
+                    <div class="row" style="margin-top: 15px;">
+                        <div class="col-md-12">
+                            <h6>{{ $label }}</h6>
+                            @if($primaryCount || $secondaryCount || $primaryRows->count() || $secondaryRows->count())
+                                <table class="table table-bordered table-condensed table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>欄位</th>
+                                            <th>保留人物 ({{ $preview['primary_id'] ?? '-' }}) — {{ $primaryCount }} 筆</th>
+                                            <th>合併來源 ({{ $preview['secondary_id'] ?? '-' }}) — {{ $secondaryCount }} 筆</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <th>內容摘要</th>
+                                            <td>
+                                                @if($primaryRows->count())
+                                                    <ul class="list-unstyled small" style="word-break: break-all;">
+                                                        @foreach($primaryRows as $row)
+                                                            <li><code style="white-space: pre-wrap; word-break: break-all;">{{ json_encode((array)$row, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code></li>
+                                                        @endforeach
+                                                    </ul>
+                                                @else
+                                                    <div class="text-muted">無資料</div>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if($secondaryRows->count())
+                                                    <ul class="list-unstyled small" style="word-break: break-all;">
+                                                        @foreach($secondaryRows as $row)
+                                                            <li><code style="white-space: pre-wrap; word-break: break-all;">{{ json_encode((array)$row, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) }}</code></li>
+                                                        @endforeach
+                                                    </ul>
+                                                @else
+                                                    <div class="text-muted">無資料</div>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            @else
+                                <p class="text-muted">無資料。</p>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+
+                <h5>SQL 操作預覽</h5>
+                <p class="text-muted small">以下為示意語句，實際合併時請依工作流程審核後執行。</p>
+                @if(!empty($preview['auto_min_target']) && $preview['auto_min_target'] != $preview['primary_id'])
+                    <p class="text-muted small">已附上將資料最終調整為 ID {{ $preview['auto_min_target'] }} 的附加語句。</p>
+                @endif
+                <pre class="bg-light" style="padding: 12px;">{{ implode("\n", $preview['sql_preview']) }}</pre>
+
+                <p class="text-muted">{{ $preview['notes'] }}</p>
+            @else
+                <p class="text-muted">輸入兩個人物編號後，系統會在此呈現合併前後的概要。</p>
+            @endif
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+    <script>
+        (function(){
+            const copyBtn = document.getElementById('copy_merge_link');
+            if (copyBtn) {
+                copyBtn.addEventListener('click', function () {
+                    const base = this.getAttribute('data-base') || window.location.pathname;
+                    const params = new URLSearchParams();
+                    const fromVal = (document.getElementById('primary_id').value || '').trim();
+                    const toVal = (document.getElementById('secondary_id').value || '').trim();
+                    const reasonVal = (document.getElementById('merge_reason').value || '').trim();
+                    const autoBox = document.querySelector('input[name=\"auto_arrange\"]');
+                    const mergeToMin = autoBox ? (autoBox.checked ? 'true' : 'false') : 'true';
+
+                    if (fromVal !== '') params.set('from', fromVal);
+                    if (toVal !== '') params.set('to', toVal);
+                    params.set('merge_to_min', mergeToMin);
+                    if (reasonVal !== '') params.set('reason', reasonVal);
+
+                    const query = params.toString();
+                    const link = query ? base + '?' + query : base;
+
+                    const copy = (txt) => {
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            navigator.clipboard.writeText(txt).then(function () {
+                                alert('連結已複製到剪貼簿。');
+                            }).catch(function () {
+                                window.prompt('請複製以下連結：', txt);
+                            });
+                        } else {
+                            window.prompt('請複製以下連結：', txt);
+                        }
+                    };
+
+                    copy(link);
+                });
+            }
+        })();
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -132,6 +132,8 @@ Route::resource('manage', 'ManagementController', ['name' => [
     'update' => 'manage.update'
 ]]);
 
+Route::match(['get', 'post'], 'merge-preview', 'MergePreviewController@index')->name('merge-preview.index');
+
 Route::resource('operations', 'OperationsController', ['name' => [
     'show' => 'operations.show',
     'create' => 'operations.create',

--- a/tests/Unit/MergePreviewControllerTest.php
+++ b/tests/Unit/MergePreviewControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\MergePreviewController;
+use Carbon\Carbon;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class MergePreviewControllerTest extends TestCase
+{
+    /** @var TestableMergePreviewController */
+    private $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new TestableMergePreviewController();
+        Carbon::setTestNow(Carbon::create(2025, 1, 2, 3, 4, 5));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function testCalculateMergedPersonCombinesAttributesAndNotes()
+    {
+        $user = new GenericUser(['id' => 999, 'name' => 'MergeAdmin']);
+        Auth::guard()->setUser($user);
+
+        $primary = [
+            'exists' => true,
+            'id' => 123,
+            'attributes' => [
+                'c_personid' => 123,
+                'c_name' => 'Primary Name',
+                'c_name_chn' => '主名',
+                'c_notes' => "Primary note",
+                'c_status' => 'Active',
+            ],
+        ];
+        $secondary = [
+            'exists' => true,
+            'id' => 456,
+            'attributes' => [
+                'c_personid' => 456,
+                'c_name' => 'Secondary Name',
+                'c_name_chn' => '次名',
+                'c_notes' => "Secondary note",
+                'c_status' => 'Inactive',
+            ],
+        ];
+
+        $result = $this->controller->callCalculateMergedPerson($primary, $secondary, 'duplicate record');
+
+        $values = $result['values'];
+        $updates = $result['updates'];
+
+        $this->assertSame(123, $values['c_personid']);
+        $this->assertSame('Primary Name', $values['c_name'], 'Primary values should override secondary');
+        $this->assertSame('Active', $values['c_status']);
+        $this->assertSame('MergeAdmin', $values['c_modified_by']);
+        $this->assertSame('20250102', $values['c_modified_date']);
+        $this->assertContains('Primary note', $values['c_notes']);
+        $this->assertContains('Secondary note', $values['c_notes']);
+        $this->assertContains('[merged #123 and #456 on 20250102 with reason] duplicate record', $values['c_notes']);
+
+        $this->assertArrayHasKey('c_notes', $updates);
+        $this->assertArrayHasKey('c_modified_by', $updates);
+        $this->assertArrayHasKey('c_modified_date', $updates);
+        $this->assertArrayNotHasKey('c_personid', $updates);
+    }
+
+    public function testCalculateMergedPersonWithoutSecondaryReturnsEmpty()
+    {
+        $primary = ['exists' => true, 'attributes' => []];
+        $secondary = ['exists' => false];
+
+        $result = $this->controller->callCalculateMergedPerson($primary, $secondary, '');
+
+        $this->assertSame([], $result['values']);
+        $this->assertSame([], $result['updates']);
+    }
+
+    public function testShouldBlockMergeDetectsNameDifference()
+    {
+        $primary = ['exists' => true, 'name' => 'Zhang San', 'name_chn' => '張三'];
+        $secondary = ['exists' => true, 'name' => 'Li Si', 'name_chn' => '李四'];
+
+        $this->assertTrue($this->controller->callShouldBlockMerge($primary, $secondary));
+
+        $secondary['name'] = 'zhang san';
+        $secondary['name_chn'] = '張三';
+        $this->assertFalse($this->controller->callShouldBlockMerge($primary, $secondary));
+    }
+
+    public function testBuildSqlPreviewIncludesAutoArrangeStatements()
+    {
+        $statements = $this->controller->callBuildSqlPreview(200, 100, ['c_name' => 'Merged'], true, 100);
+
+        $this->assertSame('START TRANSACTION;', $statements[0]);
+        $this->assertContains("UPDATE BIOG_MAIN SET c_name = 'Merged' WHERE c_personid = 200;", $statements[1]);
+        $this->assertContains('-- 調整至較小 ID 100', $statements, 'Auto arrange block should suggest moving to min ID');
+        $this->assertContains("UPDATE BIOG_MAIN SET c_personid = 100 WHERE c_personid = 200;", $statements);
+    }
+
+    public function testBuildSqlPreviewSkipsAutoArrangeWhenDisabled()
+    {
+        $statements = $this->controller->callBuildSqlPreview(300, 200, [], false, null);
+
+        $this->assertNotContains('-- 調整至較小 ID', $statements);
+        $this->assertSame('START TRANSACTION;', $statements[0]);
+        $this->assertSame('COMMIT;', $statements[count($statements) - 1]);
+    }
+}
+
+class TestableMergePreviewController extends MergePreviewController
+{
+    public function callCalculateMergedPerson(array $primary, array $secondary, $reason)
+    {
+        return $this->calculateMergedPerson($primary, $secondary, $reason);
+    }
+
+    public function callShouldBlockMerge(array $primary, array $secondary)
+    {
+        return $this->shouldBlockMerge($primary, $secondary);
+    }
+
+    public function callBuildSqlPreview($primary, $secondary, array $updates, $autoArrange, $minTargetId)
+    {
+        return $this->buildSqlPreview($primary, $secondary, $updates, $autoArrange, $minTargetId);
+    }
+}


### PR DESCRIPTION
- 新增人物欄位比對，標示姓名差異並模擬合併後值，整合 c_modified_by/c_modified_date 與 c_notes 註記 merge reason
- 顯示 ALTNAME、KIN、ASSOC 等相關表資料與筆數，附 JSON 摘要與檢視連結，並即時統計其它受影響表格
- 產生兩段 SQL 交易：先執行欄位更新與 SELECT COUNT(*) 檢驗後刪除來源記錄；若選擇將大 ID 併入小 ID，第二段交易再進行 ID 轉移
- 加入詳細提示：合併理由的說明、merge_to_min 參數、複製連結按鈕、自動換行顯示 JSON，並在欄位差異時以紅色與警告提示

目前的版本**沒有**實際合併的功能，僅提供預覽。等「復原」功能完善並測試後，再推出實際合併，防止因誤操作形成不可逆的損失。