### PR TITLE
修復 BasicInformationOfficesController 中的 Arr 類缺失問題

### DIFF
--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -9,6 +9,7 @@ use App\Repositories\ToolsRepository;
 use App\SocialInst;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -208,7 +209,7 @@ class BasicInformationOfficesController extends Controller
         }
         $data = $res2;
         $c_addr = $data2;
-        $data = array_except($data, ['_token', 'c_addr']);
+        $data = Arr::except($data, ['_token', 'c_addr']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
         $data['c_posting_id'] = DB::table('POSTED_TO_OFFICE_DATA')->max('c_posting_id') + 1;


### PR DESCRIPTION
修復內容：
1. 添加 use Illuminate\Support\Arr; import 語句 https://github.com/cbdb-project/cbdb-online-main-server/issues/498
2. 將廢棄的 array_except() 改為 Arr::except()（第 212 行）
3. 修復 Arr::has() 的缺失 import 問題（第 276 行）

錯誤訊息：Class 'App\Http\Controllers\Arr' not found
根本原因：Laravel 6.0 廢棄了全局陣列輔助函數，需要使用 Illuminate\Support\Arr 類

🤖 Generated with [Claude Code](https://claude.com/claude-code)