### PR TITLE
feat: 新增 MySQL 到 SQLite 导出工具和兼容性辅助函数   @claude

### DIFF
--- a/SQLITE_MIGRATION_PLAN.md
+++ b/SQLITE_MIGRATION_PLAN.md
@@ -16,6 +16,19 @@
 4. ✅ 生产环境继续使用 MySQL，零风险
 5. ✅ 新增代码通过 SQLite 测试自动保证兼容性
 
+## 💡 实施策略
+
+### 核心思路：向前兼容，历史不动
+
+**关键决策：**
+- ❌ **不修改**历史 migration 文件（避免风险，减少工作量）
+- ✅ **创建**一次性 MySQL → SQLite 导出脚本
+- ✅ **确保**未来新增代码保持双数据库兼容
+
+**工作量对比：**
+- 修改历史 migrations 方案：4.5-6.5 小时
+- **导出脚本方案：1-2 小时** ⭐（推荐）
+
 ## 📊 兼容性评估
 
 ### 现有代码分析结果
@@ -26,52 +39,55 @@
 | 视图（Views） | ✅ 完全兼容 | 使用标准 SQL JOIN，无需修改 |
 | 外键约束 | ✅ 兼容 | 需启用 `foreign_key_constraints = true` |
 | 查询构建器 | ✅ 完全兼容 | Eloquent ORM 和 Query Builder 自动适配 |
-| 字符串拼接 | ✅ 完全兼容 | 已使用 `\|\|` 操作符（双数据库通用） |
-| ISNULL 函数 | ❌ 需要修改 | 1 处：`app/BiogMain.php:102` |
-| VARBINARY 类型 | ❌ 需要修改 | 1 处：迁移文件 |
-| 外键检查控制 | ❌ 需要修改 | 1 处：迁移文件 |
+| 字符串拼接 | ✅ 完全兼容 | 已使用 `||` 操作符（双数据库通用） |
+| ISNULL 函数 | ⚠️ 需要修改 | 1 处：`app/BiogMain.php:102` |
 
 ### 需要修改的地方
 
-**总计：约 5-10 处代码修改**
+**总计：仅 1 处代码修改 + 1 个导出脚本**
 
-1. **`app/BiogMain.php:102`** - ISNULL 函数
-2. **`database/migrations/2025_11_13_000000_create_internal_name_search_tables.php:40-46`** - VARBINARY 类型
-3. **`database/migrations/2025_11_14_000000_michael_restructure_plan_schema_updates.php:18,220`** - SET FOREIGN_KEY_CHECKS
-4. **（可选）** `database/migrations/2025_01_01_000000_import_cbdb_schema.php` - 清理 ENGINE/CHARSET 声明
+1. **`app/BiogMain.php:102`** - ISNULL 函数（未来代码兼容性）
+2. **创建导出脚本** - 一次性从 MySQL 导出到 SQLite
 
 ## 🔧 详细实施步骤
 
-### 阶段一：代码兼容性修改（预计 2-4 小时）
+### 阶段一：创建 MySQL → SQLite 导出脚本（预计 1 小时）
 
-#### 1. 修改 BiogMain.php 中的 ISNULL 用法
+#### 1. 创建 Artisan 命令
 
-**文件：** `app/BiogMain.php:102`
+使用 Laravel 自带的数据库连接，实现智能导出。
 
-**当前代码：**
-```php
-->orderBy(DB::raw('ISNULL(c_sequence), c_sequence'), 'ASC');
+**文件：** `app/Console/Commands/ExportMysqlToSqlite.php`
+
+**功能：**
+- 自动读取 MySQL 的表结构和数据
+- 转换数据类型（VARBINARY → BLOB 等）
+- 处理外键约束
+- 批量导入数据到 SQLite
+- 显示进度和统计信息
+
+**使用方式：**
+```bash
+# 从当前 MySQL 数据库导出到 SQLite
+php artisan db:export-to-sqlite
+
+# 指定输出文件
+php artisan db:export-to-sqlite --output=database/production.sqlite
+
+# 只导出结构，不导出数据
+php artisan db:export-to-sqlite --schema-only
+
+# 导出特定表
+php artisan db:export-to-sqlite --tables=BIOG_MAIN,ALTNAME_DATA
 ```
-
-**修改为：**
-```php
-->orderByRaw('CASE WHEN c_sequence IS NULL THEN 1 ELSE 0 END')
-->orderBy('c_sequence', 'ASC');
-```
-
-或更简洁的写法：
-```php
-->orderByRaw('c_sequence IS NULL')
-->orderBy('c_sequence', 'ASC');
-```
-
-**兼容性：** ✅ MySQL 和 SQLite 都支持 `IS NULL` 和 `CASE` 语句
 
 ---
 
 #### 2. 创建数据库兼容性辅助函数
 
 **文件：** `database/migrations/helpers.php` (新建)
+
+这些辅助函数供**未来的 migrations** 使用，确保新迁移文件兼容双数据库。
 
 ```php
 <?php
@@ -105,25 +121,6 @@ if (!function_exists('enable_foreign_keys')) {
         }
     }
 }
-
-if (!function_exists('create_varbinary_column')) {
-    /**
-     * 创建 VARBINARY 列（MySQL）或 BLOB 列（SQLite）
-     *
-     * @param int $size MySQL VARBINARY 的大小
-     * @return string SQL 片段
-     */
-    function create_varbinary_column($size = 255)
-    {
-        $driver = DB::getDriverName();
-        if ($driver === 'mysql') {
-            return "VARBINARY({$size})";
-        } elseif ($driver === 'sqlite') {
-            return "BLOB";
-        }
-        return "BLOB"; // 默认
-    }
-}
 ```
 
 **加载方式：** 在 `composer.json` 中添加：
@@ -143,71 +140,28 @@ composer dump-autoload
 
 ---
 
-#### 3. 修改迁移文件 - VARBINARY 类型
+### 阶段二：修改现有兼容性问题（预计 30 分钟）
 
-**文件：** `database/migrations/2025_11_13_000000_create_internal_name_search_tables.php`
+#### 1. 修改 BiogMain.php 中的 ISNULL 用法
 
-**当前代码（第 40-46 行）：**
+**文件：** `app/BiogMain.php:102`
+
+**当前代码：**
 ```php
-DB::statement("
-    CREATE TABLE CBDB__TRAD_SIMP_MAP (
-        trad_char VARBINARY(4) NOT NULL COMMENT '繁體字（UTF-8二進制）',
-        simp_char VARBINARY(4) NOT NULL COMMENT '簡體字（UTF-8二進制）',
-        PRIMARY KEY (trad_char)
-    ) ENGINE=InnoDB
-");
+->orderBy(DB::raw('ISNULL(c_sequence), c_sequence'), 'ASC');
 ```
 
 **修改为：**
 ```php
-$driver = DB::getDriverName();
-$varbinaryType = create_varbinary_column(4);
-$engine = $driver === 'mysql' ? 'ENGINE=InnoDB' : '';
-
-DB::statement("
-    CREATE TABLE CBDB__TRAD_SIMP_MAP (
-        trad_char {$varbinaryType} NOT NULL,
-        simp_char {$varbinaryType} NOT NULL,
-        PRIMARY KEY (trad_char)
-    ) {$engine}
-");
+->orderByRaw('c_sequence IS NULL')
+->orderBy('c_sequence', 'ASC');
 ```
 
-**说明：**
-- MySQL: 使用 `VARBINARY(4)` 存储 UTF-8 字符
-- SQLite: 使用 `BLOB` 类型，功能等价
+**兼容性：** ✅ MySQL 和 SQLite 都支持 `IS NULL` 表达式
 
 ---
 
-#### 4. 修改迁移文件 - 外键约束控制
-
-**文件：** `database/migrations/2025_11_14_000000_michael_restructure_plan_schema_updates.php`
-
-**当前代码（第 18 行）：**
-```php
-DB::statement('SET FOREIGN_KEY_CHECKS=0');
-```
-
-**修改为：**
-```php
-disable_foreign_keys();
-```
-
-**当前代码（第 220 行）：**
-```php
-DB::statement('SET FOREIGN_KEY_CHECKS=1');
-```
-
-**修改为：**
-```php
-enable_foreign_keys();
-```
-
-**同样修改 `down()` 方法中的第 231 和 363 行。**
-
----
-
-### 阶段二：配置测试环境（预计 1 小时）
+### 阶段三：配置测试环境（预计 30 分钟）
 
 #### 1. 配置 SQLite 测试数据库
 
@@ -302,32 +256,6 @@ class DatabaseCompatibilityTest extends TestCase
     }
 
     /**
-     * 测试 NULL 排序的兼容性
-     *
-     * @test
-     */
-    public function it_handles_null_ordering_correctly()
-    {
-        // 创建测试数据
-        DB::table('BIOG_MAIN')->insert([
-            ['c_personid' => 1, 'c_name' => 'Test1', 'c_name_chn' => '测试1'],
-            ['c_personid' => 2, 'c_name' => 'Test2', 'c_name_chn' => '测试2'],
-        ]);
-
-        DB::table('ALTNAME_DATA')->insert([
-            ['c_personid' => 1, 'c_alt_name_type_code' => 1, 'c_alt_name' => 'Alt1', 'c_alt_name_chn' => '别名1', 'c_sequence' => 1],
-            ['c_personid' => 1, 'c_alt_name_type_code' => 2, 'c_alt_name' => 'Alt2', 'c_alt_name_chn' => '别名2', 'c_sequence' => null],
-        ]);
-
-        // 测试 BiogMain 的 altnames() 关联（使用了 ISNULL 排序）
-        $person = BiogMain::find(1);
-        $altnames = $person->altnames;
-
-        // 应该能正常查询，不报错
-        $this->assertNotNull($altnames);
-    }
-
-    /**
      * 测试事务支持
      *
      * @test
@@ -347,28 +275,6 @@ class DatabaseCompatibilityTest extends TestCase
         DB::rollBack();
 
         $this->assertDatabaseMissing('users', ['email' => 'test@transaction.com']);
-    }
-
-    /**
-     * 测试嵌套事务
-     *
-     * @test
-     */
-    public function it_supports_nested_transactions()
-    {
-        $this->assertEquals(0, DB::transactionLevel());
-
-        DB::beginTransaction();
-        $this->assertEquals(1, DB::transactionLevel());
-
-        DB::beginTransaction();
-        $this->assertEquals(2, DB::transactionLevel());
-
-        DB::commit();
-        $this->assertEquals(1, DB::transactionLevel());
-
-        DB::commit();
-        $this->assertEquals(0, DB::transactionLevel());
     }
 
     /**
@@ -392,74 +298,49 @@ class DatabaseCompatibilityTest extends TestCase
 
 ---
 
-### 阶段三：开发环境配置（预计 30 分钟）
+### 阶段四：文档和工具（预计 30 分钟）
 
-#### 1. 创建 SQLite 环境配置示例
+#### 1. 创建快速切换脚本
 
-**文件：** `.env.sqlite.example` (新建)
-
-```bash
-APP_NAME="CBDB Online (SQLite Dev)"
-APP_ENV=local
-APP_KEY=base64:YOUR_APP_KEY_HERE
-APP_DEBUG=true
-APP_URL=http://localhost:8000
-
-LOG_CHANNEL=stack
-LOG_LEVEL=debug
-
-# SQLite 数据库配置
-DB_CONNECTION=sqlite
-DB_DATABASE=/full/path/to/cbdb-online-main-server/database/database.sqlite
-
-BROADCAST_DRIVER=log
-CACHE_DRIVER=file
-SESSION_DRIVER=file
-QUEUE_CONNECTION=sync
-
-# 其他配置保持不变...
-```
-
-#### 2. 添加快速切换脚本
-
-**文件：** `scripts/switch-to-sqlite.sh` (新建)
+**文件：** `scripts/use-sqlite.sh` (新建)
 
 ```bash
 #!/bin/bash
 
-echo "切换到 SQLite 数据库..."
+echo "🔄 切换到 SQLite 数据库..."
 
 # 备份当前 .env
 if [ -f .env ]; then
     cp .env .env.backup.$(date +%Y%m%d_%H%M%S)
-    echo "已备份当前配置到 .env.backup.$(date +%Y%m%d_%H%M%S)"
+    echo "✅ 已备份当前配置"
 fi
 
-# 创建 SQLite 数据库文件
+# 创建 SQLite 数据库文件（如果不存在）
 DB_PATH="database/database.sqlite"
 if [ ! -f "$DB_PATH" ]; then
     touch "$DB_PATH"
-    echo "已创建 SQLite 数据库文件: $DB_PATH"
+    echo "✅ 已创建 SQLite 数据库文件"
 fi
 
 # 更新 .env 配置
 sed -i.bak 's/DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
 sed -i.bak "s|DB_DATABASE=.*|DB_DATABASE=$(pwd)/$DB_PATH|" .env
 
-echo "✅ 已切换到 SQLite"
 echo ""
-echo "下一步："
-echo "1. 运行迁移: php artisan migrate:fresh"
-echo "2. （可选）导入数据: php artisan db:seed"
-echo "3. 启动服务: php artisan serve"
+echo "✅ 已切换到 SQLite！"
+echo ""
+echo "📋 下一步："
+echo "   1. 从 MySQL 导出数据: php artisan db:export-to-sqlite"
+echo "   2. 或者运行全新迁移: php artisan migrate:fresh"
+echo "   3. 启动服务: php artisan serve"
 ```
 
-**文件：** `scripts/switch-to-mysql.sh` (新建)
+**文件：** `scripts/use-mysql.sh` (新建)
 
 ```bash
 #!/bin/bash
 
-echo "切换到 MySQL 数据库..."
+echo "🔄 切换到 MySQL 数据库..."
 
 # 恢复配置
 sed -i.bak 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
@@ -467,21 +348,17 @@ sed -i.bak 's|DB_DATABASE=.*|DB_DATABASE=homestead|' .env
 
 echo "✅ 已切换到 MySQL"
 echo ""
-echo "请确保 MySQL 服务正在运行"
-echo "然后运行: php artisan migrate"
+echo "⚠️  请确保 MySQL 服务正在运行"
 ```
 
 添加执行权限：
 ```bash
-chmod +x scripts/switch-to-sqlite.sh
-chmod +x scripts/switch-to-mysql.sh
+chmod +x scripts/use-sqlite.sh scripts/use-mysql.sh
 ```
 
 ---
 
-### 阶段四：文档和指南（预计 1 小时）
-
-#### 1. 更新 README.md
+#### 2. 更新 README.md
 
 在 README.md 中添加数据库配置章节：
 
@@ -496,12 +373,15 @@ chmod +x scripts/switch-to-mysql.sh
 
 ```bash
 # 1. 切换到 SQLite
-./scripts/switch-to-sqlite.sh
+./scripts/use-sqlite.sh
 
-# 2. 运行迁移
-php artisan migrate:fresh
+# 2. 从生产 MySQL 导出数据（如果有）
+php artisan db:export-to-sqlite
 
-# 3. 启动开发服务器
+# 3. 或运行全新迁移
+php artisan migrate:fresh --seed
+
+# 4. 启动开发服务器
 php artisan serve
 ```
 
@@ -537,14 +417,7 @@ php artisan migrate
 
 ---
 
-#### 2. 创建开发者指南
-
-**文件：** `docs/DATABASE_COMPATIBILITY_GUIDE.md` (新建)
-
-```markdown
-# 数据库兼容性开发指南
-
-## 编写兼容 MySQL 和 SQLite 的代码
+## 📝 编写兼容代码指南
 
 ### ✅ 推荐做法
 
@@ -579,7 +452,7 @@ DB::raw("CONCAT(first_name, ' ', last_name)")
 DB::raw("first_name || ' ' || last_name")
 ```
 
-#### 4. 迁移文件中使用辅助函数
+#### 4. 未来 Migrations 使用辅助函数
 
 ```php
 // ✅ 使用提供的辅助函数
@@ -592,29 +465,133 @@ public function up() {
 }
 ```
 
-### 🧪 测试数据库兼容性
+### 📋 代码审查检查清单
 
-每次添加新功能后，运行测试确保兼容性：
-
-```bash
-# 运行所有测试（使用 SQLite）
-./vendor/bin/phpunit
-
-# 运行特定测试
-./vendor/bin/phpunit tests/Feature/DatabaseCompatibilityTest.php
-```
-
-### 📋 兼容性检查清单
-
-提交代码前检查：
+提交新代码前检查：
 
 - [ ] 没有使用 `ISNULL()`、`IFNULL()`（MySQL 特定）
 - [ ] 没有使用 `CONCAT()`（用 `||` 代替）
-- [ ] 没有使用 `NOW()`（用 `DB::raw('CURRENT_TIMESTAMP')` 或 Laravel 辅助函数）
-- [ ] 迁移文件中的原始 SQL 使用了兼容性辅助函数
+- [ ] 没有使用 `NOW()`（用 `DB::raw('CURRENT_TIMESTAMP')` 或 Laravel 函数）
+- [ ] 新 migration 文件使用了兼容性辅助函数
 - [ ] 所有测试在 SQLite 下通过
 
-### 🔍 常见问题
+---
+
+## 🗓️ 实施时间表
+
+| 阶段 | 任务 | 预计时间 | 负责人 |
+|------|------|---------|--------|
+| 1 | 创建 MySQL → SQLite 导出脚本 | 1 小时 | 开发团队 |
+| 2 | 修改现有兼容性问题 | 30 分钟 | 开发团队 |
+| 3 | 配置测试环境 | 30 分钟 | 开发团队 |
+| 4 | 文档和工具 | 30 分钟 | 开发团队 |
+| **总计** | | **2.5 小时** | |
+
+## ✅ 验收标准
+
+1. ✅ 导出脚本能成功将 MySQL 数据导入 SQLite
+2. ✅ 所有现有测试在 SQLite 下通过
+3. ✅ 新建的 `DatabaseCompatibilityTest` 全部通过
+4. ✅ 可以使用 `./scripts/use-sqlite.sh` 切换到 SQLite 并成功运行
+5. ✅ 可以使用 `./scripts/use-mysql.sh` 切换回 MySQL 并成功运行
+6. ✅ 文档完整，新成员可以按照文档完成环境配置
+
+## 📈 预期收益
+
+### 开发体验改善
+
+- ⚡ 测试速度提升 **10-100 倍**（从分钟级到秒级）
+- 🚀 新成员上手时间从 1-2 小时降到 **5 分钟**（无需配置 MySQL）
+- 🔄 数据库重置从手动操作变成 `php artisan migrate:fresh`
+- 📦 可以将 SQLite 数据库文件提交到版本控制（seed 数据）
+
+### 成本节约
+
+- 💰 CI/CD 运行时间减少 **80%+**（节省 GitHub Actions 额度）
+- 🖥️ 本地开发机器资源占用降低（无需运行 MySQL 服务）
+
+### 代码质量
+
+- 🛡️ 自动检测数据库特定语法，减少生产环境 bug
+- 📊 可以频繁运行全量测试，提高代码覆盖率
+
+## 🔄 日常使用流程
+
+### 新成员入职
+
+```bash
+# 1. 克隆项目
+git clone <repository>
+
+# 2. 安装依赖
+composer install
+
+# 3. 配置环境（自动使用 SQLite）
+cp .env.example .env
+php artisan key:generate
+
+# 4. 创建并导入数据
+touch database/database.sqlite
+php artisan db:export-to-sqlite  # 从生产环境导出
+# 或
+php artisan migrate:fresh --seed  # 使用测试数据
+
+# 5. 开始开发
+php artisan serve
+```
+
+**总耗时：5 分钟** 🚀
+
+### 日常开发
+
+```bash
+# 开发新功能（使用 SQLite）
+php artisan make:migration create_something_table
+
+# 运行测试（自动使用 in-memory SQLite）
+./vendor/bin/phpunit
+
+# 重置数据库
+php artisan migrate:fresh --seed
+```
+
+### 部署前验证
+
+```bash
+# 切换到 MySQL 测试
+./scripts/use-mysql.sh
+php artisan migrate
+
+# 确认没有问题后部署
+git push
+```
+
+---
+
+## 🔍 常见问题
+
+**Q: 导出脚本会导出所有数据吗？**
+
+A: 默认会导出所有表的结构和数据。可以使用 `--schema-only` 只导出结构，或使用 `--tables` 指定特定表。
+
+**Q: SQLite 数据库文件应该提交到 git 吗？**
+
+A: 建议：
+- 开发环境的 seed 数据库：✅ 可以提交
+- 生产数据：❌ 不要提交（添加到 .gitignore）
+
+**Q: 如何处理大数据集？**
+
+A: SQLite 适合中小型数据集（< 100GB）。CBDB 数据量适中，完全没问题。如果数据量很大，建议：
+- 开发环境：使用导出脚本创建的 SQLite 数据库
+- 生产环境：继续使用 MySQL
+
+**Q: 遇到 "database is locked" 错误？**
+
+A: SQLite 不支持高并发写入。解决方案：
+1. 已配置 `busy_timeout = 5000ms`
+2. 开发环境单用户通常不会遇到此问题
+3. 生产环境使用 MySQL
 
 **Q: 如何在代码中检测当前使用的数据库？**
 
@@ -628,73 +605,7 @@ if ($driver === 'mysql') {
 }
 ```
 
-**Q: SQLite 不支持某些 ALTER TABLE 操作怎么办？**
-
-SQLite 不支持某些列修改操作。解决方案：
-
-1. 使用 Laravel 的 Schema Builder（会自动处理）
-2. 或者创建新表 → 复制数据 → 删除旧表 → 重命名
-
-**Q: 遇到 "database is locked" 错误？**
-
-SQLite 默认不支持高并发写入。解决方案：
-
-1. 增加 `busy_timeout`（已在配置中设置为 5000ms）
-2. 考虑使用 WAL 模式（Write-Ahead Logging）
-3. 生产环境使用 MySQL
-```
-
 ---
-
-## 🗓️ 实施时间表
-
-| 阶段 | 任务 | 预计时间 | 负责人 |
-|------|------|---------|--------|
-| 1 | 代码兼容性修改 | 2-4 小时 | 开发团队 |
-| 2 | 配置测试环境 | 1 小时 | 开发团队 |
-| 3 | 开发环境配置 | 30 分钟 | 开发团队 |
-| 4 | 文档和指南 | 1 小时 | 开发团队 |
-| **总计** | | **4.5-6.5 小时** | |
-
-## ✅ 验收标准
-
-1. ✅ 所有现有测试在 SQLite 下通过
-2. ✅ 新建的 `DatabaseCompatibilityTest` 全部通过
-3. ✅ 可以使用 `./scripts/switch-to-sqlite.sh` 切换到 SQLite 并成功运行
-4. ✅ 可以使用 `./scripts/switch-to-mysql.sh` 切换回 MySQL 并成功运行
-5. ✅ 文档完整，新成员可以按照文档完成环境配置
-
-## 📈 预期收益
-
-### 开发体验改善
-
-- ⚡ 测试速度提升 **10-100 倍**（从分钟级到秒级）
-- 🚀 新成员上手时间从 1-2 小时降到 **5 分钟**（无需配置 MySQL）
-- 🔄 数据库重置从手动操作变成 `php artisan migrate:fresh`
-
-### 成本节约
-
-- 💰 CI/CD 运行时间减少 **80%+**（节省 GitHub Actions 额度）
-- 🖥️ 本地开发机器资源占用降低（无需运行 MySQL 服务）
-
-### 代码质量
-
-- 🛡️ 自动检测数据库特定语法，减少生产环境 bug
-- 📊 可以频繁运行全量测试，提高代码覆盖率
-
-## 🔄 后续维护
-
-### 日常开发
-
-1. **新功能开发：** 使用 SQLite 本地开发
-2. **运行测试：** 自动使用 in-memory SQLite
-3. **代码审查：** 检查是否遵循兼容性指南
-4. **合并前：** 确保所有测试通过
-
-### 定期检查
-
-- 每月运行一次 MySQL 测试，确保生产环境兼容性
-- 每季度检查是否有新的数据库特定语法引入
 
 ## 📚 参考资料
 
@@ -725,6 +636,6 @@ SQLite 默认不支持高并发写入。解决方案：
 
 ---
 
-**文档版本：** 1.0
+**文档版本：** 2.0
 **最后更新：** 2025-11-17
 **维护者：** CBDB 开发团队

--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 class ExportMysqlToSqlite extends Command
 {
@@ -53,6 +52,13 @@ class ExportMysqlToSqlite extends Command
     ];
 
     /**
+     * 表結構附加資訊（如主鍵欄位）
+     *
+     * @var array
+     */
+    protected $tableMetadata = [];
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -81,7 +87,7 @@ class ExportMysqlToSqlite extends Command
         }
 
         $this->info(sprintf('准备导出 %d 个表...', count($tables)));
-        $this->newLine();
+        $this->output->newLine();
 
         // 导出表结构和数据
         $bar = $this->output->createProgressBar(count($tables));
@@ -93,14 +99,14 @@ class ExportMysqlToSqlite extends Command
                 $bar->advance();
             } catch (\Exception $e) {
                 $this->stats['errors']++;
-                $this->newLine();
-                $this->error(sprintf('导出表 %s 失败: %s', $table, $e->getMessage()));
+                $this->output->newLine();
+                $this->error(sprintf('导出表 %s 失败: %s', $table['name'], $e->getMessage()));
                 $bar->advance();
             }
         }
 
         $bar->finish();
-        $this->newLine(2);
+        $this->output->newLine(2);
 
         // 显示统计信息
         $this->displayStats();
@@ -195,20 +201,38 @@ class ExportMysqlToSqlite extends Command
     {
         $specifiedTables = $this->option('tables');
 
-        if ($specifiedTables) {
-            return array_map('trim', explode(',', $specifiedTables));
-        }
-
-        // 获取所有表
         $tables = DB::connection($this->sourceConnection)
-            ->select('SHOW TABLES');
+            ->select('SHOW FULL TABLES');
 
         $databaseName = DB::connection($this->sourceConnection)->getDatabaseName();
         $tableKey = 'Tables_in_' . $databaseName;
 
-        return array_map(function ($table) use ($tableKey) {
-            return $table->$tableKey;
-        }, $tables);
+        $result = [];
+
+        foreach ($tables as $table) {
+            $name = $table->$tableKey;
+            $result[$name] = [
+                'name' => $name,
+                'type' => isset($table->Table_type) ? strtoupper($table->Table_type) : 'BASE TABLE',
+            ];
+        }
+
+        if ($specifiedTables) {
+            $names = array_map('trim', explode(',', $specifiedTables));
+            $filtered = [];
+
+            foreach ($names as $name) {
+                if (isset($result[$name])) {
+                    $filtered[] = $result[$name];
+                } else {
+                    $this->warn(sprintf('⚠ 未找到表: %s', $name));
+                }
+            }
+
+            return $filtered;
+        }
+
+        return array_values($result);
     }
 
     /**
@@ -217,14 +241,18 @@ class ExportMysqlToSqlite extends Command
      * @param string $tableName
      * @return void
      */
-    protected function exportTable($tableName)
+    protected function exportTable(array $table)
     {
-        // 1. 导出表结构
-        $this->exportTableSchema($tableName);
+        $tableName = $table['name'];
+        $isView = strtoupper($table['type']) === 'VIEW';
 
-        // 2. 导出数据（如果不是 schema-only 模式）
-        if (!$this->option('schema-only')) {
-            $this->exportTableData($tableName);
+        // 1. 导出表结构
+        $this->exportTableSchema($tableName, $isView);
+
+        // 2. 导出数据（如果不是 schema-only 模式且不是视图）
+        if (!$isView && !$this->option('schema-only')) {
+            $rowCount = $this->getTableRowCount($tableName);
+            $this->exportTableData($tableName, $rowCount);
         }
 
         $this->stats['tables']++;
@@ -236,19 +264,49 @@ class ExportMysqlToSqlite extends Command
      * @param string $tableName
      * @return void
      */
-    protected function exportTableSchema($tableName)
+    protected function exportTableSchema($tableName, $isView = false)
     {
-        // 获取 MySQL 的 CREATE TABLE 语句
+        $statement = $isView
+            ? "SHOW CREATE VIEW `{$tableName}`"
+            : "SHOW CREATE TABLE `{$tableName}`";
+
         $createTableResult = DB::connection($this->sourceConnection)
-            ->select("SHOW CREATE TABLE `{$tableName}`");
+            ->select($statement);
 
-        $createTableSql = $createTableResult[0]->{'Create Table'};
+        if (empty($createTableResult)) {
+            throw new \RuntimeException(sprintf('无法获取 %s 的结构信息', $tableName));
+        }
 
-        // 转换为 SQLite 兼容的 SQL
-        $sqliteCreateSql = $this->convertCreateTableToSqlite($createTableSql, $tableName);
+        $definition = (array) $createTableResult[0];
+        $sqliteCreateSql = null;
 
-        // 在 SQLite 中执行
-        DB::connection('sqlite_export')->statement($sqliteCreateSql);
+        if ($isView) {
+            $key = 'Create View';
+            if (!isset($definition[$key])) {
+                throw new \RuntimeException(sprintf('未找到视图 %s 的定义', $tableName));
+            }
+
+            $sqliteCreateSql = $this->convertCreateViewToSqlite($definition[$key], $tableName);
+        } else {
+            $key = 'Create Table';
+            if (!isset($definition[$key])) {
+                throw new \RuntimeException(sprintf('未找到数据表 %s 的定义', $tableName));
+            }
+
+            $sqliteCreateSql = $this->convertCreateTableToSqlite($definition[$key], $tableName);
+        }
+
+        if ($isView) {
+            DB::connection('sqlite_export')->statement($sqliteCreateSql);
+            return;
+        }
+
+        DB::connection('sqlite_export')->statement($sqliteCreateSql['table']);
+        $this->tableMetadata[$tableName] = $sqliteCreateSql['meta'] ?? [];
+
+        foreach ($sqliteCreateSql['indexes'] as $indexSql) {
+            DB::connection('sqlite_export')->statement($indexSql);
+        }
     }
 
     /**
@@ -260,55 +318,320 @@ class ExportMysqlToSqlite extends Command
      */
     protected function convertCreateTableToSqlite($mysqlSql, $tableName)
     {
-        // 移除 MySQL 特定的选项
-        $sql = preg_replace('/ENGINE=\w+/i', '', $mysqlSql);
-        $sql = preg_replace('/DEFAULT CHARSET=\w+/i', '', $sql);
-        $sql = preg_replace('/COLLATE=\w+/i', '', $sql);
-        $sql = preg_replace('/ROW_FORMAT=\w+/i', '', $sql);
-        $sql = preg_replace('/AUTO_INCREMENT=\d+/i', '', $sql);
-        $sql = preg_replace('/COMMENT\s*=\s*\'[^\']*\'/i', '', $sql);
+        $cleanSql = preg_replace('/`' . preg_quote($tableName, '/') . '`/i', '"' . $tableName . '"', $mysqlSql);
+        $cleanSql = preg_replace('/ENGINE=.*$/is', '', $cleanSql);
+        $cleanSql = preg_replace('/ROW_FORMAT=\w+/i', '', $cleanSql);
+        $cleanSql = preg_replace('/AUTO_INCREMENT=\d+/i', '', $cleanSql);
+        $cleanSql = preg_replace('/DEFAULT CHARSET=\w+/i', '', $cleanSql);
+        $cleanSql = preg_replace('/COLLATE=\w+/i', '', $cleanSql);
+        $cleanSql = trim($cleanSql);
 
-        // 转换数据类型
-        $sql = preg_replace('/\s+unsigned/i', '', $sql);
-        $sql = preg_replace('/VARBINARY\(\d+\)/i', 'BLOB', $sql);
-        $sql = preg_replace('/TINYINT\(\d+\)/i', 'INTEGER', $sql);
-        $sql = preg_replace('/SMALLINT\(\d+\)/i', 'INTEGER', $sql);
-        $sql = preg_replace('/MEDIUMINT\(\d+\)/i', 'INTEGER', $sql);
-        $sql = preg_replace('/BIGINT\(\d+\)/i', 'INTEGER', $sql);
-        $sql = preg_replace('/INT\(\d+\)/i', 'INTEGER', $sql);
-        $sql = preg_replace('/DOUBLE/i', 'REAL', $sql);
-        $sql = preg_replace('/DATETIME/i', 'TEXT', $sql);
-        $sql = preg_replace('/TIMESTAMP/i', 'TEXT', $sql);
-        $sql = preg_replace('/ENUM\([^)]+\)/i', 'TEXT', $sql);
+        if (!preg_match('/^CREATE TABLE\s+"?([^"\s]+)"?\s*\((.*)\)/is', $cleanSql, $matches)) {
+            throw new \RuntimeException(sprintf('无法解析数据表 %s 的结构', $tableName));
+        }
 
-        // 转换 VARCHAR/CHAR 为 TEXT（SQLite 没有长度限制）
-        $sql = preg_replace('/VARCHAR\(\d+\)/i', 'TEXT', $sql);
-        $sql = preg_replace('/CHAR\(\d+\)/i', 'TEXT', $sql);
+        $definitions = $matches[2];
+        $items = $this->splitDefinitionItems($definitions);
 
-        // 移除 CHARACTER SET 和 COLLATE 子句
-        $sql = preg_replace('/CHARACTER SET \w+/i', '', $sql);
-        $sql = preg_replace('/COLLATE \w+/i', '', $sql);
+        $columns = [];
+        $primaryKeys = [];
+        $indexes = [];
+        $autoIncrementColumns = [];
+        $primaryKeyColumnsList = [];
+        $chunkColumn = null;
+        $firstColumn = null;
 
-        // 移除列级 COMMENT
-        $sql = preg_replace('/COMMENT \'[^\']*\'/i', '', $sql);
+        foreach ($items as $item) {
+            $trimmed = trim($item);
 
-        // 处理 AUTO_INCREMENT（转换为 AUTOINCREMENT）
-        $sql = preg_replace('/AUTO_INCREMENT/i', 'AUTOINCREMENT', $sql);
+            if ($trimmed === '') {
+                continue;
+            }
 
-        // 移除 USING BTREE/HASH
-        $sql = preg_replace('/USING (BTREE|HASH)/i', '', $sql);
+            if (stripos($trimmed, 'PRIMARY KEY') === 0) {
+                $columnsString = $this->extractColumnsFromDefinition($trimmed);
+                $columnNames = $this->extractColumnNames($columnsString);
+                $primaryKeyColumnsList[] = $columnNames;
 
-        // 移除外键约束（稍后单独处理）
-        $sql = preg_replace('/,\s*CONSTRAINT[^,]+FOREIGN KEY[^,]+REFERENCES[^,)]+/is', '', $sql);
-        $sql = preg_replace('/,\s*FOREIGN KEY[^,]+REFERENCES[^,)]+/is', '', $sql);
+                if (count($columnNames) === 1 && in_array($columnNames[0], $autoIncrementColumns, true)) {
+                    continue;
+                }
 
-        // 清理多余的逗号和空格
-        $sql = preg_replace('/,\s*,/', ',', $sql);
-        $sql = preg_replace('/,\s*\)/', ')', $sql);
-        $sql = preg_replace('/\s+/', ' ', $sql);
-        $sql = trim($sql);
+                $primaryKeys[] = sprintf('PRIMARY KEY (%s)', $this->normalizeIndexColumns($columnsString));
+                continue;
+            }
 
-        return $sql;
+            if (preg_match('/^(UNIQUE\s+)?KEY\s+`?([^`(]+)`?\s*\((.+)\)/i', $trimmed, $match)
+                || preg_match('/^(FULLTEXT\s+)?KEY\s+`?([^`(]+)`?\s*\((.+)\)/i', $trimmed, $match)) {
+                $columnsString = $match[3];
+                $normalizedColumns = $this->normalizeIndexColumns($columnsString);
+                $isUnique = stripos($match[1], 'UNIQUE') !== false;
+                $indexName = $this->sanitizeIdentifier($tableName . '_' . $match[2]);
+
+                $indexes[] = sprintf(
+                    'CREATE %sINDEX "%s" ON "%s" (%s);',
+                    $isUnique ? 'UNIQUE ' : '',
+                    $indexName,
+                    $tableName,
+                    $normalizedColumns
+                );
+
+                continue;
+            }
+
+            if (stripos($trimmed, 'CONSTRAINT') === 0 || stripos($trimmed, 'FOREIGN KEY') === 0) {
+                continue;
+            }
+
+            $column = $this->convertColumnDefinition($trimmed);
+
+            if ($column === null) {
+                continue;
+            }
+
+            $columns[] = $column['definition'];
+
+            if ($column['auto_increment']) {
+                $autoIncrementColumns[] = $column['name'];
+                if ($chunkColumn === null) {
+                    $chunkColumn = $column['name'];
+                }
+            }
+
+            if ($firstColumn === null) {
+                $firstColumn = $column['name'];
+            }
+        }
+
+        if ($chunkColumn === null) {
+            foreach ($primaryKeyColumnsList as $pkColumns) {
+                if (count($pkColumns) === 1) {
+                    $chunkColumn = $pkColumns[0];
+                    break;
+                }
+            }
+        }
+
+        if ($chunkColumn === null) {
+            $chunkColumn = $firstColumn;
+        }
+
+        $body = array_merge($columns, $primaryKeys);
+
+        if (empty($body)) {
+            throw new \RuntimeException(sprintf('无法生成 %s 的字段定义', $tableName));
+        }
+
+        $tableSql = sprintf("CREATE TABLE \"%s\" (\n    %s\n);", $tableName, implode(",\n    ", $body));
+
+        return [
+            'table' => $tableSql,
+            'indexes' => $indexes,
+            'meta' => [
+                'chunk_column' => $chunkColumn,
+            ],
+        ];
+    }
+
+    /**
+     * 将 MySQL CREATE VIEW 语句转换为 SQLite 兼容格式
+     *
+     * @param string $mysqlSql
+     * @param string $viewName
+     * @return string
+     */
+    protected function convertCreateViewToSqlite($mysqlSql, $viewName)
+    {
+        $sql = trim($mysqlSql);
+
+        if (!preg_match('/\sAS\s/i', $sql, $match, PREG_OFFSET_CAPTURE)) {
+            throw new \RuntimeException(sprintf('无法解析视图 %s 的定义', $viewName));
+        }
+
+        $start = $match[0][1] + strlen($match[0][0]);
+        $definition = substr($sql, $start);
+
+        if ($definition === false) {
+            throw new \RuntimeException(sprintf('无法解析视图 %s 的 SELECT 语句', $viewName));
+        }
+
+        $definition = trim(rtrim($definition, ';'));
+        $viewIdentifier = str_replace('"', '""', $viewName);
+
+        return sprintf('CREATE VIEW "%s" AS %s', $viewIdentifier, $definition);
+    }
+
+    /**
+     * 将列定义拆分成单独项目
+     */
+    protected function splitDefinitionItems($definitions)
+    {
+        $items = [];
+        $current = '';
+        $depth = 0;
+
+        $length = strlen($definitions);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $definitions[$i];
+
+            if ($char === '(') {
+                $depth++;
+            } elseif ($char === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+            } elseif ($char === ',' && $depth === 0) {
+                $items[] = trim($current);
+                $current = '';
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        if (trim($current) !== '') {
+            $items[] = trim($current);
+        }
+
+        return $items;
+    }
+
+    /**
+     * 将 MySQL 列定义转换为 SQLite
+     */
+    protected function convertColumnDefinition($definition)
+    {
+        if (!preg_match('/^`?([^`\s]+)`?\s+(.+)$/s', $definition, $matches)) {
+            return null;
+        }
+
+        $columnName = $matches[1];
+        $rest = $matches[2];
+
+        $autoIncrement = stripos($rest, 'auto_increment') !== false;
+
+        $rest = $this->convertColumnType($rest);
+        $rest = preg_replace('/\bUNSIGNED\b/i', '', $rest);
+        $rest = preg_replace('/\bZEROFILL\b/i', '', $rest);
+        $rest = preg_replace('/\bCHARACTER SET\s+\w+/i', '', $rest);
+        $rest = preg_replace('/\bCOLLATE\s+\w+/i', '', $rest);
+        $rest = preg_replace('/\bCOMMENT\s+\'.*?\'/i', '', $rest);
+        $rest = preg_replace('/\bON UPDATE\b[^,]+/i', '', $rest);
+        $rest = preg_replace('/\s+DEFAULT\s+NULL/i', ' DEFAULT NULL', $rest);
+        $rest = preg_replace('/\s+DEFAULT\s+\'0000-00-00 00:00:00\'/i', ' DEFAULT NULL', $rest);
+        $rest = preg_replace('/,\s*$/', '', $rest);
+        $rest = preg_replace('/\s+/', ' ', trim($rest));
+
+        if ($autoIncrement) {
+            $rest = preg_replace('/\bAUTO_INCREMENT\b/i', '', $rest);
+            $rest = preg_replace('/\bNOT NULL\b/i', '', $rest);
+            $rest = 'INTEGER PRIMARY KEY AUTOINCREMENT';
+        }
+
+        return [
+            'definition' => sprintf('"%s" %s', $columnName, trim($rest)),
+            'auto_increment' => $autoIncrement,
+            'name' => $columnName,
+        ];
+    }
+
+    /**
+     * 转换 MySQL 数据类型到 SQLite
+     */
+    protected function convertColumnType($definition)
+    {
+        $map = [
+            '/\bTINYINT\(\d+\)\b/i' => 'INTEGER',
+            '/\bSMALLINT\(\d+\)\b/i' => 'INTEGER',
+            '/\bMEDIUMINT\(\d+\)\b/i' => 'INTEGER',
+            '/\bBIGINT\(\d+\)\b/i' => 'INTEGER',
+            '/\bINT\(\d+\)\b/i' => 'INTEGER',
+            '/\bBIGINT\b/i' => 'INTEGER',
+            '/\bINT\b/i' => 'INTEGER',
+            '/\bDOUBLE\b/i' => 'REAL',
+            '/\bFLOAT\b/i' => 'REAL',
+            '/\bDECIMAL\([^)]*\)/i' => 'NUMERIC',
+            '/\bNUMERIC\([^)]*\)/i' => 'NUMERIC',
+            '/\bVARBINARY\(\d+\)\b/i' => 'BLOB',
+            '/\bBINARY\(\d+\)\b/i' => 'BLOB',
+            '/\bLONGTEXT\b/i' => 'TEXT',
+            '/\bMEDIUMTEXT\b/i' => 'TEXT',
+            '/\bTINYTEXT\b/i' => 'TEXT',
+            '/\bTEXT\b/i' => 'TEXT',
+            '/\bVARCHAR\(\d+\)\b/i' => 'TEXT',
+            '/\bCHAR\(\d+\)\b/i' => 'TEXT',
+            '/\bDATETIME\b/i' => 'TEXT',
+            '/\bTIMESTAMP\b/i' => 'TEXT',
+            '/\bDATE\b/i' => 'TEXT',
+            '/\bTIME\b/i' => 'TEXT',
+            '/\bENUM\([^)]+\)/i' => 'TEXT',
+            '/\bSET\([^)]+\)/i' => 'TEXT',
+        ];
+
+        foreach ($map as $pattern => $replacement) {
+            $definition = preg_replace($pattern, $replacement, $definition);
+        }
+
+        return $definition;
+    }
+
+    /**
+     * 获取索引列定义
+     */
+    protected function extractColumnsFromDefinition($definition)
+    {
+        if (preg_match('/\((.+)\)/s', $definition, $matches)) {
+            return $matches[1];
+        }
+
+        return '';
+    }
+
+    /**
+     * 转换索引列为 SQLite 兼容格式
+     */
+    protected function normalizeIndexColumns($columnsString)
+    {
+        $columns = $this->extractColumnNames($columnsString);
+
+        $quoted = array_map(function ($column) {
+            return sprintf('"%s"', $column);
+        }, $columns);
+
+        return implode(', ', $quoted);
+    }
+
+    /**
+     * 解析索引列名称
+     */
+    protected function extractColumnNames($columnsString)
+    {
+        $parts = preg_split('/\s*,\s*/', $columnsString);
+        $columns = [];
+
+        foreach ($parts as $part) {
+            $column = trim($part);
+            $column = preg_replace('/`([^`]+)`/', '$1', $column);
+            $column = preg_replace('/"([^"]+)"/', '$1', $column);
+            $column = preg_replace('/\(\d+\)/', '', $column);
+            $column = preg_replace('/\s+(ASC|DESC)$/i', '', $column);
+
+            if ($column !== '') {
+                $columns[] = $column;
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * 清理索引名称
+     */
+    protected function sanitizeIdentifier($identifier)
+    {
+        $clean = preg_replace('/[^A-Za-z0-9_]+/', '_', $identifier);
+        return trim($clean, '_');
     }
 
     /**
@@ -317,39 +640,97 @@ class ExportMysqlToSqlite extends Command
      * @param string $tableName
      * @return void
      */
-    protected function exportTableData($tableName)
+    protected function exportTableData($tableName, $rowCount = 0)
     {
-        $batchSize = (int) $this->option('batch');
+        $metadata = $this->tableMetadata[$tableName] ?? [];
+        $chunkColumn = $metadata['chunk_column'] ?? null;
+        $insertBatchSize = $this->getSqliteInsertBatchSize();
+        $buffer = [];
 
-        // 获取总行数
-        $totalRows = DB::connection($this->sourceConnection)
-            ->table($tableName)
-            ->count();
+        $query = DB::connection($this->sourceConnection)
+            ->table($tableName);
 
-        if ($totalRows === 0) {
-            return;
+        if ($chunkColumn) {
+            $query->orderBy($chunkColumn);
         }
 
         // 禁用外键约束
         DB::connection('sqlite_export')->statement('PRAGMA foreign_keys = OFF');
 
-        // 分批导出数据
-        DB::connection($this->sourceConnection)
-            ->table($tableName)
-            ->orderBy(DB::raw('1')) // 使用常量排序避免表没有主键的情况
-            ->chunk($batchSize, function ($rows) use ($tableName) {
-                $data = json_decode(json_encode($rows), true);
+        $dataBar = null;
+        if ($rowCount > 0) {
+            $this->output->newLine();
+            $dataBar = $this->output->createProgressBar($rowCount);
+            $dataBar->setBarCharacter('▓');
+            $dataBar->setEmptyBarCharacter('░');
+            $dataBar->setFormat('  %current%/%max% 行 (%percent:3s%%)');
+            $dataBar->start();
+        }
 
-                // 批量插入到 SQLite
-                DB::connection('sqlite_export')
-                    ->table($tableName)
-                    ->insert($data);
+        foreach ($query->cursor() as $row) {
+            $buffer[] = (array) $row;
 
-                $this->stats['rows'] += count($data);
-            });
+            if (count($buffer) >= $insertBatchSize) {
+                $count = count($buffer);
+                $this->insertRowsIntoSqlite($tableName, $buffer);
+                $this->stats['rows'] += $count;
+                if ($dataBar) {
+                    $dataBar->advance($count);
+                }
+                $buffer = [];
+            }
+        }
+
+        if (!empty($buffer)) {
+            $count = count($buffer);
+            $this->insertRowsIntoSqlite($tableName, $buffer);
+            $this->stats['rows'] += $count;
+            if ($dataBar) {
+                $dataBar->advance($count);
+            }
+        }
+
+        if ($dataBar) {
+            $dataBar->finish();
+            $this->output->newLine(2);
+        }
 
         // 重新启用外键约束
         DB::connection('sqlite_export')->statement('PRAGMA foreign_keys = ON');
+    }
+
+    /**
+     * 批量寫入資料到 SQLite
+     */
+    protected function insertRowsIntoSqlite($tableName, array $rows)
+    {
+        DB::connection('sqlite_export')
+            ->table($tableName)
+            ->insert($rows);
+    }
+
+    /**
+     * 计算数据表的总行数
+     */
+    protected function getTableRowCount($tableName)
+    {
+        try {
+            return (int) DB::connection($this->sourceConnection)
+                ->table($tableName)
+                ->count();
+        } catch (\Exception $e) {
+            $this->warn(sprintf('⚠ 无法统计表 %s 行数: %s', $tableName, $e->getMessage()));
+            return 0;
+        }
+    }
+
+    /**
+     * 取得 SQLite 插入批次大小。SQLite 允許的 compound SELECT 條件數為 500，
+     * 但保守使用 400 以避免觸發 "too many terms" 錯誤。
+     */
+    protected function getSqliteInsertBatchSize()
+    {
+        return 400;
     }
 
     /**
@@ -370,14 +751,14 @@ class ExportMysqlToSqlite extends Command
             $this->warn(sprintf('⚠ 遇到 %d 个错误', $this->stats['errors']));
         }
 
-        $this->newLine();
+        $this->output->newLine();
         $this->info(sprintf('SQLite 数据库路径: %s', base_path($this->outputPath)));
 
         // 显示文件大小
         $fileSize = filesize(base_path($this->outputPath));
         $this->info(sprintf('文件大小: %s', $this->formatBytes($fileSize)));
 
-        $this->newLine();
+        $this->output->newLine();
         $this->info('下一步:');
         $this->line('  1. 更新 .env 文件:');
         $this->line('     DB_CONNECTION=sqlite');

--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ExportMysqlToSqlite extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:export-to-sqlite
+                            {--output=database/database.sqlite : SQLite 数据库文件路径}
+                            {--schema-only : 只导出结构，不导出数据}
+                            {--tables= : 只导出指定的表（逗号分隔）}
+                            {--batch=1000 : 批量插入的行数}
+                            {--source=mysql : 源数据库连接名称}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '从 MySQL 导出数据到 SQLite';
+
+    /**
+     * 源数据库连接
+     *
+     * @var string
+     */
+    protected $sourceConnection;
+
+    /**
+     * 目标 SQLite 数据库路径
+     *
+     * @var string
+     */
+    protected $outputPath;
+
+    /**
+     * 统计信息
+     *
+     * @var array
+     */
+    protected $stats = [
+        'tables' => 0,
+        'rows' => 0,
+        'errors' => 0,
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->sourceConnection = $this->option('source');
+        $this->outputPath = $this->option('output');
+
+        // 验证源数据库连接
+        if (!$this->validateSourceConnection()) {
+            return 1;
+        }
+
+        // 准备 SQLite 数据库
+        if (!$this->prepareSqliteDatabase()) {
+            return 1;
+        }
+
+        // 获取要导出的表
+        $tables = $this->getTablesToExport();
+
+        if (empty($tables)) {
+            $this->error('没有找到要导出的表');
+            return 1;
+        }
+
+        $this->info(sprintf('准备导出 %d 个表...', count($tables)));
+        $this->newLine();
+
+        // 导出表结构和数据
+        $bar = $this->output->createProgressBar(count($tables));
+        $bar->start();
+
+        foreach ($tables as $table) {
+            try {
+                $this->exportTable($table);
+                $bar->advance();
+            } catch (\Exception $e) {
+                $this->stats['errors']++;
+                $this->newLine();
+                $this->error(sprintf('导出表 %s 失败: %s', $table, $e->getMessage()));
+                $bar->advance();
+            }
+        }
+
+        $bar->finish();
+        $this->newLine(2);
+
+        // 显示统计信息
+        $this->displayStats();
+
+        return 0;
+    }
+
+    /**
+     * 验证源数据库连接
+     *
+     * @return bool
+     */
+    protected function validateSourceConnection()
+    {
+        try {
+            $driver = DB::connection($this->sourceConnection)->getDriverName();
+
+            if ($driver !== 'mysql') {
+                $this->error(sprintf('源数据库必须是 MySQL，当前是: %s', $driver));
+                return false;
+            }
+
+            // 测试连接
+            DB::connection($this->sourceConnection)->getPdo();
+
+            $this->info(sprintf('✓ 源数据库连接正常 (%s)', $this->sourceConnection));
+
+            return true;
+        } catch (\Exception $e) {
+            $this->error(sprintf('无法连接到源数据库: %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    /**
+     * 准备 SQLite 数据库
+     *
+     * @return bool
+     */
+    protected function prepareSqliteDatabase()
+    {
+        $absolutePath = base_path($this->outputPath);
+        $directory = dirname($absolutePath);
+
+        // 确保目录存在
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0755, true)) {
+                $this->error(sprintf('无法创建目录: %s', $directory));
+                return false;
+            }
+        }
+
+        // 如果文件已存在，询问是否覆盖
+        if (file_exists($absolutePath)) {
+            if (!$this->confirm(sprintf('文件 %s 已存在，是否覆盖？', $this->outputPath), false)) {
+                $this->info('操作已取消');
+                return false;
+            }
+
+            unlink($absolutePath);
+        }
+
+        // 创建空的 SQLite 数据库文件
+        touch($absolutePath);
+
+        // 配置临时的 SQLite 连接
+        config([
+            'database.connections.sqlite_export' => [
+                'driver' => 'sqlite',
+                'database' => $absolutePath,
+                'prefix' => '',
+                'foreign_key_constraints' => false, // 导出时先禁用外键
+            ]
+        ]);
+
+        try {
+            DB::connection('sqlite_export')->getPdo();
+            $this->info(sprintf('✓ SQLite 数据库已创建: %s', $this->outputPath));
+            return true;
+        } catch (\Exception $e) {
+            $this->error(sprintf('无法创建 SQLite 数据库: %s', $e->getMessage()));
+            return false;
+        }
+    }
+
+    /**
+     * 获取要导出的表列表
+     *
+     * @return array
+     */
+    protected function getTablesToExport()
+    {
+        $specifiedTables = $this->option('tables');
+
+        if ($specifiedTables) {
+            return array_map('trim', explode(',', $specifiedTables));
+        }
+
+        // 获取所有表
+        $tables = DB::connection($this->sourceConnection)
+            ->select('SHOW TABLES');
+
+        $databaseName = DB::connection($this->sourceConnection)->getDatabaseName();
+        $tableKey = 'Tables_in_' . $databaseName;
+
+        return array_map(function ($table) use ($tableKey) {
+            return $table->$tableKey;
+        }, $tables);
+    }
+
+    /**
+     * 导出单个表
+     *
+     * @param string $tableName
+     * @return void
+     */
+    protected function exportTable($tableName)
+    {
+        // 1. 导出表结构
+        $this->exportTableSchema($tableName);
+
+        // 2. 导出数据（如果不是 schema-only 模式）
+        if (!$this->option('schema-only')) {
+            $this->exportTableData($tableName);
+        }
+
+        $this->stats['tables']++;
+    }
+
+    /**
+     * 导出表结构
+     *
+     * @param string $tableName
+     * @return void
+     */
+    protected function exportTableSchema($tableName)
+    {
+        // 获取 MySQL 的 CREATE TABLE 语句
+        $createTableResult = DB::connection($this->sourceConnection)
+            ->select("SHOW CREATE TABLE `{$tableName}`");
+
+        $createTableSql = $createTableResult[0]->{'Create Table'};
+
+        // 转换为 SQLite 兼容的 SQL
+        $sqliteCreateSql = $this->convertCreateTableToSqlite($createTableSql, $tableName);
+
+        // 在 SQLite 中执行
+        DB::connection('sqlite_export')->statement($sqliteCreateSql);
+    }
+
+    /**
+     * 将 MySQL CREATE TABLE 语句转换为 SQLite 兼容格式
+     *
+     * @param string $mysqlSql
+     * @param string $tableName
+     * @return string
+     */
+    protected function convertCreateTableToSqlite($mysqlSql, $tableName)
+    {
+        // 移除 MySQL 特定的选项
+        $sql = preg_replace('/ENGINE=\w+/i', '', $mysqlSql);
+        $sql = preg_replace('/DEFAULT CHARSET=\w+/i', '', $sql);
+        $sql = preg_replace('/COLLATE=\w+/i', '', $sql);
+        $sql = preg_replace('/ROW_FORMAT=\w+/i', '', $sql);
+        $sql = preg_replace('/AUTO_INCREMENT=\d+/i', '', $sql);
+        $sql = preg_replace('/COMMENT\s*=\s*\'[^\']*\'/i', '', $sql);
+
+        // 转换数据类型
+        $sql = preg_replace('/\s+unsigned/i', '', $sql);
+        $sql = preg_replace('/VARBINARY\(\d+\)/i', 'BLOB', $sql);
+        $sql = preg_replace('/TINYINT\(\d+\)/i', 'INTEGER', $sql);
+        $sql = preg_replace('/SMALLINT\(\d+\)/i', 'INTEGER', $sql);
+        $sql = preg_replace('/MEDIUMINT\(\d+\)/i', 'INTEGER', $sql);
+        $sql = preg_replace('/BIGINT\(\d+\)/i', 'INTEGER', $sql);
+        $sql = preg_replace('/INT\(\d+\)/i', 'INTEGER', $sql);
+        $sql = preg_replace('/DOUBLE/i', 'REAL', $sql);
+        $sql = preg_replace('/DATETIME/i', 'TEXT', $sql);
+        $sql = preg_replace('/TIMESTAMP/i', 'TEXT', $sql);
+        $sql = preg_replace('/ENUM\([^)]+\)/i', 'TEXT', $sql);
+
+        // 转换 VARCHAR/CHAR 为 TEXT（SQLite 没有长度限制）
+        $sql = preg_replace('/VARCHAR\(\d+\)/i', 'TEXT', $sql);
+        $sql = preg_replace('/CHAR\(\d+\)/i', 'TEXT', $sql);
+
+        // 移除 CHARACTER SET 和 COLLATE 子句
+        $sql = preg_replace('/CHARACTER SET \w+/i', '', $sql);
+        $sql = preg_replace('/COLLATE \w+/i', '', $sql);
+
+        // 移除列级 COMMENT
+        $sql = preg_replace('/COMMENT \'[^\']*\'/i', '', $sql);
+
+        // 处理 AUTO_INCREMENT（转换为 AUTOINCREMENT）
+        $sql = preg_replace('/AUTO_INCREMENT/i', 'AUTOINCREMENT', $sql);
+
+        // 移除 USING BTREE/HASH
+        $sql = preg_replace('/USING (BTREE|HASH)/i', '', $sql);
+
+        // 移除外键约束（稍后单独处理）
+        $sql = preg_replace('/,\s*CONSTRAINT[^,]+FOREIGN KEY[^,]+REFERENCES[^,)]+/is', '', $sql);
+        $sql = preg_replace('/,\s*FOREIGN KEY[^,]+REFERENCES[^,)]+/is', '', $sql);
+
+        // 清理多余的逗号和空格
+        $sql = preg_replace('/,\s*,/', ',', $sql);
+        $sql = preg_replace('/,\s*\)/', ')', $sql);
+        $sql = preg_replace('/\s+/', ' ', $sql);
+        $sql = trim($sql);
+
+        return $sql;
+    }
+
+    /**
+     * 导出表数据
+     *
+     * @param string $tableName
+     * @return void
+     */
+    protected function exportTableData($tableName)
+    {
+        $batchSize = (int) $this->option('batch');
+
+        // 获取总行数
+        $totalRows = DB::connection($this->sourceConnection)
+            ->table($tableName)
+            ->count();
+
+        if ($totalRows === 0) {
+            return;
+        }
+
+        // 禁用外键约束
+        DB::connection('sqlite_export')->statement('PRAGMA foreign_keys = OFF');
+
+        // 分批导出数据
+        DB::connection($this->sourceConnection)
+            ->table($tableName)
+            ->orderBy(DB::raw('1')) // 使用常量排序避免表没有主键的情况
+            ->chunk($batchSize, function ($rows) use ($tableName) {
+                $data = json_decode(json_encode($rows), true);
+
+                // 批量插入到 SQLite
+                DB::connection('sqlite_export')
+                    ->table($tableName)
+                    ->insert($data);
+
+                $this->stats['rows'] += count($data);
+            });
+
+        // 重新启用外键约束
+        DB::connection('sqlite_export')->statement('PRAGMA foreign_keys = ON');
+    }
+
+    /**
+     * 显示统计信息
+     *
+     * @return void
+     */
+    protected function displayStats()
+    {
+        $this->info('=== 导出完成 ===');
+        $this->info(sprintf('✓ 成功导出 %d 个表', $this->stats['tables']));
+
+        if (!$this->option('schema-only')) {
+            $this->info(sprintf('✓ 共导出 %s 行数据', number_format($this->stats['rows'])));
+        }
+
+        if ($this->stats['errors'] > 0) {
+            $this->warn(sprintf('⚠ 遇到 %d 个错误', $this->stats['errors']));
+        }
+
+        $this->newLine();
+        $this->info(sprintf('SQLite 数据库路径: %s', base_path($this->outputPath)));
+
+        // 显示文件大小
+        $fileSize = filesize(base_path($this->outputPath));
+        $this->info(sprintf('文件大小: %s', $this->formatBytes($fileSize)));
+
+        $this->newLine();
+        $this->info('下一步:');
+        $this->line('  1. 更新 .env 文件:');
+        $this->line('     DB_CONNECTION=sqlite');
+        $this->line(sprintf('     DB_DATABASE=%s', base_path($this->outputPath)));
+        $this->line('  2. 测试应用: php artisan serve');
+    }
+
+    /**
+     * 格式化字节数
+     *
+     * @param int $bytes
+     * @return string
+     */
+    protected function formatBytes($bytes)
+    {
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $unitIndex = 0;
+
+        while ($bytes >= 1024 && $unitIndex < count($units) - 1) {
+            $bytes /= 1024;
+            $unitIndex++;
+        }
+
+        return sprintf('%.2f %s', $bytes, $units[$unitIndex]);
+    }
+}

--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -17,7 +17,9 @@ class ExportMysqlToSqlite extends Command
                             {--schema-only : 只导出结构，不导出数据}
                             {--tables= : 只导出指定的表（逗号分隔）}
                             {--batch=1000 : 批量插入的行数}
-                            {--source=mysql : 源数据库连接名称}';
+                            {--source=mysql : 源数据库连接名称}
+                            {--with-indexes : 包含索引定义（默认跳过）}
+                            {--with-internal : 包含 CBDB__ 开头的内部表（默认跳过）}';
 
     /**
      * The console command description.
@@ -232,6 +234,13 @@ class ExportMysqlToSqlite extends Command
             return $filtered;
         }
 
+        // 过滤掉 CBDB__ 开头的内部表（除非用户明确指定 --with-internal）
+        if (!$this->option('with-internal')) {
+            $result = array_filter($result, function ($table) {
+                return strpos($table['name'], 'CBDB__') !== 0;
+            });
+        }
+
         return array_values($result);
     }
 
@@ -424,9 +433,12 @@ class ExportMysqlToSqlite extends Command
 
         $tableSql = sprintf("CREATE TABLE \"%s\" (\n    %s\n);", $tableName, implode(",\n    ", $body));
 
+        // 根据 --with-indexes 选项决定是否包含索引
+        $exportIndexes = $this->option('with-indexes') ? $indexes : [];
+
         return [
             'table' => $tableSql,
-            'indexes' => $indexes,
+            'indexes' => $exportIndexes,
             'meta' => [
                 'chunk_column' => $chunkColumn,
             ],

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\WikiTaskManager::class,
         \App\Console\Commands\ImportTradSimpMap::class,
         \App\Console\Commands\RebuildNameSearchIndex::class,
+        \App\Console\Commands\ExportMysqlToSqlite::class,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
             "App\\": "app/"
         },
         "files": [
-            "app/helpers.php"
+            "app/helpers.php",
+            "database/migrations/helpers.php"
         ]
     },
     "autoload-dev": {

--- a/database/migrations/helpers.php
+++ b/database/migrations/helpers.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * 数据库兼容性辅助函数
+ *
+ * 这些函数用于编写兼容 MySQL 和 SQLite 的迁移文件
+ */
+
+use Illuminate\Support\Facades\DB;
+
+if (!function_exists('disable_foreign_keys')) {
+    /**
+     * 禁用外键约束检查（兼容 MySQL 和 SQLite）
+     *
+     * @return void
+     */
+    function disable_foreign_keys()
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        } elseif ($driver === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys = OFF');
+        }
+    }
+}
+
+if (!function_exists('enable_foreign_keys')) {
+    /**
+     * 启用外键约束检查（兼容 MySQL 和 SQLite）
+     *
+     * @return void
+     */
+    function enable_foreign_keys()
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        } elseif ($driver === 'sqlite') {
+            DB::statement('PRAGMA foreign_keys = ON');
+        }
+    }
+}
+
+if (!function_exists('get_current_timestamp_sql')) {
+    /**
+     * 获取当前时间戳的 SQL 表达式（兼容 MySQL 和 SQLite）
+     *
+     * @return string
+     */
+    function get_current_timestamp_sql()
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql') {
+            return 'NOW()';
+        } elseif ($driver === 'sqlite') {
+            return "datetime('now')";
+        }
+
+        return 'CURRENT_TIMESTAMP';
+    }
+}
+
+if (!function_exists('is_mysql')) {
+    /**
+     * 检查当前数据库是否为 MySQL
+     *
+     * @return bool
+     */
+    function is_mysql()
+    {
+        return DB::getDriverName() === 'mysql';
+    }
+}
+
+if (!function_exists('is_sqlite')) {
+    /**
+     * 检查当前数据库是否为 SQLite
+     *
+     * @return bool
+     */
+    function is_sqlite()
+    {
+        return DB::getDriverName() === 'sqlite';
+    }
+}

--- a/scripts/use-mysql.sh
+++ b/scripts/use-mysql.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "🔄 切换到 MySQL 数据库..."
+
+# 更新 .env 配置
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
+    sed -i '' 's|DB_DATABASE=.*|DB_DATABASE=homestead|' .env
+else
+    # Linux
+    sed -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
+    sed -i 's|DB_DATABASE=.*|DB_DATABASE=homestead|' .env
+fi
+
+echo "✅ 已切换到 MySQL"
+echo ""
+echo "⚠️  请确保 MySQL 服务正在运行"
+echo ""
+echo "📋 如需创建数据库："
+echo "   mysql -u root -p -e \"CREATE DATABASE homestead CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\""

--- a/scripts/use-sqlite.sh
+++ b/scripts/use-sqlite.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "🔄 切换到 SQLite 数据库..."
+
+# 备份当前 .env
+if [ -f .env ]; then
+    cp .env .env.backup.$(date +%Y%m%d_%H%M%S)
+    echo "✅ 已备份当前配置"
+fi
+
+# 创建 SQLite 数据库文件（如果不存在）
+DB_PATH="database/database.sqlite"
+if [ ! -f "$DB_PATH" ]; then
+    touch "$DB_PATH"
+    echo "✅ 已创建 SQLite 数据库文件"
+fi
+
+# 更新 .env 配置
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' 's/DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
+    sed -i '' "s|DB_DATABASE=.*|DB_DATABASE=$(pwd)/$DB_PATH|" .env
+else
+    # Linux
+    sed -i 's/DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
+    sed -i "s|DB_DATABASE=.*|DB_DATABASE=$(pwd)/$DB_PATH|" .env
+fi
+
+echo ""
+echo "✅ 已切换到 SQLite！"
+echo ""
+echo "📋 下一步："
+echo "   1. 从 MySQL 导出数据: php artisan db:export-to-sqlite"
+echo "   2. 或者运行全新迁移: php artisan migrate:fresh"
+echo "   3. 启动服务: php artisan serve"


### PR DESCRIPTION
```
$ php artisan db:export-to-sqlite --help
Description:
  从 MySQL 导出数据到 SQLite

Usage:
  db:export-to-sqlite [options]

Options:
      --output[=OUTPUT]  SQLite 数据库文件路径 [default: "database/database.sqlite"]
      --schema-only      只导出结构，不导出数据
      --tables[=TABLES]  只导出指定的表（逗号分隔）
      --batch[=BATCH]    批量插入的行数 [default: "1000"]
      --source[=SOURCE]  源数据库连接名称 [default: "mysql"]
  -h, --help             Display this help message
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi             Force ANSI output
      --no-ansi          Disable ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --env[=ENV]        The environment the command should run under
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

使用范例：
```
$ php artisan db:export-to-sqlite --schema-only --output=database/schema.sqlite3
$ php artisan db:export-to-sqlite --tables=BIOG_MAIN --output=database/biog_main.sqlite3
$ php artisan db:export-to-sqlite --output=database/export.sqlite3
```