### PR TITLE
調整合併資料表欄位名稱支援 (`c_merged_to_personid` -> `c_merged_from_personid`)

### DIFF
--- a/MERGE.md
+++ b/MERGE.md
@@ -12,7 +12,7 @@
 
 - **相關資料預覽**  
   額外列出 `ALTNAME_DATA`（別名）與 `KIN_DATA`（親屬）之筆數與內容摘要，並將 `KinID` 連結到對應的人物編輯頁面。頁面也會顯示 `ASSOC_DATA` 對四個欄位（`c_personid`、`c_kin_id`、`c_assoc_id`、`c_assoc_kin_id`）的資料、以及其它會受影響的資料表（如 `BIOG_ADDR_DATA`、`ENTRY_DATA`、`EVENTS_DATA` 等）在保留與來源人物的筆數與前 20 筆 JSON 摘要，以協助評估合併範圍。
-  其中 `MERGED_PERSON_DATA` 額外統計 `c_personid` 與 `c_merged_to_personid` 兩種角色，便於確認歷史合併紀錄。
+  其中 `MERGED_PERSON_DATA` 額外統計 `c_personid` 與 `c_merged_from_personid` 兩種角色，便於確認歷史合併紀錄。
 
 - **SQL 操作預覽**  
   工具會產生兩段 SQL 交易：
@@ -32,7 +32,7 @@
 - `merge_to_min=true` 或勾選「將較大 ID 自動合併至較小 ID」時，頁面僅模擬欄位值，實際 SQL 仍會先以原 ID 順序合併，並在第一段交易完成後另行執行「轉至最小 ID」的交易，避免前端邏輯自動交換 ID。
 - `merge_reason` 欄位會被寫入 `c_notes`、用於複製連結與提示文字，請在此描述合併依據、史料證據或分析方法。
 - 如果 `ALTNAME`、`KIN` 或 `ASSOC` 等表在合併前有待人工比對的差異，管理員可以利用 JSON 摘要快速檢視各欄位，必要時手動調整資料並重新預覽。
-- `MERGED_PERSON_DATA` 會同步列出（`c_personid` 與 `c_merged_to_personid`兩種角色），目前僅保存合併理由（`c_notes`），預設不刪除歷史記錄。
+- `MERGED_PERSON_DATA` 會同步列出（`c_personid` 與 `c_merged_from_personid`兩種角色），目前僅保存合併理由（`c_notes`），預設不刪除歷史記錄。
 
 ## 注意事項
 
@@ -60,7 +60,7 @@
      1. `BEGIN` 交易。
      2. 更新 `BIOG_MAIN`：保留人物欄位與 `c_notes`，刷 `c_modified_*`。
      3. 更新所有關聯表的 `c_personid`（`ASSOC_DATA` 還包含其他欄位）、`MERGED_PERSON_DATA` 等指向。
-        - `MERGED_PERSON_DATA`：以 `INSERT ... ON DUPLICATE KEY UPDATE` 保存 reason，不刪歷史；若 `merge_to_min`，只交換 `c_personid`/`c_merged_to_personid`。
+       - `MERGED_PERSON_DATA`：以 `INSERT ... ON DUPLICATE KEY UPDATE` 保存 reason，不刪歷史；若 `merge_to_min`，只交換 `c_personid`/`c_merged_from_personid`。
      4. 刪除來源人物的 `BIOG_MAIN`。
      5. 若勾選「merge_to_min」，第二段交易把保留人物轉成較小 ID，並更新關聯表與 `MERGED_PERSON_DATA` 的鍵值。
      6. 全程捕捉例外，失敗時 `ROLLBACK`。

--- a/app/Http/Controllers/CbdbApiController.php
+++ b/app/Http/Controllers/CbdbApiController.php
@@ -415,7 +415,7 @@ protected function findPersonIdByName(string $name): ?int
 
         $record = DB::table('MERGED_PERSON_DATA')
             ->select('c_personid', 'c_notes')
-            ->where('c_merged_to_personid', $personId)
+            ->where('c_merged_from_personid', $personId)
             ->orderByDesc('c_modified_date')
             ->orderByDesc('c_created_date')
             ->first();

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -79,7 +79,7 @@ class CodesController extends Controller
         ],
         'MERGED_PERSON_DATA' => [
             'c_personid',
-            'c_merged_to_personid',
+            'c_merged_from_personid',
             'c_notes',
             'c_source',
             'c_pages',

--- a/app/Http/Controllers/MergePreviewController.php
+++ b/app/Http/Controllers/MergePreviewController.php
@@ -312,18 +312,18 @@ class MergePreviewController extends Controller
 
         if ($mergeRecord) {
             $personIdValue = $this->formatSqlValue($mergeRecord['person_id'] ?? null);
-            $mergedToValue = $this->formatSqlValue($mergeRecord['merged_to'] ?? null);
+            $mergedFromValue = $this->formatSqlValue($mergeRecord['merged_from'] ?? null);
             $noteValue = $this->formatSqlValue($mergeRecord['note'] ?? null);
             $createdByValue = $this->formatSqlValue($mergeRecord['created_by'] ?? null);
             $createdDateValue = $this->formatSqlValue($mergeRecord['created_date'] ?? null);
             $modifiedByValue = $this->formatSqlValue($mergeRecord['modified_by'] ?? null);
             $modifiedDateValue = $this->formatSqlValue($mergeRecord['modified_date'] ?? null);
 
-            if ($personIdValue !== 'NULL' && $mergedToValue !== 'NULL') {
+            if ($personIdValue !== 'NULL' && $mergedFromValue !== 'NULL') {
                 $statements[] = sprintf(
-                    'INSERT INTO MERGED_PERSON_DATA (c_personid, c_merged_to_personid, c_notes, c_source, c_pages, c_created_by, c_created_date, c_modified_by, c_modified_date) VALUES (%s, %s, %s, NULL, NULL, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE c_notes = VALUES(c_notes), c_modified_by = VALUES(c_modified_by), c_modified_date = VALUES(c_modified_date);',
+                    'INSERT INTO MERGED_PERSON_DATA (c_personid, c_merged_from_personid, c_notes, c_source, c_pages, c_created_by, c_created_date, c_modified_by, c_modified_date) VALUES (%s, %s, %s, NULL, NULL, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE c_notes = VALUES(c_notes), c_modified_by = VALUES(c_modified_by), c_modified_date = VALUES(c_modified_date);',
                     $personIdValue,
-                    $mergedToValue,
+                    $mergedFromValue,
                     $noteValue,
                     $createdByValue,
                     $createdDateValue,
@@ -365,13 +365,14 @@ class MergePreviewController extends Controller
                 }
             }
             if ($mergeRecord) {
-                $statements[] = sprintf(
-                    'UPDATE MERGED_PERSON_DATA SET c_personid = %s, c_merged_to_personid = %s WHERE c_personid = %s AND c_merged_to_personid = %s;',
-                    $primaryValue,
-                    $minTargetValue ?? $this->formatSqlValue($minTargetId),
-                    $personIdValue ?? $this->formatSqlValue($mergeRecord['person_id'] ?? null),
-                    $mergedToValue ?? $this->formatSqlValue($mergeRecord['merged_to'] ?? null)
-                );
+                $updatedPersonIdValue = $personIdValue ?? $this->formatSqlValue($mergeRecord['person_id'] ?? null);
+                if ($updatedPersonIdValue !== 'NULL') {
+                    $statements[] = sprintf(
+                        'UPDATE MERGED_PERSON_DATA SET c_personid = %s WHERE c_personid = %s;',
+                        $minTargetValue,
+                        $updatedPersonIdValue
+                    );
+                }
             }
             $statements[] = sprintf('UPDATE BIOG_MAIN SET c_personid = %s WHERE c_personid = %s;', $minTargetValue, $primaryValue);
             $statements[] = 'COMMIT;';
@@ -481,8 +482,8 @@ class MergePreviewController extends Controller
         $mergeReasonText = trim((string)$mergeReason);
         if (!is_null($primaryPersonId) && $primaryPersonId !== '' && !is_null($mergedSourceId) && $mergedSourceId !== '') {
             $mergeRecord = [
-                'person_id' => (int)$mergedSourceId,
-                'merged_to' => (int)$primaryPersonId,
+                'person_id' => (int)$primaryPersonId,
+                'merged_from' => (int)$mergedSourceId,
                 'note' => $mergeReasonText === '' ? null : $mergeReasonText,
                 'reason' => $mergeReason,
                 'created_by' => $result['c_modified_by'],
@@ -684,10 +685,10 @@ class MergePreviewController extends Controller
                     $noteSuffix
                 );
             case 'MERGED_PERSON_DATA':
-                $fromId = $get('c_personid');
-                $toId = $get('c_merged_to_personid');
-                $fromLabel = $this->getPersonLabel($fromId);
+                $toId = $get('c_personid');
+                $fromId = $get('c_merged_from_personid');
                 $toLabel = $this->getPersonLabel($toId);
+                $fromLabel = $this->getPersonLabel($fromId);
                 $reason = trim((string)$get('c_notes'));
                 $reasonSuffix = $reason !== '' ? ' | Reason: '.$reason : '';
                 return sprintf(
@@ -943,7 +944,7 @@ class MergePreviewController extends Controller
             'POSTED_TO_ADDR_DATA' => ['columns' => ['c_personid']],
             'POSTING_DATA' => ['columns' => ['c_personid']],
             'POSTED_TO_OFFICE_DATA' => ['columns' => ['c_personid']],
-            'MERGED_PERSON_DATA' => ['columns' => ['c_personid', 'c_merged_to_personid']],
+            'MERGED_PERSON_DATA' => ['columns' => ['c_personid', 'c_merged_from_personid']],
         ];
         $otherDetails = [];
         foreach ($otherConfigs as $table => $info) {
@@ -1022,7 +1023,7 @@ class MergePreviewController extends Controller
             'posted_to_addr' => ['table' => 'POSTED_TO_ADDR_DATA', 'columns' => ['c_personid']],
             'posting' => ['table' => 'POSTING_DATA', 'columns' => ['c_personid']],
             'posted_to_office' => ['table' => 'POSTED_TO_OFFICE_DATA', 'columns' => ['c_personid']],
-            'merged_person' => ['table' => 'MERGED_PERSON_DATA', 'columns' => ['c_personid', 'c_merged_to_personid']],
+            'merged_person' => ['table' => 'MERGED_PERSON_DATA', 'columns' => ['c_personid', 'c_merged_from_personid']],
         ];
 
         $counts = [

--- a/database/migrations/2025_11_12_140940_rename_merged_to_personid_column_in_merged_person_data_table.php
+++ b/database/migrations/2025_11_12_140940_rename_merged_to_personid_column_in_merged_person_data_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameMergedToPersonidColumnInMergedPersonDataTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('MERGED_PERSON_DATA', function (Blueprint $table) {
+            $table->renameColumn('c_merged_to_personid', 'c_merged_from_personid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('MERGED_PERSON_DATA', function (Blueprint $table) {
+            $table->renameColumn('c_merged_from_personid', 'c_merged_to_personid');
+        });
+    }
+}

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -95,7 +95,7 @@ class CbdbApiPersonTest extends TestCase
 
         Schema::create('MERGED_PERSON_DATA', function (Blueprint $table) {
             $table->integer('c_personid');
-            $table->integer('c_merged_to_personid');
+            $table->integer('c_merged_from_personid');
             $table->text('c_notes')->nullable();
             $table->integer('c_source')->nullable();
             $table->string('c_pages')->nullable();
@@ -420,7 +420,7 @@ SQL
 
         \DB::table('MERGED_PERSON_DATA')->insert([
             'c_personid' => 1001,
-            'c_merged_to_personid' => 2000,
+            'c_merged_from_personid' => 2000,
             'c_notes' => 'Duplicate record merged',
             'c_created_by' => 'tester',
             'c_created_date' => '20240101',


### PR DESCRIPTION
執行順序:

1. 合併 https://github.com/cbdb-project/cbdb-online-main-server/pull/431
2. 合併 此 PR （包含與上述 migration 檔案完全一樣的變更）
3. 從伺服器上 `git pull` 並執行 `php artisan migrate`