### PR TITLE
feat: 在頁腳添加版本號顯示功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+version.txt

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,44 @@
+<?php
+
+if (!function_exists('get_app_version')) {
+    /**
+     * 获取应用版本号（基于 Git commit ID）
+     *
+     * @return string 返回短版本的 commit ID（前7位）或 'unknown'
+     */
+    function get_app_version()
+    {
+        // 尝试从缓存中获取版本号（避免频繁读取文件或执行 git 命令）
+        $cacheKey = 'app_version';
+        $cachedVersion = \Cache::get($cacheKey);
+
+        if ($cachedVersion !== null) {
+            return $cachedVersion;
+        }
+
+        $version = 'unknown';
+
+        try {
+            // 优先从 version.txt 文件读取（适用于生产环境）
+            $versionFile = base_path('version.txt');
+            if (file_exists($versionFile)) {
+                $version = trim(file_get_contents($versionFile));
+            }
+
+            // 如果文件不存在或为空，尝试从 Git 获取（适用于开发环境）
+            if (empty($version) || $version === 'unknown') {
+                $gitVersion = trim(shell_exec('git rev-parse --short=7 HEAD 2>/dev/null') ?? '');
+                if (!empty($gitVersion)) {
+                    $version = $gitVersion;
+                }
+            }
+
+            // 缓存版本号10分钟
+            \Cache::put($cacheKey, $version, 10);
+
+            return $version;
+        } catch (\Exception $e) {
+            return 'unknown';
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
         ],
         "psr-4": {
             "App\\": "app/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# CBDB Online Main Server 部署脚本
+# 用于在服务器上部署应用时执行必要的更新操作
+
+set -e
+
+echo "开始部署..."
+
+# 1. 生成版本号文件
+echo "生成版本号文件..."
+git rev-parse --short=7 HEAD > version.txt
+echo "版本号: $(cat version.txt)"
+
+# 2. 安装/更新依赖
+echo "更新 Composer 依赖..."
+composer install --no-dev --optimize-autoloader
+
+# 3. 清除缓存
+echo "清除应用缓存..."
+php artisan cache:clear
+php artisan config:clear
+php artisan route:clear
+php artisan view:clear
+
+# 4. 优化缓存（可选，生产环境建议开启）
+# echo "优化缓存..."
+# php artisan config:cache
+# php artisan route:cache
+# php artisan view:cache
+
+echo "部署完成！"

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -2,7 +2,7 @@
 <footer class="main-footer">
     <!-- To the right -->
     <div class="pull-right hidden-xs">
-        
+        <b>Version:</b> {{ get_app_version() }}
     </div>
     <!-- Default to the left -->
     <strong>Copyright &copy; <a href="https://cbdb.hsites.harvard.edu/" target="_blank">Chinese Biographical Database Project (CBDB)</a>.</strong> Content licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">CC BY-NC-SA 4.0 International</a>.


### PR DESCRIPTION
實作內容：
- 新增 app/helpers.php 輔助函數檔案，包含 get_app_version() 函數
- 優先從 version.txt 檔案讀取版本號（適用於生產環境）
- 若檔案不存在，則從 Git commit ID 動態獲取（適用於開發環境）
- 在 composer.json 中配置自動載入 helpers.php
- 更新頁腳視圖，在右側顯示版本號
- 使用快取機制（10分鐘）避免頻繁讀取檔案或執行 Git 指令
- 新增 deploy.sh 部署腳本，自動生成版本號檔案並執行部署操作
- 將 version.txt 加入 .gitignore（由部署腳本動態生成）

使用方式：
在生產環境部署時執行 ./deploy.sh 即可自動生成版本號檔案