### PR TITLE
解決 #351 回饋的問題

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -66,6 +66,14 @@ class CodesController extends Controller
             'c_office_trans',
         ],
     ];
+    /**
+     * Explicit primary key definitions for code tables.
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected $tablePrimaryKeyOverrides = [
+        'TEXT_CODES' => ['c_textid'],
+    ];
 
     public function __construct(CodesRepository $codesRepository, OperationRepository $operationRepository)
     {
@@ -122,6 +130,7 @@ class CodesController extends Controller
             }
 
             $isReadOnly = $this->isReadOnlyTable($table);
+            $keyColumns = $this->getKeyColumns($table);
 
             return view('codes.show', [
                 'page_title' => 'Codes',
@@ -134,6 +143,7 @@ class CodesController extends Controller
                 'search' => $search,
                 'dynastyMap' => $dynastyMap,
                 'isReadOnly' => $isReadOnly,
+                'keyColumns' => $keyColumns,
             ]);
         }catch (\PDOException $e){
             flash('找不到该数据表', 'warning');
@@ -425,6 +435,14 @@ class CodesController extends Controller
 
         $columns = Schema::getColumnListing($table);
         $keys = [];
+        $upperTable = strtoupper($table);
+
+        if (isset($this->tablePrimaryKeyOverrides[$upperTable])) {
+            $overrideKeys = array_values(array_unique(array_filter($this->tablePrimaryKeyOverrides[$upperTable])));
+            if (!empty($overrideKeys)) {
+                return $cache[$table] = $overrideKeys;
+            }
+        }
 
         try {
             $connection = DB::connection();

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -175,14 +175,15 @@ class CodesController extends Controller
                     return redirect()->back();
                 }
 
-                $compositeId = $this->buildCompositeId($keyColumns, $this->convertRowToArray($data));
+                $rowArray = $this->prepareAuditFieldsForDisplay($this->convertRowToArray($data));
+                $compositeId = $this->buildCompositeId($keyColumns, $rowArray);
 
                 return view('codes.edit', [
                     'page_title' => 'Codes',
                     'page_description' => $table,
                     'page_url' => '/codes',
                     'archer' => "<li><a href='/codes/".rawurlencode($table)."'>".e($table)."</a></li>",
-                    'id' => $compositeId, 'row' => $data,
+                    'id' => $compositeId, 'row' => $rowArray,
                     'table' => $table]);
             }catch (\PDOException $e) {
                 flash('找不到该数据表', 'warning');
@@ -217,6 +218,7 @@ class CodesController extends Controller
             $query->where($column, $value);
         }
         $data = array_except($request->all(), ['_method', '_token']);
+        $data = $this->enforceAuditFieldsForUpdate($data, $originalRow ?: []);
 
         try {
             $query->update($data);
@@ -516,6 +518,57 @@ class CodesController extends Controller
         return implode('_._', array_filter($parts, function ($part) {
             return $part !== '';
         }));
+    }
+
+    /**
+     * Prepare immutable/mutable audit columns before rendering edit form.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    protected function prepareAuditFieldsForDisplay(array $row): array
+    {
+        if (array_key_exists('c_modified_by', $row) && Auth::check()) {
+            $row['c_modified_by'] = Auth::user()->name;
+        }
+
+        if (array_key_exists('c_modified_date', $row)) {
+            $row['c_modified_date'] = Carbon::now()->format('Ymd');
+        }
+
+        return $row;
+    }
+
+    /**
+     * Ensure audit columns cannot be tampered with via requests.
+     *
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $original
+     * @return array<string, mixed>
+     */
+    protected function enforceAuditFieldsForUpdate(array $data, array $original): array
+    {
+        foreach (['c_created_by', 'c_created_date'] as $field) {
+            if (array_key_exists($field, $data) && array_key_exists($field, $original)) {
+                $data[$field] = $original[$field];
+            }
+        }
+
+        if (array_key_exists('c_modified_by', $data)) {
+            if (Auth::check()) {
+                $data['c_modified_by'] = Auth::user()->name;
+            } elseif (array_key_exists('c_modified_by', $original)) {
+                $data['c_modified_by'] = $original['c_modified_by'];
+            }
+        }
+
+        if (array_key_exists('c_modified_date', $data)) {
+            $data['c_modified_date'] = Carbon::now()->format('Ymd');
+        } elseif (array_key_exists('c_modified_date', $original)) {
+            $data['c_modified_date'] = $original['c_modified_date'];
+        }
+
+        return $data;
     }
 
     protected function buildConditionsFromRow(array $keyColumns, array $row): array

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -9,6 +9,17 @@
                 <form action="/codes/{{ $table }}/{{ $id }}" class="form-horizontal" method="post">
                     {{ method_field('PATCH') }}
                     {{ csrf_field() }}
+                    @if($table === 'TEXT_CODES')
+                    <div class="form-group">
+                        <label for="author" class="col-sm-2 control-label">author</label>
+                        <div class="col-sm-8">
+                            <select class="form-control author" name="" readonly="readonly"></select>
+                        </div>
+                        <div class="col-sm-2">
+                            <button type="button" id="button_ajax_load" class="btn btn-info">Jump to author</button>
+                        </div>
+                    </div>
+                    @endif
                     @foreach($row as $key => $value)
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
@@ -30,5 +41,32 @@
 
 @endsection
 @section('js')
+@if($table === 'TEXT_CODES')
+<script>
+    author_first_load();
+    function author_first_load(){
+        let c_textid = $("input[name='c_textid']").val();
+        let data = [{
+            id: 0,
+            text: 'author'
+        }];
+        $.get('/api/select/search/textauthor', {q: c_textid}, function (data, textStatus){
+            for (let i=data.data.length-1; i>-1; i--){
+                item = data.data[i];
+                $(".author").append(new Option(item['text'], item['value']));
+            }
+        });
+    }
 
+    $("#button_ajax_load").click(function(){
+        let author = $(".author").val();
+        if (!author) {
+            return;
+        }
+        let url = "/basicinformation/" + author + "/texts";
+        let new_window = window.open('_blank');
+        new_window.location = url ;
+    });
+</script>
+@endif
 @endsection

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -2,6 +2,11 @@
 
 @section('content')
 
+    @php
+        $currentUserName = optional(Auth::user())->name;
+        $currentDateYmd = \Carbon\Carbon::now()->format('Ymd');
+    @endphp
+
     <div class="panel panel-default">
         <div class="panel-heading">{{ $table }}</div>
         <div class="panel-body">
@@ -21,11 +26,24 @@
                     </div>
                     @endif
                     @foreach($row as $key => $value)
+                        @php
+                            $isCreatedField = in_array($key, ['c_created_by', 'c_created_date'], true);
+                            $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date'], true);
+                            $inputValue = $value;
+                            if ($isModifiedField) {
+                                if ($key === 'c_modified_by' && $currentUserName !== null) {
+                                    $inputValue = $currentUserName;
+                                } elseif ($key === 'c_modified_date') {
+                                    $inputValue = $currentDateYmd;
+                                }
+                            }
+                            $shouldDisable = $isCreatedField || $isModifiedField;
+                        @endphp
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
                             <div class="col-sm-10">
                                 <input type="text" name="{{ $key }}" class="form-control"
-                                       value="{{ $value }}">
+                                       value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/codes/show.blade.php
+++ b/resources/views/codes/show.blade.php
@@ -6,6 +6,7 @@
         $dynastyMap = $dynastyMap ?? [];
         $isReadOnly = $isReadOnly ?? false;
         $showActions = Auth::check() && !$isReadOnly;
+        $keyColumns = $keyColumns ?? [];
     @endphp
 
     <div class="box">
@@ -52,10 +53,25 @@
                         @php
                             $row = (array) $item;
                             $idParts = [];
-                            foreach ($row as $value) {
-                                $idParts[] = $value;
-                                if (count($idParts) >= 2) {
-                                    break;
+                            if (!empty($keyColumns)) {
+                                foreach ($keyColumns as $column) {
+                                    if (array_key_exists($column, $row)) {
+                                        $value = (string) $row[$column];
+                                        if ($value !== '') {
+                                            $idParts[] = $value;
+                                        }
+                                    }
+                                }
+                            }
+                            if (empty($idParts)) {
+                                foreach ($row as $value) {
+                                    $stringValue = (string) $value;
+                                    if ($stringValue !== '') {
+                                        $idParts[] = $stringValue;
+                                    }
+                                    if (count($idParts) >= 2) {
+                                        break;
+                                    }
                                 }
                             }
                             $id_ = implode('_._', $idParts);

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -23,7 +23,7 @@ class CodesControllerTest extends TestCase
     {
         parent::setUp();
 
-        config(['codes.tables' => ['TEST_CODES']]);
+        config(['codes.tables' => ['TEST_CODES', 'TEXT_CODES']]);
         config(['codes.connection' => null]);
 
         $compiledPath = base_path('tests/storage/views');
@@ -33,18 +33,30 @@ class CodesControllerTest extends TestCase
         config(['view.compiled' => $compiledPath]);
 
         $this->originalDb = DB::getFacadeRoot();
-        $this->fakeDb = new FakeDatabaseManager(['TEST_CODES' => []]);
+        $this->fakeDb = new FakeDatabaseManager(
+            [
+                'TEST_CODES' => [],
+                'TEXT_CODES' => [],
+            ],
+            [
+                'TEST_CODES' => ['code_id', 'code_sub', 'description'],
+                'TEXT_CODES' => ['c_textid', 'c_title', 'c_title_chn'],
+            ]
+        );
         DB::swap($this->fakeDb);
 
         $this->app->instance(CodesRepository::class, new class extends CodesRepository {
             public function allowedTables(): array
             {
-                return ['TEST_CODES'];
+                return ['TEST_CODES', 'TEXT_CODES'];
             }
 
             public function allowedTableMap(): array
             {
-                return ['TEST_CODES' => 'TEST_CODES'];
+                return [
+                    'TEST_CODES' => 'TEST_CODES',
+                    'TEXT_CODES' => 'TEXT_CODES',
+                ];
             }
         });
 
@@ -171,6 +183,30 @@ class CodesControllerTest extends TestCase
         $this->assertEmpty($this->operationSpy->calls);
     }
 
+    public function testTextCodesUsesExplicitPrimaryKeyOverride()
+    {
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 'T001', 'c_title' => 'Sample Title', 'c_title_chn' => 'Sample Title CHN'],
+        ]);
+
+        $user = new User([
+            'name' => 'text-admin',
+            'email' => 'text-admin@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 5;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->get('/codes/TEXT_CODES');
+
+        $response->assertStatus(200);
+        $response->assertViewHas('keyColumns', ['c_textid']);
+        $response->assertSee('href="/codes/TEXT_CODES/T001/edit"', false);
+        $response->assertDontSee('href="/codes/TEXT_CODES/T001_._', false);
+        $this->assertEmpty($this->operationSpy->calls);
+    }
+
     public function testActiveUserUpdateLogsOperation()
     {
         DB::table('TEST_CODES')->insert([
@@ -269,10 +305,12 @@ class FakeDatabaseManager
     public $tables = [];
     public $failures = [];
     public $failuresCleared = [];
+    public $schemaColumns = [];
 
-    public function __construct(array $tables = [])
+    public function __construct(array $tables = [], array $schemaColumns = [])
     {
         $this->tables = $tables;
+        $this->schemaColumns = $schemaColumns;
     }
 
     public function table($name)
@@ -302,7 +340,7 @@ class FakeDatabaseManager
 
     public function getSchemaBuilder()
     {
-        return new FakeSchemaBuilder();
+        return new FakeSchemaBuilder($this->schemaColumns);
     }
 
     public function setFailure(string $operation, string $message = 'Simulated failure'): void
@@ -350,8 +388,19 @@ class FakeTableDetails
 
 class FakeSchemaBuilder
 {
+    private $schemaColumns = [];
+
+    public function __construct(array $schemaColumns = [])
+    {
+        $this->schemaColumns = $schemaColumns;
+    }
+
     public function getColumnListing($table)
     {
+        if (isset($this->schemaColumns[$table]) && !empty($this->schemaColumns[$table])) {
+            return $this->schemaColumns[$table];
+        }
+
         return ['code_id', 'code_sub', 'description'];
     }
 }

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -11,6 +11,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Carbon\Carbon;
 use Tests\TestCase;
 
 class CodesControllerTest extends TestCase
@@ -40,7 +41,7 @@ class CodesControllerTest extends TestCase
             ],
             [
                 'TEST_CODES' => ['code_id', 'code_sub', 'description'],
-                'TEXT_CODES' => ['c_textid', 'c_title', 'c_title_chn'],
+                'TEXT_CODES' => ['c_textid', 'c_title', 'c_title_chn', 'c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'],
             ]
         );
         DB::swap($this->fakeDb);
@@ -186,7 +187,15 @@ class CodesControllerTest extends TestCase
     public function testTextCodesUsesExplicitPrimaryKeyOverride()
     {
         DB::table('TEXT_CODES')->insert([
-            ['c_textid' => 'T001', 'c_title' => 'Sample Title', 'c_title_chn' => 'Sample Title CHN'],
+            [
+                'c_textid' => 'T001',
+                'c_title' => 'Sample Title',
+                'c_title_chn' => 'Sample Title CHN',
+                'c_created_by' => 'origin',
+                'c_created_date' => '20200101',
+                'c_modified_by' => 'previous',
+                'c_modified_date' => '20200102',
+            ],
         ]);
 
         $user = new User([
@@ -205,6 +214,60 @@ class CodesControllerTest extends TestCase
         $response->assertSee('href="/codes/TEXT_CODES/T001/edit"', false);
         $response->assertDontSee('href="/codes/TEXT_CODES/T001_._', false);
         $this->assertEmpty($this->operationSpy->calls);
+    }
+
+    public function testAuditFieldsAreReadonlyAndPrefilledOnEdit()
+    {
+        Carbon::setTestNow(Carbon::create(2024, 3, 22, 12));
+
+        DB::table('TEXT_CODES')->insert([
+            [
+                'c_textid' => 'T001',
+                'c_title' => 'Sample Title',
+                'c_title_chn' => 'Sample Title CHN',
+                'c_created_by' => 'origin',
+                'c_created_date' => '20200101',
+                'c_modified_by' => 'previous',
+                'c_modified_date' => '20200102',
+            ],
+        ]);
+
+        $user = new User([
+            'name' => 'text-admin',
+            'email' => 'text-admin@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 6;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->get('/codes/TEXT_CODES/T001/edit');
+
+        $response->assertStatus(200);
+        $content = $response->getContent();
+        $createdByPos = strpos($content, 'name="c_created_by"');
+        $this->assertNotFalse($createdByPos);
+        $this->assertNotFalse(strpos($content, 'value="origin"', $createdByPos));
+        $this->assertNotFalse(strpos($content, 'readonly', $createdByPos));
+
+        $createdDatePos = strpos($content, 'name="c_created_date"');
+        $this->assertNotFalse($createdDatePos);
+        $this->assertNotFalse(strpos($content, 'value="20200101"', $createdDatePos));
+        $this->assertNotFalse(strpos($content, 'readonly', $createdDatePos));
+
+        $modifiedByPos = strpos($content, 'name="c_modified_by"');
+        $this->assertNotFalse($modifiedByPos);
+        $this->assertNotFalse(strpos($content, 'value="text-admin"', $modifiedByPos));
+        $this->assertNotFalse(strpos($content, 'readonly', $modifiedByPos));
+
+        $modifiedDatePos = strpos($content, 'name="c_modified_date"');
+        $this->assertNotFalse($modifiedDatePos);
+        $this->assertNotFalse(strpos($content, 'value="'.Carbon::now()->format('Ymd').'"', $modifiedDatePos));
+        $this->assertNotFalse(strpos($content, 'readonly', $modifiedDatePos));
+        $response->assertDontSee('value="previous"', false);
+        $response->assertDontSee('value="20200102"', false);
+
+        Carbon::setTestNow();
     }
 
     public function testActiveUserUpdateLogsOperation()


### PR DESCRIPTION
`TEXT_CODES` 編輯頁新增作者搜尋下拉與快速跳轉按鈕。
為 `TEXT_CODES` 明確設定主鍵為 `c_textid`，更新列表與對應測試讓 `/codes/TEXT_CODES` 走單一 ID。
泛用 `/codes/*` 編輯畫面現在會自動填入 `c_modified_*`、保留 `c_created_*` 並改成 read-only，控制器也確保這些欄位不會被竄改。

經過本次 PR 修改後的 `/codes/TEXT_CODES/<id>/edit` 行為應與 `/textcodes/<id>/edit` 基本上一樣了。