### PR TITLE
修復 Laravel 8 升級後分頁按鈕樣式問題

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Services\QueryProfile;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -29,6 +30,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // 使用 Bootstrap 分页样式（Laravel 8 默认为 Tailwind）
+        Paginator::useBootstrap();
+
         $profiler = $this->app->make(QueryProfile::class);
 
         DB::listen(function (QueryExecuted $query) use ($profiler) {


### PR DESCRIPTION
Laravel 8 將分頁器預設樣式從 Bootstrap 改為 Tailwind CSS，
但本專案使用 Bootstrap 3 + AdminLTE，因此需在 AppServiceProvider 中明確指定使用 Bootstrap 分頁樣式，以恢復原有的翻頁按鈕顯示。