### PR TITLE
批次匯入書稿流程實作

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Repositories\OperationRepository;
+use App\Repositories\ToolsRepository;
+use App\TextCode;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class AdminBatchLoadBookTitlesController extends Controller
+{
+    /**
+     * @var OperationRepository
+     */
+    protected $operationRepository;
+
+    /**
+     * @var ToolsRepository
+     */
+    protected $toolsRepository;
+
+    public function __construct(OperationRepository $operationRepository, ToolsRepository $toolsRepository)
+    {
+        $this->operationRepository = $operationRepository;
+        $this->toolsRepository = $toolsRepository;
+    }
+
+    /**
+     * Render the batch upload form.
+     */
+    public function showForm()
+    {
+        $this->ensureAdmin();
+
+        return view('admin.batch_load_book_titles', [
+            'page_title' => '批次匯入書稿資料',
+            'page_description' => '貼上以 tab 分隔的作者 ID 與書名，新增至 TEXT_CODES',
+            'page_url' => route('admin.batch-load-book-titles'),
+            'input' => old('entries', ''),
+            'results' => session('batch_results', []),
+            'batchErrors' => session('batch_errors', []),
+        ]);
+    }
+
+    /**
+     * Handle the batch upload submission.
+     */
+    public function store(Request $request)
+    {
+        $this->ensureAdmin();
+
+        $data = $request->validate([
+            'entries' => 'required|string',
+        ]);
+
+        [$rows, $errors] = $this->parseEntries($data['entries']);
+
+        if (!empty($errors)) {
+            return redirect()
+                ->route('admin.batch-load-book-titles')
+                ->withInput()
+                ->with('batch_errors', $errors);
+        }
+
+        $results = [];
+
+        DB::transaction(function () use (&$results, $rows) {
+            $nextId = (int) DB::table('TEXT_CODES')->max('c_textid');
+            if ($nextId < 0) {
+                $nextId = 0;
+            }
+
+            foreach ($rows as $row) {
+                $nextId++;
+
+                $payload = [
+                    'c_textid' => $nextId,
+                    'c_title_chn' => $row['title'],
+                    'c_text_type_id' => '01',
+                ];
+
+                $payload = $this->toolsRepository->timestamp($payload, true);
+
+                TextCode::create($payload);
+
+                $this->operationRepository->store(
+                    Auth::id(),
+                    '',
+                    1,
+                    'TEXT_CODES',
+                    $nextId,
+                    $payload
+                );
+
+                $results[] = [
+                    'line' => $row['line'],
+                    'author_id' => $row['author_id'],
+                    'title' => $row['title'],
+                    'c_textid' => $nextId,
+                ];
+            }
+        });
+
+        return redirect()
+            ->route('admin.batch-load-book-titles')
+            ->with('batch_results', $results)
+            ->with('batch_errors', []);
+    }
+
+    /**
+     * Ensure the current user is an active admin.
+     */
+    protected function ensureAdmin(): void
+    {
+        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+            abort(403);
+        }
+    }
+
+    /**
+     * Parse the submitted tab-separated lines.
+     *
+     * @param string $input
+     * @return array{0: array<int,array<string,mixed>>, 1: array<int,string>}
+     */
+    protected function parseEntries(string $input): array
+    {
+        $lines = preg_split('/\r\n|\n|\r/', $input);
+        $rows = [];
+        $errors = [];
+
+        foreach ($lines as $index => $line) {
+            $lineNumber = $index + 1;
+            $trimmed = trim($line);
+
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $parts = preg_split("/\t+/", $line);
+
+            if (!$parts || count($parts) < 2) {
+                $errors[] = "第 {$lineNumber} 行未找到兩欄資料";
+                continue;
+            }
+
+            $authorId = trim($parts[0]);
+            $title = trim($parts[1]);
+
+            if ($authorId === '') {
+                $errors[] = "第 {$lineNumber} 行作者 ID 為空";
+                continue;
+            }
+
+            if (!ctype_digit($authorId)) {
+                $errors[] = "第 {$lineNumber} 行作者 ID 必須為整數";
+                continue;
+            }
+
+            if ($title === '') {
+                $errors[] = "第 {$lineNumber} 行書名為空";
+                continue;
+            }
+
+            $rows[] = [
+                'line' => $lineNumber,
+                'author_id' => (int) $authorId,
+                'title' => $title,
+            ];
+        }
+
+        if (empty($rows) && empty($errors)) {
+            $errors[] = '沒有有效資料，請確認輸入格式。';
+        }
+
+        return [$rows, $errors];
+    }
+}

--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Pinyin;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\TextCode;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class AdminBatchLoadBookTitlesController extends Controller
 {
@@ -36,11 +38,12 @@ class AdminBatchLoadBookTitlesController extends Controller
 
         return view('admin.batch_load_book_titles', [
             'page_title' => '批次匯入書稿資料',
-            'page_description' => '貼上以 tab 分隔的作者 ID 與書名，新增至 TEXT_CODES',
+            'page_description' => '貼上以 tab 分隔的作者 ID、書名與來源 TEXT_ID，新增至 TEXT_CODES',
             'page_url' => route('admin.batch-load-book-titles'),
             'input' => old('entries', ''),
             'results' => session('batch_results', []),
             'batchErrors' => session('batch_errors', []),
+            'batchId' => session('batch_id'),
         ]);
     }
 
@@ -64,9 +67,10 @@ class AdminBatchLoadBookTitlesController extends Controller
                 ->with('batch_errors', $errors);
         }
 
+        $batchId = $this->generateBatchId();
         $results = [];
 
-        DB::transaction(function () use (&$results, $rows) {
+        DB::transaction(function () use (&$results, $rows, $batchId) {
             $nextId = (int) DB::table('TEXT_CODES')->max('c_textid');
             if ($nextId < 0) {
                 $nextId = 0;
@@ -75,10 +79,19 @@ class AdminBatchLoadBookTitlesController extends Controller
             foreach ($rows as $row) {
                 $nextId++;
 
+                $normalizedTitle = $this->normalizeTitle($row['title']);
+                $titleWithoutVolume = $this->stripVolumeInfo($row['title']);
+                $pinyinTitle = $this->buildPinyin($titleWithoutVolume);
+                $dynasty = $this->lookupDynasty($row['author_id']);
+
                 $payload = [
                     'c_textid' => $nextId,
-                    'c_title_chn' => $row['title'],
+                    'c_title_chn' => $normalizedTitle,
+                    'c_title' => $pinyinTitle,
                     'c_text_type_id' => '01',
+                    'c_text_dy' => $dynasty,
+                    'c_source' => $row['source'],
+                    'c_notes' => '[' . $batchId . ']',
                 ];
 
                 $payload = $this->toolsRepository->timestamp($payload, true);
@@ -97,7 +110,9 @@ class AdminBatchLoadBookTitlesController extends Controller
                 $results[] = [
                     'line' => $row['line'],
                     'author_id' => $row['author_id'],
-                    'title' => $row['title'],
+                    'title' => $normalizedTitle,
+                    'source' => $row['source'],
+                    'dynasty' => $dynasty,
                     'c_textid' => $nextId,
                 ];
             }
@@ -106,7 +121,8 @@ class AdminBatchLoadBookTitlesController extends Controller
         return redirect()
             ->route('admin.batch-load-book-titles')
             ->with('batch_results', $results)
-            ->with('batch_errors', []);
+            ->with('batch_errors', [])
+            ->with('batch_id', $batchId);
     }
 
     /**
@@ -141,13 +157,14 @@ class AdminBatchLoadBookTitlesController extends Controller
 
             $parts = preg_split("/\t+/", $line);
 
-            if (!$parts || count($parts) < 2) {
-                $errors[] = "第 {$lineNumber} 行未找到兩欄資料";
+            if (!$parts || count($parts) < 3) {
+                $errors[] = "第 {$lineNumber} 行未找到三欄資料（作者 ID、書名、來源 TEXT_ID）";
                 continue;
             }
 
             $authorId = trim($parts[0]);
             $title = trim($parts[1]);
+            $source = trim($parts[2]);
 
             if ($authorId === '') {
                 $errors[] = "第 {$lineNumber} 行作者 ID 為空";
@@ -164,10 +181,16 @@ class AdminBatchLoadBookTitlesController extends Controller
                 continue;
             }
 
+            if ($source === '') {
+                $errors[] = "第 {$lineNumber} 行來源 TEXT_ID 為空";
+                continue;
+            }
+
             $rows[] = [
                 'line' => $lineNumber,
                 'author_id' => (int) $authorId,
                 'title' => $title,
+                'source' => $source,
             ];
         }
 
@@ -176,5 +199,76 @@ class AdminBatchLoadBookTitlesController extends Controller
         }
 
         return [$rows, $errors];
+    }
+
+    /**
+     * Generate a batch identifier for audit trail.
+     */
+    protected function generateBatchId(): string
+    {
+        return now()->format('YmdHis');
+    }
+
+    /**
+     * Remove redundant punctuation/spaces from the supplied title.
+     */
+    protected function normalizeTitle(string $title): string
+    {
+        $title = preg_replace('/\s+/u', '', $title);
+        $title = preg_replace('/[:：]\s*/u', ': ', $title);
+        return trim($title);
+    }
+
+    /**
+     * Remove volume/annotation info trailing after colon characters.
+     */
+    protected function stripVolumeInfo(string $title): string
+    {
+        return trim(preg_replace('/[:：].*$/u', '', $title));
+    }
+
+    /**
+     * Convert Chinese title to a space-separated pinyin string.
+     */
+    protected function buildPinyin(string $title): string
+    {
+        $chars = preg_split('//u', $title, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $syllables = [];
+
+        foreach ($chars as $char) {
+            if (preg_match('/\p{Han}/u', $char)) {
+                $syllables[] = strtolower(Pinyin::getPinyin($char));
+            } elseif (preg_match('/[A-Za-z0-9]/u', $char)) {
+                $syllables[] = strtolower($char);
+            }
+        }
+
+        $syllables = array_filter($syllables, static function ($syllable) {
+            return $syllable !== '';
+        });
+
+        if (empty($syllables)) {
+            return strtolower(trim(preg_replace('/\s+/u', ' ', $title)));
+        }
+
+        return implode(' ', $syllables);
+    }
+
+    /**
+     * Look up dynasty (c_dy) for the given person ID.
+     */
+    protected function lookupDynasty(int $personId): ?string
+    {
+        try {
+            $value = DB::table('BIOG_MAIN')->where('c_personid', $personId)->value('c_dy');
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        return (string) $value;
     }
 }

--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -111,8 +111,13 @@ class AdminBatchLoadBookTitlesController extends Controller
                     'line' => $row['line'],
                     'author_id' => $row['author_id'],
                     'title' => $normalizedTitle,
+                    'title_pinyin' => $pinyinTitle,
                     'source' => $row['source'],
                     'dynasty' => $dynasty,
+                    'text_type' => $payload['c_text_type_id'],
+                    'notes' => $payload['c_notes'],
+                    'created_by' => $payload['c_created_by'] ?? null,
+                    'created_date' => $payload['c_created_date'] ?? null,
                     'c_textid' => $nextId,
                 ];
             }

--- a/resources/views/admin/batch_load_book_titles.blade.php
+++ b/resources/views/admin/batch_load_book_titles.blade.php
@@ -56,8 +56,13 @@
                             <th>行號</th>
                             <th>作者 ID</th>
                             <th>書名（已清理）</th>
+                            <th>書名拼音</th>
                             <th>來源 TEXT_ID</th>
                             <th>書籍朝代</th>
+                            <th>文本類型</th>
+                            <th>批次編號</th>
+                            <th>建立者</th>
+                            <th>建立日期</th>
                             <th>新 c_textid</th>
                         </tr>
                         </thead>
@@ -67,8 +72,13 @@
                                 <td>{{ $row['line'] }}</td>
                                 <td>{{ $row['author_id'] }}</td>
                                 <td>{{ $row['title'] }}</td>
+                                <td>{{ $row['title_pinyin'] }}</td>
                                 <td>{{ $row['source'] }}</td>
                                 <td>{{ $row['dynasty'] ?? '—' }}</td>
+                                <td>{{ $row['text_type'] }}</td>
+                                <td>{{ $row['notes'] }}</td>
+                                <td>{{ $row['created_by'] }}</td>
+                                <td>{{ $row['created_date'] }}</td>
                                 <td>{{ $row['c_textid'] }}</td>
                             </tr>
                         @endforeach

--- a/resources/views/admin/batch_load_book_titles.blade.php
+++ b/resources/views/admin/batch_load_book_titles.blade.php
@@ -7,10 +7,16 @@
         </div>
         <div class="panel-body">
             <p class="text-muted">
-                將作者 CBDB ID 與書名貼在下方文字框，每行以 <code>Tab</code> 分隔兩欄。
-                範例：<code>12345[TAB]某某書名</code>。系統會依序建立 <code>TEXT_CODES</code> 資料，
-                目前預設 <code>c_text_type_id</code> 為 <code>01</code>。
+                將作者 CBDB ID、書名、來源 <code>TEXT_ID</code> 貼在下方文字框，每行以 <code>Tab</code> 分隔三欄。
+                範例：<code>12345[TAB]某某書名[TAB]67890</code>。系統會依序建立 <code>TEXT_CODES</code>，
+                自動排定 <code>c_textid</code>、轉換拼音並標記書籍朝代，預設 <code>c_text_type_id</code> 為 <code>01</code>。
             </p>
+
+            @if(!empty($batchId))
+                <div class="alert alert-info">
+                    本次批次編號：<code>{{ $batchId }}</code>
+                </div>
+            @endif
 
             @if(!empty($batchErrors))
                 <div class="alert alert-danger">
@@ -33,7 +39,7 @@
                 {{ csrf_field() }}
                 <div class="form-group @if($errors->has('entries')) has-error @endif">
                     <label for="entries">批次資料（以 Tab 分隔）</label>
-                    <textarea name="entries" id="entries" class="form-control" rows="10" placeholder="作者ID[TAB]書名">{{ old('entries', $input) }}</textarea>
+                    <textarea name="entries" id="entries" class="form-control" rows="10" placeholder="作者ID[TAB]書名[TAB]來源TEXT_ID">{{ old('entries', $input) }}</textarea>
                     @if($errors->has('entries'))
                         <span class="help-block">{{ $errors->first('entries') }}</span>
                     @endif
@@ -49,7 +55,9 @@
                         <tr>
                             <th>行號</th>
                             <th>作者 ID</th>
-                            <th>書名</th>
+                            <th>書名（已清理）</th>
+                            <th>來源 TEXT_ID</th>
+                            <th>書籍朝代</th>
                             <th>新 c_textid</th>
                         </tr>
                         </thead>
@@ -59,6 +67,8 @@
                                 <td>{{ $row['line'] }}</td>
                                 <td>{{ $row['author_id'] }}</td>
                                 <td>{{ $row['title'] }}</td>
+                                <td>{{ $row['source'] }}</td>
+                                <td>{{ $row['dynasty'] ?? '—' }}</td>
                                 <td>{{ $row['c_textid'] }}</td>
                             </tr>
                         @endforeach

--- a/resources/views/admin/batch_load_book_titles.blade.php
+++ b/resources/views/admin/batch_load_book_titles.blade.php
@@ -1,0 +1,71 @@
+@extends('layouts.dashboard')
+
+@section('content')
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">批次匯入書稿資料</h3>
+        </div>
+        <div class="panel-body">
+            <p class="text-muted">
+                將作者 CBDB ID 與書名貼在下方文字框，每行以 <code>Tab</code> 分隔兩欄。
+                範例：<code>12345[TAB]某某書名</code>。系統會依序建立 <code>TEXT_CODES</code> 資料，
+                目前預設 <code>c_text_type_id</code> 為 <code>01</code>。
+            </p>
+
+            @if(!empty($batchErrors))
+                <div class="alert alert-danger">
+                    <p class="text-bold">匯入失敗：</p>
+                    <ul class="list-unstyled">
+                        @foreach($batchErrors as $message)
+                            <li>・{{ $message }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            @if(!empty($results))
+                <div class="alert alert-success">
+                    已新增 {{ count($results) }} 筆資料。
+                </div>
+            @endif
+
+            <form method="post" action="{{ route('admin.batch-load-book-titles.store') }}">
+                {{ csrf_field() }}
+                <div class="form-group @if($errors->has('entries')) has-error @endif">
+                    <label for="entries">批次資料（以 Tab 分隔）</label>
+                    <textarea name="entries" id="entries" class="form-control" rows="10" placeholder="作者ID[TAB]書名">{{ old('entries', $input) }}</textarea>
+                    @if($errors->has('entries'))
+                        <span class="help-block">{{ $errors->first('entries') }}</span>
+                    @endif
+                </div>
+                <button type="submit" class="btn btn-primary">送出匯入</button>
+                <a href="{{ route('admin.batch-load-book-titles') }}" class="btn btn-default">清除重填</a>
+            </form>
+
+            @if(!empty($results))
+                <div class="table-responsive" style="margin-top: 20px;">
+                    <table class="table table-bordered table-striped table-condensed">
+                        <thead>
+                        <tr>
+                            <th>行號</th>
+                            <th>作者 ID</th>
+                            <th>書名</th>
+                            <th>新 c_textid</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($results as $row)
+                            <tr>
+                                <td>{{ $row['line'] }}</td>
+                                <td>{{ $row['author_id'] }}</td>
+                                <td>{{ $row['title'] }}</td>
+                                <td>{{ $row['c_textid'] }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -84,6 +84,7 @@
             @if(Auth::check() and Auth::user()->is_admin == 1)
                 <li class="header">Management</li>
                 <li class="{{ $page_title == 'SQL 執行計畫' ? 'active' : '' }}"><a href="{{ route('admin.explainsql') }}"><i class="fa fa-search"></i> <span>SQL EXPLAIN</span></a></li>
+                <li class="{{ $page_title == '批次匯入書稿資料' ? 'active' : '' }}"><a href="{{ route('admin.batch-load-book-titles') }}"><i class="fa fa-upload"></i> <span>批次匯入書稿</span></a></li>
                 <li class="{{ $page_title == 'MergePreview' ? 'active' : '' }}"><a href="{{ route('merge-preview.index') }}"><i class="ion ion-shuffle"></i> <span>人物記錄合併</span></a></li>
                 <li class="{{ $page_title == 'Management' ? 'active' : '' }}"><a href="{{ route('manage.index') }}"><i class="ion ion-ios-people-outline"></i> <span>管理用戶</span></a></li>
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -161,6 +161,7 @@ Route::resource('crowdsourcing', 'CrowdsourcingController', ['name' => [
     'update' => 'crowdsourcing.update'
 ]]);
 
+
 Route::get('crowdsourcing/{id}/confirm', 'CrowdsourcingController@confirm');
 Route::get('crowdsourcing/{id}/reject', 'CrowdsourcingController@reject');
 
@@ -205,6 +206,8 @@ Route::resource('addrbelongsdata', 'AddrBelongsDataController', ['name' => [
 Route::middleware('auth')->group(function () {
     Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
     Route::post('admin/explainsql', 'AdminExplainSqlController@explain');
+    Route::get('admin/batch-load-book-titles', 'AdminBatchLoadBookTitlesController@showForm')->name('admin.batch-load-book-titles');
+    Route::post('admin/batch-load-book-titles', 'AdminBatchLoadBookTitlesController@store')->name('admin.batch-load-book-titles.store');
 });
 
 Route::get('addrbelongsdata/{id}/delete', 'AddrBelongsDataController@destroy');

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AdminBatchLoadBookTitlesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->string('avatar')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('TEXT_CODES', function (Blueprint $table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title_chn')->nullable();
+            $table->string('c_text_type_id')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid');
+            $table->smallInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id');
+            $table->longText('resource_data');
+            $table->longText('resource_original')->nullable();
+            $table->timestamps();
+            $table->smallInteger('crowdsourcing_status')->default(0);
+            $table->smallInteger('rate')->default(0);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('TEXT_CODES');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    protected function makeUser(array $attributes = []): User
+    {
+        $user = new User([
+            'name' => 'Batch Admin',
+            'email' => uniqid('admin', true).'@example.com',
+            'password' => bcrypt('secret'),
+            'avatar' => 'avatar5.png',
+            'confirmation_token' => str_random(10),
+        ]);
+
+        foreach ($attributes as $key => $value) {
+            $user->{$key} = $value;
+        }
+
+        if (!isset($attributes['is_active'])) {
+            $user->is_active = 1;
+        }
+
+        if (!isset($attributes['is_admin'])) {
+            $user->is_admin = 1;
+        }
+
+        $user->save();
+
+        return $user;
+    }
+
+    public function test_non_admin_cannot_access_page(): void
+    {
+        $user = $this->makeUser(['is_admin' => 0]);
+        $this->actingAs($user);
+
+        $response = $this->get(route('admin.batch-load-book-titles'));
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_view_form(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->get(route('admin.batch-load-book-titles'));
+        $response->assertStatus(200)->assertSee('批次匯入書稿資料');
+    }
+
+    public function test_admin_can_upload_batch_entries(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "12345\t測試書名",
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+
+        $record = DB::table('TEXT_CODES')->where('c_title_chn', '測試書名')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('01', $record->c_text_type_id);
+        $this->assertSame('Batch Admin', $record->c_created_by);
+
+        $operation = DB::table('operations')->where('resource', 'TEXT_CODES')->first();
+        $this->assertNotNull($operation);
+        $this->assertSame((string) $record->c_textid, $operation->resource_id);
+    }
+
+    public function test_invalid_lines_are_reported(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "abc\t\n",
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+
+        $followUp = $this->get(route('admin.batch-load-book-titles'));
+        $followUp->assertSee('匯入失敗');
+        $this->assertSame(0, DB::table('TEXT_CODES')->count());
+    }
+}

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -35,11 +35,20 @@ class AdminBatchLoadBookTitlesTest extends TestCase
         Schema::create('TEXT_CODES', function (Blueprint $table) {
             $table->integer('c_textid')->primary();
             $table->string('c_title_chn')->nullable();
+            $table->string('c_title')->nullable();
             $table->string('c_text_type_id')->nullable();
+            $table->string('c_text_dy')->nullable();
+            $table->string('c_source')->nullable();
+            $table->longText('c_notes')->nullable();
             $table->string('c_created_by')->nullable();
             $table->string('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
             $table->string('c_modified_date')->nullable();
+        });
+
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_dy')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {
@@ -60,6 +69,7 @@ class AdminBatchLoadBookTitlesTest extends TestCase
     protected function tearDown(): void
     {
         Schema::dropIfExists('operations');
+        Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('TEXT_CODES');
         Schema::dropIfExists('users');
 
@@ -116,20 +126,39 @@ class AdminBatchLoadBookTitlesTest extends TestCase
         $user = $this->makeUser();
         $this->actingAs($user);
 
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 12345,
+            'c_dy' => '88',
+        ]);
+
         $response = $this->post(route('admin.batch-load-book-titles.store'), [
-            'entries' => "12345\t測試書名",
+            'entries' => "12345\t測試稿: 卷一\t54321",
         ]);
 
         $response->assertRedirect(route('admin.batch-load-book-titles'));
 
-        $record = DB::table('TEXT_CODES')->where('c_title_chn', '測試書名')->first();
+        $record = DB::table('TEXT_CODES')->where('c_textid', 1)->first();
         $this->assertNotNull($record);
+        $this->assertSame('測試稿: 卷一', $record->c_title_chn);
+        $this->assertSame('ce shi gao', $record->c_title);
         $this->assertSame('01', $record->c_text_type_id);
         $this->assertSame('Batch Admin', $record->c_created_by);
+        $this->assertSame('88', $record->c_text_dy);
+        $this->assertSame('54321', $record->c_source);
+        $this->assertRegExp('/^\[[0-9]{14}\]$/', $record->c_notes);
+        $this->assertNull($record->c_modified_by);
+        $this->assertNull($record->c_modified_date);
 
         $operation = DB::table('operations')->where('resource', 'TEXT_CODES')->first();
         $this->assertNotNull($operation);
         $this->assertSame((string) $record->c_textid, $operation->resource_id);
+        $encoded = json_decode($operation->resource_data, true);
+        $this->assertSame('ce shi gao', $encoded['c_title']);
+        $this->assertSame('54321', $encoded['c_source']);
+        $this->assertSame($record->c_notes, $encoded['c_notes']);
+
+        $followUp = $this->get(route('admin.batch-load-book-titles'));
+        $followUp->assertSee('本次批次編號');
     }
 
     public function test_invalid_lines_are_reported(): void
@@ -142,6 +171,26 @@ class AdminBatchLoadBookTitlesTest extends TestCase
         ]);
 
         $response->assertRedirect(route('admin.batch-load-book-titles'));
+
+        $followUp = $this->get(route('admin.batch-load-book-titles'));
+        $followUp->assertSee('匯入失敗');
+        $followUp->assertSee('未找到三欄資料');
+        $this->assertSame(0, DB::table('TEXT_CODES')->count());
+    }
+
+    public function test_blank_source_is_rejected(): void
+    {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "12345\t測試稿\t",
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+        $response->assertSessionHas('batch_errors');
+        $errors = $response->getSession()->get('batch_errors', []);
+        $this->assertNotEmpty($errors);
 
         $followUp = $this->get(route('admin.batch-load-book-titles'));
         $followUp->assertSee('匯入失敗');

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -159,6 +159,8 @@ class AdminBatchLoadBookTitlesTest extends TestCase
 
         $followUp = $this->get(route('admin.batch-load-book-titles'));
         $followUp->assertSee('本次批次編號');
+        $followUp->assertSee('書名拼音');
+        $followUp->assertSee('批次編號');
     }
 
     public function test_invalid_lines_are_reported(): void


### PR DESCRIPTION
- 新增書名清理、拼音與朝代自動填寫並紀錄來源與批次
- 批次編號改用時間戳方括號格式，介面顯示批次資訊
- 追加功能測試覆蓋第三欄解析與錯誤提示