### PR TITLE
feat: 列表介面優化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## UI 調整 (2025)
+
+- Basicinformation 子頁面（addresses、altnames、assoc、entries、events、kinship、offices、possession、socialinst、sources、statuses、texts）之列表新增 `.table-responsive`，改善窄螢幕上的橫向捲動體驗。
+- Operations / Modified 頁面套用 `.table-responsive`，按鈕文字調整為「內容快照」與「比較」，相關 Bootstrap Modal 皆設 `tabindex="-1"` 以支援 `ESC` 關閉；Crowdsourcing 頁面則加入 `.table-responsive` 與 `tabindex="-1"`。

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 https://input.cbdb.fas.harvard.edu/basicinformation
 
+## UI 調整（2025）
+
+詳情請參見 [CHANGELOG](./CHANGELOG.md)。
+
 ### Database migrations
 
 数据库配置文件在.env中

--- a/resources/views/biogmains/addresses/index.blade.php
+++ b/resources/views/biogmains/addresses/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">地址清單</div>
         <div class="panel-body">
             <a href="{{ route('basicinformation.addresses.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <caption>共查询到{{ $basicinformation->biog_addresses_count }}条记录</caption>
                 <thead>
                 <tr>
@@ -48,7 +49,8 @@
                     </tr>
                 @endfor
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/altname/index.blade.php
+++ b/resources/views/biogmains/altname/index.blade.php
@@ -7,7 +7,8 @@
         <div class="panel-heading">别名</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.altnames.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->altnames_count }}条记录</caption>
                 <thead>
@@ -67,7 +68,8 @@ if($value->pivot->c_sequence === 0) {
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/assoc/index.blade.php
+++ b/resources/views/biogmains/assoc/index.blade.php
@@ -7,7 +7,8 @@
         <div class="panel-heading">社會關係清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.assoc.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->assoc_count }}条记录</caption>
                 <thead>
@@ -62,7 +63,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/entries/index.blade.php
+++ b/resources/views/biogmains/entries/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">入仕清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.entries.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->entries_count }}条记录</caption>
                 <thead>
@@ -47,7 +48,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/events/index.blade.php
+++ b/resources/views/biogmains/events/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">事件清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.events.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->events_count }}条记录</caption>
                 <thead>
@@ -47,7 +48,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/kinship/index.blade.php
+++ b/resources/views/biogmains/kinship/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">親屬清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.kinship.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->kinship_count }}条记录</caption>
                 <thead>
@@ -47,7 +48,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/resources/views/biogmains/offices/index.blade.php
+++ b/resources/views/biogmains/offices/index.blade.php
@@ -7,7 +7,8 @@
 
         <div class="panel-body">
             <a href="{{ route('basicinformation.offices.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <caption>共查询到{{ $basicinformation->offices_count }}条记录</caption>
                 <thead>
                 <tr>
@@ -54,7 +55,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/possession/index.blade.php
+++ b/resources/views/biogmains/possession/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">財產清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.possession.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->possession_count }}条记录</caption>
                 <thead>
@@ -49,7 +50,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/resources/views/biogmains/socialinst/index.blade.php
+++ b/resources/views/biogmains/socialinst/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">社交機構清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.socialinst.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->inst_count }}条记录</caption>
                 <thead>
@@ -52,7 +53,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/resources/views/biogmains/sources/index.blade.php
+++ b/resources/views/biogmains/sources/index.blade.php
@@ -7,7 +7,8 @@
         <div class="panel-heading">出處</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.sources.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->sources_count }}条记录</caption>
                 <thead>
@@ -52,7 +53,8 @@ $c_pages_view = unionPKDef_decode_for_convert($value->pivot->c_pages);
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/resources/views/biogmains/statuses/index.blade.php
+++ b/resources/views/biogmains/statuses/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">社會區分清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.statuses.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->statuses_count }}条记录</caption>
                 <thead>
@@ -53,7 +54,8 @@
                     </tr>
                 @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 

--- a/resources/views/biogmains/texts/index.blade.php
+++ b/resources/views/biogmains/texts/index.blade.php
@@ -6,7 +6,8 @@
         <div class="panel-heading">著述清單</div>
 
         <div class="panel-body">
-            <table class="table table-hover table-condensed">
+            <div class="table-responsive">
+                <table class="table table-hover table-condensed">
                 <a href="{{ route('basicinformation.texts.create', $basicinformation->c_personid) }}" class="btn btn-default pull-right">新增</a>
                 <caption>共查询到{{ $basicinformation->texts_count }}条记录</caption>
                 <thead>
@@ -47,7 +48,8 @@
                     </tr>
                 @endfor
                 </tbody>
-            </table>
+                </table>
+            </div>
         </div>
     </div>
 @endsection

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -5,7 +5,8 @@
     <div class="panel panel-default">
         <div class="panel-heading">最近眾包錄入記錄</div>
         <div class="panel-body">
-            <table id="example1" class="table table-bordered table-striped">
+            <div class="table-responsive">
+                <table id="example1" class="table table-bordered table-striped">
                 <p>* 修改类型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示删除<br />
                 * 狀態 1表示crowdsourcing記錄並已插入數據庫，2表示記錄還沒有被處理，3表示記錄reject，4表示記錄處理失敗。
                 </p>
@@ -43,8 +44,7 @@
                                     {{ $hasDiffContent ? '' : 'disabled' }}>
                                     compare
                                 </button>                                
-
-                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog">
                                     <div class="modal-content">
                                       <div class="modal-header">
@@ -61,7 +61,7 @@
                                   </div>
                                 </div>
 
-                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
                                     <div class="modal-content">
                                       <div class="modal-header">
@@ -95,7 +95,8 @@
                         </tr>
                     @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
             <div class="pull-right">
                 {{ $lists->links() }}
             </div>

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -3,9 +3,9 @@
 @section('content')
 @include('biogmains.defense')
     <div class="panel panel-default">
-        <div class="panel-heading">最近修改記錄</div>
         <div class="panel-body">
-            <table class="table table-bordered table-striped">
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped">
                 <p>* 修改类型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示删除<br />
                 * 狀態 0代表是專業用戶修改的記錄，1代表crowdsourcing記錄並且已經被插入數據庫。
                 </p>
@@ -103,18 +103,18 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 }
                             @endphp
                             <td>
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">內容快照</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ $hasDiffContent ? '' : 'disabled' }}>
-                                    compare
+                                    {{ $hasDiffContent && (int)$item->op_type !== 4 ? '' : 'disabled' }}>
+                                    比較
                                 </button>
 
-                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog">
                                     <div class="modal-content">
                                       <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                        <h4 class="modal-title">resource_data</h4>
+                                        <h4 class="modal-title">內容快照</h4>
                                       </div>
                                       <div class="modal-body" style="word-break: break-all;">
                                         @include('components.key-value-table', ['data' => $resourceDataParsed])
@@ -126,12 +126,12 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                   </div>
                                 </div>
 
-                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
                                     <div class="modal-content">
                                       <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                        <h4 class="modal-title">compare</h4>
+                                        <h4 class="modal-title">比較</h4>
                                       </div>
                                       <div class="modal-body" style="word-break: break-all;">
                                         <div>
@@ -146,7 +146,17 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 </div>
                             </td>
                             <td>{{ $item->resource_id }}</td>
-                            <td>{{ $item->op_type }}</td>
+                            <td>
+                                @php
+                                    $opTypeLabels = [
+                                        1 => '1-新增',
+                                        2 => '2-整體覆寫',
+                                        3 => '3-修改',
+                                        4 => '4-刪除',
+                                    ];
+                                @endphp
+                                {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
+                            </td>
                             <td>{{ $item->user->name }}</td>
                             <td>{{ $item->created_at }}</td>
                             <td>{{ $item->updated_at }}</td>
@@ -154,7 +164,8 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                         </tr>
                     @endforeach
                 </tbody>
-            </table>
+                </table>
+            </div>
             <div class="pull-right">
                 {{ $lists->links() }}
             </div>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -3,10 +3,9 @@
 @section('content')
 @include('biogmains.defense')
     <div class="panel panel-default">
-        <div class="panel-heading">人名列表</div>
         <div class="panel-body">
-            <table class="table table-bordered table-striped">
-                <p>* 修改类型 1表示新增， 3表示修改，4表示删除</p>
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped">
                 <thead>
                 <tr>
                     <th>人物</th>
@@ -98,18 +97,18 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 }
                             @endphp
                             <td>
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">resource_data</button>
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">內容快照</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ $hasDiffContent ? '' : 'disabled' }}>
-                                    compare
+                                    {{ $hasDiffContent && (int)$item->op_type !== 4 ? '' : 'disabled' }}>
+                                    比較
                                 </button>
 
-                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog">
                                     <div class="modal-content">
                                       <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                        <h4 class="modal-title">resource_data</h4>
+                                        <h4 class="modal-title">內容快照</h4>
                                       </div>
                                       <div class="modal-body" style="word-break: break-all;">
                                         @include('components.key-value-table', ['data' => $resourceDataParsed])
@@ -121,12 +120,12 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                   </div>
                                 </div>
 
-                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog">
+                                <div id="myModal-mapping{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
                                     <div class="modal-content">
                                       <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                        <h4 class="modal-title">compare</h4>
+                                        <h4 class="modal-title">比較</h4>
                                       </div>
                                       <div class="modal-body" style="word-break: break-all;">
                                         <div>
@@ -141,14 +140,25 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 </div>
                             </td>
                             <td>{{ $item->resource_id }}</td>
-                            <td>{{ $item->op_type }}</td>
+                            <td>
+                                @php
+                                    $opTypeLabels = [
+                                        1 => '1-新增',
+                                        2 => '2-整體覆寫',
+                                        3 => '3-修改',
+                                        4 => '4-刪除',
+                                    ];
+                                @endphp
+                                {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
+                            </td>
                             <td>{{ $item->user->name }}</td>
                             <td>{{ $item->updated_at }}</td>
                         </tr>
                     @endforeach
                 </tbody>
 
-            </table>
+                </table>
+            </div>
             <div class="pull-right">
                 {{ $lists->links() }}
             </div>


### PR DESCRIPTION
- 更新按鈕介面及顯示條件, 將 /operations 及 /modified 頁的 resource_data 與 compare 按鈕及對話框標題改為「內容快照」與「比較」，並加入 `tabindex="-1"` 以支援 ESC 關閉
- 將 operations／modified 表格包入 `.table-responsive` 提升行動裝置瀏覽體驗
- /crowdsourcing 及所有 /basicinformation 子頁面的表格統一包進 `.table-responsive`，讓寬表格可橫向捲動
- Document UI table responsiveness updates