### PR TITLE
整合 TEXT_INSTANCE_DATA 和 ADDR_BELONGS_DATA 至 /codes 統一介面

### DIFF
--- a/CODES.md
+++ b/CODES.md
@@ -3,7 +3,9 @@
 ## 現況
 - `/codes/{table}` 為唯一介面：`CodesController` 依網址動態查詢資料表，提供列表、CRUD、提案／審核等完整流程。
 - 2025-11 起移除 6 個既有的 Vue 單頁（`/altnamecodes`、`/addrcodes`、`/appointcodes`、`/officecodes`、`/socialinstitutioncodes`、`/textcodes` 與其對應 API），原功能已整合回 `/codes/*`。
-- 目前仍保留 2 個 Vue 頁面：`/addrbelongsdata` 和 `/textinstancedata`，提供數據表格的互動式管理功能。
+- 2025-11 起將 `/addrbelongsdata` 和 `/textinstancedata` 整合至 `/codes/ADDR_BELONGS_DATA` 和 `/codes/TEXT_INSTANCE_DATA`。
+  - 新增頁面提供欄位說明和連結，方便用戶查看相關代碼表。
+  - `TEXT_INSTANCE_DATA` 提供 Load Data 功能，可從 `TEXT_CODES` 自動載入書籍資訊。
 - 常用 *_CODES 表的欄位順序與 Vue 版本一致，並會：
   - 自動排序主鍵欄位並預估下一個編號（含複合鍵組合）。
   - 在新增／編輯時計入 `c_created_*`、`c_modified_*` 與 `operations` 日誌。

--- a/resources/views/codes/create.blade.php
+++ b/resources/views/codes/create.blade.php
@@ -12,11 +12,39 @@
                     @foreach($row as $key)
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
+                            @if($table === 'TEXT_INSTANCE_DATA' && $key === 'c_textid')
+                            <div class="col-sm-8">
+                                @php($defaultValue = $defaults[$key] ?? ($i === 1 ? $id : null))
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $defaultValue) }}">
+                            </div>
+                            <div class="col-sm-2">
+                                <button type="button" id="button_ajax_load" class="btn btn-info">Load Data</button>
+                            </div>
+                            <div class="col-sm-offset-2 col-sm-10">
+                                <p class="help-block text-muted">請確保 <a href="/codes/TEXT_CODES" target="_blank">TEXT_CODES</a> 表中存在這本書的 c_textid，再複製 ID 填入</p>
+                            </div>
+                            @elseif($table === 'ADDR_BELONGS_DATA' && $key === 'c_addr_id')
+                            <div class="col-sm-10">
+                                @php($defaultValue = $defaults[$key] ?? ($i === 1 ? $id : null))
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $defaultValue) }}">
+                                <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                            </div>
+                            @elseif($table === 'ADDR_BELONGS_DATA' && $key === 'c_belongs_to')
+                            <div class="col-sm-10">
+                                @php($defaultValue = $defaults[$key] ?? ($i === 1 ? $id : null))
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $defaultValue) }}">
+                                <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                            </div>
+                            @else
                             <div class="col-sm-10">
                                 @php($defaultValue = $defaults[$key] ?? ($i === 1 ? $id : null))
                                 <input type="text" name="{{ $key }}" class="form-control"
                                        value="{{ old($key, $defaultValue) }}">
                             </div>
+                            @endif
                         </div>
                     @php($i++)
                     @endforeach
@@ -42,5 +70,59 @@
 
 @endsection
 @section('js')
+@if($table === 'TEXT_INSTANCE_DATA')
+<script type="text/javascript">
+$(document).ready(function (){
 
+    var DoAjax = function(requestUrl, sentData, sHandler, eHandler, pageNotFoundHandler){
+        $.ajax({
+            type: 'GET',
+            url: requestUrl,
+            cache: false,
+            data: sentData,
+            success: sHandler,
+            error: eHandler,
+            statusCode: {
+              404: pageNotFoundHandler
+            }
+        });
+    };
+
+    /* Load Data from TEXT_CODES */
+    $("#button_ajax_load").click(function(){
+
+        var c_textid = $("input[name='c_textid']").val();
+        var url = "/api/select/search/text?q=" + c_textid + "";
+        /* disable trigger button, preventing multiple requests */
+        $(this).attr("disabled", true);
+
+        /* wait for ajax */
+        setTimeout(function(){
+
+            DoAjax(url, {todo : "exSucceed"},
+                function(data, textStatus, jqXHR){
+                    if(data.data == '') {
+                        alert('Load Data 沒有查詢到資料');
+                    }
+                    else if(data.data != '') {
+                        /* 在這裡添加錄入表單更新的欄位與資料 */
+                        $("input[name='c_instance_title_chn']").val(data.data[0].c_title_chn);
+                        $("input[name='c_instance_title_chn']").css("background","#FFFFBB");
+                        $("input[name='c_instance_title']").val(data.data[0].c_title);
+                        $("input[name='c_instance_title']").css("background","#FFFFBB");
+                        alert('Load Data 更新[c_instance_title_chn]與[c_instance_title]成功');
+                    }
+                    else {
+                        alert('Load Data 查詢失敗');
+                    }
+                });
+
+            /* enable trigger button */
+            $("#button_ajax_load").attr("disabled", false);
+        }, 10);
+    });
+
+});
+</script>
+@endif
 @endsection

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -41,10 +41,35 @@
                         @endphp
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
+                            @if($table === 'TEXT_INSTANCE_DATA' && $key === 'c_textid')
+                            <div class="col-sm-8">
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
+                            </div>
+                            <div class="col-sm-2">
+                                <button type="button" id="button_ajax_load_instance" class="btn btn-info">Load Data</button>
+                            </div>
+                            <div class="col-sm-offset-2 col-sm-10">
+                                <p class="help-block text-muted">請確保 <a href="/codes/TEXT_CODES" target="_blank">TEXT_CODES</a> 表中存在這本書的 c_textid，再複製 ID 填入</p>
+                            </div>
+                            @elseif($table === 'ADDR_BELONGS_DATA' && $key === 'c_addr_id')
+                            <div class="col-sm-10">
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
+                                <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                            </div>
+                            @elseif($table === 'ADDR_BELONGS_DATA' && $key === 'c_belongs_to')
+                            <div class="col-sm-10">
+                                <input type="text" name="{{ $key }}" class="form-control"
+                                       value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
+                                <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                            </div>
+                            @else
                             <div class="col-sm-10">
                                 <input type="text" name="{{ $key }}" class="form-control"
                                        value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
                             </div>
+                            @endif
                         </div>
                     @endforeach
                     @if(Auth::check() && Auth::user()->isActive())
@@ -98,6 +123,61 @@
         let new_window = window.open('_blank');
         new_window.location = url ;
     });
+</script>
+@endif
+@if($table === 'TEXT_INSTANCE_DATA')
+<script type="text/javascript">
+$(document).ready(function (){
+
+    var DoAjax = function(requestUrl, sentData, sHandler, eHandler, pageNotFoundHandler){
+        $.ajax({
+            type: 'GET',
+            url: requestUrl,
+            cache: false,
+            data: sentData,
+            success: sHandler,
+            error: eHandler,
+            statusCode: {
+              404: pageNotFoundHandler
+            }
+        });
+    };
+
+    /* Load Data from TEXT_CODES */
+    $("#button_ajax_load_instance").click(function(){
+
+        var c_textid = $("input[name='c_textid']").val();
+        var url = "/api/select/search/text?q=" + c_textid + "";
+        /* disable trigger button, preventing multiple requests */
+        $(this).attr("disabled", true);
+
+        /* wait for ajax */
+        setTimeout(function(){
+
+            DoAjax(url, {todo : "exSucceed"},
+                function(data, textStatus, jqXHR){
+                    if(data.data == '') {
+                        alert('Load Data 沒有查詢到資料');
+                    }
+                    else if(data.data != '') {
+                        /* 在這裡添加錄入表單更新的欄位與資料 */
+                        $("input[name='c_instance_title_chn']").val(data.data[0].c_title_chn);
+                        $("input[name='c_instance_title_chn']").css("background","#FFFFBB");
+                        $("input[name='c_instance_title']").val(data.data[0].c_title);
+                        $("input[name='c_instance_title']").css("background","#FFFFBB");
+                        alert('Load Data 更新[c_instance_title_chn]與[c_instance_title]成功');
+                    }
+                    else {
+                        alert('Load Data 查詢失敗');
+                    }
+                });
+
+            /* enable trigger button */
+            $("#button_ajax_load_instance").attr("disabled", false);
+        }, 10);
+    });
+
+});
 </script>
 @endif
 @endsection

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -57,8 +57,8 @@
             <li class="{{ $page_title == 'Office Codes' ? 'active' : '' }}"><a href="/codes/OFFICE_CODES"><i class="ion ion-ios-people-outline"></i> <span>任官編碼表 (OFFICE_CODES)</span></a></li>
             <li class="{{ $page_title == 'Social Institution Codes' ? 'active' : '' }}"><a href="/codes/SOCIAL_INSTITUTION_CODES"><i class="ion ion-ios-people-outline"></i> <span>社會機構編碼表<br>(SOCIAL_INSTITUTION_CODES)</span></a></li>
             <li class="header">資料表 DATA</li>
-            <li class="{{ $page_title == 'Addrbelongsdata Type Codes' ? 'active' : '' }}"><a href="{{ route('addrbelongsdata.index') }}"><i class="ion ion-ios-people-outline"></i> <span>地址從屬表</span></a></li>
-            <li class="{{ $page_title == 'Text Instance Data' ? 'active' : '' }}"><a href="{{ route('textinstancedata.index') }}"><i class="ion ion-ios-people-outline"></i> <span>著作版本表</span></a></li>
+            <li class="{{ $page_title == 'Addrbelongsdata Type Codes' ? 'active' : '' }}"><a href="/codes/ADDR_BELONGS_DATA"><i class="ion ion-ios-people-outline"></i> <span>地址從屬表<br>(ADDR_BELONGS_DATA)</span></a></li>
+            <li class="{{ $page_title == 'Text Instance Data' ? 'active' : '' }}"><a href="/codes/TEXT_INSTANCE_DATA"><i class="ion ion-ios-people-outline"></i> <span>著作版本表<br>(TEXT_INSTANCE_DATA)</span></a></li>
             <li class="header">檢視表 VIEW</li>
             <li class="{{ $page_title == '檢視表總覽' ? 'active' : '' }}"><a href="{{ route('view.index') }}"><i class="fa fa-th-list"></i> <span>檢視表總覽</span></a></li>
             <li class="{{ $page_title == '地址層級檢視' ? 'active' : '' }}"><a href="{{ route('view.show', 'addresses') }}"><i class="fa fa-table"></i> <span>地址層級檢視</span></a></li>


### PR DESCRIPTION
## 主要變更

### 1. TEXT_INSTANCE_DATA 整合
- 在創建和編輯頁面添加 c_textid 欄位說明
- 添加 Load Data 按鈕，可從 TEXT_CODES 自動載入書籍資訊
- 將 TEXT_CODES 表名改為可點擊連結，在新窗口打開
- 側邊欄連結更新為 /codes/TEXT_INSTANCE_DATA

### 2. ADDR_BELONGS_DATA 整合
- 在創建和編輯頁面添加 c_addr_id 和 c_belongs_to 欄位說明
- 將 ADDR_CODES 表名改為可點擊連結，在新窗口打開
- 側邊欄連結更新為 /codes/ADDR_BELONGS_DATA

### 3. 文檔更新
- 更新 CODES.md，記錄整合進度和新增功能
- 統一側邊欄顯示格式，加上表名括號說明

## 技術細節

### 視圖文件修改
- resources/views/codes/create.blade.php
- resources/views/codes/edit.blade.php
- resources/views/layouts/sidebar.blade.php
- CODES.md

### 新增功能
- TEXT_INSTANCE_DATA 的 Load Data 功能使用 AJAX 從 /api/select/search/text 查詢
- 欄位說明使用 Bootstrap help-block 樣式
- 所有連結使用 target="_blank" 在新窗口打開