### PR TITLE
統一提案撤回者時間顯示格式

### DIFF
--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -181,12 +181,15 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     }
                                 }
                                 $cancelledDisplay = '';
+                                $cancelledUtc = '';
                                 if (!empty($proposalMeta['cancelled_at'])) {
                                     try {
                                         $cancelledCarbon = \Carbon\Carbon::parse($proposalMeta['cancelled_at'], config('app.timezone', 'Asia/Shanghai'));
                                         $cancelledDisplay = $cancelledCarbon;
+                                        $cancelledUtc = $cancelledCarbon->copy()->setTimezone('UTC')->toIso8601String();
                                     } catch (\Exception $e) {
                                         $cancelledDisplay = $proposalMeta['cancelled_at'];
+                                        $cancelledUtc = $proposalMeta['cancelled_at'];
                                     }
                                 }
                                 $cancelledBy = $proposalMeta['cancelled_by'] ?? null;
@@ -232,8 +235,8 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         @if($reviewStatus === 'cancelled')
                                             <small class="text-muted" style="display:block;">
                                                 撤回者：{{ $cancelledBy ?? '（未知）' }}
-                                                @if($cancelledDisplay !== '')
-                                                    （{{ $cancelledDisplay }}）
+                                                @if($cancelledUtc)
+                                                    （<span class="js-utc-datetime" data-utc="{{ $cancelledUtc }}">{{ $cancelledDisplay }}</span>）
                                                 @endif
                                             </small>
                                             @if(!empty($proposalMeta['cancel_reason']))


### PR DESCRIPTION
- 修改 /operations 頁面中撤回者時間的顯示邏輯
- 添加撤回時間的 UTC 轉換處理
- 使用 js-utc-datetime 類統一時間顯示格式
- 現在撤回者時間與提案者、審核者時間顯示保持一致：
  - 顯示用戶本地時區時間（如 PST）
  - hover 時顯示 GMT+8 時區時間