### PR TITLE
解決大批量索引重建時卡頓問題

### DIFF
--- a/NAME_SEARCH_COMMANDS.md
+++ b/NAME_SEARCH_COMMANDS.md
@@ -124,6 +124,7 @@ php artisan cbdb:rebuild-name-search
 |------|------|--------|------|
 | `--truncate` | 選填 | false | 重建前清空現有索引 |
 | `--batch` | 選填 | 500 | 每批插入記錄數 |
+| `--commit-interval` | 選填 | 5000 | 每個事務提交的記錄數 |
 
 ### 使用範例
 
@@ -135,6 +136,16 @@ php artisan cbdb:rebuild-name-search --truncate
 **增量重建**（保留現有資料）
 ```bash
 php artisan cbdb:rebuild-name-search
+```
+
+**調整事務大小**（伺服器記憶體較小時）
+```bash
+php artisan cbdb:rebuild-name-search --truncate --commit-interval=2000
+```
+
+**大記憶體伺服器優化**
+```bash
+php artisan cbdb:rebuild-name-search --truncate --commit-interval=20000
 ```
 
 **自訂批次大小**

--- a/NAME_SEARCH_COMMANDS.md
+++ b/NAME_SEARCH_COMMANDS.md
@@ -125,6 +125,8 @@ php artisan cbdb:rebuild-name-search
 | `--truncate` | 選填 | false | 重建前清空現有索引 |
 | `--batch` | 選填 | 500 | 每批插入記錄數 |
 | `--commit-interval` | 選填 | 5000 | 每個事務提交的記錄數 |
+| `--id-from` | 選填 | null | 起始 c_personid（包含） |
+| `--id-to` | 選填 | null | 結束 c_personid（包含） |
 
 ### 使用範例
 
@@ -151,6 +153,30 @@ php artisan cbdb:rebuild-name-search --truncate --commit-interval=20000
 **自訂批次大小**
 ```bash
 php artisan cbdb:rebuild-name-search --truncate --batch=1000
+```
+
+**分批處理**（避免記憶體累積，可並行處理）
+```bash
+# 處理 ID 1-100000
+php artisan cbdb:rebuild-name-search --id-from=1 --id-to=100000
+
+# 處理 ID 100001-200000
+php artisan cbdb:rebuild-name-search --id-from=100001 --id-to=200000
+
+# 處理 ID 200001 以後
+php artisan cbdb:rebuild-name-search --id-from=200001
+```
+
+**並行處理**（多終端機同時執行，加速重建）
+```bash
+# 終端機 1
+php artisan cbdb:rebuild-name-search --id-from=1 --id-to=100000 &
+
+# 終端機 2
+php artisan cbdb:rebuild-name-search --id-from=100001 --id-to=200000 &
+
+# 終端機 3
+php artisan cbdb:rebuild-name-search --id-from=200001 &
 ```
 
 ### 執行輸出

--- a/app/Console/Commands/RebuildNameSearchIndex.php
+++ b/app/Console/Commands/RebuildNameSearchIndex.php
@@ -17,7 +17,9 @@ class RebuildNameSearchIndex extends Command
     protected $signature = 'cbdb:rebuild-name-search
                             {--truncate : Truncate CBDB__NAME_FTS before rebuilding}
                             {--batch=500 : Number of records to insert per batch}
-                            {--commit-interval=5000 : Number of records to commit per transaction}';
+                            {--commit-interval=5000 : Number of records to commit per transaction}
+                            {--id-from= : Start from this c_personid (inclusive)}
+                            {--id-to= : End at this c_personid (inclusive)}';
 
     /**
      * The console command description.
@@ -47,10 +49,19 @@ class RebuildNameSearchIndex extends Command
 
         $batchSize = max(1, (int) $this->option('batch'));
         $commitInterval = max(100, (int) $this->option('commit-interval'));
+        $idFrom = $this->option('id-from') ? (int) $this->option('id-from') : null;
+        $idTo = $this->option('id-to') ? (int) $this->option('id-to') : null;
 
         $this->info('開始重建姓名搜尋倒排索引...');
         $this->info(sprintf('批次大小：%d，事務提交間隔：%d 條記錄',
             $batchSize, $commitInterval));
+
+        if ($idFrom !== null || $idTo !== null) {
+            $this->info(sprintf('ID 範圍：%s 到 %s',
+                $idFrom ?? '開始',
+                $idTo ?? '結束'
+            ));
+        }
 
         // 載入繁簡映射表
         $this->loadTradSimpMap();
@@ -62,7 +73,7 @@ class RebuildNameSearchIndex extends Command
 
         // 流式處理：邊收集邊生成邊插入
         $this->info('流式處理姓名資料...');
-        $this->streamProcessNames($batchSize, $commitInterval);
+        $this->streamProcessNames($batchSize, $commitInterval, $idFrom, $idTo);
 
         $this->info('索引重建完成！');
         $this->displayStatistics();
@@ -75,13 +86,15 @@ class RebuildNameSearchIndex extends Command
      *
      * @param int $batchSize
      * @param int $commitInterval
+     * @param int|null $idFrom
+     * @param int|null $idTo
      */
-    protected function streamProcessNames(int $batchSize, int $commitInterval)
+    protected function streamProcessNames(int $batchSize, int $commitInterval, ?int $idFrom = null, ?int $idTo = null)
     {
         $recordBuffer = [];
         $totalInserted = 0;
 
-        $this->streamProcessNamesInTransaction($batchSize, $recordBuffer, $totalInserted, $commitInterval);
+        $this->streamProcessNamesInTransaction($batchSize, $recordBuffer, $totalInserted, $commitInterval, $idFrom, $idTo);
 
         $this->info(sprintf('成功插入 %s 條倒排記錄', number_format($totalInserted)));
     }
@@ -93,38 +106,64 @@ class RebuildNameSearchIndex extends Command
      * @param array $recordBuffer
      * @param int $totalInserted
      * @param int $commitInterval
+     * @param int|null $idFrom
+     * @param int|null $idTo
      */
-    protected function streamProcessNamesInTransaction(int $batchSize, array &$recordBuffer, int &$totalInserted, int $commitInterval)
+    protected function streamProcessNamesInTransaction(int $batchSize, array &$recordBuffer, int &$totalInserted, int $commitInterval, ?int $idFrom = null, ?int $idTo = null)
     {
+        // 禁用查詢日誌以避免記憶體累積
+        DB::connection()->disableQueryLog();
+
         // 統計總數用於進度條
-        $totalMainNames = DB::table('BIOG_MAIN')
+        $mainQuery = DB::table('BIOG_MAIN')
             ->where('c_personid', '>', 0)
             ->whereNotNull('c_name_chn')
-            ->where('c_name_chn', '!=', '')
-            ->count();
-        $totalAltNames = DB::table('ALTNAME_DATA')
+            ->where('c_name_chn', '!=', '');
+        if ($idFrom !== null) {
+            $mainQuery->where('c_personid', '>=', $idFrom);
+        }
+        if ($idTo !== null) {
+            $mainQuery->where('c_personid', '<=', $idTo);
+        }
+        $totalMainNames = $mainQuery->count();
+
+        $altQuery = DB::table('ALTNAME_DATA')
             ->where('c_personid', '>', 0)
             ->whereNotNull('c_alt_name_chn')
-            ->where('c_alt_name_chn', '!=', '')
-            ->count();
+            ->where('c_alt_name_chn', '!=', '');
+        if ($idFrom !== null) {
+            $altQuery->where('c_personid', '>=', $idFrom);
+        }
+        if ($idTo !== null) {
+            $altQuery->where('c_personid', '<=', $idTo);
+        }
+        $totalAltNames = $altQuery->count();
         $totalNames = $totalMainNames + $totalAltNames;
 
         $bar = $this->output->createProgressBar($totalNames);
         $bar->start();
 
         $lastCommitCount = 0; // 上次提交時的記錄數
+        $timestamp = now(); // 快取時間戳，避免每次都創建新物件
 
         // 開始第一個事務
         DB::beginTransaction();
 
-        // 1. 處理本名（流式）
-        DB::table('BIOG_MAIN')
+        // 1. 處理本名（流式，使用 chunkById 避免 OFFSET 造成的記憶體累積）
+        $mainProcessQuery = DB::table('BIOG_MAIN')
             ->select('c_personid', 'c_name_chn')
             ->where('c_personid', '>', 0)
             ->whereNotNull('c_name_chn')
-            ->where('c_name_chn', '!=', '')
+            ->where('c_name_chn', '!=', '');
+        if ($idFrom !== null) {
+            $mainProcessQuery->where('c_personid', '>=', $idFrom);
+        }
+        if ($idTo !== null) {
+            $mainProcessQuery->where('c_personid', '<=', $idTo);
+        }
+        $mainProcessQuery
             ->orderBy('c_personid')
-            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames) {
+            ->chunkById(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames, $timestamp) {
                 foreach ($rows as $row) {
                     $fullName = $this->normalizeName($row->c_name_chn);
                     if (!$fullName) {
@@ -141,9 +180,10 @@ class RebuildNameSearchIndex extends Command
                         'full_name' => $fullName,
                         'source' => 'BIOG_MAIN',
                         'source_key' => 'biog_main:' . $row->c_personid,
-                    ]);
+                    ], $timestamp);
 
-                    $recordBuffer = array_merge($recordBuffer, $records);
+                    // 使用 array_push 展開，避免 array_merge 的記憶體複製
+                    array_push($recordBuffer, ...$records);
 
                     // 當緩衝區達到批次大小時，插入資料庫
                     if (count($recordBuffer) >= $batchSize) {
@@ -154,7 +194,6 @@ class RebuildNameSearchIndex extends Command
                         // 分段提交：每插入 commitInterval 條記錄就提交並開啟新事務
                         if ($totalInserted - $lastCommitCount >= $commitInterval) {
                             DB::commit();
-                            $bar->finish();
                             $this->line('');
                             $this->info(sprintf('已提交 %s 條記錄（內存：%s MB）',
                                 number_format($totalInserted),
@@ -163,17 +202,15 @@ class RebuildNameSearchIndex extends Command
                             DB::beginTransaction();
                             $lastCommitCount = $totalInserted;
                             gc_collect_cycles(); // 清理內存
-                            $bar = $this->output->createProgressBar($totalNames);
-                            $bar->start();
                         }
                     }
 
                     $bar->advance();
                 }
-            });
+            }, 'c_personid');
 
         // 2. 處理別名（流式）
-        DB::table('ALTNAME_DATA as ad')
+        $altProcessQuery = DB::table('ALTNAME_DATA as ad')
             ->join('ALTNAME_CODES as codes', 'codes.c_name_type_code', '=', 'ad.c_alt_name_type_code')
             ->select(
                 'ad.c_personid',
@@ -184,9 +221,16 @@ class RebuildNameSearchIndex extends Command
             )
             ->where('ad.c_personid', '>', 0)
             ->whereNotNull('ad.c_alt_name_chn')
-            ->where('ad.c_alt_name_chn', '!=', '')
+            ->where('ad.c_alt_name_chn', '!=', '');
+        if ($idFrom !== null) {
+            $altProcessQuery->where('ad.c_personid', '>=', $idFrom);
+        }
+        if ($idTo !== null) {
+            $altProcessQuery->where('ad.c_personid', '<=', $idTo);
+        }
+        $altProcessQuery
             ->orderBy('ad.c_personid')
-            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames) {
+            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames, $timestamp) {
                 foreach ($rows as $row) {
                     $fullName = $this->normalizeName($row->c_alt_name_chn);
                     if (!$fullName) {
@@ -207,9 +251,10 @@ class RebuildNameSearchIndex extends Command
                             $row->c_alt_name_type_code,
                             $row->c_alt_name_chn
                         ),
-                    ]);
+                    ], $timestamp);
 
-                    $recordBuffer = array_merge($recordBuffer, $records);
+                    // 使用 array_push 展開，避免 array_merge 的記憶體複製
+                    array_push($recordBuffer, ...$records);
 
                     // 當緩衝區達到批次大小時，插入資料庫
                     if (count($recordBuffer) >= $batchSize) {
@@ -220,7 +265,6 @@ class RebuildNameSearchIndex extends Command
                         // 分段提交：每插入 commitInterval 條記錄就提交並開啟新事務
                         if ($totalInserted - $lastCommitCount >= $commitInterval) {
                             DB::commit();
-                            $bar->finish();
                             $this->line('');
                             $this->info(sprintf('已提交 %s 條記錄（內存：%s MB）',
                                 number_format($totalInserted),
@@ -229,8 +273,6 @@ class RebuildNameSearchIndex extends Command
                             DB::beginTransaction();
                             $lastCommitCount = $totalInserted;
                             gc_collect_cycles(); // 清理內存
-                            $bar = $this->output->createProgressBar($totalNames);
-                            $bar->start();
                         }
                     }
 
@@ -255,12 +297,18 @@ class RebuildNameSearchIndex extends Command
      * 為單個姓名生成倒排記錄（包含繁簡體）
      *
      * @param array $nameInfo
+     * @param \Illuminate\Support\Carbon|null $timestamp
      * @return array
      */
-    protected function generateRecordsForName(array $nameInfo): array
+    protected function generateRecordsForName(array $nameInfo, $timestamp = null): array
     {
         $records = [];
         $insertedTerms = []; // 記錄已插入的 search_term，避免重複
+
+        // 使用傳入的時間戳或創建新的（避免在循環中重複創建）
+        if ($timestamp === null) {
+            $timestamp = now();
+        }
 
         // 生成繁體版本的後綴
         $tradSuffixes = $this->generateSuffixes($nameInfo['full_name']);
@@ -269,8 +317,8 @@ class RebuildNameSearchIndex extends Command
                 $records[] = array_merge($nameInfo, [
                     'search_term' => $suffix,
                     'is_simplified' => 0,
-                    'created_at' => now(),
-                    'updated_at' => now(),
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
                 ]);
                 $insertedTerms[$suffix] = true; // 標記已插入
             }
@@ -286,8 +334,8 @@ class RebuildNameSearchIndex extends Command
                     $records[] = array_merge($nameInfo, [
                         'search_term' => $suffix,
                         'is_simplified' => 1,
-                        'created_at' => now(),
-                        'updated_at' => now(),
+                        'created_at' => $timestamp,
+                        'updated_at' => $timestamp,
                     ]);
                 }
             }

--- a/app/Console/Commands/RebuildNameSearchIndex.php
+++ b/app/Console/Commands/RebuildNameSearchIndex.php
@@ -16,7 +16,8 @@ class RebuildNameSearchIndex extends Command
      */
     protected $signature = 'cbdb:rebuild-name-search
                             {--truncate : Truncate CBDB__NAME_FTS before rebuilding}
-                            {--batch=500 : Number of records to insert per batch}';
+                            {--batch=500 : Number of records to insert per batch}
+                            {--commit-interval=5000 : Number of records to commit per transaction}';
 
     /**
      * The console command description.
@@ -45,8 +46,11 @@ class RebuildNameSearchIndex extends Command
         }
 
         $batchSize = max(1, (int) $this->option('batch'));
+        $commitInterval = max(100, (int) $this->option('commit-interval'));
 
         $this->info('開始重建姓名搜尋倒排索引...');
+        $this->info(sprintf('批次大小：%d，事務提交間隔：%d 條記錄',
+            $batchSize, $commitInterval));
 
         // 載入繁簡映射表
         $this->loadTradSimpMap();
@@ -58,7 +62,7 @@ class RebuildNameSearchIndex extends Command
 
         // 流式處理：邊收集邊生成邊插入
         $this->info('流式處理姓名資料...');
-        $this->streamProcessNames($batchSize);
+        $this->streamProcessNames($batchSize, $commitInterval);
 
         $this->info('索引重建完成！');
         $this->displayStatistics();
@@ -70,28 +74,27 @@ class RebuildNameSearchIndex extends Command
      * 流式處理姓名（邊收集邊生成邊插入，降低記憶體佔用）
      *
      * @param int $batchSize
+     * @param int $commitInterval
      */
-    protected function streamProcessNames(int $batchSize)
+    protected function streamProcessNames(int $batchSize, int $commitInterval)
     {
         $recordBuffer = [];
         $totalInserted = 0;
 
-        // 使用事務包裹整個導入過程，大幅提升性能
-        DB::transaction(function () use ($batchSize, &$recordBuffer, &$totalInserted) {
-            $this->streamProcessNamesInTransaction($batchSize, $recordBuffer, $totalInserted);
-        });
+        $this->streamProcessNamesInTransaction($batchSize, $recordBuffer, $totalInserted, $commitInterval);
 
         $this->info(sprintf('成功插入 %s 條倒排記錄', number_format($totalInserted)));
     }
 
     /**
-     * 在事務中流式處理姓名
+     * 流式處理姓名（分段事務）
      *
      * @param int $batchSize
      * @param array $recordBuffer
      * @param int $totalInserted
+     * @param int $commitInterval
      */
-    protected function streamProcessNamesInTransaction(int $batchSize, array &$recordBuffer, int &$totalInserted)
+    protected function streamProcessNamesInTransaction(int $batchSize, array &$recordBuffer, int &$totalInserted, int $commitInterval)
     {
         // 統計總數用於進度條
         $totalMainNames = DB::table('BIOG_MAIN')
@@ -109,6 +112,11 @@ class RebuildNameSearchIndex extends Command
         $bar = $this->output->createProgressBar($totalNames);
         $bar->start();
 
+        $lastCommitCount = 0; // 上次提交時的記錄數
+
+        // 開始第一個事務
+        DB::beginTransaction();
+
         // 1. 處理本名（流式）
         DB::table('BIOG_MAIN')
             ->select('c_personid', 'c_name_chn')
@@ -116,7 +124,7 @@ class RebuildNameSearchIndex extends Command
             ->whereNotNull('c_name_chn')
             ->where('c_name_chn', '!=', '')
             ->orderBy('c_personid')
-            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, $batchSize, $bar) {
+            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames) {
                 foreach ($rows as $row) {
                     $fullName = $this->normalizeName($row->c_name_chn);
                     if (!$fullName) {
@@ -142,6 +150,22 @@ class RebuildNameSearchIndex extends Command
                         DB::table('CBDB__NAME_FTS')->insert($recordBuffer);
                         $totalInserted += count($recordBuffer);
                         $recordBuffer = [];
+
+                        // 分段提交：每插入 commitInterval 條記錄就提交並開啟新事務
+                        if ($totalInserted - $lastCommitCount >= $commitInterval) {
+                            DB::commit();
+                            $bar->finish();
+                            $this->line('');
+                            $this->info(sprintf('已提交 %s 條記錄（內存：%s MB）',
+                                number_format($totalInserted),
+                                number_format(memory_get_usage(true) / 1024 / 1024, 2)
+                            ));
+                            DB::beginTransaction();
+                            $lastCommitCount = $totalInserted;
+                            gc_collect_cycles(); // 清理內存
+                            $bar = $this->output->createProgressBar($totalNames);
+                            $bar->start();
+                        }
                     }
 
                     $bar->advance();
@@ -162,7 +186,7 @@ class RebuildNameSearchIndex extends Command
             ->whereNotNull('ad.c_alt_name_chn')
             ->where('ad.c_alt_name_chn', '!=', '')
             ->orderBy('ad.c_personid')
-            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, $batchSize, $bar) {
+            ->chunk(1000, function ($rows) use (&$recordBuffer, &$totalInserted, &$lastCommitCount, $batchSize, $commitInterval, &$bar, $totalNames) {
                 foreach ($rows as $row) {
                     $fullName = $this->normalizeName($row->c_alt_name_chn);
                     if (!$fullName) {
@@ -192,6 +216,22 @@ class RebuildNameSearchIndex extends Command
                         DB::table('CBDB__NAME_FTS')->insert($recordBuffer);
                         $totalInserted += count($recordBuffer);
                         $recordBuffer = [];
+
+                        // 分段提交：每插入 commitInterval 條記錄就提交並開啟新事務
+                        if ($totalInserted - $lastCommitCount >= $commitInterval) {
+                            DB::commit();
+                            $bar->finish();
+                            $this->line('');
+                            $this->info(sprintf('已提交 %s 條記錄（內存：%s MB）',
+                                number_format($totalInserted),
+                                number_format(memory_get_usage(true) / 1024 / 1024, 2)
+                            ));
+                            DB::beginTransaction();
+                            $lastCommitCount = $totalInserted;
+                            gc_collect_cycles(); // 清理內存
+                            $bar = $this->output->createProgressBar($totalNames);
+                            $bar->start();
+                        }
                     }
 
                     $bar->advance();
@@ -203,6 +243,9 @@ class RebuildNameSearchIndex extends Command
             DB::table('CBDB__NAME_FTS')->insert($recordBuffer);
             $totalInserted += count($recordBuffer);
         }
+
+        // 最後提交剩餘的事務
+        DB::commit();
 
         $bar->finish();
         $this->line('');


### PR DESCRIPTION
新增 ID 範圍參數：
- --id-from：起始 c_personid（包含）
- --id-to：結束 c_personid（包含）

用途：
- 分批處理大量數據，控制記憶體使用
- 支援中斷後從特定 ID 繼續處理
- 可並行處理不同 ID 範圍加速重建

使用範例：
```bash
# 分批處理
php artisan cbdb:rebuild-name-search --id-from=1 --id-to=100000 --truncate
php artisan cbdb:rebuild-name-search --id-from=100001 --id-to=200000
...
```