### PR TITLE
[EXPERIMENTAL] 20251023 改造前後端以避免 POSTED_TO_OFFICE_DATA 表內容發生非實質更改

### DIFF
--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -167,9 +167,17 @@ class BasicInformationOfficesController extends Controller
         }
         //return $request;
         //修改結束
-        $id_ = $this->biogMainRepository->officeUpdateById($request, $id_, $id);
-        flash('Update success @ '.Carbon::now(), 'success');
-        return redirect()->route('basicinformation.offices.edit', ['id' => $id, 'office' => $id_]);
+        $result = $this->biogMainRepository->officeUpdateById($request, $id_, $id);
+        $officeKey = is_array($result) ? ($result['id'] ?? $id_) : $result;
+        $noChanges = is_array($result) && !empty($result['no_changes']);
+
+        if ($noChanges) {
+            flash('無實質更新，資料未變更 @ '.Carbon::now(), 'info');
+        } else {
+            flash('Update success @ '.Carbon::now(), 'success');
+        }
+
+        return redirect()->route('basicinformation.offices.edit', ['id' => $id, 'office' => $officeKey]);
     }
 
     //20190225新增另存功能

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -25,6 +25,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use App\Repositories\Concerns\DetectsModelChanges;
 
 //20181112建安修改
 use App\SocialInstCode;
@@ -50,6 +51,7 @@ ini_set('max_execution_time', 300);
  */
 class BiogMainRepository
 {
+    use DetectsModelChanges;
     /**
      * @param $id
      * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|null|static|static[]
@@ -416,21 +418,47 @@ class BiogMainRepository
         $_postingid = $data['_postingid'];
         $_officeid = $data['_officeid']; //目前与officeid无关
 
-        if (!empty($data['c_addr'])){
-            $this->insertAddr($data['c_addr'], $_id, $_postingid, $_officeid);
+        $incomingAddr = array_key_exists('c_addr', $data) ? (array)$data['c_addr'] : null;
+
+        $oriRecord = DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->first();
+        $ori = $oriRecord ? json_decode(json_encode($oriRecord), true) : [];
+
+        $addressCollection = DB::table('POSTED_TO_ADDR_DATA')
+            ->where('c_personid', $_id)
+            ->where('c_posting_id', $_postingid)
+            ->pluck('c_addr_id');
+
+        $existingAddresses = $addressCollection ? $addressCollection->all() : [];
+        $hasAddressChange = $incomingAddr !== null
+            && $this->selectionListHasChanges($incomingAddr, $existingAddresses, -999);
+
+        if ($hasAddressChange) {
+            $this->insertAddr($incomingAddr, $_id, $_postingid, $_officeid);
         }
+
         $data = array_except($data, ['_method', '_token', 'c_addr', '_id', '_postingid', '_officeid']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
         $data['c_office_id'] = $data['c_office_id'] == -999 ? '0' : $data['c_office_id'];
         //$data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
+
+        $hasPostingChange = $this->hasMeaningfulChanges($data, $ori, ['c_modified_by', 'c_modified_date']);
+
+        if (!$hasPostingChange && !$hasAddressChange) {
+            return [
+                'id' => $_officeid."-".$_postingid,
+                'no_changes' => true,
+            ];
+        }
+
         $data = (new ToolsRepository)->timestamp($data);
-        //20251214新增差異比對紀錄
-        $ori = DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->first();
         DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->update($data);
         (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'POSTED_TO_OFFICE_DATA', $data['c_office_id']."-".$_postingid, $data, $ori);
-        return $data['c_office_id']."-".$_postingid;
+        return [
+            'id' => $data['c_office_id']."-".$_postingid,
+            'no_changes' => false,
+        ];
     }
 
     public function officeStoreById(Request $request, $id)

--- a/app/Repositories/Concerns/DetectsModelChanges.php
+++ b/app/Repositories/Concerns/DetectsModelChanges.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Repositories\Concerns;
+
+trait DetectsModelChanges
+{
+    /**
+     * Normalize scalar or structured values so they can be compared consistently.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    protected function normalizeComparisonValue($value)
+    {
+        if (is_array($value) || is_object($value)) {
+            return json_encode($value);
+        }
+        if ($value === null) {
+            return '';
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+        return trim((string)$value);
+    }
+
+    /**
+     * Determine whether the provided data differs from the original.
+     *
+     * @param array $newData
+     * @param array $original
+     * @param array $ignoredKeys
+     * @return bool
+     */
+    protected function hasMeaningfulChanges(array $newData, array $original, array $ignoredKeys = [])
+    {
+        if (empty($original)) {
+            return true;
+        }
+
+        foreach ($newData as $key => $value) {
+            if (in_array($key, $ignoredKeys, true)) {
+                continue;
+            }
+
+            $left = $this->normalizeComparisonValue($value);
+            $right = array_key_exists($key, $original)
+                ? $this->normalizeComparisonValue($original[$key])
+                : '';
+
+            if ($left !== $right) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Normalize a list of identifiers (typically from multi-select inputs) for comparison.
+     *
+     * @param iterable $values
+     * @param mixed $nullToken Value that should be treated as null before normalization.
+     * @return array
+     */
+    protected function normalizeSelectionList($values, $nullToken = null)
+    {
+        $normalized = [];
+
+        foreach ((array)$values as $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if ($nullToken !== null && $value == $nullToken) {
+                $value = 0;
+            }
+
+            $normalized[] = (string)$value;
+        }
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * Compare two selection lists after normalization.
+     *
+     * @param iterable $incoming
+     * @param iterable $existing
+     * @param mixed $nullToken
+     * @return bool True when lists differ.
+     */
+    protected function selectionListHasChanges($incoming, $existing, $nullToken = null)
+    {
+        return $this->normalizeSelectionList($incoming, $nullToken) !== $this->normalizeSelectionList($existing, $nullToken);
+    }
+}

--- a/resources/views/biogmains/offices/edit.blade.php
+++ b/resources/views/biogmains/offices/edit.blade.php
@@ -5,7 +5,7 @@
         <div class="panel-heading">官名 Postings</div>
         <div class="panel-body">
             <div class="panel-body">
-            <form action="{{ route('basicinformation.offices.update', ['id' => $id, 'id_'=> $row->c_office_id.'-'.$row->c_posting_id]) }}" class="form-horizontal" method="post">
+            <form id="office-edit-form" action="{{ route('basicinformation.offices.update', ['id' => $id, 'id_'=> $row->c_office_id.'-'.$row->c_posting_id]) }}" class="form-horizontal" method="post">
                 {{ method_field('PATCH') }}
                 {{ csrf_field() }}
                 <input name="_id" type="text" class="hidden" value="{{ $id }}">
@@ -219,7 +219,7 @@
                 </div>
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
-                        <button type="submit" class="btn btn-default">Submit</button>
+                        <button type="submit" class="btn btn-default" id="office-edit-submit">Submit</button>
                         <a href="../../../../basicinformation/{{ $row->c_personid }}/offices/{{ $row->c_office_id.'-'.$row->c_posting_id }}/saveas" class="btn btn-success" style="margin-left:40px;">create</a>
                     </div>
                 </div>
@@ -232,6 +232,26 @@
 @endsection
 @section('js')
     <script>
+        var $officeForm = $('#office-edit-form');
+        var $submitButton = $('#office-edit-submit');
+        var pristineSnapshot = $officeForm.serialize();
+
+        function evaluateFormDirty() {
+            var isDirty = $officeForm.serialize() !== pristineSnapshot;
+            $submitButton.prop('disabled', !isDirty);
+        }
+
+        evaluateFormDirty();
+
+        $officeForm.on('change input', 'input, select, textarea', function () {
+            evaluateFormDirty();
+        });
+
+        $officeForm.on('submit', function () {
+            pristineSnapshot = $officeForm.serialize();
+            $submitButton.prop('disabled', true);
+        });
+
         $(".select2").select2();
         textperson_pair_first_load();
         $(".c_office_id").select2(options('office'));

--- a/tests/Unit/BiogMainRepositoryTest.php
+++ b/tests/Unit/BiogMainRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\BiogMainRepository;
+use Tests\TestCase;
+
+class BiogMainRepositoryTest extends TestCase
+{
+    /** @var TestableBiogMainRepository */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new TestableBiogMainRepository();
+    }
+
+    public function testHasMeaningfulChangesTreatsNumericStringsAsEqual()
+    {
+        $newData = ['c_fy_nh_code' => '652', 'c_dy' => '19'];
+        $original = ['c_fy_nh_code' => 652, 'c_dy' => 19];
+
+        $this->assertFalse(
+            $this->repository->callHasMeaningfulChanges($newData, $original, ['c_modified_by', 'c_modified_date']),
+            'Numeric strings should be treated as equal to their integer counterparts.'
+        );
+    }
+
+    public function testHasMeaningfulChangesDetectsActualDifferences()
+    {
+        $newData = ['c_dy' => '20'];
+        $original = ['c_dy' => 19];
+
+        $this->assertTrue(
+            $this->repository->callHasMeaningfulChanges($newData, $original),
+            'Changed values must be reported as differences.'
+        );
+    }
+
+    public function testHasMeaningfulChangesTreatsMissingOriginalAsChange()
+    {
+        $newData = ['c_sequence' => '1'];
+        $original = [];
+
+        $this->assertTrue($this->repository->callHasMeaningfulChanges($newData, $original));
+    }
+
+    public function testNormalizeSelectionListHandlesMinus999AndSorts()
+    {
+        $input = ['-999', 123, '456', 123];
+        $expected = ['0', '123', '456'];
+
+        $this->assertSame($expected, $this->repository->callNormalizeSelectionList($input, -999));
+    }
+
+    public function testNormalizeSelectionListIgnoresEmptyValues()
+    {
+        $input = ['', null, '-999'];
+        $expected = ['0'];
+
+        $this->assertSame($expected, $this->repository->callNormalizeSelectionList($input, -999));
+    }
+
+    public function testSelectionListHasChangesDetectsDifferences()
+    {
+        $this->assertTrue(
+            $this->repository->callSelectionListHasChanges([1, 2], [1], null)
+        );
+
+        $this->assertFalse(
+            $this->repository->callSelectionListHasChanges(['-999', 5], [0, 5], -999)
+        );
+    }
+}
+
+class TestableBiogMainRepository extends BiogMainRepository
+{
+    public function callHasMeaningfulChanges(array $newData, array $original, array $ignored = []): bool
+    {
+        $ref = new \ReflectionClass(BiogMainRepository::class);
+        $method = $ref->getMethod('hasMeaningfulChanges');
+        $method->setAccessible(true);
+
+        return $method->invoke($this, $newData, $original, $ignored);
+    }
+
+    public function callNormalizeSelectionList($values, $nullToken): array
+    {
+        $ref = new \ReflectionClass(BiogMainRepository::class);
+        $method = $ref->getMethod('normalizeSelectionList');
+        $method->setAccessible(true);
+
+        return $method->invoke($this, $values, $nullToken);
+    }
+
+    public function callSelectionListHasChanges($incoming, $existing, $nullToken): bool
+    {
+        $ref = new \ReflectionClass(BiogMainRepository::class);
+        $method = $ref->getMethod('selectionListHasChanges');
+        $method->setAccessible(true);
+
+        return $method->invoke($this, $incoming, $existing, $nullToken);
+    }
+}


### PR DESCRIPTION
- 前端變更：submit 按鈕預設為停用，除非表單內容有變更；保存後再次停用。
- 後端改動：保存前先比較內容，若無「實質」變動，則不予保存。在比較時，last modified by/date 欄的變更會被忽略。
- 本次改動為嘗試性，且僅限 POSTED_TO_OFFICE_DATA 一個表。如功能驗證正常，後續會逐步推廣到其他表格/輸入表單。

注意：合并前請協助再次測試，如果有問題請及時 revert，以免影響輸入工作。

<img width="406" height="114" alt="image" src="https://github.com/user-attachments/assets/d49e82b6-0461-4190-94af-28f3d4ec2872" />
