### PR TITLE
改用友善措辭：將「不可直接編輯」改為「無需手動填寫」

### DIFF
--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -130,7 +130,7 @@
                                value="{{ $basicinformation->c_name_chn }}"
                                style="background-color: #f5f5f5; cursor: not-allowed;">
                         <span class="help-block">
-                            <small class="text-muted">此欄位由「姓」和「名」自動合併生成，不可直接編輯</small>
+                            <small class="text-muted">此欄位由「姓」和「名」自動合併生成，無需手動填寫</small>
                         </span>
                     </div>
                 </div>
@@ -141,7 +141,7 @@
                                value="{{ $basicinformation->c_name }}"
                                style="background-color: #f5f5f5; cursor: not-allowed;">
                         <span class="help-block">
-                            <small class="text-muted">此欄位由「Xing」和「Ming」自動合併生成，不可直接編輯</small>
+                            <small class="text-muted">此欄位由「Xing」和「Ming」自動合併生成，無需手動填寫</small>
                         </span>
                     </div>
                 </div>
@@ -152,7 +152,7 @@
                                value="{{ $basicinformation->c_name_proper }}"
                                style="background-color: #f5f5f5; cursor: not-allowed;">
                         <span class="help-block">
-                            <small class="text-muted">此欄位由「外文名」和「外文姓」自動合併生成（名+姓順序），不可直接編輯</small>
+                            <small class="text-muted">此欄位由「外文名」和「外文姓」自動合併生成（名+姓順序），無需手動填寫</small>
                         </span>
                     </div>
                 </div>
@@ -163,7 +163,7 @@
                                value="{{ $basicinformation->c_name_rm }}"
                                style="background-color: #f5f5f5; cursor: not-allowed;">
                         <span class="help-block">
-                            <small class="text-muted">此欄位由「外文羅馬字轉寫姓」和「外文羅馬字轉寫名」自動合併生成，不可直接編輯</small>
+                            <small class="text-muted">此欄位由「外文羅馬字轉寫姓」和「外文羅馬字轉寫名」自動合併生成，無需手動填寫</small>
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## 變更說明

將基本資料編輯頁面中的提示文字從較生硬的「不可直接編輯」改為更友善的「無需手動填寫」，提升使用者體驗。

## 變更內容

- 檔案：resources/views/biogmains/basicinformation/edit.blade.php
- 修改了 4 處自動生成欄位的提示文字：
  - 中文姓名 (c_name_chn)
  - Name (c_name)
  - Name (proper) (c_name_proper)
  - Name (romanized) (c_name_rm)

## 影響範圍

僅影響 UI 文字顯示，不涉及功能變更。