### PR TITLE
專家提案審核篩選優化

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -29,9 +29,37 @@ class OperationsController extends Controller
 //        Operation::all();
     }
 
-    public function index()
+    public function index(Request $request)
     {
-        $lists = Operation::where('crowdsourcing_status', 0)->orderBy('updated_at', 'desc')->limit(100)->paginate(20);
+        $proposalsOnly = filter_var($request->input('proposals_only', false), FILTER_VALIDATE_BOOLEAN);
+
+        $query = Operation::where('crowdsourcing_status', 0);
+        $statusFilters = [];
+
+        if ($proposalsOnly) {
+            $rawStatuses = $request->input('status', []);
+            if (!is_array($rawStatuses)) {
+                $rawStatuses = [$rawStatuses];
+            }
+            $allowedStatuses = ['pending', 'approved', 'rejected'];
+            $statusFilters = array_values(array_intersect($rawStatuses, $allowedStatuses));
+
+            $query->whereIn('op_type', [
+                Operation::TYPE_PROPOSAL_CREATE,
+                Operation::TYPE_PROPOSAL_UPDATE,
+            ]);
+
+            if (!empty($statusFilters)) {
+                $query->where(function ($subQuery) use ($statusFilters) {
+                    foreach ($statusFilters as $status) {
+                        $subQuery->orWhere('resource_data', 'like', '%"__review_status":"' . $status . '"%');
+                    }
+                });
+            }
+        }
+
+        $lists = $query->orderBy('updated_at', 'desc')->paginate(20);
+        $lists->appends($request->except('page'));
         //將物件轉為陣列進行陣列比對
         $listsArr = $this->operationRepository->objectToArray($lists);
         $all = count($listsArr['data']);
@@ -158,9 +186,15 @@ class OperationsController extends Controller
         //echo "<pre><code>";
         //print_r($lists[0]['resource_original']); //成功
         //echo "</code></pre>";
+        $pageTitle = $proposalsOnly ? 'OperationsProposals' : 'NewUpdate';
+        $pageDescription = $proposalsOnly ? '最近提案列表' : '最近編輯列表';
+        $pageUrl = $proposalsOnly ? '/operations?proposals_only=1' : '/operations';
+
         return view('operations.index', ['lists' => $lists,
-            'page_title' => 'NewUpdate', 'page_description' => '最近編輯列表',
-            'page_url' => '/operations'
+            'page_title' => $pageTitle, 'page_description' => $pageDescription,
+            'page_url' => $pageUrl,
+            'proposals_only' => $proposalsOnly,
+            'status_filters' => $statusFilters,
         ]);
     }
 

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -17,12 +17,31 @@
         <!-- /.search form -->
 
         <!-- Sidebar Menu -->
+        @php
+            $hasPendingProposals = false;
+            if (Auth::check() && Auth::user()->is_admin == 1 && Auth::user()->is_active == 1) {
+                try {
+                    if (\Illuminate\Support\Facades\Schema::hasTable('operations')) {
+                        $hasPendingProposals = \App\Operation::where('crowdsourcing_status', 0)
+                            ->whereIn('op_type', [
+                                \App\Operation::TYPE_PROPOSAL_CREATE,
+                                \App\Operation::TYPE_PROPOSAL_UPDATE,
+                            ])
+                            ->where('resource_data', 'like', '%"__review_status":"pending"%')
+                            ->exists();
+                    }
+                } catch (\Throwable $e) {
+                    $hasPendingProposals = false;
+                }
+            }
+        @endphp
         <ul class="sidebar-menu">
             <li class="header">MAIN NAVIGATION</li>
             <!-- Optionally, you can add icons to the links -->
             {{--<li class="{{ $page_title == 'Dashboard' ? 'active' : '' }}"><a href="/home"><i class="fa fa-dashboard"></i> <span>控制面板</span></a></li>--}}
             <li class="{{ $page_title == 'Basicinformation' ? 'active' : '' }}"><a href="{{ route('basicinformation.index') }}"><i class="ion ion-ios-people-outline"></i> <span>個人基本信息</span></a></li>
             <li class="{{ $page_title == 'NewUpdate' ? 'active' : '' }}"><a href="{{ route('operations.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近編輯列表</span></a></li>
+            <li class="{{ $page_title == 'OperationsProposals' ? 'active' : '' }}"><a href="{{ route('operations.index', ['proposals_only' => 1]) }}"><i class="ion ion-ios-people-outline"></i> <span>最近提案列表{{ $hasPendingProposals ? '（待審核）' : '' }}</span></a></li>
             <li class="{{ $page_title == 'Crowdsourcing' ? 'active' : '' }}"><a href="{{ route('crowdsourcing.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近眾包錄入記錄</span></a></li>
             <li class="{{ $page_title == 'Modified' ? 'active' : '' }}"><a href="{{ route('modified.index') }}"><i class="ion ion-ios-people-outline"></i> <span>最近修改記錄</span></a></li>
 

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -4,6 +4,37 @@
 @include('biogmains.defense')
     <div class="panel panel-default">
         <div class="panel-body">
+            @if(!empty($proposals_only))
+                @php
+                    $statusOptions = [
+                        'pending' => '待審核',
+                        'approved' => '已核准',
+                        'rejected' => '已退修',
+                    ];
+                    $selectedStatuses = $status_filters ?? [];
+                @endphp
+                <form method="GET" action="{{ route('operations.index') }}" class="form-inline" style="margin-bottom: 15px;" id="proposal-status-filters">
+                    <input type="hidden" name="proposals_only" value="1">
+                    @foreach($statusOptions as $value => $label)
+                        <label class="checkbox-inline" style="margin-right: 12px;">
+                            <input type="checkbox" name="status[]" value="{{ $value }}" {{ in_array($value, $selectedStatuses, true) ? 'checked' : '' }}>
+                            {{ $label }}
+                        </label>
+                    @endforeach
+                    <a href="{{ route('operations.index', ['proposals_only' => 1]) }}" class="btn btn-default btn-sm" style="margin-left: 8px;">清除篩選</a>
+                </form>
+                <script>
+                    document.addEventListener('DOMContentLoaded', function () {
+                        var form = document.getElementById('proposal-status-filters');
+                        if (!form) {
+                            return;
+                        }
+                        form.addEventListener('change', function () {
+                            form.submit();
+                        });
+                    });
+                </script>
+            @endif
             <div class="table-responsive">
                 <table class="table table-bordered table-striped">
                 <thead>


### PR DESCRIPTION
- /operations?proposals_only=1 支援按審核狀態篩選提案並保留查詢參數
- 側欄提示待審核提案，並新增提案列表連結
- 提案篩選勾選即時生效，移除手動套用按鈕
<img width="787" height="435" alt="image" src="https://github.com/user-attachments/assets/af83c88d-4b4d-45e1-bb1b-3b941e527914" />
