### PR TITLE
test: fix phpunit bootstrap path so APP_ENV=testing takes effect

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="bootstrap/autoload.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"


### PR DESCRIPTION
Previously phpunit.xml used `bootstrap/autoload.php`, which does not load Laravel's environment configuration in testing mode. As a result, local test runs used APP_ENV=local and triggered CSRF (419) errors.

Changing the bootstrap to `vendor/autoload.php` ensures Laravel loads the correct environment (`testing`) and matches CI behavior.