### PR TITLE
重構權限檢查：將魔術數字替換為語義化的輔助方法

### DIFF
--- a/app/Http/Controllers/AddrBelongsDataController.php
+++ b/app/Http/Controllers/AddrBelongsDataController.php
@@ -61,7 +61,7 @@ class AddrBelongsDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -112,7 +112,7 @@ class AddrBelongsDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -135,7 +135,7 @@ class AddrBelongsDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/AddressCodesController.php
+++ b/app/Http/Controllers/AddressCodesController.php
@@ -71,7 +71,7 @@ class AddressCodesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -122,7 +122,7 @@ class AddressCodesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -135,7 +135,7 @@ class AdminBatchLoadBookTitlesController extends Controller
      */
     protected function ensureAdmin(): void
     {
-        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::check() || !Auth::user()->canRunBatchImport()) {
             abort(403);
         }
     }

--- a/app/Http/Controllers/AdminBatchLoadOfficesController.php
+++ b/app/Http/Controllers/AdminBatchLoadOfficesController.php
@@ -119,7 +119,7 @@ class AdminBatchLoadOfficesController extends Controller
 
     protected function ensureAdmin(): void
     {
-        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::check() || !Auth::user()->canRunBatchImport()) {
             abort(403);
         }
     }

--- a/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
+++ b/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
@@ -161,7 +161,7 @@ class AdminBatchLoadSocialInstitutesController extends Controller
      */
     protected function ensureAdmin(): void
     {
-        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::check() || !Auth::user()->canRunBatchImport()) {
             abort(403);
         }
     }

--- a/app/Http/Controllers/AdminExplainSqlController.php
+++ b/app/Http/Controllers/AdminExplainSqlController.php
@@ -10,7 +10,7 @@ class AdminExplainSqlController extends Controller
 {
     protected function ensureAdmin()
     {
-        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::check() || !Auth::user()->canManageUsers()) {
             abort(403);
         }
     }

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -199,12 +199,11 @@ class OperationsController extends Controller
         $user_password = $request->p;
         //呼叫這行就可以進行帳號與密碼的認證了
         if (Auth::attempt(['email' => $user_id, 'password' => $user_password])) {
-            $data = DB::table('users')->where('email','=',$user_id)->get();
-            foreach($data as $item){
-                if($item->is_admin != 2) { return "帳號須為眾包身分，才可以取得token。"; }
-                $data = $item->confirmation_token;
+            $user = \App\User::where('email', $user_id)->first();
+            if ($user && !$user->isCrowdsourcingUser()) {
+                return "帳號須為眾包身分，才可以取得token。";
             }
-            return $data;
+            return $user ? $user->confirmation_token : "無法取得token";
         }
         else { return "您的帳號與密碼輸入錯誤"; }
     }

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -70,7 +70,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -211,7 +211,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -264,7 +264,7 @@ class BasicInformationAddressesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -67,7 +67,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -156,7 +156,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -213,7 +213,7 @@ class BasicInformationAltnamesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -86,7 +86,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -161,7 +161,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -208,7 +208,7 @@ class BasicInformationAssocController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -88,7 +88,7 @@ class BasicInformationController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -106,7 +106,7 @@ class BasicInformationController extends Controller
         #$data['tts_sysno'] = BiogMain::max('tts_sysno') + 1;
         $data = $this->toolRepository->timestamp($data, True);
         //20190531判別是否為眾包用戶
-        if (Auth::user()->is_admin == 2) {
+        if (Auth::user()->isCrowdsourcingUser()) {
             $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data, '', 2);
             flash('眾包紀錄 Create success @ '.Carbon::now(), 'success');
             return redirect()->route('basicinformation.index');
@@ -167,13 +167,13 @@ class BasicInformationController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
         $this->biogMainRepository->updateById($request, $id);
         //20190531判別是否為眾包用戶
-        if (Auth::user()->is_admin == 2) {
+        if (Auth::user()->isCrowdsourcingUser()) {
             flash('眾包紀錄 Update success @ '.Carbon::now(), 'success');
             return redirect()->route('basicinformation.index');
         }
@@ -191,7 +191,7 @@ class BasicInformationController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -218,7 +218,7 @@ class BasicInformationController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -358,7 +358,7 @@ class BasicInformationController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -366,7 +366,7 @@ class BasicInformationController extends Controller
         $biog = BiogMain::find($id);
         $biog->c_name_chn = '<待删除>';
         //20190605判別是否為眾包用戶
-        if (Auth::user()->is_admin == 2) {
+        if (Auth::user()->isCrowdsourcingUser()) {
             $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_MAIN', $id, $biog, $ori, 2);
             flash('眾包紀錄 Delete success @ '.Carbon::now(), 'success');
             return redirect()->route('basicinformation.index');

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -67,7 +67,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -179,7 +179,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -258,7 +258,7 @@ class BasicInformationEntriesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -58,7 +58,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -110,7 +110,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -134,7 +134,7 @@ class BasicInformationEventsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -59,7 +59,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -112,7 +112,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -144,7 +144,7 @@ class BasicInformationKinshipController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -75,7 +75,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -147,7 +147,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -194,7 +194,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -255,7 +255,7 @@ class BasicInformationOfficesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -58,7 +58,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -112,7 +112,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -136,7 +136,7 @@ class BasicInformationPossessionController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -67,7 +67,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -138,7 +138,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -202,7 +202,7 @@ class BasicInformationSocialInstController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -66,7 +66,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -122,7 +122,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -149,7 +149,7 @@ class BasicInformationSourcesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -58,7 +58,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -111,7 +111,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -136,7 +136,7 @@ class BasicInformationStatusesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -69,7 +69,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -135,7 +135,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -178,7 +178,7 @@ class BasicInformationTextsController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1 || Auth::user()->is_admin == 2){
+        elseif (!Auth::user()->canWriteDirectly()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/CbdbTableMaintenanceController.php
+++ b/app/Http/Controllers/CbdbTableMaintenanceController.php
@@ -39,7 +39,7 @@ class CbdbTableMaintenanceController extends Controller
     {
         $this->middleware('auth');
         $this->middleware(function ($request, $next) {
-            if (!Auth::user() || Auth::user()->is_admin != 1 || Auth::user()->is_active != 1) {
+            if (!Auth::user() || !Auth::user()->canRunBatchImport()) {
                 abort(403, '此功能僅限活躍管理員使用');
             }
             return $next($request);

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -294,7 +294,7 @@ class CodesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -552,7 +552,7 @@ class CodesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -658,7 +658,7 @@ class CodesController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -1113,7 +1113,7 @@ class CodesController extends Controller
             flash('請登入後再進行操作 @ '.Carbon::now(), 'error');
             return redirect()->back()->withInput();
         }
-        if (Auth::user()->is_active != 1) {
+        if (!Auth::user()->isActive()) {
             flash('該用戶沒有權限，請聯絡管理員 @ '.Carbon::now(), 'error');
             return redirect()->back()->withInput();
         }

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -108,7 +108,7 @@ class CrowdsourcingController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -278,7 +278,7 @@ class CrowdsourcingController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -20,7 +20,7 @@ class ManagementController extends Controller
      */
     public function index()
     {
-        if (Auth::user()->is_admin != 1){
+        if (!Auth::user()->isAdmin()) {
             return redirect('/home');
         }
         $data = User::all()->where('confirmation_token', '!=', '-')->where('remember_token', '!=', '-')->where('password', '!=', '-');
@@ -68,22 +68,22 @@ class ManagementController extends Controller
     public function edit(Request $request, $id)
     {
         $type = $request['type'];
-        if (Auth::user()->is_admin != 1){
+        if (!Auth::user()->canManageUsers()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
         if($type == 1) {
             $user = User::find($id);
-            $user->is_active = 1 - $user->is_active;
+            $user->is_active = ($user->is_active == User::STATUS_ACTIVE) ? User::STATUS_INACTIVE : User::STATUS_ACTIVE;
             $user->save();
             flash('修改成功 @ '.Carbon::now(), 'success');
             return redirect()->route('manage.index');
         }
         if($type == 2) {
             $user = User::find($id);
-            if($user->is_admin == 1) { $user->is_admin = 2; }
-            elseif($user->is_admin == 2) { $user->is_admin = 0; }
-            elseif($user->is_admin == 0) { $user->is_admin = 1; }
+            if($user->is_admin == User::ROLE_EXPERT) { $user->is_admin = User::ROLE_CROWDSOURCING; }
+            elseif($user->is_admin == User::ROLE_CROWDSOURCING) { $user->is_admin = User::ROLE_REGULAR; }
+            elseif($user->is_admin == User::ROLE_REGULAR) { $user->is_admin = User::ROLE_EXPERT; }
             $user->save();
             flash('修改成功 @ '.Carbon::now(), 'success');
             return redirect()->route('manage.index');

--- a/app/Http/Controllers/MergePreviewController.php
+++ b/app/Http/Controllers/MergePreviewController.php
@@ -29,7 +29,7 @@ class MergePreviewController extends Controller
 
     public function index(Request $request)
     {
-        if (Auth::user()->is_admin != 1) {
+        if (!Auth::user()->isAdmin()) {
             flash('該用戶沒有權限，請聯絡管理員。', 'error');
             return redirect('/home');
         }

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -208,7 +208,7 @@ class OperationsController extends Controller
             flash('請登入後再試。', 'error');
             return redirect()->back();
         }
-        if (Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::user()->canRestoreOperations()) {
             flash('該用戶沒有權限，請聯絡管理員。', 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -70,7 +70,7 @@ class OperationsProposalController extends Controller
 
     protected function ensureCanReview(Operation $operation): void
     {
-        if (!Auth::check() || Auth::user()->is_active != 1 || Auth::user()->is_admin != 1) {
+        if (!Auth::check() || !Auth::user()->canRestoreOperations()) {
             abort(403, '無權審核提案。');
         }
 

--- a/app/Http/Controllers/TextInstanceDataController.php
+++ b/app/Http/Controllers/TextInstanceDataController.php
@@ -62,7 +62,7 @@ class TextInstanceDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -118,7 +118,7 @@ class TextInstanceDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
@@ -141,7 +141,7 @@ class TextInstanceDataController extends Controller
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (Auth::user()->is_active != 1){
+        elseif (!Auth::user()->isActive()){
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }

--- a/app/Http/Controllers/WikiMaintenanceController.php
+++ b/app/Http/Controllers/WikiMaintenanceController.php
@@ -22,7 +22,7 @@ class WikiMaintenanceController extends Controller
     {
         $this->middleware('auth');
         $this->middleware(function ($request, $next) {
-            if (!Auth::user() || Auth::user()->is_admin != 1 || Auth::user()->is_active != 1) {
+            if (!Auth::user() || !Auth::user()->canRunBatchImport()) {
                 abort(403, '此功能僅限活躍管理員使用');
             }
             return $next($request);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -223,7 +223,7 @@ class BiogMainRepository
         $biogbasicinformation = BiogMain::find($id);
         $ori = $this->byPersonId($id);
         //20190531判別是否為眾包用戶
-        if (Auth::user()->is_admin == 2) {
+        if (Auth::user()->isCrowdsourcingUser()) {
             (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori, 2);
         }
         else {

--- a/app/User.php
+++ b/app/User.php
@@ -142,6 +142,16 @@ class User extends Authenticatable
     }
 
     /**
+     * 检查用户是否可以运行批量导入操作（活跃的专家或系统管理员）
+     *
+     * @return bool
+     */
+    public function canRunBatchImport(): bool
+    {
+        return $this->isActive() && $this->isAdmin();
+    }
+
+    /**
      * 获取用户角色名称（中文）
      *
      * @return string

--- a/resources/views/addrbelongsdata/create.blade.php
+++ b/resources/views/addrbelongsdata/create.blade.php
@@ -32,7 +32,7 @@
                             <input type="text" name="c_lastyear" class="form-control" placeholder="c_lastyear" required>
                         </div>
                     </div>
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>

--- a/resources/views/addrbelongsdata/edit.blade.php
+++ b/resources/views/addrbelongsdata/edit.blade.php
@@ -18,7 +18,7 @@
                             </div>
                         </div>
                     @endforeach
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>

--- a/resources/views/addrbelongsdata/index.blade.php
+++ b/resources/views/addrbelongsdata/index.blade.php
@@ -4,11 +4,11 @@
     <div class="panel panel-default">
         <div class="panel-heading">地址從屬表</div>
         <div class="panel-body">
-            @if(Auth::check() && Auth::user()->is_active == 1)
+            @if(Auth::check() && Auth::user()->isActive())
             <a href="{{ route('addrbelongsdata.create') }}" class="pull-right btn btn-default">新增</a>
             @endif
             <div class="panel-body">
-                <addr-belongs-data-list :user-can-edit="{{ Auth::check() && Auth::user()->is_active == 1 ? 'true' : 'false' }}"></addr-belongs-data-list>
+                <addr-belongs-data-list :user-can-edit="{{ Auth::check() && Auth::user()->isActive() ? 'true' : 'false' }}"></addr-belongs-data-list>
             </div>
         </div>
     </div>

--- a/resources/views/biogmains/addresses/index.blade.php
+++ b/resources/views/biogmains/addresses/index.blade.php
@@ -6,7 +6,7 @@
         <div class="panel-heading">地址清單</div>
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.addresses.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -21,7 +21,7 @@
                     <th>始年</th>
                     <th>終年</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -36,7 +36,7 @@
                         <td>{{ $basicinformation->biog_addresses[$i]->c_firstyear }}</td>
                         <td>{{ $basicinformation->biog_addresses[$i]->c_lastyear }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.addresses.edit', ['basicinformation' => $basicinformation->c_personid, 'address' => $basicinformation->c_personid.'-'.$basicinformation->biog_addresses[$i]->c_addr_id.'-'.$basicinformation->biog_addresses[$i]->c_addr_type.'-'.$basicinformation->biog_addresses[$i]->c_sequence]) }}">edit</a>

--- a/resources/views/biogmains/altname/index.blade.php
+++ b/resources/views/biogmains/altname/index.blade.php
@@ -8,7 +8,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.altnames.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -22,7 +22,7 @@
                     <th>別名漢字</th>
                     <th>別名類型</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -64,7 +64,7 @@ if($value->pivot->c_sequence === 0) {
                         <td>{{ $c_alt_name_chn_view }}</td>
                         <td>{{ $altTypeLabel }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.altnames.edit', ['basicinformation' => $basicinformation->c_personid, 'altname' => $value->pivot->c_personid.'-'.$value->pivot->c_sequence.'-'.$value->pivot->c_alt_name_chn.'-'.$value->pivot->c_alt_name_type_code]) }}">edit</a>

--- a/resources/views/biogmains/assoc/index.blade.php
+++ b/resources/views/biogmains/assoc/index.blade.php
@@ -8,7 +8,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.assoc.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -23,7 +23,7 @@
                     <th>社會關係人</th>
                     <th>作品標題</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -45,7 +45,7 @@
                             @endif
                         <td>{{ $value->pivot->c_text_title }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                     @php

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -385,7 +385,7 @@
                     </div>
                 </div>
                 @auth
-                    @if(Auth::user()->is_active == 1)
+                    @if(Auth::user()->isActive())
                         <div class="form-group">
                             <div class="col-sm-offset-2 col-sm-10">
                                 <button type="submit" class="btn btn-default">Submit</button>
@@ -396,7 +396,7 @@
 
             </form>
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <div class="btn-group pull-right">
                         <a href=""
                            onclick="
@@ -414,7 +414,7 @@
                 @endif
             @endauth
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <div class="btn-group pull-right">
                         <a href="../../basicinformation/{{$basicinformation->c_personid}}/Duplicate_Collateral_Info" class="btn btn-success" style="margin-right:40px;">Duplicate Collateral Info</a>
                     </div>
@@ -424,7 +424,7 @@
                 @endif
             @endauth
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <form id="delete-form" action="{{ route('basicinformation.destroy', ['basicinformation' => $basicinformation->c_personid]) }}" method="POST" style="display: none;">
                         {{ method_field('DELETE') }}
                         {{ csrf_field() }}

--- a/resources/views/biogmains/basicinformation/index.blade.php
+++ b/resources/views/biogmains/basicinformation/index.blade.php
@@ -6,7 +6,7 @@
         <div class="panel-heading">人名查詢</div>
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.create') }}" class="pull-right btn btn-default">新增</a>
                 @endif
             @endauth

--- a/resources/views/biogmains/entries/index.blade.php
+++ b/resources/views/biogmains/entries/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.entries.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -20,7 +20,7 @@
                     <th>sequence</th>
                     <th>入仕法</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -33,7 +33,7 @@
                         <td>{{ $value->pivot->c_sequence }}</td>
                         <td>{{ $value->c_entry_desc_chn }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         @php($id_ = $value->pivot->c_personid."-".$value->pivot->c_entry_code."-".$value->pivot->c_sequence."-".$value->pivot->c_kin_code."-".$value->pivot->c_assoc_code."-".$value->pivot->c_kin_id."-".$value->pivot->c_year."-".$value->pivot->c_assoc_id."-".$value->pivot->c_inst_code."-".$value->pivot->c_inst_name_code)

--- a/resources/views/biogmains/events/index.blade.php
+++ b/resources/views/biogmains/events/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.events.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -20,7 +20,7 @@
                     <th>SEQUENCE</th>
                     <th>事件名稱</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth

--- a/resources/views/biogmains/kinship/index.blade.php
+++ b/resources/views/biogmains/kinship/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.kinship.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -20,7 +20,7 @@
                     <th>親屬關係類別</th>
                     <th>親戚姓名</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -33,7 +33,7 @@
                         <td>{{ $value->c_kinrel_chn. ' '. $value->c_kinrel_alt }}</td>
                         <td><a href="{{ route('basicinformation.edit', $basicinformation->kinship_name[$key]->c_kin_id) }}" target="_blank">{{ $basicinformation->kinship_name[$key]->c_name_chn.' '.$basicinformation->kinship_name[$key]->c_name }}</a></td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.kinship.edit', ['basicinformation' => $basicinformation->c_personid, 'kinship' => $value->pivot->c_personid.'-'.$value->pivot->c_kin_id.'-'.$value->pivot->c_kin_code]) }}">edit</a>

--- a/resources/views/biogmains/offices/index.blade.php
+++ b/resources/views/biogmains/offices/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.offices.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -24,7 +24,7 @@
                     <th>始年</th>
                     <th>終年</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -41,7 +41,7 @@
                         <td>{{ $value->pivot->c_firstyear }}</td>
                         <td>{{ $value->pivot->c_lastyear }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.offices.edit', ['basicinformation' => $basicinformation->c_personid, 'office' => $value->pivot->c_office_id.'-'.$value->pivot->c_posting_id]) }}">edit</a>

--- a/resources/views/biogmains/possession/index.blade.php
+++ b/resources/views/biogmains/possession/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.possession.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -21,7 +21,7 @@
                     <th>行為</th>
                     <th>財產</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -35,7 +35,7 @@
                         <td>{{ $value->c_possession_act_desc_chn }}</td>
                         <td>{{ $value->pivot->c_possession_desc_chn }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.possession.edit', ['basicinformation' => $basicinformation->c_personid, 'possession' => $value->pivot->c_possession_record_id]) }}">edit</a>

--- a/resources/views/biogmains/socialinst/index.blade.php
+++ b/resources/views/biogmains/socialinst/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.socialinst.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -22,7 +22,7 @@
                     <th>始年</th>
                     <th>終年</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -37,7 +37,7 @@
                         <td>{{ $value->pivot->c_bi_begin_year }}</td>
                         <td>{{ $value->pivot->c_bi_end_year }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         @php($id_ = $value->pivot->c_personid."-".$value->pivot->c_inst_code."-".$value->pivot->c_inst_name_code."-".$value->pivot->c_bi_role_code)

--- a/resources/views/biogmains/sources/index.blade.php
+++ b/resources/views/biogmains/sources/index.blade.php
@@ -8,7 +8,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.sources.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -21,7 +21,7 @@
                     <th>出處</th>
                     <th>頁碼</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -51,7 +51,7 @@ $c_pages_view = unionPKDef_decode_for_convert($value->pivot->c_pages);
                             @endif
                         </td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                         <td>
                             <div class="btn-group">
                                 <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.sources.edit', ['basicinformation' => $basicinformation->c_personid, 'source' => $value->pivot->c_personid.'-'.$value->pivot->c_textid.'-'.$value->pivot->c_pages]) }}">edit</a>

--- a/resources/views/biogmains/statuses/index.blade.php
+++ b/resources/views/biogmains/statuses/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.statuses.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -23,7 +23,7 @@
                     <th>始年</th>
                     <th>終年</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -39,7 +39,7 @@
                         <td>{{ $value->pivot->c_firstyear }}</td>
                         <td>{{ $value->pivot->c_lastyear }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.statuses.edit', ['basicinformation' => $basicinformation->c_personid, 'status' => $value->pivot->c_personid.'-'.$value->pivot->c_sequence.'-'.$value->pivot->c_status_code]) }}">edit</a>

--- a/resources/views/biogmains/texts/index.blade.php
+++ b/resources/views/biogmains/texts/index.blade.php
@@ -7,7 +7,7 @@
 
         <div class="panel-body">
             @auth
-                @if(Auth::user()->is_active == 1)
+                @if(Auth::user()->isActive())
                     <a href="{{ route('basicinformation.texts.create', ['basicinformation' => $basicinformation->c_personid]) }}" class="btn btn-default pull-right">新增</a>
                 @endif
             @endauth
@@ -20,7 +20,7 @@
                     <th>書名</th>
                     <th>著述角色</th>
                     @auth
-                        @if(Auth::user()->is_active == 1)
+                        @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
                         @endif
                     @endauth
@@ -33,7 +33,7 @@
                         <td>{{ $basicinformation->texts[$i]->c_title_chn }}</td>
                         <td>{{ $basicinformation->texts_role[$i]->c_role_desc_chn }}</td>
                         @auth
-                            @if(Auth::user()->is_active == 1)
+                            @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
                                         <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.texts.edit', ['basicinformation' => $basicinformation->c_personid, 'text' => $basicinformation->c_personid.'-'.$basicinformation->texts[$i]->pivot->c_textid.'-'.$basicinformation->texts[$i]->pivot->c_role_id]) }}">edit</a>

--- a/resources/views/codes/create.blade.php
+++ b/resources/views/codes/create.blade.php
@@ -20,7 +20,7 @@
                         </div>
                     @php($i++)
                     @endforeach
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
                         <div class="col-sm-10">

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -47,7 +47,7 @@
                             </div>
                         </div>
                     @endforeach
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
                         <div class="col-sm-10">

--- a/resources/views/crowdsourcing/index.blade.php
+++ b/resources/views/crowdsourcing/index.blade.php
@@ -115,8 +115,8 @@
                             </td>
                             <td>{{ $item->crowdsourcing_status }}</td>
                             <td>
-                                @if($item->crowdsourcing_status == 2 and Auth::check() and Auth::user()->is_admin != 2)
-                                <a href="../../crowdsourcing/{{$item->id}}/confirm" type="button" class="btn btn-success">confirm</a>　
+                                @if($item->crowdsourcing_status == 2 and Auth::check() and !Auth::user()->isCrowdsourcingUser())
+                                <a href="../../crowdsourcing/{{$item->id}}/confirm" type="button" class="btn btn-success">confirm</a>
                                 <a href="../../crowdsourcing/{{$item->id}}/reject" type="button" class="btn btn-danger">reject</a>
                                 @endif
                             </td>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -81,7 +81,7 @@ desired effect
             @yield('content')
 
             @php
-                $canViewQueryDetails = Auth::check() && Auth::user()->is_admin == 1;
+                $canViewQueryDetails = Auth::check() && Auth::user()->isAdmin();
             @endphp
 
             @if(!empty($queryProfileSummary['count']))

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -19,7 +19,7 @@
         <!-- Sidebar Menu -->
         @php
             $hasPendingProposals = false;
-            if (Auth::check() && Auth::user()->is_admin == 1 && Auth::user()->is_active == 1) {
+            if (Auth::check() && Auth::user()->canManageUsers()) {
                 try {
                     if (\Illuminate\Support\Facades\Schema::hasTable('operations')) {
                         $hasPendingProposals = \App\Operation::where('crowdsourcing_status', 0)
@@ -81,7 +81,7 @@
             <li class="{{ $page_title == '任官職務資料檢視' ? 'active' : '' }}"><a href="{{ route('view.show', 'posting-office-data') }}"><i class="fa fa-table"></i> <span>任官職務資料檢視<br>(View_PostingOfficeData)</span></a></li>
             <li class="{{ $page_title == '人物身份資料檢視' ? 'active' : '' }}"><a href="{{ route('view.show', 'status-data') }}"><i class="fa fa-table"></i> <span>人物身份資料檢視<br>(View_StatusData)</span></a></li>
 
-            @if(Auth::check() and Auth::user()->is_admin == 1)
+            @if(Auth::check() and Auth::user()->isAdmin())
                 <li class="header">Management</li>
                 <li class="{{ $page_title == 'SQL 執行計畫' ? 'active' : '' }}"><a href="{{ route('admin.explainsql') }}"><i class="fa fa-search"></i> <span>SQL EXPLAIN</span></a></li>
                 <li class="{{ $page_title == '批次匯入書稿資料' ? 'active' : '' }}"><a href="{{ route('admin.batch-load-book-titles') }}"><i class="fa fa-upload"></i> <span>批次匯入書稿</span></a></li>

--- a/resources/views/manage/index.blade.php
+++ b/resources/views/manage/index.blade.php
@@ -26,14 +26,14 @@
                         <td>{{ $user->name }}</td>
                         <td>{{ $user->email }}</td>
                         <td>{{ $user->institution }}</td>
-                        <td>{{ $user->is_active == 1 ? 'Yes' : 'No' }}</td>
+                        <td>{{ $user->isActive() ? 'Yes' : 'No' }}</td>
                         <td>
                             <div class="btn-group">
                                 <a type="button" class="btn btn-sm btn-default" href="{{ route('manage.edit', ['manage' => $user->id , 'type' => '1']) }}">改变审核状态</a>
                             </div>
                         </td>
                         <td>
-                            {{ $user->is_admin == 2 ? '眾包' : ( $user->is_admin == 1 ? '專家' : '一般' ) }}
+                            {{ $user->getRoleName() }}
                         </td>
                         <td>
                             <div class="btn-group">

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -241,7 +241,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     </div>
                                   </div>
                                 </div>
-                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
+                                @if(Auth::check() && Auth::user()->isAdmin() && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
                                     <form method="post" action="{{ route('operations.restore', $item->id) }}" style="display:inline;">
                                         {{ csrf_field() }}
                                         <button type="submit" class="btn btn-warning"
@@ -250,7 +250,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         </button>
                                     </form>
                                 @endif
-                                @if($isProposal && Auth::check() && Auth::user()->is_admin == 1 && Auth::user()->is_active == 1 && $reviewStatus === 'pending')
+                                @if($isProposal && Auth::check() && Auth::user()->canManageUsers() && $reviewStatus === 'pending')
                                     <div class="proposal-actions" style="margin-top:8px;">
                                         <form method="post" action="{{ route('operations.proposals.approve', $item->id) }}" style="display:inline;">
                                             {{ csrf_field() }}

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -297,7 +297,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     </div>
                                   </div>
                                 </div>
-                                @if(Auth::check() && Auth::user()->is_admin == 1 && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
+                                @if(Auth::check() && Auth::user()->isAdmin() && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
                                     <form method="post" action="{{ route('operations.restore', $item->id) }}" style="display:inline;">
                                         {{ csrf_field() }}
                                         <button type="submit" class="btn btn-warning"
@@ -324,7 +324,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         </form>
                                     </div>
                                 @endif
-                                @if($isProposal && Auth::check() && Auth::user()->is_admin == 1 && Auth::user()->is_active == 1 && $reviewStatus === 'pending')
+                                @if($isProposal && Auth::check() && Auth::user()->canManageUsers() && $reviewStatus === 'pending')
                                     <div class="proposal-actions" style="margin-top:8px;">
                                         <form method="post" action="{{ route('operations.proposals.approve', $item->id) }}" style="display:inline;">
                                             {{ csrf_field() }}

--- a/resources/views/textinstancedata/create.blade.php
+++ b/resources/views/textinstancedata/create.blade.php
@@ -41,7 +41,7 @@
                             <input type="text" name="c_text_instance_id" class="form-control" placeholder="c_instance_title（版本實例 ID）" required>
                         </div>
                     </div>
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>

--- a/resources/views/textinstancedata/edit.blade.php
+++ b/resources/views/textinstancedata/edit.blade.php
@@ -33,7 +33,7 @@
                         </div>
                         @endif
                     @endforeach
-                    @if(Auth::check() && Auth::user()->is_active == 1)
+                    @if(Auth::check() && Auth::user()->isActive())
                     <div class="form-group">
                         <div class="col-sm-offset-2 col-sm-10">
                             <button type="submit" class="btn btn-default">Submit</button>

--- a/resources/views/textinstancedata/index.blade.php
+++ b/resources/views/textinstancedata/index.blade.php
@@ -4,11 +4,11 @@
     <div class="panel panel-default">
         <div class="panel-heading">著作版本表</div>
         <div class="panel-body">
-            @if(Auth::check() && Auth::user()->is_active == 1)
+            @if(Auth::check() && Auth::user()->isActive())
             <a href="{{ route('textinstancedata.create') }}" class="pull-right btn btn-default">新增</a>
             @endif
             <div class="panel-body">
-                <text-instance-data-list :user-can-edit="{{ Auth::check() && Auth::user()->is_active == 1 ? 'true' : 'false' }}"></text-instance-data-list>
+                <text-instance-data-list :user-can-edit="{{ Auth::check() && Auth::user()->isActive() ? 'true' : 'false' }}"></text-instance-data-list>
             </div>
         </div>
     </div>

--- a/tests/Unit/UserRoleTest.php
+++ b/tests/Unit/UserRoleTest.php
@@ -209,6 +209,39 @@ class UserRoleTest extends TestCase
     }
 
     /**
+     * 测试 canRunBatchImport() 方法
+     */
+    public function testCanRunBatchImport()
+    {
+        $user = new User();
+
+        // 未启用的专家用户
+        $user->is_active = User::STATUS_INACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertFalse($user->canRunBatchImport());
+
+        // 已启用的一般用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_REGULAR;
+        $this->assertFalse($user->canRunBatchImport());
+
+        // 已启用的专家用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $this->assertTrue($user->canRunBatchImport());
+
+        // 已启用的系统管理员
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $this->assertTrue($user->canRunBatchImport());
+
+        // 已启用的众包用户
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_CROWDSOURCING;
+        $this->assertFalse($user->canRunBatchImport());
+    }
+
+    /**
      * 测试 getRoleName() 方法
      */
     public function testGetRoleName()


### PR DESCRIPTION
## 新增常數定義

在 User 模型中新增狀態和角色常數：

**狀態常數：**
- STATUS_INACTIVE (0) - 未啟用
- STATUS_ACTIVE (1) - 已啟用
- STATUS_RESERVED (2) - 保留

**角色常數：**
- ROLE_REGULAR (0) - 一般用戶
- ROLE_EXPERT (1) - 專家用戶
- ROLE_CROWDSOURCING (2) - 眾包用戶
- ROLE_SUPER_ADMIN (3) - 系統管理員（預留）

## 新增類型轉換

在 User 模型的 $casts 中新增：
- is_active => 'integer'
- is_admin => 'integer'

確保從資料庫讀取的字串值轉換為整數，使嚴格比較（===）正確運作。

## 新增輔助方法

在 User 模型中新增 12 個語義化的權限檢查方法：

**狀態檢查方法：**
- isActive(): 檢查用戶是否為啟用狀態

**角色檢查方法：**
- isAdmin(): 檢查是否為管理員（專家或系統管理員）
- isExpert(): 檢查是否為專家用戶
- isSuperAdmin(): 檢查是否為系統管理員
- isCrowdsourcingUser(): 檢查是否為眾包用戶
- isRegularUser(): 檢查是否為一般用戶

**權限檢查方法：**
- canManageUsers(): 檢查是否可管理用戶（活躍的管理員）
- canRestoreOperations(): 檢查是否可恢復操作記錄（活躍的管理員）
- canWriteDirectly(): 檢查是否可直接寫入資料（活躍的非眾包用戶）
- canRunBatchImport(): 檢查是否可運行批量導入（活躍的管理員）

**工具方法：**
- getRoleName(): 取得角色的中文名稱

## 重構範圍

將以下 59 個檔案中的魔術數字替換為語義化的輔助方法：

**30 個控制器檔案：**
- ManagementController
- OperationsController
- AddrBelongsController
- AddressCodesController
- Api/OperationsController
- BiogMainRepository
- CodesController
- CrowdsourcingController
- TextInstanceDataController
- AdminBatchLoadBookTitlesController (使用 canRunBatchImport)
- AdminBatchLoadOfficesController (使用 canRunBatchImport)
- AdminBatchLoadSocialInstitutesController (使用 canRunBatchImport)
- WikiMaintenanceController (使用 canRunBatchImport)
- CbdbTableMaintenanceController (使用 canRunBatchImport)
- 以及 16 個 BasicInformation 系列控制器

**29 個視圖檔案：**
- manage/index.blade.php
- layouts/sidebar.blade.php
- operations/index.blade.php
- modified/index.blade.php
- addrbelongsdata/index.blade.php
- textinstancedata/index.blade.php
- codes/index.blade.php
- crowdsourcing/index.blade.php
- 以及 21 個 biogmains 系列視圖檔案

## 測試

新增 UserRoleTest 單元測試，包含 13 個測試方法，共 44 個斷言，全部通過。

## 文檔更新

更新 USER_PRIVILEGES.md 文檔：
- 新增常數定義說明
- 新增輔助方法使用範例
- 新增系統管理員角色實作指引