### PR TITLE
修復Wikidata腳本統計功能的KeyError錯誤

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,7 @@
 # CBDB Scripts
 
+[中文說明](./README.zh.md)
+
 This directory contains utility scripts for the CBDB Online project.
 
 ## fetch_wikidata_cbdb.py

--- a/scripts/fetch_wikidata_cbdb.py
+++ b/scripts/fetch_wikidata_cbdb.py
@@ -190,9 +190,9 @@ class WikidataCBDBFetcher:
             print(f"Total records: {len(records)}")
 
             # Print some statistics
-            zh_wiki_count = sum(1 for r in records if r['wikipedia'].get('zh'))
-            en_wiki_count = sum(1 for r in records if r['wikipedia'].get('en'))
-            ja_wiki_count = sum(1 for r in records if r['wikipedia'].get('ja'))
+            zh_wiki_count = sum(1 for r in records if r.get('wikipedia', {}).get('zh'))
+            en_wiki_count = sum(1 for r in records if r.get('wikipedia', {}).get('en'))
+            ja_wiki_count = sum(1 for r in records if r.get('wikipedia', {}).get('ja'))
             print(f"Records with Chinese Wikipedia: {zh_wiki_count}")
             print(f"Records with English Wikipedia: {en_wiki_count}")
             print(f"Records with Japanese Wikipedia: {ja_wiki_count}")


### PR DESCRIPTION
- 修復訪問不存在wikipedia字段導致的KeyError異常
- 使用安全的dict.get()方法處理可選的wikipedia字段
- 確保統計功能能正確處理沒有Wikipedia條目的CBDB人物記錄
