### PR TITLE
為 OpenCC 數據添加 Apache 2.0 授權聲明

### DIFF
--- a/CODES.md
+++ b/CODES.md
@@ -11,6 +11,7 @@
   - `CBDB_NAME_LIST`：姓名列表（無主鍵定義，為確保數據完整性設為只讀）
   - `CBDB__NAME_FTS`：姓名搜尋倒排索引（內部輔助表，由系統自動維護）
   - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射表（內部輔助表，透過 `cbdb:import-trad-simp-map` 指令匯入）
+    - ⚠️ **授權例外**：此表數據來自 [OpenCC 項目](https://github.com/BYVoid/OpenCC) 的字典文件，以 **Apache 2.0 License** 授權，而非 CBDB 其他部分使用的 CC BY-NC-SA 4.0 International 授權
   - `DYNASTIES`：朝代代碼
   - `GANZHI_CODES`：干支代碼
 

--- a/CODES_TABLES.md
+++ b/CODES_TABLES.md
@@ -26,7 +26,7 @@
 | 9 | BIOG_INST_CODES | 人物機構類型代碼 |
 |10 | CBDB_NAME_LIST | 姓名列表 |
 |11 | CBDB__NAME_FTS | 姓名搜尋倒排索引（內部表）|
-|12 | CBDB__TRAD_SIMP_MAP | 繁簡字符映射表（內部表）|
+|12 | CBDB__TRAD_SIMP_MAP | 繁簡字符映射表（內部表，⚠️ Apache 2.0 授權）|
 |13 | CHORONYM_CODES | 地名類型代碼 |
 |14 | COUNTRY_CODES | 國家代碼 |
 |15 | DYNASTIES | 朝代代碼 |
@@ -63,6 +63,7 @@
 > - `CBDB_NAME_LIST`：姓名列表（無主鍵定義）
 > - `CBDB__NAME_FTS`：姓名搜尋倒排索引（內部輔助表，由系統自動維護）
 > - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射表（內部輔助表，透過 `php artisan cbdb:import-trad-simp-map` 指令匯入）
+>   - ⚠️ **授權例外**：此表數據來自 [OpenCC 項目](https://github.com/BYVoid/OpenCC) 的字典文件，以 **Apache 2.0 License** 授權，而非 CBDB 其他部分使用的 CC BY-NC-SA 4.0 International 授權
 > - `DYNASTIES`：朝代代碼
 > - `GANZHI_CODES`：干支代碼
 >

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,52 @@
+# 授權聲明 / License
+
+## 主要授權 / Main License
+
+本專案（CBDB Online Main Server）的源代碼和數據（除下述例外情況外）採用 [CC BY-NC-SA 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/) 授權。
+
+The source code and data of this project (CBDB Online Main Server), except where otherwise noted, are licensed under [CC BY-NC-SA 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+---
+
+## 第三方授權例外 / Third-Party License Exceptions
+
+### OpenCC 繁簡字典數據 / OpenCC Traditional-Simplified Character Mapping Data
+
+本專案中的 `CBDB__TRAD_SIMP_MAP` 表格數據來自 [OpenCC（Open Chinese Convert）項目](https://github.com/BYVoid/OpenCC)，該數據以 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 授權。
+
+The data in the `CBDB__TRAD_SIMP_MAP` table comes from the [OpenCC (Open Chinese Convert) project](https://github.com/BYVoid/OpenCC) and is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+**相關文件 / Related Files:**
+- `database/migrations/2025_11_13_000000_create_internal_name_search_tables.php` (表結構定義)
+- `app/Console/Commands/ImportTradSimpMap.php` (數據導入指令)
+- OpenCC 源數據：`TSCharacters.txt` / `STCharacters.txt`
+
+**Apache License 2.0 摘要 / Apache License 2.0 Summary:**
+
+該授權允許使用者自由使用、修改、分發該數據，包括商業用途，但需保留版權聲明和授權聲明。詳見 [Apache License 2.0 全文](https://www.apache.org/licenses/LICENSE-2.0)。
+
+This license permits users to freely use, modify, and distribute the data, including for commercial purposes, provided that copyright and license notices are retained. See [full text of Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+---
+
+## 引用說明 / Attribution
+
+如使用本專案數據或代碼，請引用：
+
+When using data or code from this project, please cite:
+
+**China Biographical Database (CBDB)**
+https://cbdb.hsites.harvard.edu/
+
+**對於 OpenCC 數據 / For OpenCC Data:**
+
+BYVoid et al. OpenCC - Open Chinese Convert.
+https://github.com/BYVoid/OpenCC
+
+---
+
+## 免責聲明 / Disclaimer
+
+本軟件按「現狀」提供，不提供任何明示或暗示的保證。在任何情況下，作者或版權持有人均不對因使用本軟件而產生的任何索賠、損害或其他責任負責。
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY ARISING FROM THE USE OF THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [中國歷代人物傳在線記录入系统](https://input.cbdb.fas.harvard.edu/)原始碼。
 
+**授權 / License:** [CC BY-NC-SA 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/) (主要授權，詳見 [LICENSE.md](./LICENSE.md))
+
 ## 開發指南(2025 更新)
 
 * [AGENTS 指南](./AGENTS.md) - AI 代理開發必讀

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -40,6 +40,14 @@ class CodesController extends Controller
         'GANZHI_CODES',
     ];
     /**
+     * Copyright notices for specific tables.
+     *
+     * @var array<string, string>
+     */
+    protected $tableCopyrightNotes = [
+        'CBDB__TRAD_SIMP_MAP' => '此表格數據來自 <a href="https://github.com/BYVoid/OpenCC" target="_blank">OpenCC 項目</a>的字典文件，該文件以 <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache 2.0 License</a> 授權，因此這個表格的授權也是 Apache 2.0，而非 CC BY-NC-SA 4.0 International 授權。',
+    ];
+    /**
      * Custom column configurations for specific tables.
      *
      * @var array<string, array<int, string>>
@@ -184,6 +192,7 @@ class CodesController extends Controller
 
             $isReadOnly = $this->isReadOnlyTable($table);
             $keyColumns = $this->getKeyColumns($table);
+            $copyrightNote = $this->tableCopyrightNotes[$table] ?? null;
 
             return view('codes.show', [
                 'page_title' => 'Codes',
@@ -197,6 +206,7 @@ class CodesController extends Controller
                 'dynastyMap' => $dynastyMap,
                 'isReadOnly' => $isReadOnly,
                 'keyColumns' => $keyColumns,
+                'copyrightNote' => $copyrightNote,
             ]);
         }catch (\PDOException $e){
             flash('找不到该数据表', 'warning');

--- a/resources/views/codes/show.blade.php
+++ b/resources/views/codes/show.blade.php
@@ -21,6 +21,11 @@
         </div>
         <!-- /.box-header -->
         <div class="box-body">
+            @if(!empty($copyrightNote))
+                <div class="alert alert-info">
+                    <i class="fa fa-info-circle"></i> {!! $copyrightNote !!}
+                </div>
+            @endif
             <form method="GET" action="{{ route('codes.show', ['table_name' => $q]) }}" style="margin-bottom: 15px;">
                 <div class="input-group input-group-sm" style="width: 100%; max-width: 420px;">
                     <input type="text"


### PR DESCRIPTION
## 新增內容

### 1. LICENSE.md（新文件）
- 明確聲明主要授權為 CC BY-NC-SA 4.0 International
- 詳細說明 OpenCC 數據使用 Apache 2.0 License 的例外情況
- 列出相關文件和引用說明
- 包含中英雙語免責聲明

### 2. 授權提示功能
- CodesController 新增 tableCopyrightNotes 屬性
- /codes/CBDB__TRAD_SIMP_MAP 頁面頂部顯示藍色提示框
- 說明此表數據來自 OpenCC 項目，使用 Apache 2.0 授權

### 3. 文檔更新
- README.md: 添加授權聲明和 LICENSE.md 鏈接
- CODES.md: 在只讀表說明中標注授權例外
- CODES_TABLES.md: 在表格和備註中標注授權例外

## 技術細節

文件修改：
- app/Http/Controllers/CodesController.php:47-49, 195, 209
- resources/views/codes/show.blade.php:24-27
- LICENSE.md（新建）
- README.md:5
- CODES.md:14
- CODES_TABLES.md:29, 66

這確保了項目符合開源最佳實踐，正確歸功於第三方數據源。

🤖 Generated with [Claude Code](https://claude.com/claude-code)