### PR TITLE
修復出處頁面的總數顯示

### DIFF
--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -29,14 +29,14 @@ class BasicInformationSourcesController extends Controller
      */
     public function index($id)
     {
-        $biogbasicinformation = $this->biogMainRepository->simpleByPersonId($id);
+        $basicinformation = $this->biogMainRepository->byIdWithSources($id);
 
-        $basicinformation = \App\BiogMain::with(['sources' => function($query) {
-            $query->select('TEXT_CODES.*')->withPivot('c_pages', 'c_notes', 'c_main_source', 'c_self_bio');
-        }])->find($id);
+        if (blank($basicinformation)) {
+            abort(404);
+        }
 
         return view('biogmains.sources.index', [
-            'basicinformation' => $basicinformation ?: $biogbasicinformation,
+            'basicinformation' => $basicinformation,
             'page_title' => 'Basicinformation',
             'page_description' => '基本信息表 出處'
         ]);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -132,6 +132,17 @@ class BiogMainRepository
         return $basicinformation;
     }
 
+    public function byIdWithSources($id)
+    {
+        $basicinformation = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])
+            ->withCount('sources','texts', 'biog_addresses', 'altnames', 'offices', 'entries', 'statuses', 'kinship', 'assoc', 'possession', 'inst', 'events')
+            ->with(['sources' => function ($query) {
+                $query->select('TEXT_CODES.*')->withPivot('c_pages', 'c_notes', 'c_main_source', 'c_self_bio');
+            }])->find($id);
+
+        return $basicinformation;
+    }
+
     public function byIdWithOff($id)
     {
         $basicinformation = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])->withCount('sources','texts', 'biog_addresses', 'altnames', 'offices', 'entries', 'statuses', 'kinship', 'assoc', 'possession', 'inst', 'events')->with('offices', 'offices_addr')->find($id);


### PR DESCRIPTION
- app/Repositories/BiogMainRepository.php:129-144 新增 byIdWithSources()，沿用簡化欄位集並一次載入 sources 關聯（含 pivot 欄位）以及 banner 需要的所有 *_count，讓來源頁面與共用橫幅都能拿到數量資訊。
- app/Http/Controllers/BasicInformationSourcesController.php:30-42 改用上述 repository 方法並在查無人物時回傳 404，從根源修復「出處 / 別名 / 地址」頁面 caption 與 banner 顯示的總數缺失問題 https://github.com/cbdb-project/cbdb-online-main-server/issues/430

<img width="1439" height="627" alt="image" src="https://github.com/user-attachments/assets/f966cea9-6276-4815-8561-442080392d31" />
