### PR TITLE
Altname fix for #354 (work around)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## UI 調整 (2025)
 
 - 官名地址（POSTED_TO_ADDR_DATA）變動現在會額外留下操作紀錄，內容採取整筆列資料的 JSON （包含 c_personid、c_posting_id、c_office_id、c_addr_id），以利差異比對與復原。 同時暫時隱藏此類操作的復原按鈕，避免使用者誤觸不支援的還原流程。
+- ALTNAME_DATA 在 `/modified` 顯示現況時改以 log 中的主鍵（`c_personid`／`c_alt_name_type_code`／`c_alt_name_chn`）查詢，不再依賴 `resource_id` 裡的舊別名，避免別名更新或含 dash 時抓不到現況，並補上 `OperationsAltnameResolverTest` 覆蓋。
 - Basicinformation → 任官（office）操作全面交易化：`BiogMainRepository::officeStoreById`／`officeUpdateById`／`officeDeleteById` 會鎖定職官、同步維護地址清單並一併寫入 Operations；`officeUpdateById` 僅在主表欄位有異動時才更新 timestamp，純地址調整會重建 `POSTED_TO_ADDR_DATA` 並留下前後 JSON。
 
 
 - Basicinformation 子頁面（addresses、altnames、assoc、entries、events、kinship、offices、possession、socialinst、sources、statuses、texts）之列表新增 `.table-responsive`，改善窄螢幕上的橫向捲動體驗。
 - Operations / Modified 頁面套用 `.table-responsive`，按鈕文字調整為「內容快照」與「比較」，相關 Bootstrap Modal 皆設 `tabindex="-1"` 以支援 `ESC` 關閉；Crowdsourcing 頁面則加入 `.table-responsive` 與 `tabindex="-1"`。
 - 操作復原僅開放活躍管理員使用，還原後會以當前使用者身分寫入 `op_type = 3` 的修改紀錄，並補上 `OperationsRestoreAuthorizeTest` 覆蓋授權與紀錄流程；介面按鈕改為「復原」，提示訊息說明此動作等同自行修改。
-

--- a/RESOURCE_TTS_NOTES.md
+++ b/RESOURCE_TTS_NOTES.md
@@ -1,0 +1,20 @@
+# Resource TTS 注意事項
+
+## ALTNAME_DATA 主鍵處理
+- `resource_id` 原採用 `personid-sequence-alt_name_chn-type_code` 組合；因別名可能更新或包含 `-`（記錄中會轉寫成 `minus`），直接依賴此字串在名稱變更時會失敗。
+- 改為從操作紀錄的 `resource_data` 取得 `c_personid`、`c_sequence`、`c_alt_name_type_code` 等欄位，若缺值再回退 `resource_original`。如此 `/modified` 在別名調整後仍能取得現況。
+
+## 主鍵考量
+- ALTNAME_DATA 實際主鍵為 `(c_personid, c_alt_name_type_code, c_alt_name_chn)`，`c_sequence` 僅為選填排序欄位並非 PK 一部分；查詢時應將 `c_alt_name_chn` 納入條件，避免抓到舊版本。
+
+## TTS 中的 NULL
+- 表單允許 `c_sequence` 留空，資料庫會存 `NULL`；在 TTS 上會顯示成 "NULL"。新版 JSON API 會將 null 轉為空字串，以符合舊版介面呈現。
+
+## 排序唯一性
+- 資料庫沒有針對 `c_sequence` 設唯一鍵（僅 PK 限制），重新排序需由程式端控制，避免同一類別出現相同序號。
+
+## BIOG_MAIN 特例
+- `/modified` 顯示 BIOG_MAIN 現況時，直接透過 `BiogMain::find()` 取得，不依賴 `resource_id` 解析，因此不受上述別名問題影響。
+
+## Log 與空字串
+- 舊版 API 期望 null 欄位輸出為空字串，現行 JSON API 亦採此方式，避免前端資料處理需要特殊判斷。

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -74,13 +74,7 @@ class OperationsController extends Controller
                         $arr3 = json_decode($arr3, true);
                         break;
                     case "ALTNAME_DATA":
-                        $addr_l = explode("-", $resource_id);
-                        $arr3 = DB::table('ALTNAME_DATA')->where([
-                            ['c_personid', '=', $addr_l[0]],
-                            ['c_sequence', '=', $addr_l[1]],
-                            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-                            ['c_alt_name_type_code', '=', $addr_l[3]],
-                        ])->first();
+                        $arr3 = $this->fetchAltnameCurrentRow($listsArr['data'][$x]);
                         $arr3 = json_encode($arr3);
                         $arr3 = json_decode($arr3, true);
                         break;
@@ -383,6 +377,39 @@ class OperationsController extends Controller
             $segments[$index] = str_replace('minus', '-', $segment);
         }
         return $segments;
+    }
+
+    protected function fetchAltnameCurrentRow(array $operation)
+    {
+        $decoded = $this->decodeJson($operation['resource_data'] ?? null);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        $personId = $decoded['c_personid'] ?? null;
+        $sequence = $decoded['c_sequence'] ?? null;
+        $typeCode = $decoded['c_alt_name_type_code'] ?? null;
+
+        if ($personId === null || $sequence === null || $typeCode === null) {
+            $parts = $this->parseCompoundKey($operation['resource_id'] ?? null);
+            if ($personId === null && isset($parts[0]) && is_numeric($parts[0])) {
+                $personId = (int) $parts[0];
+            }
+            if ($sequence === null && isset($parts[1]) && is_numeric($parts[1])) {
+                $sequence = (int) $parts[1];
+            }
+            if ($typeCode === null && isset($parts[3]) && is_numeric($parts[3])) {
+                $typeCode = (int) $parts[3];
+            }
+        }
+
+        if ($personId === null || $sequence === null || $typeCode === null) {
+            return null;
+        }
+
+        return DB::table('ALTNAME_DATA')->where([
+            ['c_personid', '=', $personId],
+            ['c_sequence', '=', $sequence],
+            ['c_alt_name_type_code', '=', $typeCode],
+        ])->first();
     }
 
     protected function resourceKeyColumns($resource)

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\OperationsController;
+use App\Repositories\OperationRepository;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class OperationsAltnameResolverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence');
+            $table->integer('c_alt_name_type_code');
+            $table->string('c_alt_name')->nullable();
+            $table->string('c_alt_name_chn')->nullable();
+        });
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 123,
+            'c_sequence' => 1,
+            'c_alt_name_type_code' => 10,
+            'c_alt_name' => 'Zi Jing',
+            'c_alt_name_chn' => '張-一',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('ALTNAME_DATA');
+        parent::tearDown();
+    }
+
+    public function test_fetch_altname_current_row_handles_dash_in_resource_id(): void
+    {
+        $controller = new class(new OperationRepository) extends OperationsController {
+            public function resolveAltname(array $payload)
+            {
+                return $this->fetchAltnameCurrentRow($payload);
+            }
+        };
+
+        $operationPayload = [
+            'resource_id' => '123-1-張_minus一-10',
+            'resource_data' => json_encode([
+                'c_personid' => 123,
+                'c_sequence' => 1,
+                'c_alt_name_type_code' => 10,
+            ]),
+        ];
+
+        $row = $controller->resolveAltname($operationPayload);
+
+        $this->assertNotNull($row);
+        $this->assertSame('張-一', $row->c_alt_name_chn);
+        $this->assertSame('Zi Jing', $row->c_alt_name);
+    }
+}
+


### PR DESCRIPTION
解釋一下「目前資料(未取得)」，今後如有再發現類似現象，一般都是如下兩個根因之一：

1. 主鍵內容被改 或 TTS 記錄的資訊不足

歷史操作記錄中的 resource_id／TTS 在回查當前資料時會失配——不僅「目前資料」抓不到，點連結也可能打不開。近期案例（任官改地址 https://github.com/cbdb-project/cbdb-online-main-server/issues/326 、人物改別名 https://github.com/cbdb-project/cbdb-online-main-server/issues/354 ）皆屬此類：把可變的文字欄位（如別名）納入 key 或依賴它回查，只要名稱有改，必然對不上，需要在程式內加特別的匹配邏輯來補救。

以 ALTNAME_DATA 為例，中文別名本身在 primary key 裡；若之後別名被改，依當時記下的名稱就找不到。現改以 (c_personid, c_alt_name_type_code, c_sequence) 查，只屬權宜（「杜甫的第 2 個「字」类別名」），嚴格說並不理想。若要徹底嚴密，必須讓別名有獨立 altname_id，另設表維護「id - 名稱」的對應；但考量整體成本與收益，大家應該不會想現在走這條重構之路吧。

2. 未註冊的表沒有查詢邏輯，預設查不到

每一種表都需要對應的 resolver；未在支援清單內，即使有 log 也無法抓回目前資料。目前已支援的 9 張表為（其中數個為建安近期新增 https://github.com/cbdb-project/cbdb-online-main-server/commit/e86d93c0d15d4321758080f67e7b2d1c68031543 ）：
BIOG_MAIN,
OFFICE_CODES,
OFFICE_CODE_TYPE_REL,
OFFICE_TYPE_TREE,
BIOG_ADDR_DATA,
ALTNAME_DATA,
BIOG_TEXT_DATA,
POSTED_TO_OFFICE_DATA,
POSTED_TO_ADDR_DATA。