### PR TITLE
隱藏未登入、未確認用戶創建、修改、删除、提案等功能

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24019,7 +24019,12 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
-  props: [],
+  props: {
+    userCanEdit: {
+      type: Boolean,
+      "default": false
+    }
+  },
   created: function created() {
     this.notes = '正在查询，请稍后';
     this.searchByName();
@@ -24476,7 +24481,12 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({
-  props: [],
+  props: {
+    userCanEdit: {
+      type: Boolean,
+      "default": false
+    }
+  },
   created: function created() {
     this.notes = '正在查询，请稍后';
     this.searchByName();
@@ -25012,33 +25022,39 @@ var _hoisted_6 = {
   "class": "table table-hover table-condensed"
 };
 var _hoisted_7 = {
+  key: 0
+};
+var _hoisted_8 = {
+  key: 0
+};
+var _hoisted_9 = {
   "class": "btn-group"
 };
-var _hoisted_8 = ["href"];
-var _hoisted_9 = ["data-target"];
-var _hoisted_10 = ["id"];
-var _hoisted_11 = {
+var _hoisted_10 = ["href"];
+var _hoisted_11 = ["data-target"];
+var _hoisted_12 = ["id"];
+var _hoisted_13 = {
   "class": "modal-dialog"
 };
-var _hoisted_12 = {
+var _hoisted_14 = {
   "class": "modal-content"
 };
-var _hoisted_13 = {
+var _hoisted_15 = {
   "class": "modal-footer"
 };
-var _hoisted_14 = ["href"];
-var _hoisted_15 = {
+var _hoisted_16 = ["href"];
+var _hoisted_17 = {
   "class": "pull-right",
   "aria-label": "Page navigation"
 };
-var _hoisted_16 = {
+var _hoisted_18 = {
   "class": "pagination"
 };
-var _hoisted_17 = {
+var _hoisted_19 = {
   key: 0
 };
-var _hoisted_18 = ["onClick"];
-var _hoisted_19 = {
+var _hoisted_20 = ["onClick"];
+var _hoisted_21 = {
   key: 1
 };
 function render(_ctx, _cache, $props, $setup, $data, $options) {
@@ -25058,21 +25074,21 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     })
   }, _toConsumableArray(_cache[4] || (_cache[4] = [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", {
     "class": "glyphicon glyphicon-search"
-  }, null, -1 /* CACHED */)])))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_5, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("table", _hoisted_6, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("caption", null, "共查询到" + (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.total) + "条记录", 1 /* TEXT */), _cache[8] || (_cache[8] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("thead", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_addr_id"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_belongs_to"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_firstyear"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_lastyear"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "操作")])], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tbody", null, [((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)(vue__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.renderList)($data.names.data, function (item) {
-    return (0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_addr_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_belongs_to), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_firstyear), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_lastyear), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_7, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+  }, null, -1 /* CACHED */)])))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_5, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("table", _hoisted_6, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("caption", null, "共查询到" + (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.total) + "条记录", 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("thead", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tr", null, [_cache[6] || (_cache[6] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_addr_id", -1 /* CACHED */)), _cache[7] || (_cache[7] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_belongs_to", -1 /* CACHED */)), _cache[8] || (_cache[8] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_firstyear", -1 /* CACHED */)), _cache[9] || (_cache[9] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_lastyear", -1 /* CACHED */)), $props.userCanEdit ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("th", _hoisted_7, "操作")) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true)])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tbody", null, [((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)(vue__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.renderList)($data.names.data, function (item) {
+    return (0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_addr_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_belongs_to), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_firstyear), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_lastyear), 1 /* TEXT */), $props.userCanEdit ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("td", _hoisted_8, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_9, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
       type: "button",
       "class": "btn btn-sm btn-info",
       href: '/addrbelongsdata/' + item.c_addr_id + '-' + item.c_belongs_to + '-' + item.c_firstyear + '-' + item.c_lastyear + '/edit'
-    }, "edit", 8 /* PROPS */, _hoisted_8), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
+    }, "edit", 8 /* PROPS */, _hoisted_10), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
       "class": "btn btn-sm btn-danger",
       "data-toggle": "modal",
       "data-target": '#myModal' + item.c_addr_id + '-' + item.c_belongs_to + '-' + item.c_firstyear + '-' + item.c_lastyear + ''
-    }, "Delete", 8 /* PROPS */, _hoisted_9)]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("Start"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
+    }, "Delete", 8 /* PROPS */, _hoisted_11)]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("Start"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
       id: 'myModal' + item.c_addr_id + '-' + item.c_belongs_to + '-' + item.c_firstyear + '-' + item.c_lastyear + '',
       "class": "modal fade",
       role: "dialog"
-    }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_11, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)(" Modal content"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_12, [_cache[7] || (_cache[7] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
+    }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_13, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)(" Modal content"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_14, [_cache[11] || (_cache[11] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
       "class": "modal-header"
     }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
@@ -25080,16 +25096,16 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
       "data-dismiss": "modal"
     }, "×"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("h4", {
       "class": "modal-title"
-    }, "確認是否刪除？")], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_13, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, "確認是否刪除？")], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_15, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
       type: "button",
       "class": "btn btn-sm btn-danger",
       href: '/addrbelongsdata/' + item.c_addr_id + '-' + item.c_belongs_to + '-' + item.c_firstyear + '-' + item.c_lastyear + '/delete'
-    }, "Confirm Delete", 8 /* PROPS */, _hoisted_14), _cache[6] || (_cache[6] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
+    }, "Confirm Delete", 8 /* PROPS */, _hoisted_16), _cache[10] || (_cache[10] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
       "class": "btn btn-default",
       "data-dismiss": "modal"
-    }, "Close", -1 /* CACHED */))])])])], 8 /* PROPS */, _hoisted_10), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("End")])]);
-  }), 256 /* UNKEYED_FRAGMENT */))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("nav", _hoisted_15, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("ul", _hoisted_16, [$options.showFirst ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_17, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, "Close", -1 /* CACHED */))])])])], 8 /* PROPS */, _hoisted_12), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("End")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true)]);
+  }), 256 /* UNKEYED_FRAGMENT */))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("nav", _hoisted_17, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("ul", _hoisted_18, [$options.showFirst ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_19, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
     href: "javascript:",
     onClick: _cache[2] || (_cache[2] = function ($event) {
       return $data.current_page--;
@@ -25104,13 +25120,13 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
         return $options.btnClick(index);
       },
       href: "javascript:"
-    }, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(index), 9 /* TEXT, PROPS */, _hoisted_18)], 2 /* CLASS */);
-  }), 256 /* UNKEYED_FRAGMENT */)), $options.showLast ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_19, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(index), 9 /* TEXT, PROPS */, _hoisted_20)], 2 /* CLASS */);
+  }), 256 /* UNKEYED_FRAGMENT */)), $options.showLast ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_21, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
     onClick: _cache[3] || (_cache[3] = function ($event) {
       return $data.current_page++;
     }),
     href: "javascript:"
-  }, "»")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("li", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", null, [_cache[9] || (_cache[9] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("共", -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.last_page), 1 /* TEXT */), _cache[10] || (_cache[10] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("页", -1 /* CACHED */))])])])])]);
+  }, "»")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("li", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", null, [_cache[12] || (_cache[12] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("共", -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.last_page), 1 /* TEXT */), _cache[13] || (_cache[13] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("页", -1 /* CACHED */))])])])])]);
 }
 
 /***/ }),
@@ -25553,33 +25569,39 @@ var _hoisted_6 = {
   "class": "table table-hover table-condensed"
 };
 var _hoisted_7 = {
+  key: 0
+};
+var _hoisted_8 = {
+  key: 0
+};
+var _hoisted_9 = {
   "class": "btn-group"
 };
-var _hoisted_8 = ["href"];
-var _hoisted_9 = ["data-target"];
-var _hoisted_10 = ["id"];
-var _hoisted_11 = {
+var _hoisted_10 = ["href"];
+var _hoisted_11 = ["data-target"];
+var _hoisted_12 = ["id"];
+var _hoisted_13 = {
   "class": "modal-dialog"
 };
-var _hoisted_12 = {
+var _hoisted_14 = {
   "class": "modal-content"
 };
-var _hoisted_13 = {
+var _hoisted_15 = {
   "class": "modal-footer"
 };
-var _hoisted_14 = ["href"];
-var _hoisted_15 = {
+var _hoisted_16 = ["href"];
+var _hoisted_17 = {
   "class": "pull-right",
   "aria-label": "Page navigation"
 };
-var _hoisted_16 = {
+var _hoisted_18 = {
   "class": "pagination"
 };
-var _hoisted_17 = {
+var _hoisted_19 = {
   key: 0
 };
-var _hoisted_18 = ["onClick"];
-var _hoisted_19 = {
+var _hoisted_20 = ["onClick"];
+var _hoisted_21 = {
   key: 1
 };
 function render(_ctx, _cache, $props, $setup, $data, $options) {
@@ -25599,21 +25621,21 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     })
   }, _toConsumableArray(_cache[4] || (_cache[4] = [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", {
     "class": "glyphicon glyphicon-search"
-  }, null, -1 /* CACHED */)])))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_5, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("table", _hoisted_6, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("caption", null, "共查询到" + (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.total) + "条记录", 1 /* TEXT */), _cache[8] || (_cache[8] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("thead", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_textid"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_text_edition_id"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_text_instance_id"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_instance_title_chn"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_publisher"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_print"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_instance_title"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "操作")])], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tbody", null, [((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)(vue__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.renderList)($data.names.data, function (item) {
-    return (0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_textid), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_text_edition_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_text_instance_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_instance_title_chn), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_publisher), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_print), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_instance_title), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_7, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+  }, null, -1 /* CACHED */)])))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_5, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("table", _hoisted_6, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("caption", null, "共查询到" + (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.total) + "条记录", 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("thead", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tr", null, [_cache[6] || (_cache[6] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_textid", -1 /* CACHED */)), _cache[7] || (_cache[7] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_text_edition_id", -1 /* CACHED */)), _cache[8] || (_cache[8] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_text_instance_id", -1 /* CACHED */)), _cache[9] || (_cache[9] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_instance_title_chn", -1 /* CACHED */)), _cache[10] || (_cache[10] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_publisher", -1 /* CACHED */)), _cache[11] || (_cache[11] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_print", -1 /* CACHED */)), _cache[12] || (_cache[12] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("th", null, "c_instance_title", -1 /* CACHED */)), $props.userCanEdit ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("th", _hoisted_7, "操作")) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true)])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("tbody", null, [((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)(vue__WEBPACK_IMPORTED_MODULE_0__.Fragment, null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.renderList)($data.names.data, function (item) {
+    return (0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("tr", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_textid), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_text_edition_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_text_instance_id), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_instance_title_chn), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_publisher), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_print), 1 /* TEXT */), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("td", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(item.c_instance_title), 1 /* TEXT */), $props.userCanEdit ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("td", _hoisted_8, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_9, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
       type: "button",
       "class": "btn btn-sm btn-info",
       href: '/textinstancedata/' + item.c_textid + '-' + item.c_text_edition_id + '-' + item.c_text_instance_id + '/edit'
-    }, "edit", 8 /* PROPS */, _hoisted_8), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
+    }, "edit", 8 /* PROPS */, _hoisted_10), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
       "class": "btn btn-sm btn-danger",
       "data-toggle": "modal",
       "data-target": '#myModal' + item.c_textid + '-' + item.c_text_edition_id + '-' + item.c_text_instance_id + ''
-    }, "Delete", 8 /* PROPS */, _hoisted_9)]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("Start"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
+    }, "Delete", 8 /* PROPS */, _hoisted_11)]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("Start"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
       id: 'myModal' + item.c_textid + '-' + item.c_text_edition_id + '-' + item.c_text_instance_id + '',
       "class": "modal fade",
       role: "dialog"
-    }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_11, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)(" Modal content"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_12, [_cache[7] || (_cache[7] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
+    }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_13, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)(" Modal content"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_14, [_cache[14] || (_cache[14] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", {
       "class": "modal-header"
     }, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
@@ -25621,16 +25643,16 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
       "data-dismiss": "modal"
     }, "×"), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("h4", {
       "class": "modal-title"
-    }, "確認是否刪除？")], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_13, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, "確認是否刪除？")], -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("div", _hoisted_15, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
       type: "button",
       "class": "btn btn-sm btn-danger",
       href: '/textinstancedata/' + item.c_textid + '-' + item.c_text_edition_id + '-' + item.c_text_instance_id + '/delete'
-    }, "Confirm Delete", 8 /* PROPS */, _hoisted_14), _cache[6] || (_cache[6] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
+    }, "Confirm Delete", 8 /* PROPS */, _hoisted_16), _cache[13] || (_cache[13] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("button", {
       type: "button",
       "class": "btn btn-default",
       "data-dismiss": "modal"
-    }, "Close", -1 /* CACHED */))])])])], 8 /* PROPS */, _hoisted_10), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("End")])]);
-  }), 256 /* UNKEYED_FRAGMENT */))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("nav", _hoisted_15, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("ul", _hoisted_16, [$options.showFirst ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_17, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, "Close", -1 /* CACHED */))])])])], 8 /* PROPS */, _hoisted_12), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("End")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true)]);
+  }), 256 /* UNKEYED_FRAGMENT */))])])]), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("nav", _hoisted_17, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("ul", _hoisted_18, [$options.showFirst ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_19, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
     href: "javascript:",
     onClick: _cache[2] || (_cache[2] = function ($event) {
       return $data.current_page--;
@@ -25645,13 +25667,13 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
         return $options.btnClick(index);
       },
       href: "javascript:"
-    }, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(index), 9 /* TEXT, PROPS */, _hoisted_18)], 2 /* CLASS */);
-  }), 256 /* UNKEYED_FRAGMENT */)), $options.showLast ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_19, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
+    }, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)(index), 9 /* TEXT, PROPS */, _hoisted_20)], 2 /* CLASS */);
+  }), 256 /* UNKEYED_FRAGMENT */)), $options.showLast ? ((0,vue__WEBPACK_IMPORTED_MODULE_0__.openBlock)(), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementBlock)("li", _hoisted_21, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", {
     onClick: _cache[3] || (_cache[3] = function ($event) {
       return $data.current_page++;
     }),
     href: "javascript:"
-  }, "»")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("li", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", null, [_cache[9] || (_cache[9] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("共", -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.last_page), 1 /* TEXT */), _cache[10] || (_cache[10] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("页", -1 /* CACHED */))])])])])]);
+  }, "»")])) : (0,vue__WEBPACK_IMPORTED_MODULE_0__.createCommentVNode)("v-if", true), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("li", null, [(0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("a", null, [_cache[15] || (_cache[15] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("共", -1 /* CACHED */)), (0,vue__WEBPACK_IMPORTED_MODULE_0__.createElementVNode)("i", null, (0,vue__WEBPACK_IMPORTED_MODULE_0__.toDisplayString)($data.names.last_page), 1 /* TEXT */), _cache[16] || (_cache[16] = (0,vue__WEBPACK_IMPORTED_MODULE_0__.createTextVNode)("页", -1 /* CACHED */))])])])])]);
 }
 
 /***/ }),

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,12 +1,12 @@
 {
-    "/js/app.js": "/js/app.js?id=481d49b5774d399100d40a67f3e84409",
+    "/js/app.js": "/js/app.js?id=04333a3e197594aa1e03c42d27bf462e",
     "/css/app.css": "/css/app.css?id=dbb0614e06bf18d62cc57ad169a022f0",
-    "/images/vendor/AdminLTE/dist/boxed-bg.jpg?0de93c39950fc78a1f792e154d9e7df5": "/images/vendor/AdminLTE/dist/boxed-bg.jpg?0de93c39950fc78a1f792e154d9e7df5?id=07dfbee6f5673414252853d9246c28d6",
     "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.eot?5be1347c682810f199c7f486f40c5974": "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.eot?5be1347c682810f199c7f486f40c5974?id=77ff91d7fa0317186a8eff6c9da3920e",
     "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.woff2?be810be3a3e14c682a257d6eff341fe4": "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.woff2?be810be3a3e14c682a257d6eff341fe4?id=349344e92fb16221dd5621c254fdc45e",
     "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.woff?82b1212e45a2bc35dd731913b27ad813": "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.woff?82b1212e45a2bc35dd731913b27ad813?id=f04acf366f6a53177950af7acfad3952",
     "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.ttf?4692b9ec53fd5972caa2f2372ae20d16": "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.ttf?4692b9ec53fd5972caa2f2372ae20d16?id=3abf0f95c0a69984006e3778b65e513f",
     "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.svg?060b2710bdbbe3dfe48b58d59bd5f1fb": "/fonts/vendor/AdminLTE/bootstrap/glyphicons-halflings-regular.svg?060b2710bdbbe3dfe48b58d59bd5f1fb?id=89889688147bd7575d6327160d64e760",
+    "/images/vendor/AdminLTE/dist/boxed-bg.jpg?0de93c39950fc78a1f792e154d9e7df5": "/images/vendor/AdminLTE/dist/boxed-bg.jpg?0de93c39950fc78a1f792e154d9e7df5?id=07dfbee6f5673414252853d9246c28d6",
     "/images/vendor/AdminLTE/plugins/iCheck/square/blue.png?47dfe954bc521a5356050b61b12c0cd0": "/images/vendor/AdminLTE/plugins/iCheck/square/blue.png?47dfe954bc521a5356050b61b12c0cd0?id=39437a6200d8066a49d4372416910b2a",
     "/images/vendor/AdminLTE/plugins/iCheck/square/blue@2x.png?eb5592d094a6555c844bc1ba04c7259e": "/images/vendor/AdminLTE/plugins/iCheck/square/blue@2x.png?eb5592d094a6555c844bc1ba04c7259e?id=127d7cfbb176dc5598545c0a229244ed"
 }

--- a/resources/assets/js/components/AddrBelongsDataList.vue
+++ b/resources/assets/js/components/AddrBelongsDataList.vue
@@ -20,7 +20,7 @@
                 <th>c_belongs_to</th>
                 <th>c_firstyear</th>
                 <th>c_lastyear</th>
-                <th>操作</th>
+                <th v-if="userCanEdit">操作</th>
             </tr>
             </thead>
             <tbody>
@@ -29,7 +29,7 @@
                 <td>{{item.c_belongs_to}}</td>
                 <td>{{item.c_firstyear}}</td>
                 <td>{{item.c_lastyear}}</td>
-                <td>
+                <td v-if="userCanEdit">
                     <div class="btn-group">
                         <a type="button" class="btn btn-sm btn-info" :href="'/addrbelongsdata/'+item.c_addr_id+'-'+item.c_belongs_to+'-'+item.c_firstyear+'-'+item.c_lastyear+'/edit'">edit</a>
                         <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" :data-target="'#myModal'+item.c_addr_id+'-'+item.c_belongs_to+'-'+item.c_firstyear+'-'+item.c_lastyear+''">Delete</button>
@@ -71,7 +71,12 @@
 
 <script>
     export default {
-        props:[],
+        props: {
+            userCanEdit: {
+                type: Boolean,
+                default: false
+            }
+        },
         created() {
             this.notes = '正在查询，请稍后';
             this.searchByName();

--- a/resources/assets/js/components/TextInstanceDataList.vue
+++ b/resources/assets/js/components/TextInstanceDataList.vue
@@ -23,7 +23,7 @@
                 <th>c_publisher</th>
                 <th>c_print</th>
                 <th>c_instance_title</th>
-                <th>操作</th>
+                <th v-if="userCanEdit">操作</th>
             </tr>
             </thead>
             <tbody>
@@ -35,7 +35,7 @@
                 <td>{{item.c_publisher}}</td>
                 <td>{{item.c_print}}</td>
                 <td>{{item.c_instance_title}}</td>
-                <td>
+                <td v-if="userCanEdit">
                     <div class="btn-group">
                         <a type="button" class="btn btn-sm btn-info" :href="'/textinstancedata/'+item.c_textid+'-'+item.c_text_edition_id+'-'+item.c_text_instance_id+'/edit'">edit</a>
                         <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" :data-target="'#myModal'+item.c_textid+'-'+item.c_text_edition_id+'-'+item.c_text_instance_id+''">Delete</button>
@@ -77,7 +77,12 @@
 
 <script>
     export default {
-        props:[],
+        props: {
+            userCanEdit: {
+                type: Boolean,
+                default: false
+            }
+        },
         created() {
             this.notes = '正在查询，请稍后';
             this.searchByName();

--- a/resources/views/addrbelongsdata/create.blade.php
+++ b/resources/views/addrbelongsdata/create.blade.php
@@ -32,11 +32,13 @@
                             <input type="text" name="c_lastyear" class="form-control" placeholder="c_lastyear" required>
                         </div>
                     </div>
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>
                         </div>
                     </div>
+                    @endif
                 </form>
             </div>
         </div>

--- a/resources/views/addrbelongsdata/edit.blade.php
+++ b/resources/views/addrbelongsdata/edit.blade.php
@@ -18,11 +18,13 @@
                             </div>
                         </div>
                     @endforeach
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>
                         </div>
                     </div>
+                    @endif
                 </form>
             </div>
         </div>

--- a/resources/views/addrbelongsdata/index.blade.php
+++ b/resources/views/addrbelongsdata/index.blade.php
@@ -4,9 +4,11 @@
     <div class="panel panel-default">
         <div class="panel-heading">地址從屬表</div>
         <div class="panel-body">
+            @if(Auth::check() && Auth::user()->is_active == 1)
             <a href="{{ route('addrbelongsdata.create') }}" class="pull-right btn btn-default">新增</a>
+            @endif
             <div class="panel-body">
-                <addr-belongs-data-list></addr-belongs-data-list>
+                <addr-belongs-data-list :user-can-edit="{{ Auth::check() && Auth::user()->is_active == 1 ? 'true' : 'false' }}"></addr-belongs-data-list>
             </div>
         </div>
     </div>

--- a/resources/views/codes/create.blade.php
+++ b/resources/views/codes/create.blade.php
@@ -20,6 +20,7 @@
                         </div>
                     @php($i++)
                     @endforeach
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
                         <div class="col-sm-10">
@@ -33,6 +34,7 @@
                             <button type="submit" class="btn btn-info" formaction="{{ route('codes.propose.store', ['table_name' => $table], false) }}">提交提案</button>
                         </div>
                     </div>
+                    @endif
                 </form>
             </div>
         </div>

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -47,6 +47,7 @@
                             </div>
                         </div>
                     @endforeach
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
                         <div class="col-sm-10">
@@ -63,6 +64,7 @@
                             </button>
                         </div>
                     </div>
+                    @endif
                 </form>
             </div>
         </div>

--- a/resources/views/textinstancedata/create.blade.php
+++ b/resources/views/textinstancedata/create.blade.php
@@ -41,11 +41,13 @@
                             <input type="text" name="c_text_instance_id" class="form-control" placeholder="c_instance_title（版本實例 ID）" required>
                         </div>
                     </div>
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>
                         </div>
                     </div>
+                    @endif
                 </form>
             </div>
         </div>

--- a/resources/views/textinstancedata/edit.blade.php
+++ b/resources/views/textinstancedata/edit.blade.php
@@ -33,11 +33,13 @@
                         </div>
                         @endif
                     @endforeach
+                    @if(Auth::check() && Auth::user()->is_active == 1)
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>
                         </div>
                     </div>
+                    @endif
 <!-- HTML -->
 <!--
 <div id="Ajax Load Data">    

--- a/resources/views/textinstancedata/index.blade.php
+++ b/resources/views/textinstancedata/index.blade.php
@@ -4,9 +4,11 @@
     <div class="panel panel-default">
         <div class="panel-heading">著作版本表</div>
         <div class="panel-body">
+            @if(Auth::check() && Auth::user()->is_active == 1)
             <a href="{{ route('textinstancedata.create') }}" class="pull-right btn btn-default">新增</a>
+            @endif
             <div class="panel-body">
-                <text-instance-data-list></text-instance-data-list>
+                <text-instance-data-list :user-can-edit="{{ Auth::check() && Auth::user()->is_active == 1 ? 'true' : 'false' }}"></text-instance-data-list>
             </div>
         </div>
     </div>


### PR DESCRIPTION
總結完成的三個 commits：

1. https://github.com/cbdb-project/cbdb-online-main-server/pull/397/commits/fb017fa1930596243a5ef5e38e758eae1e07534a ：隱藏 /codes/* 編輯和創建頁面的提案功能
2. https://github.com/cbdb-project/cbdb-online-main-server/pull/397/commits/48aebc28b6ba153f6cd40b0aeabd11d59e3baea6 ：隱藏 /addrbelongsdata 和 /textinstancedata Vue 表格頁面的操作功能
3. https://github.com/cbdb-project/cbdb-online-main-server/pull/397/commits/353988c09218e8efb588b562eb2ca43be5ab6755 ：隱藏數據編輯頁面未登入用戶的 Submit 按鈕

現在 feature/cleanup 分支上有三個新的提交，完整實現了對未登入或未確認用戶隱藏編輯和操作功能的需求。所有相關頁面的權限控制都已經到位。