### PR TITLE
將基本資料編輯頁面的姓名欄位設為只讀

### DIFF
--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -126,15 +126,23 @@
                 <div class="form-group">
                     <label for="c_name_chn" class="col-sm-2 control-label">姓名(中)</label>
                     <div class="col-sm-10">
-                        <input type="text" name="c_name_chn" class="form-control"
-                               value="{{ $basicinformation->c_name_chn }}">
+                        <input type="text" name="c_name_chn" class="form-control" readonly
+                               value="{{ $basicinformation->c_name_chn }}"
+                               style="background-color: #f5f5f5; cursor: not-allowed;">
+                        <span class="help-block">
+                            <small class="text-muted">此欄位由「姓」和「名」自動合併生成，不可直接編輯</small>
+                        </span>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="c_name" class="col-sm-2 control-label">姓名(拼音)</label>
                     <div class="col-sm-10">
-                        <input type="text" name="c_name" class="form-control"
-                               value="{{ $basicinformation->c_name }}">
+                        <input type="text" name="c_name" class="form-control" readonly
+                               value="{{ $basicinformation->c_name }}"
+                               style="background-color: #f5f5f5; cursor: not-allowed;">
+                        <span class="help-block">
+                            <small class="text-muted">此欄位由「Xing」和「Ming」自動合併生成，不可直接編輯</small>
+                        </span>
                     </div>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
## 修改說明

將 `/basicinformation/{id}/edit` 頁面中的「姓名(中)」和「姓名(拼音)」欄位設為只讀模式。

## 修改內容

- 為「姓名(中)」(c_name_chn) 欄位添加 readonly 屬性和視覺提示
- 為「姓名(拼音)」(c_name) 欄位添加 readonly 屬性和視覺提示
- 添加說明文字告知使用者這些欄位是自動生成的

## 原因

根據 BiogMainRepository::updateById() 的邏輯，這兩個欄位的值是自動生成的：
- c_name_chn = c_surname_chn + c_mingzi_chn（姓 + 名）
- c_name = c_surname + ' ' + c_mingzi（Xing + Ming）

因此不應允許直接編輯，使用者應透過修改「姓」、「名」、「Xing」、「Ming」欄位來間接更新。
