### PR TITLE
更新頁尾版權資訊和連結

### DIFF
--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -5,5 +5,5 @@
         
     </div>
     <!-- Default to the left -->
-    <strong>Copyright &copy; <a href="https://projects.iq.harvard.edu/cbdb" target="_blank">CBDB</a>.</strong> Content on this site is licensed under a <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA 4.0/a> International License.
+    <strong>Copyright &copy; <a href="https://cbdb.hsites.harvard.edu/" target="_blank">Chinese Biographical Database Project (CBDB)</a>.</strong> Content licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA 4.0 International</a>.
 </footer>


### PR DESCRIPTION
- 更新 CBDB 官方網站連結：projects.iq.harvard.edu → cbdb.hsites.harvard.edu
- 更新項目全名顯示：CBDB → Chinese Biographical Database Project (CBDB)
- 修復 CC 許可證連結的 HTML 錯誤（缺少 < 符號）
- 簡化許可證文本描述：「Content on this site is licensed under a」→「Content licensed under」

🤖 Generated with [Claude Code](https://claude.com/claude-code)