### PR TITLE
在 User 模型中新增角色和狀態常量定義及輔助方法

### DIFF
--- a/USER_PRIVILEGES.md
+++ b/USER_PRIVILEGES.md
@@ -16,13 +16,16 @@
 ---
 
 ## 二、帳號角色（`users.is_admin`）
-| 值 | 名稱 / 定位 | 主要行為 |
-|----|-------------|-----------|
-| `0` | 一般用戶 | 只要 `is_active = 1` 即可直接對 `/basicinformation/*`、`/codes/*` 等模組進行新增 / 修改，Controller 會直接呼叫對應的 Repository → Model，寫入資料表並留下操作紀錄。 |
-| `1` | 專家用戶（管理員） | 擁有一般用戶權限；另外可：<br>• 進入 `/manage` 調整帳號啟用 / 角色。<br>• 在 `/operations`、`/modified` 審核提案（核准 / 退修）、執行操作復原。<br>• 存取 `/merge-preview` 等管理工具。 |
-| `2` | 眾包用戶 | 前台頁面可編輯，但 Controller 會偵測 `is_admin == 2`，把提交內容轉成 `operations`（`crowdsourcing_status = 2`），等待專家審核後套用，並不直接寫主資料表。 |
+| 值 | 名稱 / 定位 | 常量定義 | 主要行為 |
+|----|-------------|---------|-----------|
+| `0` | 一般用戶 | `User::ROLE_REGULAR` | 只要 `is_active = 1` 即可直接對 `/basicinformation/*`、`/codes/*` 等模組進行新增 / 修改，Controller 會直接呼叫對應的 Repository → Model，寫入資料表並留下操作紀錄。 |
+| `1` | 專家用戶 | `User::ROLE_EXPERT` | 擁有一般用戶權限；另外可：<br>• 進入 `/manage` 調整帳號啟用 / 角色。<br>• 在 `/operations`、`/modified` 審核提案（核准 / 退修）、執行操作復原。<br>• 存取 `/merge-preview` 等管理工具。 |
+| `2` | 眾包用戶 | `User::ROLE_CROWDSOURCING` | 前台頁面可編輯，但 Controller 會偵測 `is_admin == 2`，把提交內容轉成 `operations`（`crowdsourcing_status = 2`），等待專家審核後套用，並不直接寫主資料表。 |
+| `3` | 系統管理員（預留） | `User::ROLE_SUPER_ADMIN` | 預留角色，擁有比專家更高階的權限，需配合程式實作後啟用。 |
 
-> 角色切換邏輯在 `ManagementController@edit(type=2)`：`1 → 2 → 0 → 1` 循環。若未來新增層級，需同步調整此處與各 Controller 的 `is_admin` 判斷。
+> **角色切換邏輯**：在 `ManagementController@edit(type=2)` 中實現循環切換：`1 → 2 → 0 → 1`。若要包含系統管理員，需調整為 `1 → 2 → 0 → 3 → 1`。
+>
+> **常量使用**：`User` 模型已定義角色和狀態常量（參見 `app/User.php`），建議在新代碼中使用常量而非魔術數字。
 
 ---
 
@@ -40,15 +43,92 @@
 
 ---
 
-## 四、新增「系統管理員」的建議
+## 四、User 模型輔助方法
 
-若未來需要比「專家」更高階的權限，可新增一個新的 `is_admin` 層級（例如值 3），但需注意：
+`User` 模型（`app/User.php`）提供以下輔助方法簡化權限檢查：
 
-1. **資料庫 / 角色輪換**：更新 migration / seeder，並調整 `ManagementController@edit` 的角色切換邏輯，避免新層級被排除或輪轉錯亂。
-2. **授權判斷**：所有以 `is_admin == 1` 判斷管理權限的程式需要改為 `in_array(Auth::user()->is_admin, [...])` 或抽象成常數，以便新層級具備管理權限。
-3. **UI 與操作流程**：像 `/manage` 的角色顯示、按鈕、以及新層級專屬的操作或頁面都要同步更新。
+### 角色檢查方法
+- `isActive(): bool` - 檢查用戶是否為活跃狀態（`is_active == 1`）
+- `isAdmin(): bool` - 檢查用戶是否為專家或系統管理員（`is_admin` 為 1 或 3）
+- `isExpert(): bool` - 檢查用戶是否為專家用戶（`is_admin == 1`）
+- `isSuperAdmin(): bool` - 檢查用戶是否為系統管理員（`is_admin == 3`）
+- `isCrowdsourcingUser(): bool` - 檢查用戶是否為眾包用戶（`is_admin == 2`）
+- `isRegularUser(): bool` - 檢查用戶是否為一般用戶（`is_admin == 0`）
 
-目前專家 (`is_admin = 1`) 已能涵蓋帳號管理與資料審核職責；如需擴充，請先完整規劃授權矩陣再實作。
+### 權限檢查方法
+- `canManageUsers(): bool` - 檢查是否可管理用戶（活躍的專家或系統管理員）
+- `canRestoreOperations(): bool` - 檢查是否可執行操作復原（活躍的專家或系統管理員）
+- `canWriteDirectly(): bool` - 檢查是否可直接寫入數據（活躍且非眾包用戶）
+
+### 其他輔助方法
+- `getRoleName(): string` - 獲取用戶角色中文名稱（「一般」、「專家」、「眾包」、「系統管理員」）
+
+### 使用示例
+
+```php
+// 舊寫法（魔術數字）
+if (Auth::user()->is_active == 1 && Auth::user()->is_admin == 1) {
+    // ...
+}
+
+// 新寫法（使用常量）
+if (Auth::user()->is_active == User::STATUS_ACTIVE && Auth::user()->is_admin == User::ROLE_EXPERT) {
+    // ...
+}
+
+// 推薦寫法（使用輔助方法）
+if (Auth::user()->canManageUsers()) {
+    // ...
+}
+```
+
+---
+
+## 五、新增「系統管理員」的實施指南
+
+系統已預留系統管理員角色（`User::ROLE_SUPER_ADMIN = 3`），若要啟用需完成以下步驟：
+
+### 1. 調整角色切換邏輯
+修改 `ManagementController@edit(type=2)` 的角色切換邏輯：
+
+```php
+// 當前：1 → 2 → 0 → 1
+// 修改為：1 → 2 → 0 → 3 → 1
+if($user->is_admin == 1) { $user->is_admin = 2; }
+elseif($user->is_admin == 2) { $user->is_admin = 0; }
+elseif($user->is_admin == 0) { $user->is_admin = 3; }
+elseif($user->is_admin == 3) { $user->is_admin = 1; }
+```
+
+### 2. 更新 UI 顯示
+修改 `resources/views/manage/index.blade.php` 的角色顯示：
+
+```php
+{{
+    $user->is_admin == 3 ? '系統管理員' :
+    ($user->is_admin == 2 ? '眾包' :
+    ($user->is_admin == 1 ? '專家' : '一般'))
+}}
+
+// 或使用輔助方法（推薦）
+{{ $user->getRoleName() }}
+```
+
+### 3. 定義系統管理員專屬權限（可選）
+若系統管理員需要比專家更高的權限，需在相關 Controller 中添加判斷：
+
+```php
+// 僅限系統管理員
+if (!Auth::user()->isSuperAdmin()) {
+    flash('該功能僅限系統管理員使用。', 'error');
+    return redirect()->back();
+}
+```
+
+### 4. 測試覆蓋
+為新角色補充測試用例，確保權限檢查正確。
+
+**注意**：目前多數功能使用 `is_admin == 1` 檢查，若要讓系統管理員也擁有相同權限，應改用 `isAdmin()` 方法（已包含專家和系統管理員）。
 
 ---
 

--- a/app/User.php
+++ b/app/User.php
@@ -10,6 +10,17 @@ class User extends Authenticatable
 {
     use HasApiTokens, Notifiable;
 
+    // 帐号启用状态常量
+    const STATUS_INACTIVE = 0;
+    const STATUS_ACTIVE = 1;
+    const STATUS_RESERVED = 2;
+
+    // 帐号角色常量
+    const ROLE_REGULAR = 0;
+    const ROLE_EXPERT = 1;
+    const ROLE_CROWDSOURCING = 2;
+    const ROLE_SUPER_ADMIN = 3;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -36,7 +47,119 @@ class User extends Authenticatable
 
     protected $casts = [
         'settings' => 'array',
+        'is_active' => 'integer',
+        'is_admin' => 'integer',
     ];
+
+    /**
+     * 检查用户是否为活跃状态
+     *
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->is_active === self::STATUS_ACTIVE;
+    }
+
+    /**
+     * 检查用户是否为专家或系统管理员
+     *
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return in_array($this->is_admin, [self::ROLE_EXPERT, self::ROLE_SUPER_ADMIN]);
+    }
+
+    /**
+     * 检查用户是否为专家用户
+     *
+     * @return bool
+     */
+    public function isExpert(): bool
+    {
+        return $this->is_admin === self::ROLE_EXPERT;
+    }
+
+    /**
+     * 检查用户是否为系统管理员
+     *
+     * @return bool
+     */
+    public function isSuperAdmin(): bool
+    {
+        return $this->is_admin === self::ROLE_SUPER_ADMIN;
+    }
+
+    /**
+     * 检查用户是否为众包用户
+     *
+     * @return bool
+     */
+    public function isCrowdsourcingUser(): bool
+    {
+        return $this->is_admin === self::ROLE_CROWDSOURCING;
+    }
+
+    /**
+     * 检查用户是否为一般用户
+     *
+     * @return bool
+     */
+    public function isRegularUser(): bool
+    {
+        return $this->is_admin === self::ROLE_REGULAR;
+    }
+
+    /**
+     * 检查用户是否可以管理其他用户（活跃的专家或系统管理员）
+     *
+     * @return bool
+     */
+    public function canManageUsers(): bool
+    {
+        return $this->isActive() && $this->isAdmin();
+    }
+
+    /**
+     * 检查用户是否可以执行操作复原（活跃的专家或系统管理员）
+     *
+     * @return bool
+     */
+    public function canRestoreOperations(): bool
+    {
+        return $this->isActive() && $this->isAdmin();
+    }
+
+    /**
+     * 检查用户是否可以直接写入数据（活跃且非众包用户）
+     *
+     * @return bool
+     */
+    public function canWriteDirectly(): bool
+    {
+        return $this->isActive() && !$this->isCrowdsourcingUser();
+    }
+
+    /**
+     * 获取用户角色名称（中文）
+     *
+     * @return string
+     */
+    public function getRoleName(): string
+    {
+        switch ($this->is_admin) {
+            case self::ROLE_SUPER_ADMIN:
+                return '系统管理员';
+            case self::ROLE_EXPERT:
+                return '专家';
+            case self::ROLE_CROWDSOURCING:
+                return '众包';
+            case self::ROLE_REGULAR:
+            default:
+                return '一般';
+        }
+    }
 
     public function operation()
     {

--- a/tests/Unit/UserRoleTest.php
+++ b/tests/Unit/UserRoleTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\User;
+use Tests\TestCase;
+
+class UserRoleTest extends TestCase
+{
+    /**
+     * 测试用户角色常量定义
+     */
+    public function testRoleConstants()
+    {
+        $this->assertSame(0, User::ROLE_REGULAR);
+        $this->assertSame(1, User::ROLE_EXPERT);
+        $this->assertSame(2, User::ROLE_CROWDSOURCING);
+        $this->assertSame(3, User::ROLE_SUPER_ADMIN);
+    }
+
+    /**
+     * 测试用户状态常量定义
+     */
+    public function testStatusConstants()
+    {
+        $this->assertSame(0, User::STATUS_INACTIVE);
+        $this->assertSame(1, User::STATUS_ACTIVE);
+        $this->assertSame(2, User::STATUS_RESERVED);
+    }
+
+    /**
+     * 测试 isActive() 方法
+     */
+    public function testIsActive()
+    {
+        $user = new User();
+
+        $user->is_active = User::STATUS_INACTIVE;
+        $this->assertFalse($user->isActive());
+
+        $user->is_active = User::STATUS_ACTIVE;
+        $this->assertTrue($user->isActive());
+
+        $user->is_active = User::STATUS_RESERVED;
+        $this->assertFalse($user->isActive());
+    }
+
+    /**
+     * 测试 isAdmin() 方法（专家或系统管理员）
+     */
+    public function testIsAdmin()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->isAdmin());
+
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->isAdmin());
+
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertFalse($user->isAdmin());
+
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertTrue($user->isAdmin());
+    }
+
+    /**
+     * 测试 isExpert() 方法
+     */
+    public function testIsExpert()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->isExpert());
+
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->isExpert());
+
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertFalse($user->isExpert());
+    }
+
+    /**
+     * 测试 isSuperAdmin() 方法
+     */
+    public function testIsSuperAdmin()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertFalse($user->isSuperAdmin());
+
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertTrue($user->isSuperAdmin());
+    }
+
+    /**
+     * 测试 isCrowdsourcingUser() 方法
+     */
+    public function testIsCrowdsourcingUser()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->isCrowdsourcingUser());
+
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertTrue($user->isCrowdsourcingUser());
+    }
+
+    /**
+     * 测试 isRegularUser() 方法
+     */
+    public function testIsRegularUser()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertTrue($user->isRegularUser());
+
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertFalse($user->isRegularUser());
+    }
+
+    /**
+     * 测试 canManageUsers() 方法
+     */
+    public function testCanManageUsers()
+    {
+        $user = new User();
+
+        // 未启用的专家用户
+        $user->is_active = User::STATUS_INACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertFalse($user->canManageUsers());
+
+        // 已启用的一般用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->canManageUsers());
+
+        // 已启用的专家用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->canManageUsers());
+
+        // 已启用的系统管理员
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertTrue($user->canManageUsers());
+
+        // 已启用的众包用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertFalse($user->canManageUsers());
+    }
+
+    /**
+     * 测试 canRestoreOperations() 方法
+     */
+    public function testCanRestoreOperations()
+    {
+        $user = new User();
+
+        // 未启用的专家用户
+        $user->is_active = User::STATUS_INACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertFalse($user->canRestoreOperations());
+
+        // 已启用的专家用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->canRestoreOperations());
+
+        // 已启用的系统管理员
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertTrue($user->canRestoreOperations());
+    }
+
+    /**
+     * 测试 canWriteDirectly() 方法
+     */
+    public function testCanWriteDirectly()
+    {
+        $user = new User();
+
+        // 未启用的一般用户
+        $user->is_active = User::STATUS_INACTIVE;
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->canWriteDirectly());
+
+        // 已启用的一般用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertTrue($user->canWriteDirectly());
+
+        // 已启用的专家用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->canWriteDirectly());
+
+        // 已启用的众包用户（不能直接写入）
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertFalse($user->canWriteDirectly());
+    }
+
+    /**
+     * 测试 getRoleName() 方法
+     */
+    public function testGetRoleName()
+    {
+        $user = new User();
+
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertSame('一般', $user->getRoleName());
+
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertSame('专家', $user->getRoleName());
+
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertSame('众包', $user->getRoleName());
+
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertSame('系统管理员', $user->getRoleName());
+    }
+}


### PR DESCRIPTION
## 新增內容

### 常量定義
- 帳號狀態常量：STATUS_INACTIVE (0), STATUS_ACTIVE (1), STATUS_RESERVED (2)
- 帳號角色常量：ROLE_REGULAR (0), ROLE_EXPERT (1), ROLE_CROWDSOURCING (2), ROLE_SUPER_ADMIN (3)
  * 使用 ROLE_EXPERT 而非 ROLE_ADMIN，以便與未來的 ROLE_SUPER_ADMIN 區分

### 類型轉換（關鍵修復）
- 在 $casts 中新增 is_active 和 is_admin 的整數類型轉換
- 確保從數據庫讀取的字符串值（'0', '1', '2', '3'）能被正確轉換為整數
- 使輔助方法中的嚴格比較（===）能正常工作

### 輔助方法（11 個）
**角色檢查方法：**
- isActive() - 檢查用戶是否為活躍狀態
- isAdmin() - 檢查用戶是否為專家或系統管理員
- isExpert() - 檢查用戶是否為專家用戶
- isSuperAdmin() - 檢查用戶是否為系統管理員
- isCrowdsourcingUser() - 檢查用戶是否為眾包用戶
- isRegularUser() - 檢查用戶是否為一般用戶

**權限檢查方法：**
- canManageUsers() - 檢查是否可管理用戶（活躍的專家或系統管理員）
- canRestoreOperations() - 檢查是否可執行操作復原（活躍的專家或系統管理員）
- canWriteDirectly() - 檢查是否可直接寫入數據（活躍且非眾包用戶）

**其他方法：**
- getRoleName() - 獲取用戶角色中文名稱

### 測試
- 新增 UserRoleTest 單元測試（12 個測試用例，39 個斷言，全部通過）

### 文檔更新
- 更新 USER_PRIVILEGES.md：
  * 在角色表格中新增常量定義列
  * 新增「User 模型輔助方法」章節，詳細說明所有方法和使用示例
  * 新增「新增系統管理員的實施指南」，提供分步實施步驟

## 設計原則

- 遵循專案現有模式（參考 Operation 模型），使用類常量而非 enum
- 向後兼容：所有常量值與現有數據庫值一致，無需數據遷移
- 零行為變更：現有代碼不受影響，新方法未被調用
- 便於未來擴展：系統管理員角色已預留，提供完整實施指南