### PR TITLE
20251029 統一 /operations、/modified、/crowdsourcing 頁面的時間格式並加入 GMT+8 時區提示

### DIFF
--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -7,19 +7,19 @@
         <div class="panel-body">
             <div class="table-responsive">
                 <table id="example1" class="table table-bordered table-striped">
-                <p>* 修改类型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示删除<br />
-                * 狀態 1表示crowdsourcing記錄並已插入數據庫，2表示記錄還沒有被處理，3表示記錄reject，4表示記錄處理失敗。
+                <p>* 修改類型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示刪除<br />
+                * 狀態 1表示crowdsourcing記錄並已插入數據庫，2表示記錄尚未處理，3表示記錄reject，4表示記錄處理失敗。
                 </p>
                 <thead>
                 <tr>
 
-                    <th>修改资源</th>
+                    <th>修改資源</th>
                     <th>修改值</th>
-                    <th>资源tts</th>
-                    <th>修改类型</th>
+                    <th>資源 TTS</th>
+                    <th>修改類型</th>
                     <th>修改人</th>
                     <th>次數</th>
-                    <th>錄入时间</th>
+                    <th>錄入時間</th>
                     <th>狀態</th>
                     <th>操作</th>
                 </tr>

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -92,7 +92,27 @@
                             <td>{{ $item->op_type }}</td>
                             <td>{{ $item->user->name }}</td>
                             <td>{{ $item->rate }}</td>
-                            <td>{{ $item->created_at }}</td>
+                            @php
+                                $createdUtc = '';
+                                $createdDisplay = '';
+                                $createdAtRaw = $item->created_at;
+                                $appTimezone = config('app.timezone', 'Asia/Shanghai');
+                                if ($createdAtRaw instanceof \Carbon\Carbon) {
+                                    $createdDisplay = $createdAtRaw;
+                                    $createdUtc = $createdAtRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                } elseif (is_string($createdAtRaw) && trim($createdAtRaw) !== '') {
+                                    $createdDisplay = trim($createdAtRaw);
+                                    try {
+                                        $parsed = \Carbon\Carbon::parse($createdAtRaw, $appTimezone);
+                                        $createdUtc = $parsed->setTimezone('UTC')->toIso8601String();
+                                    } catch (\Exception $e) {
+                                        $createdUtc = $createdDisplay;
+                                    }
+                                }
+                            @endphp
+                            <td class="js-utc-datetime" data-utc="{{ $createdUtc }}">
+                                {{ $createdDisplay }}
+                            </td>
                             <td>{{ $item->crowdsourcing_status }}</td>
                             <td>
                                 @if($item->crowdsourcing_status == 2 and Auth::check() and Auth::user()->is_admin != 2)
@@ -315,6 +335,73 @@
                 "aaSorting" : [[6, "desc"]]
             });
 
+            applyTimestampFormatting();
+
         });
+
+        var userTimeZone = (Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
+        var userOffsetMinutes = new Date().getTimezoneOffset();
+
+        function formatTimestamp(utcTimeString, targetTimeZone) {
+            try {
+                var utcDate = new Date(utcTimeString);
+                if (isNaN(utcDate.getTime())) {
+                    console.warn('Invalid time:', utcTimeString);
+                    return utcTimeString;
+                }
+
+                var zone = targetTimeZone || userTimeZone;
+                var parts = new Intl.DateTimeFormat(undefined, {
+                    timeZone: zone,
+                    timeZoneName: 'short'
+                }).formatToParts(utcDate);
+                var timeZoneName = '';
+                for (var i = 0; i < parts.length; i++) {
+                    if (parts[i].type === 'timeZoneName') {
+                        timeZoneName = parts[i].value || '';
+                        break;
+                    }
+                }
+
+                var dateTimeWithoutTZ = utcDate.toLocaleString('sv-SE', {
+                    timeZone: zone,
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    hour12: false
+                });
+
+                return dateTimeWithoutTZ + ' ' + timeZoneName;
+            } catch (error) {
+                console.warn('Time conversion failed:', utcTimeString, error);
+                return utcTimeString;
+            }
+        }
+
+        function applyTimestampFormatting() {
+            var nodes = document.querySelectorAll('.js-utc-datetime');
+            Array.prototype.forEach.call(nodes, function (node) {
+                var original = node.getAttribute('data-utc') || (node.textContent || '').trim();
+                if (!original) {
+                    return;
+                }
+
+                var displayText = formatTimestamp(original);
+                node.textContent = displayText;
+                if (userOffsetMinutes !== -480) {
+                    var chinaText = formatTimestamp(original, 'Asia/Shanghai');
+                    if (chinaText && chinaText !== original) {
+                        node.setAttribute('title', chinaText);
+                    } else {
+                        node.removeAttribute('title');
+                    }
+                } else {
+                    node.removeAttribute('title');
+                }
+            });
+        }
     </script>
 @endsection

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -92,7 +92,6 @@ else {
 $item->resource_id = unionPKDef_decode_for_convert($item->resource_id);
 $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
 @endphp
-@endphp
 /edit">{{ $item->biogmain->c_name_chn.' '.$item->biogmain->c_name }}</a>
                             </td>
                             <td>{{ $item->resource }}</td>
@@ -181,8 +180,41 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
                             </td>
                             <td>{{ $item->user->name }}</td>
-                            <td>{{ $item->created_at }}</td>
-                            <td>{{ $item->updated_at }}</td>
+                            @php
+                                $createdUtc = '';
+                                $updatedUtc = '';
+                                $createdDisplay = '';
+                                $updatedDisplay = '';
+                                $createdAtRaw = $item->created_at;
+                                $updatedAtRaw = $item->updated_at;
+                                $appTimezone = config('app.timezone', 'Asia/Shanghai');
+                                if ($createdAtRaw instanceof \Carbon\Carbon) {
+                                    $createdDisplay = $createdAtRaw;
+                                    $createdUtc = $createdAtRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                } elseif (is_string($createdAtRaw) && trim($createdAtRaw) !== '') {
+                                    $createdDisplay = trim($createdAtRaw);
+                                    try {
+                                        $parsedCreated = \Carbon\Carbon::parse($createdAtRaw, $appTimezone);
+                                        $createdUtc = $parsedCreated->setTimezone('UTC')->toIso8601String();
+                                    } catch (\Exception $e) {
+                                        $createdUtc = $createdDisplay;
+                                    }
+                                }
+                                if ($updatedAtRaw instanceof \Carbon\Carbon) {
+                                    $updatedDisplay = $updatedAtRaw;
+                                    $updatedUtc = $updatedAtRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                } elseif (is_string($updatedAtRaw) && trim($updatedAtRaw) !== '') {
+                                    $updatedDisplay = trim($updatedAtRaw);
+                                    try {
+                                        $parsedUpdated = \Carbon\Carbon::parse($updatedAtRaw, $appTimezone);
+                                        $updatedUtc = $parsedUpdated->setTimezone('UTC')->toIso8601String();
+                                    } catch (\Exception $e) {
+                                        $updatedUtc = $updatedDisplay;
+                                    }
+                                }
+                            @endphp
+                            <td class="js-utc-datetime" data-utc="{{ $createdUtc }}">{{ $createdDisplay }}</td>
+                            <td class="js-utc-datetime" data-utc="{{ $updatedUtc }}">{{ $updatedDisplay }}</td>
                             <td>{{ $item->crowdsourcing_status }}</td>
                         </tr>
                     @endforeach
@@ -198,5 +230,70 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
 @endsection
 
 @section('js')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var userTimeZone = (Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
+    var userOffsetMinutes = new Date().getTimezoneOffset();
 
+    function formatTimestamp(utcTimeString, targetTimeZone) {
+        try {
+            var utcDate = new Date(utcTimeString);
+            if (isNaN(utcDate.getTime())) {
+                console.warn('Invalid time:', utcTimeString);
+                return utcTimeString;
+            }
+
+            var zone = targetTimeZone || userTimeZone;
+            var parts = new Intl.DateTimeFormat(undefined, {
+                timeZone: zone,
+                timeZoneName: 'short'
+            }).formatToParts(utcDate);
+            var timeZoneName = '';
+            for (var i = 0; i < parts.length; i++) {
+                if (parts[i].type === 'timeZoneName') {
+                    timeZoneName = parts[i].value || '';
+                    break;
+                }
+            }
+
+            var dateTimeWithoutTZ = utcDate.toLocaleString('sv-SE', {
+                timeZone: zone,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                hour12: false
+            });
+
+            return dateTimeWithoutTZ + ' ' + timeZoneName;
+        } catch (error) {
+            console.warn('Time conversion failed:', utcTimeString, error);
+            return utcTimeString;
+        }
+    }
+
+    var nodes = document.querySelectorAll('.js-utc-datetime');
+    Array.prototype.forEach.call(nodes, function (node) {
+        var original = node.getAttribute('data-utc') || (node.textContent || '').trim();
+        if (!original) {
+            return;
+        }
+
+        var displayText = formatTimestamp(original);
+        node.textContent = displayText;
+        if (userOffsetMinutes !== -480) {
+            var chinaText = formatTimestamp(original, 'Asia/Shanghai');
+            if (chinaText && chinaText !== original) {
+                node.setAttribute('title', chinaText);
+            } else {
+                node.removeAttribute('title');
+            }
+        } else {
+            node.removeAttribute('title');
+        }
+    });
+});
+</script>
 @endsection

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -6,19 +6,19 @@
         <div class="panel-body">
             <div class="table-responsive">
                 <table class="table table-bordered table-striped">
-                <p>* 修改类型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示删除<br />
-                * 狀態 0代表是專業用戶修改的記錄，1代表crowdsourcing記錄並且已經被插入數據庫。
+                <p>* 修改類型 0表示crowdsourcing記錄，1表示新增，3表示修改，4表示刪除<br />
+                * 狀態 0代表是專業用戶修改的記錄，1代表crowdsourcing記錄並且已插入數據庫。
                 </p>
                 <thead>
                 <tr>
                     <th>人物</th>
-                    <th>修改资源</th>
+                    <th>修改資源</th>
                     <th>修改值</th>
-                    <th>资源tts</th>
-                    <th>修改类型</th>
+                    <th>資源 TTS</th>
+                    <th>修改類型</th>
                     <th>修改人</th>
-                    <th>錄入时间</th>
-                    <th>修改时间</th>
+                    <th>錄入時間</th>
+                    <th>修改時間</th>
                     <th>狀態</th>
                 </tr>
                 </thead>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -9,12 +9,12 @@
                 <thead>
                 <tr>
                     <th>人物</th>
-                    <th>修改资源</th>
+                    <th>修改資源</th>
                     <th>修改值</th>
-                    <th>资源tts</th>
-                    <th>修改类型</th>
+                    <th>資源 TTS</th>
+                    <th>修改類型</th>
                     <th>修改人</th>
-                    <th>修改时间</th>
+                    <th>修改時間</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -175,7 +175,27 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
                             </td>
                             <td>{{ $item->user->name }}</td>
-                            <td>{{ $item->updated_at }}</td>
+                            @php
+                                $updatedUtc = '';
+                                $updatedDisplay = '';
+                                $updatedAtRaw = $item->updated_at;
+                                $appTimezone = config('app.timezone', 'Asia/Shanghai');
+                                if ($updatedAtRaw instanceof \Carbon\Carbon) {
+                                    $updatedDisplay = $updatedAtRaw;
+                                    $updatedUtc = $updatedAtRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                } elseif (is_string($updatedAtRaw) && trim($updatedAtRaw) !== '') {
+                                    $updatedDisplay = trim($updatedAtRaw);
+                                    try {
+                                        $parsed = \Carbon\Carbon::parse($updatedAtRaw, $appTimezone);
+                                        $updatedUtc = $parsed->setTimezone('UTC')->toIso8601String();
+                                    } catch (\Exception $e) {
+                                        $updatedUtc = $updatedDisplay;
+                                    }
+                                }
+                            @endphp
+                            <td class="js-utc-datetime" data-utc="{{ $updatedUtc }}">
+                                {{ $updatedDisplay }}
+                            </td>
                         </tr>
                     @endforeach
                 </tbody>
@@ -191,5 +211,70 @@ $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
 @endsection
 
 @section('js')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var userTimeZone = (Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
+    var userOffsetMinutes = new Date().getTimezoneOffset();
 
+    function formatTimestamp(utcTimeString, targetTimeZone) {
+        try {
+            var utcDate = new Date(utcTimeString);
+            if (isNaN(utcDate.getTime())) {
+                console.warn('Invalid time:', utcTimeString);
+                return utcTimeString;
+            }
+
+            var zone = targetTimeZone || userTimeZone;
+            var parts = new Intl.DateTimeFormat(undefined, {
+                timeZone: zone,
+                timeZoneName: 'short'
+            }).formatToParts(utcDate);
+            var timeZoneName = '';
+            for (var i = 0; i < parts.length; i++) {
+                if (parts[i].type === 'timeZoneName') {
+                    timeZoneName = parts[i].value || '';
+                    break;
+                }
+            }
+
+            var dateTimeWithoutTZ = utcDate.toLocaleString('sv-SE', {
+                timeZone: zone,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                hour12: false
+            });
+
+            return dateTimeWithoutTZ + ' ' + timeZoneName;
+        } catch (error) {
+            console.warn('Time conversion failed:', utcTimeString, error);
+            return utcTimeString;
+        }
+    }
+
+    var nodes = document.querySelectorAll('.js-utc-datetime');
+    Array.prototype.forEach.call(nodes, function (node) {
+        var original = node.getAttribute('data-utc') || (node.textContent || '').trim();
+        if (!original) {
+            return;
+        }
+
+        var displayText = formatTimestamp(original);
+        node.textContent = displayText;
+        if (userOffsetMinutes !== -480) {
+            var chinaText = formatTimestamp(original, 'Asia/Shanghai');
+            if (chinaText && chinaText !== original) {
+                node.setAttribute('title', chinaText);
+            } else {
+                node.removeAttribute('title');
+            }
+        } else {
+            node.removeAttribute('title');
+        }
+    });
+});
+</script>
 @endsection


### PR DESCRIPTION
讓世界各地使用者在 /modified 與 /operations 等頁面看到本地時間，同時滑鼠 hover 可以看到 GMT+8 時區的時間。

滑鼠懸停顯示 GMT+8 時區時間的功能只對 GMT+8 時區以外的使用者有效。

<img width="287" height="206" alt="image" src="https://github.com/user-attachments/assets/60e41e33-922a-4ccd-9487-ca74cccff55c" />
