### PR TITLE
新增 ADMIN_CAT_CODES 的完整欄位配置

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -89,6 +89,13 @@ class CodesController extends Controller
             'belongs5_ID',
             'belongs5_Name',
         ],
+        'ADMIN_CAT_CODES' => [
+            'c_admin_cat_code',
+            'c_admin_cat_py',
+            'c_admin_cat_hz',
+            'c_admin_cat_trans',
+            'c_notes',
+        ],
         'DYNASTIES' => ['c_dy', 'c_dynasty_chn', 'c_dynasty', 'c_start', 'c_end'],
         'TEXT_INSTANCE_DATA' => [
             'c_textid',


### PR DESCRIPTION
在 CodesController 的 tableColumnOverrides 中添加 ADMIN_CAT_CODES 表的所有欄位：
- c_admin_cat_code（行政類別代碼）
- c_admin_cat_py（拼音）
- c_admin_cat_hz（漢字）
- c_admin_cat_trans（翻譯）
- c_notes（備註）

現在 /codes/ADMIN_CAT_CODES 頁面將顯示所有相關欄位。

<img width="1454" height="352" alt="image" src="https://github.com/user-attachments/assets/70a72b5a-5dd5-4c43-af13-bcb19f7a3d2a" />