### PR TITLE
重構用戶管理功能：將 /manage 改為點選式編輯介面

### DIFF
--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -65,41 +65,25 @@ class ManagementController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function edit(Request $request, $id)
+    public function edit($id)
     {
-        $type = $request['type'];
         if (!Auth::user()->canManageUsers()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        if($type == 1) {
-            $user = User::find($id);
-            $user->is_active = ($user->is_active == User::STATUS_ACTIVE) ? User::STATUS_INACTIVE : User::STATUS_ACTIVE;
-            $user->save();
-            flash('修改成功 @ '.Carbon::now(), 'success');
+
+        $user = User::find($id);
+
+        if (!$user) {
+            flash('用户不存在 @ '.Carbon::now(), 'error');
             return redirect()->route('manage.index');
         }
-        if($type == 2) {
-            $user = User::find($id);
-            if($user->is_admin == User::ROLE_EXPERT) { $user->is_admin = User::ROLE_CROWDSOURCING; }
-            elseif($user->is_admin == User::ROLE_CROWDSOURCING) { $user->is_admin = User::ROLE_REGULAR; }
-            elseif($user->is_admin == User::ROLE_REGULAR) { $user->is_admin = User::ROLE_EXPERT; }
-            $user->save();
-            flash('修改成功 @ '.Carbon::now(), 'success');
-            return redirect()->route('manage.index');
-        }
-        if($type == 3) {
-            $user = User::find($id);
-            $email = $user->email;
-            $user->email = $email.'-'.Carbon::now();
-            $user->password = '-';
-            $user->confirmation_token = '-';
-            $user->remember_token = '-';
-            $user->updated_at = Carbon::now();
-            $user->save();
-            flash('刪除成功 @ '.Carbon::now(), 'danger');
-            return redirect()->route('manage.index');
-        }
+
+        return view('manage.edit', [
+            'user' => $user,
+            'page_title' => '编辑用户',
+            'page_description' => '编辑用户 ' . $user->name . ' 的设置'
+        ]);
     }
 
     /**
@@ -111,8 +95,44 @@ class ManagementController extends Controller
      */
     public function update(Request $request, $id)
     {
-        //
+        if (!Auth::user()->canManageUsers()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            return redirect()->back();
+        }
 
+        $user = User::find($id);
+
+        if (!$user) {
+            flash('用户不存在 @ '.Carbon::now(), 'error');
+            return redirect()->route('manage.index');
+        }
+
+        // 检查是否要删除用户
+        if ($request->has('delete_user') && $request->delete_user == 1) {
+            $email = $user->email;
+            $user->email = $email . '-' . Carbon::now();
+            $user->password = '-';
+            $user->confirmation_token = '-';
+            $user->remember_token = '-';
+            $user->updated_at = Carbon::now();
+            $user->save();
+            flash('用户已删除 @ '.Carbon::now(), 'danger');
+            return redirect()->route('manage.index');
+        }
+
+        // 验证输入
+        $validated = $request->validate([
+            'is_active' => 'required|integer|in:0,1',
+            'is_admin' => 'required|integer|in:0,1,2,3',
+        ]);
+
+        // 更新用户设置
+        $user->is_active = $validated['is_active'];
+        $user->is_admin = $validated['is_admin'];
+        $user->save();
+
+        flash('用户设置已更新 @ '.Carbon::now(), 'success');
+        return redirect()->route('manage.index');
     }
 
     /**

--- a/resources/views/manage/edit.blade.php
+++ b/resources/views/manage/edit.blade.php
@@ -1,0 +1,154 @@
+@extends('layouts.dashboard')
+
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">编辑用户设置</h3>
+                <div class="box-tools pull-right">
+                    <a href="{{ route('manage.index') }}" class="btn btn-sm btn-default">
+                        <i class="fa fa-arrow-left"></i> 返回列表
+                    </a>
+                </div>
+            </div>
+
+            <form action="{{ route('manage.update', $user->id) }}" method="POST">
+                @csrf
+                @method('PUT')
+
+                <div class="box-body">
+                    <!-- 基本信息（只读） -->
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>用户 ID</label>
+                                <input type="text" class="form-control" value="{{ $user->id }}" readonly>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>用户名</label>
+                                <input type="text" class="form-control" value="{{ $user->name }}" readonly>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>电子邮箱</label>
+                                <input type="text" class="form-control" value="{{ $user->email }}" readonly>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>机构</label>
+                                <input type="text" class="form-control" value="{{ $user->institution }}" readonly>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>注册时间</label>
+                                <input type="text" class="form-control" value="{{ $user->created_at }}" readonly>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label>最后更新时间</label>
+                                <input type="text" class="form-control" value="{{ $user->updated_at }}" readonly>
+                            </div>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <!-- 可编辑的设置 -->
+                    <h4>用户设置</h4>
+
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label for="is_active">账号状态</label>
+                                <select name="is_active" id="is_active" class="form-control">
+                                    <option value="1" {{ $user->is_active == 1 ? 'selected' : '' }}>已激活</option>
+                                    <option value="0" {{ $user->is_active == 0 ? 'selected' : '' }}>未激活</option>
+                                </select>
+                                <p class="help-block">未激活的用户无法登录系统</p>
+                            </div>
+                        </div>
+
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label for="is_admin">用户角色</label>
+                                <select name="is_admin" id="is_admin" class="form-control">
+                                    <option value="0" {{ $user->is_admin == 0 ? 'selected' : '' }}>一般用户</option>
+                                    <option value="1" {{ $user->is_admin == 1 ? 'selected' : '' }}>专家</option>
+                                    <option value="2" {{ $user->is_admin == 2 ? 'selected' : '' }}>众包</option>
+                                    <option value="3" {{ $user->is_admin == 3 ? 'selected' : '' }}>系统管理员</option>
+                                </select>
+                                <p class="help-block">
+                                    <strong>一般用户：</strong>基本权限<br>
+                                    <strong>专家：</strong>拥有管理权限<br>
+                                    <strong>众包：</strong>众包用户权限<br>
+                                    <strong>系统管理员：</strong>最高权限
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <!-- 危险操作区 -->
+                    <h4 class="text-danger">危险操作</h4>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" name="delete_user" id="delete_user" value="1">
+                                    删除此用户
+                                </label>
+                                <p class="help-block text-danger">
+                                    <strong>警告：</strong>勾选此项并保存将会删除该用户账号。此操作不可恢复！
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="box-footer">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 保存修改
+                    </button>
+                    <a href="{{ route('manage.index') }}" class="btn btn-default">
+                        <i class="fa fa-times"></i> 取消
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+document.getElementById('delete_user').addEventListener('change', function() {
+    if (this.checked) {
+        if (!confirm('您真的确定要删除此用户吗？\n\n此操作不可恢复！\n\n请确认！')) {
+            this.checked = false;
+        }
+    }
+});
+
+document.querySelector('form').addEventListener('submit', function(e) {
+    const deleteCheckbox = document.getElementById('delete_user');
+    if (deleteCheckbox.checked) {
+        if (!confirm('最后确认：您真的要删除此用户吗？')) {
+            e.preventDefault();
+            return false;
+        }
+    }
+});
+</script>
+@endsection

--- a/resources/views/manage/index.blade.php
+++ b/resources/views/manage/index.blade.php
@@ -13,10 +13,8 @@
                     <th>Email</th>
                     <th>Institution</th>
                     <th>是否通过审核</th>
+                    <th>用户角色</th>
                     <th style="width: 120px">操作</th>
-                    <th>一般/專家/眾包用戶</th>
-                    <th style="width: 120px">操作</th>
-                    <th>刪除</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -26,33 +24,21 @@
                         <td>{{ $user->name }}</td>
                         <td>{{ $user->email }}</td>
                         <td>{{ $user->institution }}</td>
-                        <td>{{ $user->isActive() ? 'Yes' : 'No' }}</td>
                         <td>
-                            <div class="btn-group">
-                                <a type="button" class="btn btn-sm btn-default" href="{{ route('manage.edit', ['manage' => $user->id , 'type' => '1']) }}">改变审核状态</a>
-                            </div>
+                            @if($user->isActive())
+                                <span class="label label-success">已激活</span>
+                            @else
+                                <span class="label label-warning">未激活</span>
+                            @endif
                         </td>
                         <td>
-                            {{ $user->getRoleName() }}
-                        </td>
-                        <td>
-                            <div class="btn-group">
-                                <a type="button" class="btn btn-sm btn-default" href="{{ route('manage.edit', ['manage' => $user->id , 'type' => '2']) }}">改变用戶状态</a>
-                            </div>
+                            <span class="label label-primary">{{ $user->getRoleName() }}</span>
                         </td>
                         <td>
                             <div class="btn-group">
-                                <a type="button"
-                                    onclick="
-                                    let msg = '您真的确定要删除吗？\n\n请确认！';
-                                    if (confirm(msg)===true){
-                                        return true;
-                                    }else{
-                                        return false;
-                                    }"
-                                    class="btn btn-xs btn-danger"
-                                    href="{{ route('manage.edit', ['manage' => $user->id , 'type' => '3']) }}">
-                                del</a>
+                                <a type="button" class="btn btn-sm btn-primary" href="{{ route('manage.edit', $user->id) }}">
+                                    <i class="fa fa-edit"></i> 编辑
+                                </a>
                             </div>
                         </td>
                     </tr>

--- a/tests/Feature/ManagePagesLoadTest.php
+++ b/tests/Feature/ManagePagesLoadTest.php
@@ -150,46 +150,66 @@ class ManagePagesLoadTest extends TestCase
     }
 
     /**
-     * 测试编辑页面（改变审核状态）：/manage/{id}/edit?type=1
+     * 测试编辑页面加载：/manage/{id}/edit
      */
-    public function test_manage_edit_change_active_status()
+    public function test_manage_edit_page_loads()
     {
-        $originalStatus = $this->regularUser->is_active;
-
         $response = $this->actingAs($this->adminUser)
-            ->get("/manage/{$this->regularUser->id}/edit?type=1");
+            ->get("/manage/{$this->regularUser->id}/edit");
+
+        $response->assertStatus(200);
+        $response->assertSee('编辑用户设置');
+        $response->assertSee($this->regularUser->name);
+        $response->assertSee($this->regularUser->email);
+    }
+
+    /**
+     * 测试更新用户激活状态：PUT /manage/{id}
+     */
+    public function test_manage_update_active_status()
+    {
+        $response = $this->actingAs($this->adminUser)
+            ->put("/manage/{$this->regularUser->id}", [
+                'is_active' => 0,
+                'is_admin' => $this->regularUser->is_admin,
+            ]);
 
         $response->assertRedirect(route('manage.index'));
 
         // 验证状态已改变
         $this->regularUser->refresh();
-        $this->assertEquals(1 - $originalStatus, $this->regularUser->is_active);
+        $this->assertEquals(0, $this->regularUser->is_active);
     }
 
     /**
-     * 测试编辑页面（改变用户状态）：/manage/{id}/edit?type=2
+     * 测试更新用户角色：PUT /manage/{id}
      */
-    public function test_manage_edit_change_user_type()
+    public function test_manage_update_user_role()
     {
-        $originalType = $this->regularUser->is_admin;
-
         $response = $this->actingAs($this->adminUser)
-            ->get("/manage/{$this->regularUser->id}/edit?type=2");
+            ->put("/manage/{$this->regularUser->id}", [
+                'is_active' => $this->regularUser->is_active,
+                'is_admin' => 1, // 改为专家
+            ]);
 
         $response->assertRedirect(route('manage.index'));
 
-        // 验证用户类型已改变（0 -> 1）
+        // 验证用户类型已改变
         $this->regularUser->refresh();
-        $this->assertNotEquals($originalType, $this->regularUser->is_admin);
+        $this->assertEquals(1, $this->regularUser->is_admin);
     }
 
     /**
-     * 测试编辑页面（删除用户）：/manage/{id}/edit?type=3
+     * 测试删除用户：PUT /manage/{id} with delete_user
      */
-    public function test_manage_edit_delete_user()
+    public function test_manage_delete_user()
     {
         $response = $this->actingAs($this->adminUser)
-            ->get("/manage/{$this->regularUser->id}/edit?type=3");
+            ->put("/manage/{$this->regularUser->id}", [
+                'is_active' => $this->regularUser->is_active,
+                'is_admin' => $this->regularUser->is_admin,
+                'delete_user' => 1,
+            ]);
 
         $response->assertRedirect(route('manage.index'));
 
@@ -201,25 +221,76 @@ class ManagePagesLoadTest extends TestCase
     }
 
     /**
-     * 测试非管理员无法执行编辑操作
+     * 测试非管理员无法访问编辑页面
      */
     public function test_manage_edit_requires_admin()
     {
         $response = $this->actingAs($this->regularUser)
-            ->get("/manage/{$this->adminUser->id}/edit?type=1");
+            ->get("/manage/{$this->adminUser->id}/edit");
 
         $response->assertRedirect();
     }
 
     /**
-     * 测试路由参数正确性（验证修复后的路由参数）
+     * 测试非管理员无法执行更新操作
+     */
+    public function test_manage_update_requires_admin()
+    {
+        $response = $this->actingAs($this->regularUser)
+            ->put("/manage/{$this->adminUser->id}", [
+                'is_active' => 0,
+                'is_admin' => 0,
+            ]);
+
+        $response->assertRedirect();
+    }
+
+    /**
+     * 测试路由参数正确性
      */
     public function test_manage_edit_route_with_correct_parameters()
     {
         // 测试路由能正确生成 URL
-        $url = route('manage.edit', ['manage' => $this->regularUser->id, 'type' => '1']);
+        $url = route('manage.edit', $this->regularUser->id);
         $this->assertStringContainsString("/manage/{$this->regularUser->id}/edit", $url);
-        $this->assertStringContainsString("type=1", $url);
+    }
+
+    /**
+     * 测试更新不存在的用户
+     */
+    public function test_manage_update_nonexistent_user()
+    {
+        $response = $this->actingAs($this->adminUser)
+            ->put("/manage/99999", [
+                'is_active' => 1,
+                'is_admin' => 0,
+            ]);
+
+        $response->assertRedirect(route('manage.index'));
+    }
+
+    /**
+     * 测试验证规则
+     */
+    public function test_manage_update_validation()
+    {
+        // 测试无效的 is_active 值
+        $response = $this->actingAs($this->adminUser)
+            ->put("/manage/{$this->regularUser->id}", [
+                'is_active' => 'invalid',
+                'is_admin' => 0,
+            ]);
+
+        $response->assertSessionHasErrors('is_active');
+
+        // 测试无效的 is_admin 值
+        $response = $this->actingAs($this->adminUser)
+            ->put("/manage/{$this->regularUser->id}", [
+                'is_active' => 1,
+                'is_admin' => 99,
+            ]);
+
+        $response->assertSessionHasErrors('is_admin');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
主要變更：
- 新增用戶編輯頁面（manage/edit.blade.php），提供完整的用戶資訊查看和設置修改表單
- 重構 ManagementController::edit() 方法，從直接執行操作改為顯示編輯表單
- 重構 ManagementController::update() 方法，處理表單提交並更新用戶設置
- 簡化 manage/index.blade.php 列表頁面，移除多個操作按鈕，改為單一編輯入口
- 更新測試以符合新的編輯流程
- 新增表單驗證確保資料正確性

改進：
- 提升用戶體驗：管理員可在編輯頁面查看完整用戶資訊
- 加強資料安全：新增輸入驗證，防止無效資料
- 程式碼更清晰：分離顯示邏輯與更新邏輯
- 介面更直觀：使用標籤（label）顯示狀態，一目了然