### PR TITLE
新增 cbdb:manage-user artisan 命令並添加用戶管理使用說明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,45 @@
 | 執行完整測試 | `./vendor/bin/phpunit` |
 | 執行單一測試 | `./vendor/bin/phpunit --filter TestName` |
 | 匯入繁簡映射 | `php artisan cbdb:import-trad-simp-map --truncate` |
+| 管理用戶 | `php artisan cbdb:manage-user` （交互式）或帶選項創建/更新 |
 
 > 若修改 Vue/JS，記得在本機跑 `npm run prod` 產出 `public/js/app.js`；專案不會自動編譯。
+
+### 用戶管理
+- **管理用戶命令**：使用 `php artisan cbdb:manage-user` 創建或更新用戶。適用於環境初始設置和日常用戶管理。
+  - **交互式模式**：直接運行 `php artisan cbdb:manage-user`，系統會逐步詢問所需信息。
+  - **命令行模式**：使用選項直接指定參數，適合腳本自動化：
+    ```bash
+    # 創建系統管理員
+    php artisan cbdb:manage-user \
+      --email=admin@example.com \
+      --name="系統管理員" \
+      --password=secret123 \
+      --active=1 \
+      --role=super-admin
+
+    # 更新現有用戶角色
+    php artisan cbdb:manage-user --email=user@example.com --role=expert
+
+    # 列出所有用戶
+    php artisan cbdb:manage-user --list
+    ```
+  - **支持的角色**：`regular`（一般）、`expert`（專家）、`crowdsourcing`（眾包）、`super-admin`（系統管理員）
+  - **激活狀態**：`0`（未激活）、`1`（激活）、`2`（預留）
+- **User Factory**：測試和內部工具可使用 `User::factory()` 創建測試用戶：
+  ```php
+  // 創建普通用戶
+  $user = User::factory()->create();
+
+  // 創建活躍的系統管理員
+  $admin = User::factory()->active()->superAdmin()->create();
+
+  // 批量創建用戶
+  $users = User::factory()->count(5)->create();
+
+  // 舊語法仍然支持（向後兼容）
+  $user = factory(User::class)->create();
+  ```
 
 ### 內部表維護
 - **繁簡映射表**：使用 `php artisan cbdb:import-trad-simp-map --truncate` 從 OpenCC 匯入最新繁簡對照。支援 `--batch=N` 參數調整批次大小（預設 1000）。

--- a/USER_PRIVILEGES.md
+++ b/USER_PRIVILEGES.md
@@ -89,7 +89,7 @@ if (Auth::user()->canManageUsers()) {
 
 ### 5.1 命令行用戶管理（cbdb:manage-user）
 
-項目提供 `cbdb:manage-user` artisan 命令，用於環境初始設置和日常用戶管理。此命令使用 `User::factory()` 創建新用戶，確保數據一致性。
+項目提供 `cbdb:manage-user` artisan 命令，用於環境初始設置和日常用戶管理。此命令直接使用 `User` 模型創建新用戶，無需依賴開發環境的 Factory 組件，確保在生產環境中也能正常運行。
 
 #### 交互式模式
 

--- a/USER_PRIVILEGES.md
+++ b/USER_PRIVILEGES.md
@@ -21,7 +21,7 @@
 | `0` | 一般用戶 | `User::ROLE_REGULAR` | 只要 `is_active = 1` 即可直接對 `/basicinformation/*`、`/codes/*` 等模組進行新增 / 修改，Controller 會直接呼叫對應的 Repository → Model，寫入資料表並留下操作紀錄。 |
 | `1` | 專家用戶 | `User::ROLE_EXPERT` | 擁有一般用戶權限；另外可：<br>• 進入 `/manage` 調整帳號啟用 / 角色。<br>• 在 `/operations`、`/modified` 審核提案（核准 / 退修）、執行操作復原。<br>• 存取 `/merge-preview` 等管理工具。 |
 | `2` | 眾包用戶 | `User::ROLE_CROWDSOURCING` | 前台頁面可編輯，但 Controller 會偵測 `is_admin == 2`，把提交內容轉成 `operations`（`crowdsourcing_status = 2`），等待專家審核後套用，並不直接寫主資料表。 |
-| `3` | 系統管理員（預留） | `User::ROLE_SUPER_ADMIN` | 預留角色，擁有比專家更高階的權限，需配合程式實作後啟用。 |
+| `3` | 系統管理員 | `User::ROLE_SUPER_ADMIN` | **已在模型層面完全實現**。擁有與專家相同的基礎權限（透過 `isAdmin()` 方法識別），可用於區分更高階的管理功能。可透過 `cbdb:manage-user` 命令創建。 |
 
 > **常量使用**：`User` 模型已定義角色和狀態常量（參見 `app/User.php`），建議在新代碼中使用常量而非魔術數字。
 
@@ -29,15 +29,17 @@
 
 ## 三、權限差異總覽
 
-| 動作 | 一般用戶 (`is_admin=0`) | 專家用戶 (`is_admin=1`) | 眾包用戶 (`is_admin=2`) |
-|------|-----------------------|------------------------|------------------------|
-| `/basicinformation` 新增 / 修改 | 直接寫入 `BIOG_MAIN` | 同一般用戶 | 建立眾包提案，`crowdsourcing_status = 2`，不直接寫表 |
-| `/codes` 新增 / 修改 | 直接寫入各代碼表 | 同一般用戶，可額外審核提案 | 建立提案，交由專家審核 |
-| `/operations` 審核提案、操作復原 | 無 | ✅（僅活躍專家可用） | 無 |
-| `/modified` 審核提案 | 無 | ✅ | 無 |
-| `/crowdsourcing` 審核（Confirm） | 無 | ✅ | 只能提交提案 |
-| `/manage` 列表管理帳號 | 無 | ✅ | 無 |
-| `/merge-preview` 等管理工具 | 無 | ✅ | 無 |
+| 動作 | 一般用戶<br>(`is_admin=0`) | 專家用戶<br>(`is_admin=1`) | 眾包用戶<br>(`is_admin=2`) | 系統管理員<br>(`is_admin=3`) |
+|------|--------------------------|--------------------------|--------------------------|----------------------------|
+| `/basicinformation` 新增 / 修改 | 直接寫入 `BIOG_MAIN` | 同一般用戶 | 建立眾包提案，`crowdsourcing_status = 2`，不直接寫表 | 同專家用戶 |
+| `/codes` 新增 / 修改 | 直接寫入各代碼表 | 同一般用戶，可額外審核提案 | 建立提案，交由專家審核 | 同專家用戶 |
+| `/operations` 審核提案、操作復原 | 無 | ✅（透過 `isAdmin()` 檢查） | 無 | ✅（透過 `isAdmin()` 檢查） |
+| `/modified` 審核提案 | 無 | ✅ | 無 | ✅ |
+| `/crowdsourcing` 審核（Confirm） | 無 | ✅ | 只能提交提案 | ✅ |
+| `/manage` 列表管理帳號 | 無 | ✅（透過 `canManageUsers()` 檢查） | 無 | ✅（透過 `canManageUsers()` 檢查） |
+| `/merge-preview` 等管理工具 | 無 | ✅ | 無 | ✅ |
+
+> **註**：系統管理員目前與專家用戶擁有相同的基礎權限（透過 `isAdmin()` 方法識別）。如需為系統管理員添加專屬權限，可使用 `isSuperAdmin()` 方法進行更細緻的權限控制。
 
 ---
 
@@ -57,6 +59,7 @@
 - `canManageUsers(): bool` - 檢查是否可管理用戶（活躍的專家或系統管理員）
 - `canRestoreOperations(): bool` - 檢查是否可執行操作復原（活躍的專家或系統管理員）
 - `canWriteDirectly(): bool` - 檢查是否可直接寫入數據（活躍且非眾包用戶）
+- `canRunBatchImport(): bool` - 檢查是否可執行批量導入操作（活躍的專家或系統管理員）
 
 ### 其他輔助方法
 - `getRoleName(): string` - 獲取用戶角色中文名稱（「一般」、「專家」、「眾包」、「系統管理員」）
@@ -82,39 +85,316 @@ if (Auth::user()->canManageUsers()) {
 
 ---
 
-## 五、新增「系統管理員」的實施指南
+## 五、用戶管理工具
 
-系統已預留系統管理員角色（`User::ROLE_SUPER_ADMIN = 3`），若要啟用需完成以下步驟：
+### 5.1 命令行用戶管理（cbdb:manage-user）
 
-### 1. 更新 UI 顯示
-修改 `resources/views/manage/index.blade.php` 的角色顯示：
+項目提供 `cbdb:manage-user` artisan 命令，用於環境初始設置和日常用戶管理。此命令使用 `User::factory()` 創建新用戶，確保數據一致性。
+
+#### 交互式模式
+
+直接運行命令，系統會逐步詢問所需信息：
+
+```bash
+php artisan cbdb:manage-user
+```
+
+系統會依次詢問：
+1. Email（必填）
+2. 用戶名稱
+3. 密碼（至少 6 個字符）
+4. 激活狀態（未激活 / 激活 / 預留）
+5. 用戶角色（一般 / 專家 / 眾包 / 系統管理員）
+
+#### 命令行選項模式
+
+使用選項直接指定參數，適合腳本自動化：
+
+```bash
+# 創建系統管理員
+php artisan cbdb:manage-user \
+  --email=admin@example.com \
+  --name="系統管理員" \
+  --password=secret123 \
+  --active=1 \
+  --role=super-admin
+
+# 創建專家用戶
+php artisan cbdb:manage-user \
+  --email=expert@example.com \
+  --name="專家用戶" \
+  --password=password123 \
+  --active=1 \
+  --role=expert
+
+# 更新現有用戶（提升為專家）
+php artisan cbdb:manage-user --email=user@example.com --role=expert
+
+# 更新用戶名稱和密碼
+php artisan cbdb:manage-user \
+  --email=user@example.com \
+  --name="新名稱" \
+  --password=newpassword
+
+# 列出所有用戶
+php artisan cbdb:manage-user --list
+```
+
+#### 可用選項
+
+| 選項 | 說明 | 可選值 |
+|------|------|--------|
+| `--email` | 用戶 Email（必填，用於查找或創建用戶） | 任何有效的 Email 地址 |
+| `--name` | 用戶名稱 | 任何字符串 |
+| `--password` | 用戶密碼（至少 6 個字符） | 至少 6 個字符的字符串 |
+| `--active` | 激活狀態 | `0`（未激活）、`1`（激活）、`2`（預留） |
+| `--role` | 用戶角色 | `regular`、`expert`、`crowdsourcing`、`super-admin` |
+| `--list` | 列出所有用戶 | - |
+
+#### 工作流程
+
+1. **創建新用戶**：如果提供的 Email 不存在，命令會創建新用戶
+2. **更新現有用戶**：如果 Email 已存在，命令會更新該用戶的信息
+3. **自動生成字段**：新用戶會自動生成 `confirmation_token` 和其他必需字段
+
+### 5.2 測試和內部工具（User Factory）
+
+項目已為 `User` 模型添加 `HasFactory` trait，測試和內部工具可使用 Factory 創建測試用戶。
+
+#### 基本用法
 
 ```php
+use App\User;
+
+// 創建普通用戶（默認為激活狀態、一般角色）
+$user = User::factory()->create();
+
+// 創建但不保存到數據庫
+$user = User::factory()->make();
+
+// 批量創建用戶
+$users = User::factory()->count(5)->create();
+
+// 使用自定義屬性
+$user = User::factory()->create([
+    'name' => '張三',
+    'email' => 'zhangsan@example.com',
+    'password' => Hash::make('password123'),
+]);
+```
+
+#### 使用狀態方法
+
+Factory 提供多種狀態方法，方便創建特定類型的用戶：
+
+```php
+// 創建活躍用戶
+$activeUser = User::factory()->active()->create();
+
+// 創建未激活用戶
+$inactiveUser = User::factory()->inactive()->create();
+
+// 創建系統管理員
+$superAdmin = User::factory()->superAdmin()->create();
+
+// 創建專家用戶
+$expert = User::factory()->expert()->create();
+
+// 創建眾包用戶
+$crowdsourcing = User::factory()->crowdsourcing()->create();
+
+// 創建一般用戶
+$regular = User::factory()->regular()->create();
+
+// 組合多個狀態
+$activeAdmin = User::factory()->active()->superAdmin()->create();
+
+// 創建活躍的管理員（隨機為專家或系統管理員）
+$activeAdmin = User::factory()->activeAdmin()->create();
+```
+
+#### 在測試中使用
+
+```php
+use Tests\TestCase;
+use App\User;
+
+class MyFeatureTest extends TestCase
+{
+    /** @test */
+    public function only_active_admins_can_restore_operations()
+    {
+        // 創建活躍的專家用戶
+        $admin = User::factory()->active()->expert()->create();
+
+        // 執行需要管理員權限的操作
+        $response = $this->actingAs($admin)
+            ->post('/operations/restore/123');
+
+        $response->assertSuccessful();
+    }
+
+    /** @test */
+    public function crowdsourcing_users_cannot_write_directly()
+    {
+        // 創建眾包用戶
+        $crowdsourcingUser = User::factory()
+            ->active()
+            ->crowdsourcing()
+            ->create();
+
+        $this->assertFalse($crowdsourcingUser->canWriteDirectly());
+    }
+}
+```
+
+#### 向後兼容
+
+舊的 `factory()` 語法仍然支持，無需修改現有代碼：
+
+```php
+// 舊語法（仍然可用）
+$user = factory(User::class)->create();
+$users = factory(User::class, 5)->create();
+```
+
+---
+
+## 六、系統管理員角色實施狀態
+
+系統管理員角色（`User::ROLE_SUPER_ADMIN = 3`）已在**模型層面完全實現**，可以正常創建和使用。
+
+### ✅ 已實現的功能
+
+#### 1. User 模型支持
+- ✅ 定義了 `User::ROLE_SUPER_ADMIN = 3` 常量
+- ✅ 提供完整的輔助方法：
+  - `isSuperAdmin(): bool` - 檢查是否為系統管理員
+  - `isAdmin(): bool` - 包含專家和系統管理員
+  - `canManageUsers(): bool` - 活躍的專家或系統管理員可管理用戶
+  - `canRestoreOperations(): bool` - 活躍的專家或系統管理員可復原操作
+  - `getRoleName(): string` - 返回「系統管理員」中文名稱
+
+#### 2. 用戶創建和管理
+- ✅ `cbdb:manage-user` 命令支持創建系統管理員：
+  ```bash
+  php artisan cbdb:manage-user \
+    --email=admin@example.com \
+    --name="系統管理員" \
+    --password=secret123 \
+    --active=1 \
+    --role=super-admin
+  ```
+
+- ✅ `UserFactory` 支持創建系統管理員測試用戶：
+  ```php
+  $superAdmin = User::factory()->superAdmin()->create();
+  $activeAdmin = User::factory()->active()->superAdmin()->create();
+  ```
+
+#### 3. 權限檢查方法
+系統管理員在使用 `isAdmin()` 方法檢查時會被識別為管理員，因此在大多數需要管理員權限的地方已經可以正常工作：
+
+```php
+// ✅ 系統管理員會通過這些檢查
+if (Auth::user()->isAdmin()) {
+    // 專家和系統管理員都可以執行
+}
+
+if (Auth::user()->canManageUsers()) {
+    // 活躍的專家或系統管理員可以管理用戶
+}
+
+if (Auth::user()->canRestoreOperations()) {
+    // 活躍的專家或系統管理員可以復原操作
+}
+```
+
+### 🔧 需要進一步完善的部分
+
+#### 1. UI 顯示更新
+某些頁面的角色顯示可能仍使用硬編碼邏輯。**推薦統一使用** `$user->getRoleName()` 方法：
+
+```php
+// ❌ 舊寫法（可能不顯示系統管理員）
 {{
-    $user->is_admin == 3 ? '系統管理員' :
-    ($user->is_admin == 2 ? '眾包' :
-    ($user->is_admin == 1 ? '專家' : '一般'))
+    $user->is_admin == 2 ? '眾包' :
+    ($user->is_admin == 1 ? '專家' : '一般')
 }}
 
-// 或使用輔助方法（推薦）
+// ✅ 新寫法（自動支持所有角色）
 {{ $user->getRoleName() }}
 ```
 
-### 2. 定義系統管理員專屬權限
-若系統管理員需要比專家更高的權限，需在相關 Controller 中添加判斷：
+需要檢查的文件：
+- `resources/views/manage/index.blade.php`
+- 其他顯示用戶角色的視圖
+
+#### 2. 定義系統管理員專屬權限（可選）
+如果系統管理員需要比專家**更高**的權限，可在相關 Controller 中添加判斷：
 
 ```php
-// 僅限系統管理員
+// 僅限系統管理員的功能
 if (!Auth::user()->isSuperAdmin()) {
     flash('該功能僅限系統管理員使用。', 'error');
     return redirect()->back();
 }
 ```
 
-### 3. 測試覆蓋
-為新角色補充測試用例，確保權限檢查正確。
+#### 3. Controller 權限檢查遷移
+目前多數功能使用 `is_admin == 1` 檢查。若要讓系統管理員也擁有相同權限，**應改用 `isAdmin()` 方法**：
 
-**注意**：目前多數功能使用 `is_admin == 1` 檢查，若要讓系統管理員也擁有相同權限，應改用 `isAdmin()` 方法（已包含專家和系統管理員）。
+```php
+// ❌ 舊寫法（只允許專家）
+if (Auth::user()->is_admin == 1) {
+    // ...
+}
+
+// ✅ 新寫法（允許專家和系統管理員）
+if (Auth::user()->isAdmin()) {
+    // ...
+}
+```
+
+需要檢查和更新的地方：
+- `app/Http/Controllers/OperationsController.php`
+- `app/Http/Controllers/ManageController.php`
+- 其他需要管理員權限的 Controller
+
+#### 4. 測試覆蓋
+為系統管理員角色補充測試用例：
+
+```php
+/** @test */
+public function super_admin_can_manage_users()
+{
+    $superAdmin = User::factory()->active()->superAdmin()->create();
+
+    $this->assertTrue($superAdmin->isSuperAdmin());
+    $this->assertTrue($superAdmin->isAdmin());
+    $this->assertTrue($superAdmin->canManageUsers());
+}
+```
+
+### 📋 遷移檢查清單
+
+如果需要在整個系統中完全啟用系統管理員角色，建議按以下順序進行：
+
+- [ ] 1. 使用 `grep` 搜索所有 `is_admin == 1` 的硬編碼檢查
+- [ ] 2. 評估每處檢查是否應該包含系統管理員
+- [ ] 3. 將適當的檢查改為使用 `isAdmin()` 方法
+- [ ] 4. 更新所有視圖中的角色顯示為 `getRoleName()`
+- [ ] 5. 補充系統管理員相關的測試用例
+- [ ] 6. 在開發/測試環境創建系統管理員用戶進行端到端測試
+
+### 💡 最佳實踐
+
+1. **優先使用輔助方法**：使用 `isAdmin()`、`isSuperAdmin()` 等方法而非直接比較 `is_admin` 值
+2. **使用 `getRoleName()`**：在 UI 中顯示角色名稱時統一使用此方法
+3. **明確權限需求**：如果某功能僅限專家，使用 `isExpert()`；如果包含所有管理員，使用 `isAdmin()`
+4. **避免魔術數字**：使用 `User::ROLE_SUPER_ADMIN` 等常量而非數字 3
+
+**總結**：系統管理員角色在模型和工具層面已完全可用，可以立即開始使用。UI 和某些 Controller 的權限檢查可以根據實際需求逐步遷移和完善。
 
 ---
 

--- a/app/Console/Commands/ManageUser.php
+++ b/app/Console/Commands/ManageUser.php
@@ -130,8 +130,8 @@ class ManageUser extends Command
 
         $role = $this->roleMap[$roleInput] ?? User::ROLE_REGULAR;
 
-        // 使用 Factory 創建用戶
-        $user = User::factory()->create([
+        // 創建用戶（直接使用模型，避免依賴 dev-only 的 Faker）
+        $user = User::create([
             'name' => $name,
             'email' => $email,
             'password' => Hash::make($password),

--- a/app/Console/Commands/ManageUser.php
+++ b/app/Console/Commands/ManageUser.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class ManageUser extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cbdb:manage-user
+                            {--email= : 用戶 Email（必填，用於查找或創建用戶）}
+                            {--name= : 用戶名稱}
+                            {--password= : 用戶密碼}
+                            {--active= : 激活狀態 (0=未激活, 1=激活, 2=預留)}
+                            {--role= : 用戶角色 (regular=一般, expert=專家, crowdsourcing=眾包, super-admin=系統管理員)}
+                            {--list : 列出所有用戶}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '管理用戶：創建或更新用戶信息（名稱、Email、密碼、激活狀態、角色）';
+
+    /**
+     * 角色映射
+     */
+    protected $roleMap = [
+        'regular' => User::ROLE_REGULAR,
+        'expert' => User::ROLE_EXPERT,
+        'crowdsourcing' => User::ROLE_CROWDSOURCING,
+        'super-admin' => User::ROLE_SUPER_ADMIN,
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // 如果是列出用戶
+        if ($this->option('list')) {
+            return $this->listUsers();
+        }
+
+        // 獲取或詢問 Email
+        $email = $this->option('email') ?: $this->ask('請輸入用戶 Email');
+
+        if (!$email) {
+            $this->error('Email 是必填項！');
+            return 1;
+        }
+
+        // 驗證 Email 格式
+        $validator = Validator::make(['email' => $email], [
+            'email' => 'required|email'
+        ]);
+
+        if ($validator->fails()) {
+            $this->error('Email 格式無效！');
+            return 1;
+        }
+
+        // 檢查用戶是否存在
+        $user = User::where('email', $email)->first();
+
+        if ($user) {
+            $this->info("找到現有用戶：{$user->name} ({$user->email})");
+            return $this->updateUser($user);
+        } else {
+            $this->info("用戶不存在，將創建新用戶");
+            return $this->createUser($email);
+        }
+    }
+
+    /**
+     * 創建新用戶
+     */
+    protected function createUser($email)
+    {
+        $this->info('=== 創建新用戶 ===');
+
+        // 獲取或詢問用戶名稱
+        $name = $this->option('name') ?: $this->ask('請輸入用戶名稱');
+
+        if (!$name) {
+            $this->error('用戶名稱是必填項！');
+            return 1;
+        }
+
+        // 獲取或詢問密碼
+        $password = $this->option('password') ?: $this->secret('請輸入密碼（至少 6 個字符）');
+
+        if (!$password || strlen($password) < 6) {
+            $this->error('密碼必須至少 6 個字符！');
+            return 1;
+        }
+
+        // 獲取或詢問激活狀態
+        $active = $this->option('active');
+        if ($active === null) {
+            $active = $this->choice(
+                '請選擇激活狀態',
+                ['0' => '未激活', '1' => '激活', '2' => '預留'],
+                '1'
+            );
+        }
+
+        // 獲取或詢問角色
+        $roleInput = $this->option('role');
+        if (!$roleInput) {
+            $roleInput = $this->choice(
+                '請選擇用戶角色',
+                [
+                    'regular' => '一般用戶',
+                    'expert' => '專家',
+                    'crowdsourcing' => '眾包用戶',
+                    'super-admin' => '系統管理員'
+                ],
+                'regular'
+            );
+        }
+
+        $role = $this->roleMap[$roleInput] ?? User::ROLE_REGULAR;
+
+        // 使用 Factory 創建用戶
+        $user = User::factory()->create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make($password),
+            'is_active' => (int)$active,
+            'is_admin' => $role,
+            'confirmation_token' => Str::random(32),
+        ]);
+
+        $this->newLine();
+        $this->info('✓ 用戶創建成功！');
+        $this->displayUserInfo($user);
+
+        return 0;
+    }
+
+    /**
+     * 更新現有用戶
+     */
+    protected function updateUser(User $user)
+    {
+        $this->info('=== 更新用戶信息 ===');
+
+        $updated = false;
+
+        // 更新名稱
+        $name = $this->option('name');
+        if ($name === null && $this->confirm("是否更新用戶名稱？（當前：{$user->name}）", false)) {
+            $name = $this->ask('請輸入新的用戶名稱', $user->name);
+        }
+        if ($name && $name !== $user->name) {
+            $user->name = $name;
+            $updated = true;
+        }
+
+        // 更新密碼
+        $password = $this->option('password');
+        if ($password === null && $this->confirm('是否更新密碼？', false)) {
+            $password = $this->secret('請輸入新密碼（至少 6 個字符）');
+        }
+        if ($password) {
+            if (strlen($password) < 6) {
+                $this->error('密碼必須至少 6 個字符！');
+                return 1;
+            }
+            $user->password = Hash::make($password);
+            $updated = true;
+        }
+
+        // 更新激活狀態
+        $active = $this->option('active');
+        if ($active === null && $this->confirm("是否更新激活狀態？（當前：{$user->is_active}）", false)) {
+            $active = $this->choice(
+                '請選擇激活狀態',
+                ['0' => '未激活', '1' => '激活', '2' => '預留'],
+                (string)$user->is_active
+            );
+        }
+        if ($active !== null && (int)$active !== $user->is_active) {
+            $user->is_active = (int)$active;
+            $updated = true;
+        }
+
+        // 更新角色
+        $roleInput = $this->option('role');
+        if ($roleInput === null) {
+            $currentRoleName = array_search($user->is_admin, $this->roleMap) ?: 'regular';
+            if ($this->confirm("是否更新用戶角色？（當前：{$user->getRoleName()}）", false)) {
+                $roleInput = $this->choice(
+                    '請選擇用戶角色',
+                    [
+                        'regular' => '一般用戶',
+                        'expert' => '專家',
+                        'crowdsourcing' => '眾包用戶',
+                        'super-admin' => '系統管理員'
+                    ],
+                    $currentRoleName
+                );
+            }
+        }
+        if ($roleInput) {
+            $role = $this->roleMap[$roleInput] ?? User::ROLE_REGULAR;
+            if ($role !== $user->is_admin) {
+                $user->is_admin = $role;
+                $updated = true;
+            }
+        }
+
+        if (!$updated) {
+            $this->info('沒有任何更新。');
+            return 0;
+        }
+
+        $user->save();
+
+        $this->newLine();
+        $this->info('✓ 用戶信息更新成功！');
+        $this->displayUserInfo($user);
+
+        return 0;
+    }
+
+    /**
+     * 列出所有用戶
+     */
+    protected function listUsers()
+    {
+        $users = User::orderBy('id')->get();
+
+        if ($users->isEmpty()) {
+            $this->info('沒有找到任何用戶。');
+            return 0;
+        }
+
+        $this->info("共找到 {$users->count()} 個用戶：");
+        $this->newLine();
+
+        $headers = ['ID', '名稱', 'Email', '狀態', '角色'];
+        $rows = $users->map(function ($user) {
+            return [
+                $user->id,
+                $user->name,
+                $user->email,
+                $this->getStatusText($user->is_active),
+                $user->getRoleName(),
+            ];
+        });
+
+        $this->table($headers, $rows);
+
+        return 0;
+    }
+
+    /**
+     * 顯示用戶信息
+     */
+    protected function displayUserInfo(User $user)
+    {
+        $this->table(
+            ['屬性', '值'],
+            [
+                ['ID', $user->id],
+                ['名稱', $user->name],
+                ['Email', $user->email],
+                ['激活狀態', $this->getStatusText($user->is_active)],
+                ['角色', $user->getRoleName()],
+                ['創建時間', $user->created_at],
+            ]
+        );
+    }
+
+    /**
+     * 獲取狀態文本
+     */
+    protected function getStatusText($status)
+    {
+        $statusMap = [
+            User::STATUS_INACTIVE => '未激活',
+            User::STATUS_ACTIVE => '激活',
+            User::STATUS_RESERVED => '預留',
+        ];
+
+        return $statusMap[$status] ?? '未知';
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\RebuildNameSearchIndex::class,
         \App\Console\Commands\ExportMysqlToSqlite::class,
         \App\Console\Commands\RegenerateAddresses::class,
+        \App\Console\Commands\ManageUser::class,
     ];
 
     /**


### PR DESCRIPTION
# 新增功能
- 創建 app/Console/Commands/ManageUser.php 命令
- 支持創建和更新用戶（名稱、Email、密碼、激活狀態、角色）
- 使用 User::factory() 創建新用戶
- 提供交互式輸入和命令行選項兩種使用方式
- 添加 --list 選項列出所有用戶

# 使用方法

## 交互式創建用戶
```bash
 php artisan cbdb:manage-user
```

## 使用命令行選項創建用戶
```bash
 php artisan cbdb:manage-user \
   --email=user@example.com \
   --name="張三" \
   --password=secret123 \
   --active=1 \
   --role=super-admin
```

## 更新現有用戶
```bash
 php artisan cbdb:manage-user --email=user@example.com --role=expert
```

## 列出所有用戶
```bash
 php artisan cbdb:manage-user --list
```

支持的角色：
  - regular: 一般用戶
  - expert: 專家
  - crowdsourcing: 眾包用戶
  - super-admin: 系統管理員

此命令適用於環境初始設置和用戶管理。