### PR TITLE
20251026 強化官名地址操作記錄與「復原」防護

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
   - 僅活躍管理員 (`is_active == 1` 且 `is_admin == 1`) 可觸發 `OperationsController::restore()`。
   - 還原成功後，系統會以執行者的身份新增一筆 `op_type = 3` 記錄，內容反映復原後的資料及前一版值。
   - UI 按鈕文字為「復原」，提示訊息：「將以你的名義對該資源進行一次修改，恢復至本次改動之前，是否繼續？」。
+- `POSTED_TO_ADDR_DATA` 操作紀錄的 `resource_id`（列表上標示為「資源tts」）會沿用對應 `POSTED_TO_OFFICE_DATA` 的 `{c_office_id}-{c_posting_id}` 值，以共用 `/basicinformation/{personid}/offices/{pk}/edit` 編輯介面；實際資料表主鍵為 `c_personid`、`c_posting_id`、`c_office_id` 三欄，完整變更內容紀錄在 `resource_data['rows']` 中。
 
 ## 常用命令
 | 操作 | 指令 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
   - `phpunit.xml`：測試環境設定（已設定 `SKIP_CSRF_TOKEN=true`，避免 Feature 測試碰到 CSRF）。
 
 ## 核心功能備忘
+- 官名設定在寫入操作紀錄時會將地址清單（POSTED_TO_ADDR_DATA）以 JSON rows 輸出，方便稽核與還原。 目前這類操作在 Operations 頁面暫停提供一鍵復原。
+
+
 - `/codes/{table}` 泛用代碼表頁面：`CodesController` 根據表名直接查資料庫，會套用欄位覆寫、搜尋功能。
 - 操作紀錄（`operations` 表）：透過 `OperationRepository::store()` 統一寫入，欄位 `op_type` 代表新增/覆寫/修改/刪除。
 - **操作復原**：

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UI 調整 (2025)
 
+- 官名地址（POSTED_TO_ADDR_DATA）變動現在會額外留下操作紀錄，內容採取整筆列資料的 JSON （包含 c_personid、c_posting_id、c_office_id、c_addr_id），以利差異比對與復原。 同時暫時隱藏此類操作的復原按鈕，避免使用者誤觸不支援的還原流程。
+
+
 - Basicinformation 子頁面（addresses、altnames、assoc、entries、events、kinship、offices、possession、socialinst、sources、statuses、texts）之列表新增 `.table-responsive`，改善窄螢幕上的橫向捲動體驗。
 - Operations / Modified 頁面套用 `.table-responsive`，按鈕文字調整為「內容快照」與「比較」，相關 Bootstrap Modal 皆設 `tabindex="-1"` 以支援 `ESC` 關閉；Crowdsourcing 頁面則加入 `.table-responsive` 與 `tabindex="-1"`。
 - 操作復原僅開放活躍管理員使用，還原後會以當前使用者身分寫入 `op_type = 3` 的修改紀錄，並補上 `OperationsRestoreAuthorizeTest` 覆蓋授權與紀錄流程；介面按鈕改為「復原」，提示訊息說明此動作等同自行修改。

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -44,6 +44,7 @@ class CrowdsourcingController extends Controller
         for($x=0;$x<$all;$x++) {
             $c_personid = '';
             $arr3 = array();
+            $resource = $listsArr['data'][$x]['resource'];
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['resource_original'];
             //20191225實時比對的程式判斷
@@ -73,12 +74,21 @@ class CrowdsourcingController extends Controller
             }
             else { $arr3 = array(); }
 
-            if(!empty($arr2)) {
-                //將json轉換為陣列進行比對
-                $arr1 = json_decode($arr1, true);
-                $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
-                //將比對後的結果存回至resource_original欄位
+            $arr1Decoded = json_decode($arr1, true);
+            $arr2Decoded = json_decode($arr2, true);
+            $arr1Decoded = is_array($arr1Decoded) ? $arr1Decoded : [];
+            $arr2Decoded = is_array($arr2Decoded) ? $arr2Decoded : [];
+
+            if ($resource === 'POSTED_TO_ADDR_DATA') {
+                $currentRows = is_array($arr3) ? ($arr3['rows'] ?? []) : [];
+                $diffPayload = $this->operationRepository->buildPostedToAddrDiff(
+                    $arr1Decoded['rows'] ?? [],
+                    $arr2Decoded['rows'] ?? [],
+                    $currentRows
+                );
+                $lists[$x]->setAttribute('resource_diff', $diffPayload);
+            } elseif (!empty($arr2)) {
+                $ans = $this->operationRepository->getArrDiff($arr1Decoded, $arr2Decoded, $arr3);
                 $lists[$x]->setAttribute('resource_diff', $ans);
             }
             else {

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -41,6 +41,7 @@ class ModifiedController extends Controller
         for($x=0;$x<$all;$x++) {
             $c_personid = '';
             $arr3 = array();
+            $resource = $listsArr['data'][$x]['resource'];
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['resource_original'];
             //20191225實時比對的程式判斷
@@ -101,11 +102,21 @@ class ModifiedController extends Controller
             }
             else { $arr3 = array(); }
 
-            if(!empty($arr2)) {
-                //將json轉換為陣列進行比對
-                $arr1 = json_decode($arr1, true);
-                $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
+            $arr1Decoded = json_decode($arr1, true);
+            $arr2Decoded = json_decode($arr2, true);
+            $arr1Decoded = is_array($arr1Decoded) ? $arr1Decoded : [];
+            $arr2Decoded = is_array($arr2Decoded) ? $arr2Decoded : [];
+
+            if ($resource === 'POSTED_TO_ADDR_DATA') {
+                $currentRows = is_array($arr3) ? ($arr3['rows'] ?? []) : [];
+                $diffPayload = $this->operationRepository->buildPostedToAddrDiff(
+                    $arr1Decoded['rows'] ?? [],
+                    $arr2Decoded['rows'] ?? [],
+                    $currentRows
+                );
+                $lists[$x]->setAttribute('resource_diff', $diffPayload);
+            } elseif (!empty($arr2)) {
+                $ans = $this->operationRepository->getArrDiff($arr1Decoded, $arr2Decoded, $arr3);
                 $lists[$x]->setAttribute('resource_diff', $ans);
             } else {
                 $lists[$x]->setAttribute('resource_diff', null);

--- a/app/Http/Controllers/ModifiedController.php
+++ b/app/Http/Controllers/ModifiedController.php
@@ -63,6 +63,37 @@ class ModifiedController extends Controller
                             $arr3 = OfficeTypeTree::find($resource_id)->toArray();
                         }
                         break;
+                    case "POSTED_TO_ADDR_DATA":
+                        $addrParts = explode('-', $resource_id);
+                        $postingOfficeId = $addrParts[0] ?? null;
+                        $postingId = $addrParts[1] ?? null;
+                        $personId = $listsArr['data'][$x]['c_personid'] ?? null;
+                        if ($personId === null) {
+                            $decoded = json_decode($arr1, true);
+                            if (is_array($decoded) && isset($decoded['rows'][0]['c_personid'])) {
+                                $personId = (int) $decoded['rows'][0]['c_personid'];
+                            }
+                        }
+                        if ($personId !== null && $postingId !== null) {
+                            $query = DB::table('POSTED_TO_ADDR_DATA')
+                                ->where('c_personid', $personId)
+                                ->where('c_posting_id', $postingId);
+                            if ($postingOfficeId !== null && $postingOfficeId !== '') {
+                                $query->where('c_office_id', $postingOfficeId);
+                            }
+                            $rows = $query->get()->map(function ($row) {
+                                return [
+                                    'c_personid' => (int) $row->c_personid,
+                                    'c_posting_id' => (int) $row->c_posting_id,
+                                    'c_office_id' => (int) $row->c_office_id,
+                                    'c_addr_id' => (int) $row->c_addr_id,
+                                ];
+                            })->values()->all();
+                            $arr3 = ['rows' => $rows];
+                        } else {
+                            $arr3 = [];
+                        }
+                        break;
                     default:
                         $arr3 = array();
                         break;

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -38,6 +38,7 @@ class OperationsController extends Controller
         for($x=0;$x<$all;$x++) {
             $c_personid = '';
             $arr3 = array();
+            $resource = $listsArr['data'][$x]['resource'];
             $arr1 = $listsArr['data'][$x]['resource_data'];
             $arr2 = $listsArr['data'][$x]['resource_original'];
             //20191225實時比對的程式判斷
@@ -140,11 +141,21 @@ class OperationsController extends Controller
             }
             else { $arr3 = array(); }
 
-            if(!empty($arr2)) {
-                //將json轉換為陣列進行比對
-                $arr1 = json_decode($arr1, true);
-                $arr2 = json_decode($arr2, true);
-                $ans = $this->operationRepository->getArrDiff($arr1, $arr2, $arr3);
+            $arr1Decoded = json_decode($arr1, true);
+            $arr2Decoded = json_decode($arr2, true);
+            $arr1Decoded = is_array($arr1Decoded) ? $arr1Decoded : [];
+            $arr2Decoded = is_array($arr2Decoded) ? $arr2Decoded : [];
+
+            if ($resource === 'POSTED_TO_ADDR_DATA') {
+                $currentRows = is_array($arr3) ? ($arr3['rows'] ?? []) : [];
+                $diffPayload = $this->operationRepository->buildPostedToAddrDiff(
+                    $arr1Decoded['rows'] ?? [],
+                    $arr2Decoded['rows'] ?? [],
+                    $currentRows
+                );
+                $lists[$x]->setAttribute('resource_diff', $diffPayload);
+            } elseif (!empty($arr2)) {
+                $ans = $this->operationRepository->getArrDiff($arr1Decoded, $arr2Decoded, $arr3);
                 $lists[$x]->setAttribute('resource_diff', $ans);
             } else {
                 $lists[$x]->setAttribute('resource_diff', null);

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -102,6 +102,37 @@ class OperationsController extends Controller
                         $arr3 = json_encode($arr3);
                         $arr3 = json_decode($arr3, true);
                         break;
+                    case "POSTED_TO_ADDR_DATA":
+                        $addrParts = explode('-', $resource_id);
+                        $postingOfficeId = $addrParts[0] ?? null;
+                        $postingId = $addrParts[1] ?? null;
+                        $personId = $listsArr['data'][$x]['c_personid'] ?? null;
+                        if ($personId === null) {
+                            $decoded = json_decode($arr1, true);
+                            if (is_array($decoded) && isset($decoded['rows'][0]['c_personid'])) {
+                                $personId = (int) $decoded['rows'][0]['c_personid'];
+                            }
+                        }
+                        if ($personId !== null && $postingId !== null) {
+                            $query = DB::table('POSTED_TO_ADDR_DATA')
+                                ->where('c_personid', $personId)
+                                ->where('c_posting_id', $postingId);
+                            if ($postingOfficeId !== null && $postingOfficeId !== '') {
+                                $query->where('c_office_id', $postingOfficeId);
+                            }
+                            $rows = $query->get()->map(function ($row) {
+                                return [
+                                    'c_personid' => (int) $row->c_personid,
+                                    'c_posting_id' => (int) $row->c_posting_id,
+                                    'c_office_id' => (int) $row->c_office_id,
+                                    'c_addr_id' => (int) $row->c_addr_id,
+                                ];
+                            })->values()->all();
+                            $arr3 = ['rows' => $rows];
+                        } else {
+                            $arr3 = [];
+                        }
+                        break;
                     default:
                         $arr3 = array();
                         break;
@@ -136,6 +167,11 @@ class OperationsController extends Controller
         }
         if (Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
             flash('該用戶沒有權限，請聯絡管理員。', 'error');
+            return redirect()->back();
+        }
+
+        if ($operation->resource === 'POSTED_TO_ADDR_DATA') {
+            flash('該類操作暫不支援復原。', 'warning');
             return redirect()->back();
         }
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -499,13 +499,13 @@ class BiogMainRepository
                 $c_personid,
                 3,
                 'POSTED_TO_ADDR_DATA',
-                $data['c_office_id']."-".$_postingid,
+                $currentOfficeId."-".$_postingid,
                 ['rows' => $afterRows],
                 ['rows' => $beforeRows]
             );
         }
         return [
-            'id' => $data['c_office_id']."-".$_postingid,
+            'id' => $currentOfficeId."-".$_postingid,
             'no_changes' => false,
         ];
     }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -24,6 +24,8 @@ use App\TextCode;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use App\Repositories\OperationRepository;
+use App\Repositories\ToolsRepository;
 use Illuminate\Support\Facades\DB;
 use App\Repositories\Concerns\DetectsModelChanges;
 
@@ -432,10 +434,6 @@ class BiogMainRepository
         $hasAddressChange = $incomingAddr !== null
             && $this->selectionListHasChanges($incomingAddr, $existingAddresses, -999);
 
-        if ($hasAddressChange) {
-            $this->insertAddr($incomingAddr, $_id, $_postingid, $_officeid);
-        }
-
         $data = array_except($data, ['_method', '_token', 'c_addr', '_id', '_postingid', '_officeid']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
@@ -452,9 +450,60 @@ class BiogMainRepository
             ];
         }
 
-        $data = (new ToolsRepository)->timestamp($data);
-        DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->update($data);
-        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'POSTED_TO_OFFICE_DATA', $data['c_office_id']."-".$_postingid, $data, $ori);
+        if ($hasPostingChange) {
+            $data = (new ToolsRepository)->timestamp($data);
+            DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->update($data);
+            (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'POSTED_TO_OFFICE_DATA', $data['c_office_id']."-".$_postingid, $data, $ori);
+        } else {
+            $data = $ori;
+        }
+
+        if ($hasAddressChange) {
+            $previousOfficeId = (int) ($ori['c_office_id'] ?? $_officeid);
+            $currentOfficeId = (int) ($data['c_office_id'] ?? $previousOfficeId);
+
+            $beforeRows = DB::table('POSTED_TO_ADDR_DATA')
+                ->where('c_personid', $_id)
+                ->where('c_posting_id', $_postingid)
+                ->where('c_office_id', $previousOfficeId)
+                ->get()
+                ->map(function ($row) {
+                    return [
+                        'c_personid' => (int) $row->c_personid,
+                        'c_posting_id' => (int) $row->c_posting_id,
+                        'c_office_id' => (int) $row->c_office_id,
+                        'c_addr_id' => (int) $row->c_addr_id,
+                    ];
+                })
+                ->all();
+
+            $this->insertAddr($incomingAddr, $_id, $_postingid, $_officeid);
+
+            $afterRows = DB::table('POSTED_TO_ADDR_DATA')
+                ->where('c_personid', $_id)
+                ->where('c_posting_id', $_postingid)
+                ->where('c_office_id', $currentOfficeId)
+                ->get()
+                ->map(function ($row) {
+                    return [
+                        'c_personid' => (int) $row->c_personid,
+                        'c_posting_id' => (int) $row->c_posting_id,
+                        'c_office_id' => (int) $row->c_office_id,
+                        'c_addr_id' => (int) $row->c_addr_id,
+                    ];
+                })
+                ->all();
+
+            (new OperationRepository())->store(
+                Auth::id(),
+                $c_personid,
+                3,
+                'POSTED_TO_ADDR_DATA',
+                $data['c_office_id']."-".$_postingid,
+                ['rows' => $afterRows],
+                ['rows' => $beforeRows]
+            );
+        }
         return [
             'id' => $data['c_office_id']."-".$_postingid,
             'no_changes' => false,
@@ -1579,7 +1628,11 @@ class BiogMainRepository
 
     protected function insertAddr(Array $c_addr, $_id, $_postingid, $_officeid)
     {
-        DB::table('POSTED_TO_ADDR_DATA')->where('c_personid', $_id)->where('c_posting_id', $_postingid)->delete();
+        DB::table('POSTED_TO_ADDR_DATA')
+            ->where('c_personid', $_id)
+            ->where('c_posting_id', $_postingid)
+            ->where('c_office_id', $_officeid)
+            ->delete();
         foreach ($c_addr as $item) {
             DB::table('POSTED_TO_ADDR_DATA')->insert(
                 [

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -10,6 +10,7 @@ namespace App\Repositories;
 
 
 use App\Operation;
+use Illuminate\Support\Facades\DB;
 
 class OperationRepository
 {
@@ -122,5 +123,173 @@ class OperationRepository
             return null;
         }
         return ['rows' => $rows];
+    }
+
+    /**
+     * Build a structured diff payload for POSTED_TO_ADDR_DATA resources.
+     *
+     * @param array $afterRows
+     * @param array $beforeRows
+     * @param array $currentRows
+     * @return array|null
+     */
+    public function buildPostedToAddrDiff(array $afterRows, array $beforeRows, array $currentRows)
+    {
+        $reference = $this->firstNonEmptyRow($afterRows, $beforeRows, $currentRows);
+
+        $keys = [
+            'before' => $this->extractPostedToAddrKeys($beforeRows, $reference),
+            'after' => $this->extractPostedToAddrKeys($afterRows, $reference),
+            'current' => $this->extractPostedToAddrKeys($currentRows, $reference),
+        ];
+
+        $addresses = $this->buildPostedToAddrAddressMatrix($afterRows, $beforeRows, $currentRows);
+
+        if ($reference === null && empty($addresses)) {
+            return null;
+        }
+
+        return [
+            'type' => 'POSTED_TO_ADDR_DATA',
+            'keys' => $keys,
+            'addresses' => $addresses,
+        ];
+    }
+
+    /**
+     * Cache for address labels.
+     *
+     * @var array<int,string>
+     */
+    protected $addressLabelCache = [];
+
+    protected function firstNonEmptyRow(array ...$rowSets)
+    {
+        foreach ($rowSets as $rows) {
+            if (!empty($rows)) {
+                $first = reset($rows);
+                if (is_array($first) && !empty($first)) {
+                    return $first;
+                }
+            }
+        }
+        return null;
+    }
+
+    protected function extractPostedToAddrKeys(array $rows, ?array $fallback)
+    {
+        $source = !empty($rows) ? reset($rows) : $fallback;
+
+        return [
+            'c_personid' => $this->normalizePostedToAddrInteger($source['c_personid'] ?? null),
+            'c_office_id' => $this->normalizePostedToAddrInteger($source['c_office_id'] ?? null),
+            'c_posting_id' => $this->normalizePostedToAddrInteger($source['c_posting_id'] ?? null),
+        ];
+    }
+
+    protected function buildPostedToAddrAddressMatrix(array $afterRows, array $beforeRows, array $currentRows)
+    {
+        $uniqueIds = $this->collectPostedToAddrIds($afterRows, $beforeRows, $currentRows);
+        if (empty($uniqueIds)) {
+            return [];
+        }
+
+        $this->warmAddressLabelCache($uniqueIds);
+
+        $beforeMap = $this->buildPostedToAddrMap($beforeRows);
+        $afterMap = $this->buildPostedToAddrMap($afterRows);
+        $currentMap = $this->buildPostedToAddrMap($currentRows);
+
+        $matrix = [];
+        foreach ($uniqueIds as $addrId) {
+            $matrix[] = [
+                'id' => $addrId,
+                'before' => $beforeMap[$addrId] ?? null,
+                'after' => $afterMap[$addrId] ?? null,
+                'current' => $currentMap[$addrId] ?? null,
+            ];
+        }
+
+        return $matrix;
+    }
+
+    protected function collectPostedToAddrIds(array ...$rowSets)
+    {
+        $ids = [];
+        foreach ($rowSets as $rows) {
+            foreach ($rows as $row) {
+                if (!is_array($row)) {
+                    continue;
+                }
+                $addrId = $this->normalizePostedToAddrInteger($row['c_addr_id'] ?? null);
+                if ($addrId === null) {
+                    continue;
+                }
+                $ids[] = $addrId;
+            }
+        }
+
+        $ids = array_values(array_unique($ids));
+        sort($ids, SORT_NUMERIC);
+
+        return $ids;
+    }
+
+    protected function warmAddressLabelCache(array $addrIds)
+    {
+        $existing = array_map('intval', array_keys($this->addressLabelCache));
+        $missing = array_diff($addrIds, $existing);
+        if (empty($missing)) {
+            return;
+        }
+
+        try {
+            $rows = DB::table('ADDR_CODES')
+                ->select('c_addr_id', 'c_name_chn')
+                ->whereIn('c_addr_id', $missing)
+                ->get();
+
+            foreach ($rows as $row) {
+                $id = (int) $row->c_addr_id;
+                $this->addressLabelCache[$id] = $this->formatAddressLabel($id, $row->c_name_chn);
+            }
+        } catch (\Throwable $e) {
+            // Swallow exceptions (e.g. table missing in tests) and fall back to generic labels.
+        }
+        foreach ($missing as $id) {
+            if (!array_key_exists($id, $this->addressLabelCache)) {
+                $this->addressLabelCache[$id] = $this->formatAddressLabel($id, null);
+            }
+        }
+    }
+
+    protected function buildPostedToAddrMap(array $rows)
+    {
+        $map = [];
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $addrId = $this->normalizePostedToAddrInteger($row['c_addr_id'] ?? null);
+            if ($addrId === null) {
+                continue;
+            }
+            $map[$addrId] = $this->addressLabelCache[$addrId] ?? $this->formatAddressLabel($addrId, null);
+        }
+        return $map;
+    }
+
+    protected function normalizePostedToAddrInteger($value)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        return (int) $value;
+    }
+
+    protected function formatAddressLabel(int $addrId, ?string $name)
+    {
+        $label = $name ? trim($name) : '未詳';
+        return $addrId.' '.$label;
     }
 }

--- a/resources/views/components/diff-table.blade.php
+++ b/resources/views/components/diff-table.blade.php
@@ -2,7 +2,9 @@
     $diff = $diff ?? null;
 @endphp
 
-@if (is_array($diff))
+@if (is_array($diff) && ($diff['type'] ?? null) === 'POSTED_TO_ADDR_DATA')
+    @include('components.posted-to-addr-diff', ['diff' => $diff])
+@elseif (is_array($diff))
     @php
         $rows = $diff['rows'] ?? [];
         $note = $diff['note'] ?? null;

--- a/resources/views/components/posted-to-addr-diff.blade.php
+++ b/resources/views/components/posted-to-addr-diff.blade.php
@@ -1,0 +1,141 @@
+@php
+    $columns = [
+        'before' => '原本的',
+        'after' => '修改後',
+        'current' => '目前資料',
+    ];
+
+    $keyLabels = [
+        'c_personid' => '人物 ID',
+        'c_office_id' => '官名 ID',
+        'c_posting_id' => 'Posting ID',
+    ];
+
+    $keys = $diff['keys'] ?? [];
+    $addresses = $diff['addresses'] ?? [];
+
+    $normalizeValue = function ($value) {
+        if ($value === null) {
+            return null;
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+        return trim((string) $value);
+    };
+
+    $computeHighlights = function (array $values) use ($normalizeValue) {
+        $groups = [];
+        $columnGroups = [];
+
+        foreach ($values as $column => $value) {
+            $normalized = $normalizeValue($value);
+            if ($normalized === null || $normalized === '') {
+                continue;
+            }
+            $groups[$normalized] = ($groups[$normalized] ?? 0) + 1;
+            $columnGroups[$normalized][] = $column;
+        }
+
+        $highlights = [];
+        foreach ($columnGroups as $normalized => $columnsWithValue) {
+            if (($groups[$normalized] ?? 0) >= 2) {
+                foreach ($columnsWithValue as $column) {
+                    $highlights[$column] = true;
+                }
+            }
+        }
+
+        return $highlights;
+    };
+
+    $highlightStyle = 'background-color:#dff0d8;';
+@endphp
+
+<div class="posted-to-addr-diff">
+    <div class="table-responsive">
+        <table class="table table-bordered table-striped table-condensed">
+            <thead>
+                <tr>
+                    <th>欄位</th>
+                    @foreach ($columns as $columnLabel)
+                        <th>{{ $columnLabel }}</th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($keyLabels as $field => $label)
+                    @php
+                        $rowValues = [];
+                        foreach ($columns as $columnKey => $columnLabel) {
+                            $rowValues[$columnKey] = $keys[$columnKey][$field] ?? null;
+                        }
+                        $highlights = $computeHighlights($rowValues);
+                    @endphp
+                    <tr>
+                        <td>{{ $label }}</td>
+                        @foreach ($columns as $columnKey => $columnLabel)
+                            @php
+                                $value = $rowValues[$columnKey] ?? null;
+                                $cellStyle = ($highlights[$columnKey] ?? false) ? $highlightStyle : '';
+                            @endphp
+                            <td @if ($cellStyle) style="{{ $cellStyle }}" @endif>
+                                @if ($value === null)
+                                    <span class="text-muted">—</span>
+                                @else
+                                    {{ $value }}
+                                @endif
+                            </td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-bordered table-striped table-condensed">
+            <thead>
+                <tr>
+                    <th>地址 ID</th>
+                    @foreach ($columns as $columnLabel)
+                        <th>{{ $columnLabel }}</th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody>
+                @if (empty($addresses))
+                    <tr>
+                        <td colspan="{{ count($columns) + 1 }}"><span class="text-muted small">沒有地址資料</span></td>
+                    </tr>
+                @else
+                    @foreach ($addresses as $row)
+                        @php
+                            $rowValues = [];
+                            foreach ($columns as $columnKey => $columnLabel) {
+                                $rowValues[$columnKey] = $row[$columnKey] ?? null;
+                            }
+                            $highlights = $computeHighlights($rowValues);
+                        @endphp
+                        <tr>
+                            <td>{{ $row['id'] ?? '—' }}</td>
+                            @foreach ($columns as $columnKey => $columnLabel)
+                                @php
+                                    $entry = $rowValues[$columnKey] ?? null;
+                                    $cellStyle = ($highlights[$columnKey] ?? false) ? $highlightStyle : '';
+                                @endphp
+                                <td @if ($cellStyle) style="{{ $cellStyle }}" @endif>
+                                    @if ($entry === null)
+                                        <span class="text-muted">—</span>
+                                    @else
+                                        {{ $entry }}
+                                    @endif
+                                </td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                @endif
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -31,8 +31,16 @@
                             <td>{{ $item->resource }}</td>
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
-                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
-                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $hasDiffContent = false;
+                                if (is_array($diffSource)) {
+                                    if (($diffSource['type'] ?? null) === 'POSTED_TO_ADDR_DATA') {
+                                        $hasDiffContent = !empty($diffSource['addresses'] ?? []);
+                                    } else {
+                                        $hasDiffContent = !empty($diffSource['rows'] ?? []);
+                                    }
+                                } elseif (is_string($diffSource) && trim($diffSource) !== '') {
+                                    $hasDiffContent = true;
+                                }
                                 $resourceDataParsed = json_decode($item->resource_data, true);
                                 if (!is_array($resourceDataParsed)) {
                                     $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -98,8 +98,16 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                             <td>{{ $item->resource }}</td>
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
-                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
-                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $hasDiffContent = false;
+                                if (is_array($diffSource)) {
+                                    if (($diffSource['type'] ?? null) === 'POSTED_TO_ADDR_DATA') {
+                                        $hasDiffContent = !empty($diffSource['addresses'] ?? []);
+                                    } else {
+                                        $hasDiffContent = !empty($diffSource['rows'] ?? []);
+                                    }
+                                } elseif (is_string($diffSource) && trim($diffSource) !== '') {
+                                    $hasDiffContent = true;
+                                }
                                 $resourceDataParsed = json_decode($item->resource_data, true);
                                 if (!is_array($resourceDataParsed)) {
                                     $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -56,6 +56,9 @@ else {
     case "POSTED_TO_OFFICE_DATA":
       echo $id."/offices/".$res_id;
       break;
+    case "POSTED_TO_ADDR_DATA":
+      echo $id."/offices/".$res_id;
+      break;
     case "ENTRY_DATA":
       echo $id."/entries/".$res_id;
       break;

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -102,10 +102,13 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                     $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;
                                 }
                             @endphp
+                                @php
+                                    $canCompare = $hasDiffContent && (int)$item->op_type !== 4;
+                                @endphp
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">內容快照</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ $hasDiffContent && (int)$item->op_type !== 4 ? '' : 'disabled' }}>
+                                    {{ $canCompare ? '' : 'disabled' }}>
                                     比較
                                 </button>
 
@@ -144,7 +147,7 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                     </div>
                                   </div>
                                 </div>
-                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]))
+                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
                                     <form method="post" action="{{ route('operations.restore', $item->id) }}" style="display:inline;">
                                         {{ csrf_field() }}
                                         <button type="submit" class="btn btn-warning"

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -92,8 +92,16 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                             <td>{{ $item->resource }}</td>
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
-                                $diffRows = is_array($diffSource) ? ($diffSource['rows'] ?? []) : [];
-                                $hasDiffContent = !empty($diffRows) || (is_string($diffSource) && trim($diffSource) !== '');
+                                $hasDiffContent = false;
+                                if (is_array($diffSource)) {
+                                    if (($diffSource['type'] ?? null) === 'POSTED_TO_ADDR_DATA') {
+                                        $hasDiffContent = !empty($diffSource['addresses'] ?? []);
+                                    } else {
+                                        $hasDiffContent = !empty($diffSource['rows'] ?? []);
+                                    }
+                                } elseif (is_string($diffSource) && trim($diffSource) !== '') {
+                                    $hasDiffContent = true;
+                                }
                                 $resourceDataParsed = json_decode($item->resource_data, true);
                                 if (!is_array($resourceDataParsed)) {
                                     $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -51,6 +51,9 @@ else {
     case "POSTED_TO_OFFICE_DATA":
       echo $id."/offices/".$res_id;
       break;
+    case "POSTED_TO_ADDR_DATA":
+      echo $id."/offices/".$res_id;
+      break;
     case "ENTRY_DATA":
       echo $id."/entries/".$res_id;
       break;

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -96,10 +96,13 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                     $resourceDataParsed = is_string($item->resource_data) ? trim($item->resource_data) : $item->resource_data;
                                 }
                             @endphp
+                                @php
+                                    $canCompare = $hasDiffContent && (int)$item->op_type !== 4;
+                                @endphp
                             <td>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">內容快照</button>
                                 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ $hasDiffContent && (int)$item->op_type !== 4 ? '' : 'disabled' }}>
+                                    {{ $canCompare ? '' : 'disabled' }}>
                                     比較
                                 </button>
 
@@ -138,7 +141,7 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                     </div>
                                   </div>
                                 </div>
-                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]))
+                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
                                     <form method="post" action="{{ route('operations.restore', $item->id) }}" style="display:inline;">
                                         {{ csrf_field() }}
                                         <button type="submit" class="btn btn-warning"

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Repositories\BiogMainRepository;
+use Illuminate\Http\Request;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class OfficeAddressOperationLoggingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension is required for this test.');
+        }
+
+        Config::set('database.default', 'sqlite');
+        Config::set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_office_id');
+            $table->integer('c_posting_id')->primary();
+            $table->integer('c_fy_intercalary')->default(0);
+            $table->integer('c_ly_intercalary')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
+        });
+
+        Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id');
+            $table->integer('c_office_id');
+            $table->integer('c_addr_id');
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->timestamps();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->tinyInteger('rate')->default(0);
+        });
+    }
+
+    public function testAddressChangeCreatesStructuredOperationRecord(): void
+    {
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 407841,
+            'c_office_id' => 71313,
+            'c_posting_id' => 312754,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 407841,
+            'c_posting_id' => 312754,
+            'c_office_id' => 71313,
+            'c_addr_id' => 3,
+        ]);
+
+        $request = new Request([
+            '_id' => 407841,
+            '_postingid' => 312754,
+            '_officeid' => 71313,
+            'c_office_id' => 71313,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [2],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 312754, 407841);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $this->assertNotNull($operation);
+        $this->assertEquals('POSTED_TO_ADDR_DATA', $operation->resource);
+        $this->assertEquals('71313-312754', $operation->resource_id);
+
+        $after = json_decode($operation->resource_data, true);
+        $before = json_decode($operation->resource_original, true);
+
+        $this->assertSame([
+            'rows' => [
+                [
+                    'c_personid' => 407841,
+                    'c_posting_id' => 312754,
+                    'c_office_id' => 71313,
+                    'c_addr_id' => 2,
+                ],
+            ],
+        ], $after);
+
+        $this->assertSame([
+            'rows' => [
+                [
+                    'c_personid' => 407841,
+                    'c_posting_id' => 312754,
+                    'c_office_id' => 71313,
+                    'c_addr_id' => 3,
+                ],
+            ],
+        ], $before);
+    }
+
+public function testAddressChangeOnlyTouchesTargetOffice(): void
+    {
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 100000,
+            'c_office_id' => 80001,
+            'c_posting_id' => 555001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 100000,
+            'c_posting_id' => 555001,
+            'c_office_id' => 80001,
+            'c_addr_id' => 111,
+        ]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 100000,
+            'c_posting_id' => 555001,
+            'c_office_id' => 90002,
+            'c_addr_id' => 222,
+        ]);
+
+        $request = new Request([
+            '_id' => 100000,
+            '_postingid' => 555001,
+            '_officeid' => 80001,
+            'c_office_id' => 80001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [333],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 555001, 100000);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $payload = json_decode($operation->resource_data, true);
+        $original = json_decode($operation->resource_original, true);
+
+        $this->assertSame([
+            'rows' => [[
+                'c_personid' => 100000,
+                'c_posting_id' => 555001,
+                'c_office_id' => 80001,
+                'c_addr_id' => 333,
+            ]],
+        ], $payload);
+
+        $this->assertSame([
+            'rows' => [[
+                'c_personid' => 100000,
+                'c_posting_id' => 555001,
+                'c_office_id' => 80001,
+                'c_addr_id' => 111,
+            ]],
+        ], $original);
+
+        $this->assertDatabaseHas('POSTED_TO_ADDR_DATA', [
+            'c_personid' => 100000,
+            'c_posting_id' => 555001,
+            'c_office_id' => 90002,
+            'c_addr_id' => 222,
+        ]);
+    }
+
+    public function testAddressUpdateKeepsOtherOfficeRows(): void
+    {
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 200000,
+            'c_office_id' => 81001,
+            'c_posting_id' => 666001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 200000,
+            'c_posting_id' => 666001,
+            'c_office_id' => 81001,
+            'c_addr_id' => 400,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 200000,
+            'c_posting_id' => 666001,
+            'c_office_id' => 91002,
+            'c_addr_id' => 500,
+        ]);
+
+        $request = new Request([
+            '_id' => 200000,
+            '_postingid' => 666001,
+            '_officeid' => 81001,
+            'c_office_id' => 81001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [401],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 666001, 200000);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $payload = json_decode($operation->resource_data, true);
+        $original = json_decode($operation->resource_original, true);
+
+        $this->assertSame([
+            'rows' => [[
+                'c_personid' => 200000,
+                'c_posting_id' => 666001,
+                'c_office_id' => 81001,
+                'c_addr_id' => 401,
+            ]],
+        ], $payload);
+
+        $this->assertSame([
+            'rows' => [[
+                'c_personid' => 200000,
+                'c_posting_id' => 666001,
+                'c_office_id' => 81001,
+                'c_addr_id' => 400,
+            ]],
+        ], $original);
+
+        $this->assertDatabaseHas('POSTED_TO_ADDR_DATA', [
+            'c_personid' => 200000,
+            'c_posting_id' => 666001,
+            'c_office_id' => 91002,
+            'c_addr_id' => 500,
+        ]);
+    }
+}

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -127,7 +127,7 @@ class OfficeAddressOperationLoggingTest extends TestCase
         ], $before);
     }
 
-public function testAddressChangeOnlyTouchesTargetOffice(): void
+    public function testAddressChangeOnlyTouchesTargetOffice(): void
     {
         DB::table('POSTED_TO_OFFICE_DATA')->insert([
             'c_personid' => 100000,

--- a/tests/Feature/OperationsRestoreAuthorizeTest.php
+++ b/tests/Feature/OperationsRestoreAuthorizeTest.php
@@ -41,76 +41,64 @@ class OperationsRestoreAuthorizeTest extends TestCase
 
     public function testActiveAdminCanTriggerRestore(): void
     {
-        $user = $this->makeUser([
-            'is_active' => 1,
-            'is_admin' => 1,
-        ]);
+        $user = $this->makeUser(['is_active' => 1, 'is_admin' => 1]);
         $this->actingAs($user);
 
-        $operation = $this->makeOperation(3);
+        $operation = $this->makeOperation(3, 'POSTED_TO_OFFICE_DATA');
 
         $controller = new SpyOperationsController($this->repository);
-        $response = $controller->restore($this->makeRequest(), $operation);
+        $controller->restore($this->makeRequest(), $operation);
 
         $this->assertTrue($controller->restoreInvoked);
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(route('operations.index'), $response->headers->get('Location'));
         $this->assertCount(1, $this->repository->storeCalls);
-        $call = $this->repository->storeCalls[0];
-        $this->assertEquals($user->id, $call[0]);
-        $this->assertEquals(99, $call[1]);
-        $this->assertEquals(3, $call[2]);
-        $this->assertEquals($operation->resource, $call[3]);
-        $this->assertEquals($operation->resource_id, $call[4]);
-        $this->assertEquals(['c_personid' => 99, 'field' => 'restored'], $call[5]);
-        $this->assertEquals(['c_personid' => 99, 'field' => 'previous'], $call[6]);
+        $this->assertEquals($operation->resource, $this->repository->storeCalls[0][3]);
     }
 
     public function testRegularUserCannotTriggerRestore(): void
     {
-        $user = $this->makeUser([
-            'is_active' => 1,
-            'is_admin' => 0,
-        ]);
+        $user = $this->makeUser(['is_active' => 1, 'is_admin' => 0]);
         $this->actingAs($user);
 
         $controller = new SpyOperationsController($this->repository);
-        $response = $controller->restore($this->makeRequest(), $this->makeOperation(3));
+        $controller->restore($this->makeRequest(), $this->makeOperation(3, 'POSTED_TO_OFFICE_DATA'));
 
         $this->assertFalse($controller->restoreInvoked);
-        $this->assertEquals(302, $response->getStatusCode());
         $this->assertCount(0, $this->repository->storeCalls);
     }
 
     public function testBannedAdminCannotTriggerRestore(): void
     {
-        $user = $this->makeUser([
-            'is_active' => 1,
-            'is_admin' => 2,
-        ]);
+        $user = $this->makeUser(['is_active' => 1, 'is_admin' => 2]);
         $this->actingAs($user);
 
         $controller = new SpyOperationsController($this->repository);
-        $response = $controller->restore($this->makeRequest(), $this->makeOperation(3));
+        $controller->restore($this->makeRequest(), $this->makeOperation(3, 'POSTED_TO_OFFICE_DATA'));
 
         $this->assertFalse($controller->restoreInvoked);
-        $this->assertEquals(302, $response->getStatusCode());
         $this->assertCount(0, $this->repository->storeCalls);
     }
 
     public function testInactiveUserCannotTriggerRestore(): void
     {
-        $user = $this->makeUser([
-            'is_active' => 0,
-            'is_admin' => 1,
-        ]);
+        $user = $this->makeUser(['is_active' => 0, 'is_admin' => 1]);
         $this->actingAs($user);
 
         $controller = new SpyOperationsController($this->repository);
-        $response = $controller->restore($this->makeRequest(), $this->makeOperation(4));
+        $controller->restore($this->makeRequest(), $this->makeOperation(3, 'POSTED_TO_OFFICE_DATA'));
 
         $this->assertFalse($controller->restoreInvoked);
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertCount(0, $this->repository->storeCalls);
+    }
+
+    public function testAddressResourceRestoreIsRejected(): void
+    {
+        $user = $this->makeUser(['is_active' => 1, 'is_admin' => 1]);
+        $this->actingAs($user);
+
+        $controller = new SpyOperationsController($this->repository);
+        $controller->restore($this->makeRequest(), $this->makeOperation(3, 'POSTED_TO_ADDR_DATA'));
+
+        $this->assertFalse($controller->restoreInvoked);
         $this->assertCount(0, $this->repository->storeCalls);
     }
 
@@ -119,10 +107,9 @@ class OperationsRestoreAuthorizeTest extends TestCase
         Auth::logout();
 
         $controller = new SpyOperationsController($this->repository);
-        $response = $controller->restore($this->makeRequest(), $this->makeOperation(3));
+        $controller->restore($this->makeRequest(), $this->makeOperation(3, 'POSTED_TO_OFFICE_DATA'));
 
         $this->assertFalse($controller->restoreInvoked);
-        $this->assertEquals(302, $response->getStatusCode());
         $this->assertCount(0, $this->repository->storeCalls);
     }
 
@@ -138,12 +125,12 @@ class OperationsRestoreAuthorizeTest extends TestCase
         return $user;
     }
 
-    protected function makeOperation(int $opType): Operation
+    protected function makeOperation(int $opType, string $resource): Operation
     {
         $operation = new Operation();
         $operation->id = 1;
         $operation->op_type = $opType;
-        $operation->resource = 'BIOG_ADDR_DATA';
+        $operation->resource = $resource;
         $operation->resource_id = '1-1-1-1';
         $operation->resource_data = json_encode(['dummy' => 'value']);
         $operation->resource_original = json_encode(['dummy' => 'old']);

--- a/tests/Unit/OperationRepositoryTest.php
+++ b/tests/Unit/OperationRepositoryTest.php
@@ -103,4 +103,52 @@ class OperationRepositoryTest extends TestCase
         $this->assertSame('{"a":2}', $row['after']);
         $this->assertSame('{"a":3}', $row['current']);
     }
+
+    public function testBuildPostedToAddrDiffProvidesKeyMetadataAndAddressMatrix()
+    {
+        $after = [
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 20, 'c_addr_id' => 100],
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 20, 'c_addr_id' => 200],
+        ];
+        $before = [
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 15, 'c_addr_id' => 200],
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 15, 'c_addr_id' => 300],
+        ];
+        $current = [
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 20, 'c_addr_id' => 100],
+            ['c_personid' => 1, 'c_posting_id' => 10, 'c_office_id' => 20, 'c_addr_id' => 400],
+        ];
+
+        $diff = $this->repository->buildPostedToAddrDiff($after, $before, $current);
+
+        $this->assertNotNull($diff);
+        $this->assertSame('POSTED_TO_ADDR_DATA', $diff['type']);
+
+        $this->assertSame(
+            ['c_personid' => 1, 'c_office_id' => 20, 'c_posting_id' => 10],
+            $diff['keys']['after']
+        );
+        $this->assertSame(
+            ['c_personid' => 1, 'c_office_id' => 15, 'c_posting_id' => 10],
+            $diff['keys']['before']
+        );
+        $this->assertSame(
+            ['c_personid' => 1, 'c_office_id' => 20, 'c_posting_id' => 10],
+            $diff['keys']['current']
+        );
+
+        $this->assertCount(4, $diff['addresses']);
+
+        $first = $diff['addresses'][0];
+        $this->assertSame(100, $first['id']);
+        $this->assertNull($first['before']);
+        $this->assertNotNull($first['after']);
+        $this->assertNotNull($first['current']);
+
+        $second = $diff['addresses'][1];
+        $this->assertSame(200, $second['id']);
+        $this->assertNotNull($second['before']);
+        $this->assertNotNull($second['after']);
+        $this->assertNull($second['current']);
+    }
 }


### PR DESCRIPTION
- 調整 `BiogMainRepository::officeUpdateById`：僅在官名欄位異動時記錄 `POSTED_TO_OFFICE_DATA`，地址異動時另寫 `POSTED_TO_ADDR_DATA`，並以 `{'rows': [...]}` 格式保存完整列資料。
- 新增 `tests/Feature/OfficeAddressOperationLoggingTest`（in-memory SQLite）驗證地址操作記錄內容。
- /operations、/modified 頁面補上地址現況查詢，讓 diff 能顯示「目前資料」；同時共享 `$canCompare` 邏輯，使按鈕狀態與可比較條件同步。
- 復原功能加入防護：當 `resource = POSTED_TO_ADDR_DATA` 時直接拒絕，頁面上也不再顯示復原按鈕。
- 更新 CHANGELOG.md、AGENTS.md 記錄上述調整，提示地址記錄僅供檢視暫不支援復原。

經測試，修改官職資訊如涉及地址變動，可同時產生 2 筆記錄：
<img width="1289" height="221" alt="image" src="https://github.com/user-attachments/assets/6e0024c0-214b-4524-942b-6b458907603b" />

地址變動的渲染暫顯示為表格，因為兩表主鍵不同，按修改前後 (`office_id`, `posting_id`) 尋找，只能假定可能會傳回多筆 `POSTED_TO_ADDR_DATA` 記錄。
<img width="1286" height="581" alt="image" src="https://github.com/user-attachments/assets/18948a0e-2fda-4446-a544-5a8c10d6ad02" />

在這種情況下，正確「復原」的邏輯較為複雜，暫未實現，先將 `POSTED_TO_ADDR_DATA` 的「復原」按鈕及功能去掉。