### PR TITLE
修復外文全名欄位自動更新問題

### DIFF
--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -211,12 +211,12 @@ class BiogMainRepository
         #20230626修改外文全名呈現順序
         #$c_name_proper = $request->c_surname_proper.' '.$request->c_mingzi_proper;
         #$c_name_rm = $request->c_surname_rm.' '.$request->c_mingzi_rm;
-        $c_name_proper = $request->c_mingzi_proper.' '.$request->c_surname_proper;
-        $c_name_rm = $request->c_mingzi_rm.' '.$request->c_surname_rm;
+        $c_name_proper = trim($request->c_mingzi_proper.' '.$request->c_surname_proper);
+        $c_name_rm = trim($request->c_mingzi_rm.' '.$request->c_surname_rm);
         $data['c_name_chn'] = $c_name_chn;
         $data['c_name'] = $c_name;
-        $data['c_name_proper'] = $data['c_name_proper'] ?? $c_name_proper; //如果欄位是空白,系統自動添加,如果有填入資料,以填入資料為優先.
-        $data['c_name_rm'] = $data['c_name_rm'] ?? $c_name_rm; //如果欄位是空白,系統自動添加,這一欄在前端頁面不開放編輯,自動生成先名後姓.
+        $data['c_name_proper'] = $c_name_proper; // 自動由外文姓名組合生成
+        $data['c_name_rm'] = $c_name_rm; // 自動由外文羅馬字轉寫姓名組合生成
         $data['c_female'] = (int)($data['c_female']);
         $data['c_by_intercalary'] = (int)($data['c_by_intercalary']);
         $data['c_dy_intercalary'] = (int)($data['c_dy_intercalary']);

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -148,8 +148,12 @@
                 <div class="form-group">
                     <label for="c_name_proper" class="col-sm-2 control-label">外文全名</label>
                     <div class="col-sm-10">
-                        <input type="text" name="c_name_proper" class="form-control"
-                               value="{{ $basicinformation->c_name_proper }}">
+                        <input type="text" name="c_name_proper" class="form-control" readonly
+                               value="{{ $basicinformation->c_name_proper }}"
+                               style="background-color: #f5f5f5; cursor: not-allowed;">
+                        <span class="help-block">
+                            <small class="text-muted">此欄位由「外文名」和「外文姓」自動合併生成（名+姓順序），不可直接編輯</small>
+                        </span>
                     </div>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
## 問題描述

當用戶在 basicinformation/{id}/edit 頁面修改或清空「外文姓」、「外文名」欄位並保存時，「外文全名」欄位並不會隨之自動更新。

## 修復內容
- 修復 BiogMainRepository::updateById() 中的邏輯，移除 ?? 運算符
- 確保外文全名每次保存時都會根據外文姓名重新計算
- 將外文全名欄位設為 readonly，用戶只能通過修改外文姓或外文名來間接更新
- 添加 trim() 處理，避免多餘空格"
