### PR TITLE
Usability improvements for `/codes/*` pages

### DIFF
--- a/CODES.md
+++ b/CODES.md
@@ -11,9 +11,10 @@
 - **操作流程**：新增、編輯、刪除均由同一控制器完成，路徑為 `/codes/{table}/{id}/...`。主鍵拆解使用 `_._` 連結前兩個欄位的方式猜測複合鍵。
 - **優點**：開發維護成本低、可以快速覆蓋多張 *_CODES 表，不需為每張表寫一個 controller/view。
 - **搜尋功能**：2025 年新增 `?search=` query 支援，可在頁面頂部篩選表格列，底層會對推斷出的欄位下 `LIKE` 條件並保留原本的分頁。搜尋框值會帶入 `appends()`，翻頁時不會遺失條件。
+- **操作紀錄**：`store`、`update`、`destroy` 現已呼叫 `OperationRepository`，將 CRUD 操作寫入 `operations` 表，內容含原始列資料與合併後值，與 `/altnamecodes` 等專用頁面保持一致。
 - **既知問題**（依先前分析與實測）：
   - 欄位自動推斷不一定準確，表頭順序可能與實際需求不符。
-  - `create`/`store` 流程沒有特殊驗證或操作紀錄；相比舊版專用頁面，少了操作寫回 `operations` 的記錄。
+  - `create`/`store` 尚缺少針對各表的欄位驗證與提示訊息，易出現不合規輸入。
 
 ## 專用 `/altnamecodes` 等介面
 - **資料來源與流程**：各表有對應的 Controller（例如 `AltnameCodesController`、`AddressCodesController`），後端多半使用 Repository 讀取資料（如 `App\Repositories\AltCodeRepository`）。部分控制器在 `update`/`store` 時會寫入 `OperationRepository` 產生操作紀錄，流程較嚴謹。
@@ -28,8 +29,8 @@
 ## 差異摘要
 - **介面型態**：`/codes/*` 是 Blade server-render 表格；`/altnamecodes` 系列為 Vue + API 單頁互動列表。
 - **表格範圍**：`/codes/*` 以 URL 動態選表，可快速覆蓋多張 *_CODES 表；專用介面則固定對應單一資料表。
-- **搜尋／分頁能力**：泛用介面僅有內建分頁，沒有搜尋欄位；專用介面提供即時搜尋與客製化頁碼切換，惟仍有已知的末頁瀏覽限制。
-- **安全與權限**：專用介面經由 Laravel `Route::resource` 定義，僅暴露核准的操作；`/codes/*` 的授權則由共用的 controller 處理。
+- **搜尋／分頁能力**：泛用介面已提供單欄位關鍵字搜尋並保留翻頁；專用介面另有 debounce、複合條件與自訂頁碼等互動功能。
+- **安全與權限**：專用介面經由 Laravel `Route::resource` 定義，僅暴露核准的操作；`/codes/*` 的授權則由共用的 controller 處理，並於操作失敗時提供明確訊息。
 - **維護成本**：泛用介面一處改，多處受益；專用介面則能加入針對性驗證（例如地址代碼 ID 需唯一）與操作紀錄，但相對分散。
 
 ## 為何同時存在兩套？（推測）

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -90,21 +90,28 @@ class CodesController extends Controller
         $table = $this->guardTable($table_name);
         if($table){
             try{
-                //20210323修改聯合主鍵的邏輯
-                $temp = explode("_._", $id);
-                $id_name = $this->getIdName($table);
-                $id_name_1 = $this->getIdName_1($table);
-                $id_name_2 = $this->getIdName_2($table);
-                //$data = DB::table($table_name)->where($id_name, $id)->first();
-                $data = DB::table($table)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->first();
-                //$data = DB::table($table_name)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->where($id_name_2, $temp[2])->first();
-                //修改結束
+                $keyColumns = $this->getKeyColumns($table);
+                $conditions = $this->buildConditionsFromId($keyColumns, $id);
+
+                $query = DB::table($table);
+                foreach ($conditions as $column => $value) {
+                    $query->where($column, $value);
+                }
+                $data = $query->first();
+
+                if (!$data) {
+                    flash('找不到该数据表', 'warning');
+                    return redirect()->back();
+                }
+
+                $compositeId = $this->buildCompositeId($keyColumns, $this->convertRowToArray($data));
+
                 return view('codes.edit', [
                     'page_title' => 'Codes',
                     'page_description' => $table,
                     'page_url' => '/codes',
                     'archer' => "<li><a href='/codes/".rawurlencode($table)."'>".e($table)."</a></li>",
-                    'id' => $id, 'row' => $data,
+                    'id' => $compositeId, 'row' => $data,
                     'table' => $table]);
             }catch (\PDOException $e) {
                 flash('找不到该数据表', 'warning');
@@ -126,24 +133,36 @@ class CodesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        $data = $request->all();
-        $data = array_except($data, ['_method', '_token']);
-//        dd($data);
-        //20210323修改聯合主鍵的邏輯
-        $id_name = $this->getIdName($table);
-        $id_name_1 = $this->getIdName_1($table);
-        $id_name_2 = $this->getIdName_2($table);
-        $temp = explode("_._", $id);
-        //DB::table($table_name)->where($id_name, $id)->update($data);
-        DB::table($table)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->update($data);
-        //DB::table($table_name)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->where($id_name_2, $temp[2])->update($data);
-        //修改結束
+        $keyColumns = $this->getKeyColumns($table);
+        $conditions = $this->buildConditionsFromId($keyColumns, $id);
+        $originalRow = $this->fetchRowByKeys($table, $keyColumns, $conditions);
+
+        $query = DB::table($table);
+        foreach ($conditions as $column => $value) {
+            $query->where($column, $value);
+        }
+        $data = array_except($request->all(), ['_method', '_token']);
+
+        try {
+            $query->update($data);
+        } catch (\Illuminate\Database\QueryException $e) {
+            if ($this->isDuplicateKeyException($e)) {
+                flash('更新失敗：主鍵或唯一值已存在。', 'error');
+                return redirect()->back()
+                    ->withInput()
+                    ->withErrors(['duplicate' => '更新失敗：主鍵或唯一值已存在。']);
+            }
+            throw $e;
+        }
+
+        $updatedRow = $this->fetchRowByKeys($table, $keyColumns, $conditions) ?: ($originalRow ? array_merge($originalRow, $data) : $data);
+
+        $this->recordOperation(2, $table, $keyColumns, $updatedRow, $originalRow ?: []);
+
         flash('Update success @ '.Carbon::now(), 'success');
 
-        //20210323組合新的id，避免修改聯合主鍵的值。 
-        $id = $data[$id_name].'_._'.$data[$id_name_1];
-        //$id = $data[$id_name].'_._'.$data[$id_name_1].'_._'.$data[$id_name_2];
-        //return redirect()->route('codes.show', ['table_name' => $table_name]);
+        $id = $this->buildCompositeId($keyColumns, $updatedRow);
+
         return redirect()->route('codes.edit', ['table_name' => $table, 'id' => $id]);
     }
 
@@ -180,8 +199,7 @@ class CodesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        $data = $request->all();
-        $data = array_except($data, ['_token']);
+        $data = array_except($request->all(), ['_token']);
         //20210323遮除「第一欄預設隱藏」
         //$id_ = $this->getIdName($table_name);
         //if($table_name != 'SOCIAL_INSTITUTION_CODES') {
@@ -199,7 +217,25 @@ class CodesController extends Controller
         $id = $data[$id_name].'_._'.$data[$id_name_1];
         //$id = $data[$id_name].'_._'.$data[$id_name_1].'_._'.$data[$id_name_2];
         //修改結束
-        DB::table($table)->insert($data);
+        try {
+            DB::table($table)->insert($data);
+        } catch (\Illuminate\Database\QueryException $e) {
+            if ($this->isDuplicateKeyException($e)) {
+                flash('新增失敗：主鍵或唯一值已存在。', 'error');
+                return redirect()->back()
+                    ->withInput()
+                    ->withErrors(['duplicate' => '新增失敗：主鍵或唯一值已存在。']);
+            }
+            throw $e;
+        }
+
+        $keyColumns = $this->getKeyColumns($table);
+        $storedRow = $this->fetchRowByKeys($table, $keyColumns, $this->buildConditionsFromRow($keyColumns, $data));
+        $rowData = $storedRow ?: $data;
+        $this->recordOperation(1, $table, $keyColumns, $rowData);
+
+        $id = $this->buildCompositeId($keyColumns, $rowData);
+
         flash('Store success @ '.Carbon::now(), 'success');
         return redirect()->route('codes.edit', ['table_name' => $table, 'id' => $id]);
     }
@@ -215,28 +251,18 @@ class CodesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        //20210323修改聯合主鍵的邏輯
-        $temp = explode("_._", $id);
-        $id_name = $this->getIdName($table);
-        $id_name_1 = $this->getIdName_1($table);
-        $id_name_2 = $this->getIdName_2($table);
+        $keyColumns = $this->getKeyColumns($table);
+        $conditions = $this->buildConditionsFromId($keyColumns, $id);
+        $row = $this->fetchRowByKeys($table, $keyColumns, $conditions);
 
-        $row = DB::table($table)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->first();
-        //$row = DB::table($table_name)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->where($id_name_2, $temp[2])->first();
-        //修改結束
-        $op = [
-            'op_type' => 4,
-            'resource' => $table,
-            'resource_id' => $id,
-            'resource_data' => json_encode((array)$row)
-        ];
-        //$this->operationRepository->store($op);
-        //20181207建安修改片段
-        $row2 = json_encode((array)$row);
-        $this->operationRepository->store(Auth::id(), '', 4, $table, $id, $row2);
-        //修改結束
-        DB::table($table)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->delete();
-        //DB::table($table_name)->where($id_name, $temp[0])->where($id_name_1, $temp[1])->where($id_name_2, $temp[2])->delete();
+        $this->recordOperation(4, $table, $keyColumns, $row ?: $conditions, $row ?: []);
+
+        $query = DB::table($table);
+        foreach ($conditions as $column => $value) {
+            $query->where($column, $value);
+        }
+        $query->delete();
+
         flash('Delete success @ '.Carbon::now(), 'success');
         return redirect()->route('codes.show', ['table_name' => $table]);
     }
@@ -297,5 +323,136 @@ class CodesController extends Controller
         }
 
         return Schema::getColumnListing($table);
+    }
+
+    protected function getKeyColumns(string $table): array
+    {
+        static $cache = [];
+        if (isset($cache[$table])) {
+            return $cache[$table];
+        }
+
+        $columns = Schema::getColumnListing($table);
+        $keys = [];
+
+        try {
+            $connection = DB::connection();
+            $details = $connection->getDoctrineSchemaManager()->listTableDetails($table);
+            if ($details->hasPrimaryKey()) {
+                $keys = $details->getPrimaryKey()->getColumns();
+            }
+        } catch (\Throwable $e) {
+            $keys = [];
+        }
+
+        if (empty($keys)) {
+            $keys[] = $columns[0] ?? 'id';
+            if (isset($columns[1])) {
+                $keys[] = $columns[1];
+            }
+        }
+
+        return $cache[$table] = array_values(array_unique(array_filter($keys)));
+    }
+
+    protected function buildCompositeId(array $keyColumns, array $row): string
+    {
+        $parts = [];
+        foreach ($keyColumns as $column) {
+            if (array_key_exists($column, $row)) {
+                $parts[] = (string) $row[$column];
+            }
+        }
+
+        return implode('_._', array_filter($parts, function ($part) {
+            return $part !== '';
+        }));
+    }
+
+    protected function buildConditionsFromRow(array $keyColumns, array $row): array
+    {
+        $conditions = [];
+        foreach ($keyColumns as $column) {
+            if (array_key_exists($column, $row)) {
+                $conditions[$column] = $row[$column];
+            }
+        }
+        return $conditions;
+    }
+
+    protected function buildConditionsFromId(array $keyColumns, string $id): array
+    {
+        $conditions = [];
+        $parts = explode('_._', $id);
+        foreach ($keyColumns as $index => $column) {
+            if (isset($parts[$index]) && $parts[$index] !== '') {
+                $conditions[$column] = $parts[$index];
+            }
+        }
+        return $conditions;
+    }
+
+    protected function fetchRowByKeys(string $table, array $keyColumns, array $conditions)
+    {
+        if (empty($conditions)) {
+            return null;
+        }
+
+        $query = DB::table($table);
+        foreach ($conditions as $column => $value) {
+            $query->where($column, $value);
+        }
+
+        $row = $query->first();
+        return $row ? $this->convertRowToArray($row) : null;
+    }
+
+    protected function recordOperation(int $type, string $table, array $keyColumns, array $data, array $original = [])
+    {
+        if (!Auth::check()) {
+            return;
+        }
+
+        $resourceId = $this->buildCompositeId($keyColumns, $data);
+        if ($resourceId === '' && !empty($original)) {
+            $resourceId = $this->buildCompositeId($keyColumns, $original);
+        }
+
+        $this->operationRepository->store(
+            Auth::id(),
+            0,
+            $type,
+            $table,
+            $resourceId,
+            $data,
+            $original
+        );
+    }
+
+    protected function convertRowToArray($row): array
+    {
+        if (is_null($row)) {
+            return [];
+        }
+
+        if (is_array($row)) {
+            return $row;
+        }
+
+        if ($row instanceof \ArrayAccess) {
+            return (array) $row;
+        }
+
+        return json_decode(json_encode($row), true) ?: [];
+    }
+
+    protected function isDuplicateKeyException(\Illuminate\Database\QueryException $exception): bool
+    {
+        if ($exception->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+        return strpos($message, 'Duplicate entry') !== false;
     }
 }

--- a/resources/views/codes/show.blade.php
+++ b/resources/views/codes/show.blade.php
@@ -7,13 +7,15 @@
             <h3 class="box-title">代碼表</h3>
 
             <div class="box-tools pull-right">
-                <a class="btn btn-default" href="/codes/{{ $q }}/create">新增</a>
+                @if(Auth::check())
+                    <a class="btn btn-default" href="/codes/{{ $q }}/create">新增</a>
+                @endif
             </div>
         </div>
         <!-- /.box-header -->
         <div class="box-body">
-            <form method="GET" action="{{ route('codes.show', ['table_name' => $q]) }}" class="form-inline" style="margin-bottom: 15px;">
-                <div class="input-group input-group-sm" style="width: 420px;">
+            <form method="GET" action="{{ route('codes.show', ['table_name' => $q]) }}" style="margin-bottom: 15px;">
+                <div class="input-group input-group-sm" style="width: 100%; max-width: 420px;">
                     <input type="text"
                            name="search"
                            class="form-control"
@@ -27,67 +29,75 @@
                     </span>
                 </div>
             </form>
-            <table class="table table-bordered table-striped table-condensed">
-                <thead>
-                <tr>
-                    @foreach ($thead as $item)
-                        <th>{{ $item }}</th>
-                    @endforeach
-                    <th style="width: 120px">操作</th>
-                </tr>
-                </thead>
-                <tbody>
-                @forelse ($data as $item)
+            <div class="table-responsive" style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
+                <table class="table table-bordered table-striped table-condensed">
+                    <thead>
                     <tr>
-                        @php($count = 0)
-                        @php($sum = 0)
-                        @php($id_ = '')
-                        @foreach((array)$item as $key => $value)
-                            @if($count > count($thead)-1)
-                                @break
-                            @endif
-                            @if(str_contains($key, 'name') or str_contains($key, 'desc') or str_contains($key, 'code') or str_contains($key, 'id') or str_contains($key, 'sequence') or str_contains($key, 'chn') or str_contains($key, 'dy'))
-                                <td>{{ $value }}</td>
-                                @php($count++)
-                            @endif
-                            @if($sum <= 1)
-                                @if($sum != 0 && $sum <= 1)
-                                    @php($id_ .= '_._')
-                                @endif
-                                @php($id_ .= $value)
-                            @endif
-                            @php($sum++)
+                        @foreach ($thead as $item)
+                            <th>{{ $item }}</th>
                         @endforeach
-                        <td>
-                            <div class="btn-group">
-                                <a type="button" class="btn btn-sm btn-info" href="/codes/{{ $q }}/{{ $id_ }}/edit">edit</a>
-                                <a href="{{ route('codes.destroy', ['table_name'=>$q, 'id'=>$id_]) }}"
-                                   onclick="alert('确认删除');
-                                            event.preventDefault();
-                                           document.getElementById('delete-form-{{ $id_ }}').submit();"
-                                   class="btn btn-sm btn-danger">delete</a>
-                            </div>
-                            <form id="delete-form-{{ $id_ }}" action="{{ route('codes.destroy', ['table_name'=>$q, 'id'=>$id_]) }}" method="POST" style="display: none;">
-                                {{ method_field('DELETE') }}
-                                {{ csrf_field() }}
-                            </form>
-                        </td>
+                        @if(Auth::check())
+                            <th style="width: 120px">操作</th>
+                        @endif
                     </tr>
-                @empty
+                    </thead>
+                    <tbody>
+                    @forelse ($data as $item)
+                        <tr>
+                            @php($count = 0)
+                            @php($sum = 0)
+                            @php($id_ = '')
+                            @foreach((array)$item as $key => $value)
+                                @if($count > count($thead)-1)
+                                    @break
+                                @endif
+                                @if(str_contains($key, 'name') or str_contains($key, 'desc') or str_contains($key, 'code') or str_contains($key, 'id') or str_contains($key, 'sequence') or str_contains($key, 'chn') or str_contains($key, 'dy'))
+                                    <td>{{ $value }}</td>
+                                    @php($count++)
+                                @endif
+                                @if($sum <= 1)
+                                    @if($sum != 0 && $sum <= 1)
+                                        @php($id_ .= '_._')
+                                    @endif
+                                    @php($id_ .= $value)
+                                @endif
+                                @php($sum++)
+                            @endforeach
+                            @if(Auth::check())
+                                <td>
+                                    <div class="btn-group">
+                                        <a type="button" class="btn btn-sm btn-info" href="/codes/{{ $q }}/{{ $id_ }}/edit">edit</a>
+                                        <a href="{{ route('codes.destroy', ['table_name'=>$q, 'id'=>$id_]) }}"
+                                           onclick="alert('确认删除');
+                                                    event.preventDefault();
+                                                   document.getElementById('delete-form-{{ $id_ }}').submit();"
+                                           class="btn btn-sm btn-danger">delete</a>
+                                    </div>
+                                    <form id="delete-form-{{ $id_ }}" action="{{ route('codes.destroy', ['table_name'=>$q, 'id'=>$id_]) }}" method="POST" style="display: none;">
+                                        {{ method_field('DELETE') }}
+                                        {{ csrf_field() }}
+                                    </form>
+                                </td>
+                            @endif
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="{{ count($thead) + 1 }}" class="text-center text-muted">沒有資料</td>
+                        </tr>
+                    @endforelse
+                    </tbody>
+                    <tfoot>
                     <tr>
-                        <td colspan="{{ count($thead) + 1 }}" class="text-center text-muted">沒有資料</td>
+                        @foreach ($thead as $item)
+                            <th>{{ $item }}</th>
+                        @endforeach
+                        @if(Auth::check())
+                            <th style="width: 120px">操作</th>
+                        @endif
                     </tr>
-                @endforelse
-                </tbody>
-                <tfoot>
-                <tr>
-                    @foreach ($thead as $item)
-                        <th>{{ $item }}</th>
-                    @endforeach
-                    <th style="width: 120px">操作</th>
-                </tr>
-                </tfoot>
-            </table>
+                    </tfoot>
+                </table>
+            </div>
             <div class="pull-right">{{ $data->links() }}</div>
         </div>
         <!-- /.box-body -->

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -18,6 +18,12 @@ class CodesControllerTest extends TestCase
         parent::setUp();
 
         config(['codes.tables' => ['TEST_CODES']]);
+        $compiledPath = base_path('tests/storage/views');
+        if (!is_dir($compiledPath)) {
+            mkdir($compiledPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledPath]);
+
         $this->app->instance(CodesRepository::class, new class extends CodesRepository {
             public function allowedTables(): array
             {
@@ -189,6 +195,26 @@ class CodesControllerTest extends TestCase
         $response->assertDontSee('Alpha entry');
         $response->assertDontSee('Gamma entry');
         $response->assertSee('value="Beta"', false);
+
+        DB::swap($originalDb);
+    }
+
+    public function testGuestViewDoesNotShowActions()
+    {
+        $rows = [
+            ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'Alpha entry'],
+        ];
+
+        $fakeDb = new FakeDatabaseManager($rows);
+        $originalDb = $this->app['db'];
+        DB::swap($fakeDb);
+
+        $response = $this->get('/codes/TEST_CODES');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('edit');
+        $response->assertDontSee('delete');
+        $response->assertDontSee('新增');
 
         DB::swap($originalDb);
     }

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -6,23 +6,35 @@ use App\Http\Controllers\CodesController;
 use App\Repositories\CodesRepository;
 use App\Repositories\OperationRepository;
 use App\User;
+use Illuminate\Database\QueryException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class CodesControllerTest extends TestCase
 {
+    protected $operationSpy;
+    protected $originalDb;
+    protected $fakeDb;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         config(['codes.tables' => ['TEST_CODES']]);
+        config(['codes.connection' => null]);
+
         $compiledPath = base_path('tests/storage/views');
         if (!is_dir($compiledPath)) {
             mkdir($compiledPath, 0777, true);
         }
         config(['view.compiled' => $compiledPath]);
+
+        $this->originalDb = DB::getFacadeRoot();
+        $this->fakeDb = new FakeDatabaseManager(['TEST_CODES' => []]);
+        DB::swap($this->fakeDb);
 
         $this->app->instance(CodesRepository::class, new class extends CodesRepository {
             public function allowedTables(): array
@@ -35,10 +47,27 @@ class CodesControllerTest extends TestCase
                 return ['TEST_CODES' => 'TEST_CODES'];
             }
         });
+
+        $this->operationSpy = new class extends OperationRepository {
+            public $calls = [];
+
+            public function store($user_id, $c_personid, $op_type, $resource, $resource_id, $resource_data, $ori = '', $crowdsourcing_status = 0)
+            {
+                $this->calls[] = compact('user_id', 'c_personid', 'op_type', 'resource', 'resource_id', 'resource_data', 'ori', 'crowdsourcing_status');
+            }
+        };
+        $this->app->instance(OperationRepository::class, $this->operationSpy);
+    }
+
+    protected function tearDown(): void
+    {
+        DB::swap($this->originalDb);
+        parent::tearDown();
     }
 
     public function testGuestCannotStoreRows()
     {
+        $this->operationSpy->calls = [];
         $payload = [
             'code_id' => 'A1',
             'code_sub' => 'B1',
@@ -49,10 +78,12 @@ class CodesControllerTest extends TestCase
             ->post('/codes/TEST_CODES', $payload);
 
         $response->assertRedirect('/codes/TEST_CODES/create');
+        $this->assertEmpty($this->operationSpy->calls);
     }
 
     public function testInactiveUserCannotStoreRows()
     {
+        $this->operationSpy->calls = [];
         $inactiveUser = new User([
             'name' => 'inactive',
             'email' => 'inactive@example.com',
@@ -72,10 +103,12 @@ class CodesControllerTest extends TestCase
             ->post('/codes/TEST_CODES', $payload);
 
         $response->assertRedirect('/codes/TEST_CODES/create');
+        $this->assertEmpty($this->operationSpy->calls);
     }
 
-    public function testActiveUserStoreDoesNotInvokeOperationRepository()
+    public function testActiveUserStoreLogsOperation()
     {
+        $this->operationSpy->calls = [];
         $activeUser = new User([
             'name' => 'active',
             'email' => 'active@example.com',
@@ -90,103 +123,28 @@ class CodesControllerTest extends TestCase
             'code_sub' => 'B3',
             'description' => 'active stored',
         ];
-        $recordedInserts = new \ArrayObject();
-        $originalDb = $this->app['db'];
-        $dbStub = new class($recordedInserts) {
-            private $records;
-
-            public function __construct(\ArrayObject $records)
-            {
-                $this->records = $records;
-            }
-
-            public function table($name)
-            {
-                return new class($name, $this->records) {
-                    private $name;
-                    private $records;
-
-                    public function __construct($name, \ArrayObject $records)
-                    {
-                        $this->name = $name;
-                        $this->records = $records;
-                    }
-
-                    public function insert(array $data)
-                    {
-                        $this->records->append(['table' => $this->name, 'data' => $data]);
-                        return true;
-                    }
-                };
-            }
-        };
-        DB::swap($dbStub);
-
-        $operationStub = new class extends OperationRepository {
-            public $called = false;
-
-            public function store($user_id, $c_personid, $op_type, $resource, $resource_id, $resource_data, $ori = '', $crowdsourcing_status = 0)
-            {
-                $this->called = true;
-            }
-        };
-        $this->app->instance(OperationRepository::class, $operationStub);
-
-        $this->app->bind(CodesController::class, function ($app) use ($operationStub) {
-            return new class($app->make(CodesRepository::class), $operationStub) extends CodesController {
-                protected function getIdName($table_name)
-                {
-                    return 'code_id';
-                }
-
-                protected function getIdName_1($table_name)
-                {
-                    return 'code_sub';
-                }
-
-                protected function getIdName_2($table_name)
-                {
-                    return 'description';
-                }
-            };
-        });
-
-        $payload = $expectedInsert;
-
-        $response = $this->post('/codes/TEST_CODES', $payload);
+        $response = $this->post('/codes/TEST_CODES', $expectedInsert);
 
         $response->assertRedirect(route('codes.edit', [
             'table_name' => 'TEST_CODES',
             'id' => 'A3_._B3',
         ]));
 
-        $this->assertFalse($operationStub->called, 'OperationRepository::store should not be invoked for generic codes store');
-        $this->assertCount(1, (array) $recordedInserts);
-        $insertRecord = $recordedInserts[0];
-        $this->assertSame('TEST_CODES', $insertRecord['table']);
-        $this->assertSame($expectedInsert, $insertRecord['data']);
-
-        $this->app->bind(CodesController::class, function ($app) {
-            return new CodesController(
-                $app->make(CodesRepository::class),
-                $app->make(OperationRepository::class)
-            );
-        });
-        $this->app->instance(OperationRepository::class, new OperationRepository());
-        DB::swap($originalDb);
+        $this->assertCount(1, $this->operationSpy->calls);
+        $call = $this->operationSpy->calls[0];
+        $this->assertSame(1, $call['op_type']);
+        $this->assertSame('TEST_CODES', $call['resource']);
+        $this->assertSame('A3_._B3', $call['resource_id']);
+        $this->assertSame($expectedInsert['description'], $call['resource_data']['description']);
     }
 
     public function testSearchFiltersResults()
     {
-        $rows = [
+        DB::table('TEST_CODES')->insert([
             ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'Alpha entry'],
             ['code_id' => 'A2', 'code_sub' => 'X2', 'description' => 'Beta entry'],
             ['code_id' => 'A3', 'code_sub' => 'X3', 'description' => 'Gamma entry'],
-        ];
-
-        $fakeDb = new FakeDatabaseManager($rows);
-        $originalDb = $this->app['db'];
-        DB::swap($fakeDb);
+        ]);
 
         $response = $this->get('/codes/TEST_CODES?search=Beta');
 
@@ -195,19 +153,14 @@ class CodesControllerTest extends TestCase
         $response->assertDontSee('Alpha entry');
         $response->assertDontSee('Gamma entry');
         $response->assertSee('value="Beta"', false);
-
-        DB::swap($originalDb);
+        $this->assertEmpty($this->operationSpy->calls);
     }
 
     public function testGuestViewDoesNotShowActions()
     {
-        $rows = [
+        DB::table('TEST_CODES')->insert([
             ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'Alpha entry'],
-        ];
-
-        $fakeDb = new FakeDatabaseManager($rows);
-        $originalDb = $this->app['db'];
-        DB::swap($fakeDb);
+        ]);
 
         $response = $this->get('/codes/TEST_CODES');
 
@@ -215,23 +168,121 @@ class CodesControllerTest extends TestCase
         $response->assertDontSee('edit');
         $response->assertDontSee('delete');
         $response->assertDontSee('新增');
+        $this->assertEmpty($this->operationSpy->calls);
+    }
 
-        DB::swap($originalDb);
+    public function testActiveUserUpdateLogsOperation()
+    {
+        DB::table('TEST_CODES')->insert([
+            ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'Old'],
+        ]);
+
+        $this->operationSpy->calls = [];
+
+        $user = new User([
+            'name' => 'editor',
+            'email' => 'editor@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 3;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->put('/codes/TEST_CODES/A1_._X1', [
+            'description' => 'Updated',
+        ]);
+
+        $response->assertRedirect(route('codes.edit', [
+            'table_name' => 'TEST_CODES',
+            'id' => 'A1_._X1',
+        ]));
+
+        $this->assertCount(1, $this->operationSpy->calls);
+        $call = $this->operationSpy->calls[0];
+        $this->assertSame(2, $call['op_type']);
+        $this->assertSame('TEST_CODES', $call['resource']);
+        $this->assertSame('A1_._X1', $call['resource_id']);
+        $this->assertSame('Updated', $call['resource_data']['description']);
+        $this->assertSame('Old', $call['ori']['description']);
+    }
+
+    public function testActiveUserDestroyLogsOperation()
+    {
+        DB::table('TEST_CODES')->insert([
+            ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'To delete'],
+        ]);
+
+        $this->operationSpy->calls = [];
+
+        $user = new User([
+            'name' => 'deleter',
+            'email' => 'deleter@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 4;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->delete('/codes/TEST_CODES/A1_._X1');
+
+        $response->assertRedirect(route('codes.show', ['table_name' => 'TEST_CODES']));
+
+        $this->assertCount(1, $this->operationSpy->calls);
+        $call = $this->operationSpy->calls[0];
+        $this->assertSame(4, $call['op_type']);
+        $this->assertSame('TEST_CODES', $call['resource']);
+        $this->assertSame('A1_._X1', $call['resource_id']);
+        $this->assertSame('To delete', $call['resource_data']['description']);
+    }
+
+    public function testUpdateGracefullyHandlesDuplicateKey()
+    {
+        $this->fakeDb->tables['TEST_CODES'][] = ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'Old'];
+        $this->fakeDb->setFailure('update', 'Duplicate entry #1062');
+        $this->operationSpy->calls = [];
+
+        $user = new User([
+            'name' => 'editor',
+            'email' => 'editor@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 6;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->from('/codes/TEST_CODES/A1_._X1/edit')->put('/codes/TEST_CODES/A1_._X1', [
+            'description' => 'Updated',
+        ]);
+
+        $response->assertRedirect('/codes/TEST_CODES/A1_._X1/edit');
+        $response->assertSessionHasErrors(['duplicate']);
+        $response->assertSessionHas('_old_input.description', 'Updated');
+        $this->assertEmpty($this->operationSpy->calls);
+
+        $this->fakeDb->clearFailures();
+        $this->assertCount(1, $this->fakeDb->failuresCleared);
     }
 }
 
 class FakeDatabaseManager
 {
-    private $rows;
+    public $tables = [];
+    public $failures = [];
+    public $failuresCleared = [];
 
-    public function __construct(array $rows)
+    public function __construct(array $tables = [])
     {
-        $this->rows = $rows;
+        $this->tables = $tables;
     }
 
     public function table($name)
     {
-        return new FakeQueryBuilder($this->rows);
+        if (!array_key_exists($name, $this->tables)) {
+            $this->tables[$name] = [];
+        }
+
+        $rows =& $this->tables[$name];
+        return new FakeQueryBuilder($rows, $this, $name);
     }
 
     public function connection($name = null)
@@ -239,81 +290,229 @@ class FakeDatabaseManager
         return $this;
     }
 
+    public function getDoctrineSchemaManager()
+    {
+        return new FakeDoctrineSchemaManager();
+    }
+
     public function select($query)
     {
         return [];
+    }
+
+    public function getSchemaBuilder()
+    {
+        return new FakeSchemaBuilder();
+    }
+
+    public function setFailure(string $operation, string $message = 'Simulated failure'): void
+    {
+        $this->failures[$operation] = $message;
+    }
+
+    public function clearFailures(): void
+    {
+        $this->failures = [];
+        $this->failuresCleared[] = true;
+    }
+
+    public function shouldFail(string $operation): bool
+    {
+        return array_key_exists($operation, $this->failures);
+    }
+
+    public function failureMessage(string $operation): string
+    {
+        return $this->failures[$operation] ?? 'Simulated failure';
+    }
+}
+
+class FakeDoctrineSchemaManager
+{
+    public function listTableDetails($table)
+    {
+        return new FakeTableDetails();
+    }
+}
+
+class FakeTableDetails
+{
+    public function hasPrimaryKey()
+    {
+        return false;
+    }
+
+    public function getPrimaryKey()
+    {
+        return null;
+    }
+}
+
+class FakeSchemaBuilder
+{
+    public function getColumnListing($table)
+    {
+        return ['code_id', 'code_sub', 'description'];
     }
 }
 
 class FakeQueryBuilder
 {
     private $rows;
-    private $filters = [];
+    private $conditions = [];
+    private $table;
+    private $manager;
 
-    public function __construct(array $rows)
+    public function __construct(array &$rows, FakeDatabaseManager $manager, string $table)
     {
-        $this->rows = $rows;
+        $this->rows =& $rows;
+        $this->manager = $manager;
+        $this->table = $table;
     }
 
     public function __clone()
     {
-        $this->filters = [];
+        $this->conditions = [];
     }
 
-    public function first()
+    public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        $filtered = $this->applyFilters($this->rows);
-        $first = reset($filtered);
-        return $first ? (object) $first : null;
-    }
-
-    public function where($callback)
-    {
-        if (is_callable($callback)) {
-            $callback($this);
+        if (is_callable($column)) {
+            $column($this);
+            return $this;
         }
+
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        $this->conditions[] = [
+            'column' => $column,
+            'operator' => strtolower((string) $operator),
+            'value' => $value,
+            'boolean' => strtolower($boolean),
+        ];
+
         return $this;
     }
 
     public function orWhere($column, $operator = null, $value = null)
     {
-        if (strtolower($operator) === 'like') {
-            $this->filters[] = ['column' => $column, 'value' => $value];
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
         }
-        return $this;
+
+        return $this->where($column, $operator, $value, 'or');
+    }
+
+    public function first()
+    {
+        $filtered = $this->applyConditions();
+        $first = reset($filtered);
+        return $first ? (object) $first : null;
+    }
+
+    public function insert(array $data)
+    {
+        if ($this->manager->shouldFail('insert')) {
+            throw new QueryException('insert into '.$this->table, [], new \Exception($this->manager->failureMessage('insert')));
+        }
+
+        if (isset($data[0]) && is_array($data[0])) {
+            foreach ($data as $row) {
+                $this->rows[] = $row;
+            }
+        } else {
+            $this->rows[] = $data;
+        }
+        return true;
+    }
+
+    public function update(array $data)
+    {
+        if ($this->manager->shouldFail('update')) {
+            throw new QueryException('update '.$this->table, [], new \Exception($this->manager->failureMessage('update')));
+        }
+
+        foreach ($this->rows as &$row) {
+            if ($this->rowMatches($row)) {
+                foreach ($data as $key => $value) {
+                    $row[$key] = $value;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public function delete()
+    {
+        if ($this->manager->shouldFail('delete')) {
+            throw new QueryException('delete from '.$this->table, [], new \Exception($this->manager->failureMessage('delete')));
+        }
+
+        $this->rows = array_values(array_filter($this->rows, function ($row) {
+            return !$this->rowMatches($row);
+        }));
     }
 
     public function paginate($perPage)
     {
-        $filtered = $this->applyFilters($this->rows);
         $items = array_map(function ($row) {
             return (object) $row;
-        }, $filtered);
+        }, $this->applyConditions());
 
         return new LengthAwarePaginator(
             $items,
-            count($filtered),
+            count($items),
             $perPage,
             1,
             ['path' => url()->current()]
         );
     }
 
-    private function applyFilters(array $rows): array
+    private function applyConditions(): array
     {
-        if (empty($this->filters)) {
-            return array_values($rows);
+        if (empty($this->conditions)) {
+            return $this->rows;
         }
 
-        return array_values(array_filter($rows, function ($row) {
-            foreach ($this->filters as $filter) {
-                $needle = trim($filter['value'], '%');
-                $value = isset($row[$filter['column']]) ? (string) $row[$filter['column']] : '';
-                if (stripos($value, $needle) !== false) {
-                    return true;
-                }
-            }
-            return false;
+        return array_values(array_filter($this->rows, function ($row) {
+            return $this->rowMatches($row);
         }));
+    }
+
+    private function rowMatches(array $row): bool
+    {
+        if (empty($this->conditions)) {
+            return true;
+        }
+
+        $result = null;
+        foreach ($this->conditions as $condition) {
+            $match = $this->matchCondition($row, $condition);
+            if ($condition['boolean'] === 'or') {
+                $result = ($result ?? false) || $match;
+            } else {
+                $result = ($result ?? true) && $match;
+            }
+        }
+
+        return (bool) $result;
+    }
+
+    private function matchCondition(array $row, array $condition): bool
+    {
+        $value = $row[$condition['column']] ?? null;
+        $expected = $condition['value'];
+
+        if ($condition['operator'] === 'like') {
+            $needle = trim((string) $expected, '%');
+            return stripos((string) $value, $needle) !== false;
+        }
+
+        return (string) $value === (string) $expected;
     }
 }

--- a/tests/storage/.gitignore
+++ b/tests/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Improved the `/codes/*` page experience on mobile devices
- Hide the "create", "edit", and "delete" buttons for guest (non-logged in) users
- Log "create", "edit", and "delete" actions in the `operations` table
- Add proper error messaging when there's a failure
- Add unit tests

We should now be able to replace 6 custom "codes" pages with the generic `/codes/*` pages.
- https://input.cbdb.fas.harvard.edu/altnamecodes -> https://input.cbdb.fas.harvard.edu/codes/ALTNAME_CODES
- https://input.cbdb.fas.harvard.edu/appointcodes -> https://input.cbdb.fas.harvard.edu/codes/APPOINTMENT_CODES
- https://input.cbdb.fas.harvard.edu/textcodes -> https://input.cbdb.fas.harvard.edu/codes/TEXT_CODES
- https://input.cbdb.fas.harvard.edu/addrcodes -> https://input.cbdb.fas.harvard.edu/codes/ADDR_CODES
- https://input.cbdb.fas.harvard.edu/officecodes -> https://input.cbdb.fas.harvard.edu/codes/OFFICE_CODES
- https://input.cbdb.fas.harvard.edu/socialinstitutioncodes -> https://input.cbdb.fas.harvard.edu/codes/SOCIAL_INSTITUTION_CODES