### PR TITLE
新增管理員 SQL `EXPLAIN` 與查詢效能追蹤

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 
 - `/codes/{table}` 泛用代碼表頁面：`CodesController` 根據表名直接查資料庫，會套用欄位覆寫、搜尋功能。白名單目前已納入 `ADDRESSES`，可直接於 `/codes/ADDRESSES` 檢視原始地址主表資料。
 - `/view/{key}` 檢視表頁面：`ViewTableController` 會依 `config/view_tables.php` 設定執行查詢並套用分頁／搜尋；實際 SQL 可透過頁面右上角「顯示 SQL」按鈕檢視，判斷是否符合預期。只有登入使用者能瀏覽該模組。
+- 管理工具 `/admin/explainsql`：僅限活躍管理員，可輸入 SELECT / WITH 語句並查看 MySQL `EXPLAIN` 計畫，輸出表格供調校索引或查詢效能。
 - 操作紀錄（`operations` 表）：透過 `OperationRepository::store()` 統一寫入，欄位 `op_type` 代表新增/覆寫/修改/刪除。
   - 任官（`POSTING_DATA`、`POSTED_TO_OFFICE_DATA`、`POSTED_TO_ADDR_DATA`）相關的新增、更新、刪除已全面改成由 `BiogMainRepository::officeStoreById()`／`officeUpdateById()`／`officeDeleteById()` 以資料庫交易處理：先鎖定/寫入主表，再同步管理地址清單並一次寫入操作紀錄。請勿在 Controller 直接操作 `DB::table()`。
   - `officeUpdateById()` 只有在實際欄位變動時才對 `POSTED_TO_OFFICE_DATA` 寫入 timestamp，純地址異動會在同一交易中只更新 `POSTED_TO_ADDR_DATA`，操作紀錄也會對應保留 before/after JSON。測試這段流程時務必透過 `actingAs()` 提供使用者資訊，避免 `ToolsRepository::timestamp()` 取不到登入者姓名。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - 新增「檢視表 VIEW」模組，可在 `/view/{key}` 透過設定檔註冊查詢（目前含別名、社會關係、人物地址、社會機構地址、社會機構任職、人物來源、人物著作等資料）；頁面支援搜尋、分頁並內建「顯示 SQL」按鈕，便於比對實際執行的查詢語句。
 - 新增「地址層級檢視」(`/view/Addresses`)，直接使用資料庫 `View_Address` 展開地址與最多五層隸屬關係，並在側邊欄加入快速連結。
 - `/codes` 白名單新增 `ADDRESSES`，現可直接於 `/codes/ADDRESSES` 查詢地址主表。
+- 管理員工具新增 `/admin/explainsql`，可輸入只讀 SQL 並檢視 MySQL `EXPLAIN` 查詢計畫。
 - 官名地址（POSTED_TO_ADDR_DATA）變動現在會額外留下操作紀錄，內容採取整筆列資料的 JSON （包含 c_personid、c_posting_id、c_office_id、c_addr_id），以利差異比對與復原。 同時暫時隱藏此類操作的復原按鈕，避免使用者誤觸不支援的還原流程。
 - ALTNAME_DATA 在 `/modified` 顯示現況時改以 log 中的主鍵（`c_personid`／`c_alt_name_type_code`／`c_alt_name_chn`）查詢，不再依賴 `resource_id` 裡的舊別名，避免別名更新或含 dash 時抓不到現況，並補上 `OperationsAltnameResolverTest` 覆蓋。
 - Basicinformation → 任官（office）操作全面交易化：`BiogMainRepository::officeStoreById`／`officeUpdateById`／`officeDeleteById` 會鎖定職官、同步維護地址清單並一併寫入 Operations；`officeUpdateById` 僅在主表欄位有異動時才更新 timestamp，純地址調整會重建 `POSTED_TO_ADDR_DATA` 並留下前後 JSON。

--- a/app/Http/Controllers/AdminExplainSqlController.php
+++ b/app/Http/Controllers/AdminExplainSqlController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class AdminExplainSqlController extends Controller
+{
+    protected function ensureAdmin()
+    {
+        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+            abort(403);
+        }
+    }
+
+    public function show()
+    {
+        $this->ensureAdmin();
+
+        return view('admin.explain_sql', [
+            'page_title' => 'SQL 執行計畫',
+            'page_description' => 'EXPLAIN 查詢計畫',
+            'page_url' => route('admin.explainsql'),
+            'sql' => '',
+            'results' => null,
+            'columns' => [],
+            'error' => null,
+        ]);
+    }
+
+    public function explain(Request $request)
+    {
+        $this->ensureAdmin();
+
+        $data = $request->validate([
+            'sql' => 'required|string',
+        ]);
+
+        $sql = trim($data['sql']);
+        $error = null;
+        $results = null;
+        $columns = [];
+
+        if (strpos($sql, ';') !== false) {
+            $error = '請勿在語句中包含分號。';
+        } else {
+            $firstToken = strtoupper(strtok(ltrim($sql), " \t\n\r"));
+            $allowed = ['SELECT', 'WITH'];
+
+            if (!in_array($firstToken, $allowed, true)) {
+                $error = '僅允許只讀查詢（SELECT / WITH）。';
+            }
+        }
+
+        if (!$error) {
+            try {
+                $results = DB::select(DB::raw('EXPLAIN ' . $sql));
+                $columns = !empty($results) ? array_keys((array) $results[0]) : [];
+            } catch (\Throwable $e) {
+                $error = $e->getMessage();
+            }
+        }
+
+        return view('admin.explain_sql', [
+            'page_title' => 'SQL 執行計畫',
+            'page_description' => 'EXPLAIN 查詢計畫',
+            'page_url' => route('admin.explainsql'),
+            'sql' => $sql,
+            'results' => $results,
+            'columns' => $columns,
+            'error' => $error,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,20 +2,14 @@
 
 namespace App\Providers;
 
+use App\Services\QueryProfile;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
     /**
      * Register any application services.
      *
@@ -23,6 +17,26 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->singleton(QueryProfile::class, function () {
+            return new QueryProfile();
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $profiler = $this->app->make(QueryProfile::class);
+
+        DB::listen(function (QueryExecuted $query) use ($profiler) {
+            $profiler->add($query);
+        });
+
+        View::composer('*', function ($view) use ($profiler) {
+            $view->with('queryProfileSummary', $profiler->summary());
+        });
     }
 }

--- a/app/Services/QueryProfile.php
+++ b/app/Services/QueryProfile.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Database\Events\QueryExecuted;
+
+class QueryProfile
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    protected $queries = [];
+
+    public function add(QueryExecuted $event): void
+    {
+        $time = is_numeric($event->time) ? (float) $event->time : 0.0;
+
+        $this->queries[] = [
+            'sql' => $event->sql,
+            'bindings' => $event->bindings,
+            'time' => $time,
+        ];
+    }
+
+    public function count(): int
+    {
+        return count($this->queries);
+    }
+
+    public function totalTime(): float
+    {
+        return array_sum(array_column($this->queries, 'time'));
+    }
+
+    public function summary(): array
+    {
+        $queries = array_map(function ($query) {
+            return $query + [
+                'bindings_json' => json_encode(
+                    $query['bindings'],
+                    JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+                ),
+            ];
+        }, $this->queries);
+
+        return [
+            'count' => $this->count(),
+            'time_ms' => $this->totalTime(),
+            'queries' => $queries,
+        ];
+    }
+}

--- a/resources/views/admin/explain_sql.blade.php
+++ b/resources/views/admin/explain_sql.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.dashboard')
+
+@section('content')
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">MySQL EXPLAIN</h3>
+        </div>
+        <div class="panel-body">
+            <p class="text-muted">
+                這個工具僅供管理員用於診斷查詢效能。請輸入只讀 SQL（僅支援 SELECT / WITH），系統會送出
+                <code>EXPLAIN</code> 並顯示 MySQL 回傳的執行計畫，方便評估索引或查詢設計是否需要調整。
+            </p>
+
+            <form method="post" action="{{ route('admin.explainsql') }}" class="form">
+                {{ csrf_field() }}
+                <div class="form-group @if($errors->has('sql')) has-error @endif">
+                    <label for="sql">SQL 語句（僅支援 SELECT / WITH）</label>
+                    <textarea name="sql" id="sql" rows="5" class="form-control" placeholder="SELECT ...">{{ old('sql', $sql) }}</textarea>
+                    @if($errors->has('sql'))
+                        <span class="help-block">{{ $errors->first('sql') }}</span>
+                    @endif
+                </div>
+                <button type="submit" class="btn btn-primary">執行 EXPLAIN</button>
+            </form>
+
+            @if($error)
+                <div class="alert alert-danger" style="margin-top: 15px;">
+                    {{ $error }}
+                </div>
+            @endif
+
+            @if(is_array($results) && count($results) > 0)
+                <div class="table-responsive" style="margin-top: 20px;">
+                    <table class="table table-bordered table-striped table-condensed">
+                        <thead>
+                        <tr>
+                            @foreach($columns as $column)
+                                <th>{{ $column }}</th>
+                            @endforeach
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($results as $row)
+                            <tr>
+                                @foreach($columns as $column)
+                                    <td>{{ data_get($row, $column) }}</td>
+                                @endforeach
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @elseif($results !== null && empty($results))
+                <p style="margin-top: 20px;">查無資料。</p>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -128,13 +128,73 @@ desired effect
             <!-- Your Page Content Here -->
             @yield('content')
 
+            @php
+                $canViewQueryDetails = Auth::check() && Auth::user()->is_admin == 1;
+            @endphp
+
+            @if(!empty($queryProfileSummary['count']))
+                <p class="text-muted" style="margin-top: 20px;">
+                    本次查詢共 {{ $queryProfileSummary['count'] }} 筆，耗時 {{ number_format($queryProfileSummary['time_ms'], 2) }} ms
+                    @if($canViewQueryDetails)
+                        <a href="#" data-toggle="modal" data-target="#query-profile-modal" style="margin-left: 8px;">查看詳細</a>
+                    @endif
+                </p>
+            @endif
+
         </section>
         <!-- /.content -->
     </div>
     <!-- /.content-wrapper -->
 
     <!-- Footer -->
-    @include('layouts.footer')
+@include('layouts.footer')
+
+@if(!empty($queryProfileSummary['count']) && $canViewQueryDetails)
+    <div class="modal fade" id="query-profile-modal" tabindex="-1" role="dialog" aria-labelledby="queryProfileModalLabel">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="queryProfileModalLabel">SQL 查詢明細</h4>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted">
+                        共 {{ $queryProfileSummary['count'] }} 筆查詢，累計 {{ number_format($queryProfileSummary['time_ms'], 2) }} ms。
+                        以下數據依執行順序列出，時間單位為毫秒。
+                    </p>
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-striped table-condensed">
+                            <thead>
+                            <tr>
+                                <th style="width: 60px;">#</th>
+                                <th style="width: 120px;">耗時 (ms)</th>
+                                <th>SQL</th>
+                                <th style="width: 220px;">綁定參數</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach(array_slice($queryProfileSummary['queries'], 0, 100) as $index => $query)
+                                <tr>
+                                    <td>{{ $index + 1 }}</td>
+                                    <td>{{ number_format($query['time'], 2) }}</td>
+                                    <td><code style="white-space: pre-wrap; word-break: break-all;">{{ $query['sql'] }}</code></td>
+                                    <td><code style="white-space: pre-wrap; word-break: break-all;">{{ $query['bindings_json'] }}</code></td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                        @if(count($queryProfileSummary['queries']) > 100)
+                            <p class="text-muted">僅顯示前 100 筆查詢。</p>
+                        @endif
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">關閉</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endif
 
     <!-- Control Sidebar -->
     <aside class="control-sidebar control-sidebar-dark">

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -68,6 +68,7 @@
 
             @if(Auth::check() and Auth::user()->is_admin == 1)
                 <li class="header">Management</li>
+                <li class="{{ $page_title == 'SQL 執行計畫' ? 'active' : '' }}"><a href="{{ route('admin.explainsql') }}"><i class="fa fa-search"></i> <span>SQL EXPLAIN</span></a></li>
                 <li class="{{ $page_title == 'MergePreview' ? 'active' : '' }}"><a href="{{ route('merge-preview.index') }}"><i class="ion ion-shuffle"></i> <span>人物記錄合併</span></a></li>
                 <li class="{{ $page_title == 'Management' ? 'active' : '' }}"><a href="{{ route('manage.index') }}"><i class="ion ion-ios-people-outline"></i> <span>管理用戶</span></a></li>
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -193,6 +193,11 @@ Route::resource('addrbelongsdata', 'AddrBelongsDataController', ['name' => [
     'update' => 'addrbelongsdata.update'
 ]]);
 
+Route::middleware('auth')->group(function () {
+    Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
+    Route::post('admin/explainsql', 'AdminExplainSqlController@explain');
+});
+
 Route::get('addrbelongsdata/{id}/delete', 'AddrBelongsDataController@destroy');
 
 Route::resource('addrcodes', 'AddrCodesController', ['name' => [

--- a/tests/Feature/AdminExplainSqlTest.php
+++ b/tests/Feature/AdminExplainSqlTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AdminExplainSqlTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->string('avatar')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    protected function makeUser(array $attributes = []): User
+    {
+        $user = new User([
+            'name' => 'Tester',
+            'email' => uniqid().'@example.com',
+            'password' => bcrypt('secret'),
+            'avatar' => 'avatar5.png',
+            'confirmation_token' => str_random(10),
+        ]);
+
+        foreach ($attributes as $key => $value) {
+            $user->{$key} = $value;
+        }
+
+        if (!isset($attributes['is_active'])) {
+            $user->is_active = 1;
+        }
+
+        if (!isset($attributes['is_admin'])) {
+            $user->is_admin = 1;
+        }
+
+        $user->save();
+
+        return $user;
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $response = $this->get('/admin/explainsql');
+        $response->assertStatus(302);
+    }
+
+    public function test_non_admin_is_forbidden(): void
+    {
+        $user = $this->makeUser(['is_admin' => 0]);
+
+        $this->actingAs($user);
+        $response = $this->get('/admin/explainsql');
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_view_form(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->get('/admin/explainsql');
+        $response->assertStatus(200)->assertSee('SQL 語句');
+    }
+
+    public function test_admin_can_run_explain(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::statement('CREATE TABLE sample (id INTEGER)');
+
+        $response = $this->post('/admin/explainsql', [
+            'sql' => 'SELECT * FROM sample',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertSee('MySQL EXPLAIN')
+            ->assertSee('本次查詢共');
+    }
+}


### PR DESCRIPTION
- 新增 `/admin/explainsql` 管理頁：限制活躍管理員使用，只允許 `SELECT`/`WITH` 語句並顯示 MySQL `EXPLAIN` 查詢計畫；側欄加入連結並附頁面說明
- 建立 QueryProfile 服務，在 AppServiceProvider 透過 `DB::listen` 累積單頁所有查詢與耗時，統一注入到視圖
- 在主版頁腳顯示查詢腳註（筆數、耗時），並提供僅管理員可見的 modal 查看前 100 筆 SQL 與綁定參數
- 補充 AGENTS.md 與 CHANGELOG.md，記錄工具用途與 UI 變更；新增 AdminExplainSqlTest 覆蓋授權與功能流程