### PR TITLE
feat: 实现 BiogMain 别名（ALTNAME_DATA）审批流程

### DIFF
--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -67,16 +67,35 @@ class BasicInformationAltnamesController extends Controller
      */
     public function store(Request $request, $id)
     {
+        // 權限檢查
         if (!Auth::check()) {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (!Auth::user()->canWriteDirectly()){
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'altnames');
+        }
+
+        // 直接儲存需要額外權限檢查
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            return redirect()->back();
+        }
+
+        // 原有的直接儲存邏輯
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data = $this->toolsRepository->timestamp($data, True);
         $temp = DB::table('ALTNAME_DATA')->where([
@@ -159,16 +178,35 @@ class BasicInformationAltnamesController extends Controller
      */
     public function update(Request $request, $id, $alt)
     {
+        // 權限檢查
         if (!Auth::check()) {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        elseif (!Auth::user()->canWriteDirectly()){
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdate($request, $id, 'altnames', $alt);
+        }
+
+        // 直接儲存需要額外權限檢查
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            return redirect()->back();
+        }
+
+        // 原有的直接儲存邏輯
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
         $addr_l = $this->parseAltnameId($alt);
 

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -1,0 +1,389 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Operation;
+use App\Repositories\BiogMainRepository;
+use App\Repositories\OperationRepository;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class BasicInformationProposalController extends Controller
+{
+    protected $biogMainRepository;
+    protected $operationRepository;
+
+    /**
+     * 資源配置數組
+     * 定義每個資源類型的表名、主鍵、控制器等信息
+     */
+    protected $resourceConfigs = [
+        'altnames' => [
+            'table' => 'ALTNAME_DATA',
+            'key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            'controller' => 'BasicInformationAltnamesController',
+            'route_prefix' => 'basicinformation.altnames',
+            'display_name' => '別名',
+        ],
+        'addresses' => [
+            'table' => 'BIOG_ADDR_DATA',
+            'key_columns' => ['c_personid', 'c_addr_id', 'c_sequence', 'c_addr_type'],
+            'controller' => 'BasicInformationAddressesController',
+            'route_prefix' => 'basicinformation.addresses',
+            'display_name' => '地址',
+        ],
+        'texts' => [
+            'table' => 'BIOG_TEXT_DATA',
+            'key_columns' => ['c_personid', 'c_textid', 'c_year_year', 'c_text_role_code'],
+            'controller' => 'BasicInformationTextsController',
+            'route_prefix' => 'basicinformation.texts',
+            'display_name' => '著述',
+        ],
+        'statuses' => [
+            'table' => 'STATUS_DATA',
+            'key_columns' => ['c_personid', 'c_status_code', 'c_sequence'],
+            'controller' => 'BasicInformationStatusesController',
+            'route_prefix' => 'basicinformation.statuses',
+            'display_name' => '身份',
+        ],
+        'possessions' => [
+            'table' => 'POSSESSION_DATA',
+            'key_columns' => ['c_personid', 'c_poss_code', 'c_sequence'],
+            'controller' => 'BasicInformationPossessionController',
+            'route_prefix' => 'basicinformation.possession',
+            'display_name' => '所有物',
+        ],
+        // 其他資源配置待後續添加
+    ];
+
+    public function __construct(
+        BiogMainRepository $biogMainRepository,
+        OperationRepository $operationRepository
+    ) {
+        $this->biogMainRepository = $biogMainRepository;
+        $this->operationRepository = $operationRepository;
+    }
+
+    /**
+     * 提交新增提案（子資源）
+     */
+    public function proposalStore(Request $request, $personid, $resourceType)
+    {
+        $this->ensureCanPropose();
+
+        $config = $this->getResourceConfig($resourceType);
+        $table = $config['table'];
+        $keyColumns = $config['key_columns'];
+
+        // 提取表單數據
+        $payload = $this->extractFormData($request);
+        $payload['c_personid'] = $personid;
+
+        // 驗證主鍵完整性
+        if (!$this->hasPrimaryKeyValues($keyColumns, $payload)) {
+            flash('提案失敗：請確認主鍵欄位已填寫完整。', 'error');
+            return redirect()->back()->withInput();
+        }
+
+        // 檢查資料是否已存在
+        $conditions = $this->buildConditionsFromRow($keyColumns, $payload);
+        $existing = $this->fetchRowByKeys($table, $keyColumns, $conditions);
+        if ($existing) {
+            flash('提案失敗：資料已存在，請改用修改提案。', 'warning');
+            return redirect()->back()->withInput();
+        }
+
+        // 檢查是否有待審核的新增提案衝突
+        if ($this->hasActiveProposalConflict($table, $keyColumns, $payload, Operation::TYPE_PROPOSAL_CREATE)) {
+            flash('提案失敗：已有其他新增提案使用相同主鍵，請調整後再提交。', 'warning');
+            return redirect()->back()->withInput();
+        }
+
+        // 構建提案元數據
+        $meta = $this->buildProposalMeta('create', $resourceType, $request);
+
+        // 記錄提案操作
+        $operation = $this->recordProposalOperation(
+            Operation::TYPE_PROPOSAL_CREATE,
+            $table,
+            $keyColumns,
+            $personid,
+            $payload,
+            [],
+            $meta
+        );
+
+        if ($operation) {
+            flash('已提交新增提案，等待管理員審核 @ ' . Carbon::now(), 'info');
+        }
+
+        return redirect()->route($config['route_prefix'] . '.index', [
+            'basicinformation' => $personid,
+        ]);
+    }
+
+    /**
+     * 提交修改提案（子資源）
+     */
+    public function proposalUpdate(Request $request, $personid, $resourceType, $id)
+    {
+        $this->ensureCanPropose();
+
+        $config = $this->getResourceConfig($resourceType);
+        $table = $config['table'];
+        $keyColumns = $config['key_columns'];
+
+        // 解析複合主鍵
+        $conditions = $this->parseCompositeId($id, $keyColumns);
+        $originalRow = $this->fetchRowByKeys($table, $keyColumns, $conditions);
+
+        if (!$originalRow) {
+            flash('提案失敗：找不到對應的資料列。', 'error');
+            return redirect()->back()->withInput();
+        }
+
+        // 提取表單數據
+        $payload = $this->extractFormData($request);
+        $payload['c_personid'] = $personid;
+
+        // 檢查是否有實際修改
+        $diff = $this->operationRepository->getArrDiff($payload, $originalRow, $originalRow);
+        if ($diff === null) {
+            flash('提案失敗：未偵測到任何修改內容。', 'warning');
+            return redirect()->back()->withInput();
+        }
+
+        // 構建提案元數據
+        $meta = $this->buildProposalMeta('update', $resourceType, $request);
+
+        // 記錄提案操作
+        $operation = $this->recordProposalOperation(
+            Operation::TYPE_PROPOSAL_UPDATE,
+            $table,
+            $keyColumns,
+            $personid,
+            $payload,
+            $originalRow,
+            $meta
+        );
+
+        if ($operation) {
+            flash('已提交修改提案，等待管理員審核 @ ' . Carbon::now(), 'info');
+        }
+
+        return redirect()->route($config['route_prefix'] . '.edit', [
+            'basicinformation' => $personid,
+            Str::singular($resourceType) => $id,
+        ]);
+    }
+
+    /**
+     * 獲取資源配置
+     */
+    protected function getResourceConfig($resourceType)
+    {
+        if (!isset($this->resourceConfigs[$resourceType])) {
+            abort(404, "未知的資源類型：{$resourceType}");
+        }
+
+        return $this->resourceConfigs[$resourceType];
+    }
+
+    /**
+     * 構建提案元數據
+     */
+    protected function buildProposalMeta($action, $resourceType, Request $request)
+    {
+        $config = $this->getResourceConfig($resourceType);
+
+        return [
+            'action' => $action,
+            'resource_type' => $resourceType,
+            'table' => $config['table'],
+            'display_name' => $config['display_name'],
+            'submitted_by' => Auth::user()->name ?? Auth::id(),
+            'submitted_by_id' => Auth::id(),
+            'submitted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+            'comment' => $request->input('__proposal_comment', ''),
+        ];
+    }
+
+    /**
+     * 記錄提案操作
+     */
+    protected function recordProposalOperation(
+        $opType,
+        $table,
+        $keyColumns,
+        $personId,
+        $data,
+        $original,
+        $meta
+    ) {
+        $resourceId = $this->buildCompositeId($keyColumns, $data);
+
+        $resourceData = $data;
+        $resourceData['__proposal_meta'] = $meta;
+        $resourceData['__review_status'] = 'pending';
+        $resourceData['__key_columns'] = $keyColumns;
+
+        return $this->operationRepository->store(
+            Auth::id(),
+            $personId,
+            $opType,
+            $table,
+            $resourceId,
+            $resourceData,
+            $original
+        );
+    }
+
+    /**
+     * 構建複合主鍵 ID
+     */
+    protected function buildCompositeId($keyColumns, $data)
+    {
+        $parts = [];
+        foreach ($keyColumns as $column) {
+            $value = $data[$column] ?? '';
+            // 處理 NULL 值
+            if ($value === null || $value === '') {
+                $value = 'NULL';
+            }
+            // 處理特殊字符（連字符）
+            $value = str_replace('-', 'minus', (string) $value);
+            $parts[] = $value;
+        }
+        return implode('-', $parts);
+    }
+
+    /**
+     * 解析複合主鍵 ID
+     */
+    protected function parseCompositeId($id, $keyColumns)
+    {
+        // 使用現有的 unionPKDef_decode
+        $id = $this->biogMainRepository->unionPKDef_decode($id);
+
+        $parts = explode('-', $id);
+
+        $conditions = [];
+        foreach ($keyColumns as $index => $column) {
+            if (!isset($parts[$index])) {
+                throw new \Exception("主鍵解析失敗：缺少 {$column}");
+            }
+
+            $value = $parts[$index];
+            // 還原特殊字符
+            $value = str_replace('minus', '-', $value);
+            // 處理 NULL
+            if ($value === 'NULL') {
+                $value = null;
+            }
+
+            $conditions[$column] = $value;
+        }
+
+        return $conditions;
+    }
+
+    /**
+     * 提取表單數據
+     */
+    protected function extractFormData(Request $request)
+    {
+        return Arr::except($request->all(), ['_token', '_method', 'action', '__proposal_comment']);
+    }
+
+    /**
+     * 檢查主鍵完整性
+     */
+    protected function hasPrimaryKeyValues($keyColumns, $row)
+    {
+        foreach ($keyColumns as $column) {
+            if (!array_key_exists($column, $row) || $row[$column] === null || $row[$column] === '') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 從資料表讀取行
+     */
+    protected function fetchRowByKeys($table, $keyColumns, $conditions)
+    {
+        $query = DB::table($table);
+        foreach ($conditions as $column => $value) {
+            if ($value === null) {
+                $query->whereNull($column);
+            } else {
+                $query->where($column, $value);
+            }
+        }
+        $row = $query->first();
+
+        return $row ? (array) $row : null;
+    }
+
+    /**
+     * 構建查詢條件
+     */
+    protected function buildConditionsFromRow($keyColumns, $row)
+    {
+        $conditions = [];
+        foreach ($keyColumns as $column) {
+            if (!array_key_exists($column, $row)) {
+                throw new \RuntimeException("缺少主鍵欄位 {$column}");
+            }
+            $conditions[$column] = $row[$column];
+        }
+        return $conditions;
+    }
+
+    /**
+     * 檢查是否有待審核的提案衝突
+     */
+    protected function hasActiveProposalConflict($table, $keyColumns, $data, $opType)
+    {
+        $resourceId = $this->buildCompositeId($keyColumns, $data);
+
+        return Operation::where('resource', $table)
+            ->where('resource_id', $resourceId)
+            ->where('op_type', $opType)
+            ->whereRaw("JSON_EXTRACT(resource_data, '$.__review_status') = 'pending'")
+            ->exists();
+    }
+
+    /**
+     * 確保用戶可以提案
+     */
+    protected function ensureCanPropose()
+    {
+        if (!Auth::check()) {
+            abort(403, '請登入後提交提案');
+        }
+
+        if (!Auth::user()->isActive()) {
+            abort(403, '該用戶沒有權限，請聯繫管理員');
+        }
+    }
+
+    /**
+     * 確保用戶可以直接儲存
+     */
+    protected function ensureCanDirectSave()
+    {
+        if (!Auth::check()) {
+            abort(403, '請登入後編輯');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            abort(403, '該用戶沒有權限，請聯繫管理員');
+        }
+    }
+}

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -347,16 +347,25 @@ class BasicInformationProposalController extends Controller
 
     /**
      * 檢查是否有待審核的提案衝突
+     *
+     * 注意：不使用 JSON_EXTRACT 直接在 SQL 中比較，因為 MySQL/MariaDB 的 JSON_EXTRACT
+     * 返回帶引號的 JSON 字符串（如 "pending"），需要 JSON_UNQUOTE 才能正確比較。
+     * 為了跨資料庫兼容性（SQLite/MySQL），採用在 PHP 端解析 JSON 的方式。
      */
     protected function hasActiveProposalConflict($table, $keyColumns, $data, $opType)
     {
         $resourceId = $this->buildCompositeId($keyColumns, $data);
 
-        return Operation::where('resource', $table)
+        $operations = Operation::where('resource', $table)
             ->where('resource_id', $resourceId)
             ->where('op_type', $opType)
-            ->whereRaw("JSON_EXTRACT(resource_data, '$.__review_status') = 'pending'")
-            ->exists();
+            ->get();
+
+        return $operations->contains(function (Operation $operation) {
+            $payload = json_decode($operation->resource_data, true);
+            $status = is_array($payload) ? ($payload['__review_status'] ?? null) : null;
+            return $status === 'pending';
+        });
     }
 
     /**

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -214,9 +214,12 @@ class OperationsProposalController extends Controller
             ? Operation::TYPE_CREATE
             : Operation::TYPE_UPDATE;
 
+        // 對於 BiogMain 相關提案，使用實際的 c_personid；對於 Codes 提案使用 0
+        $personId = $proposal->c_personid ?? 0;
+
         $this->operationRepository->store(
             Auth::id(),
-            0,
+            $personId,
             $type,
             $proposal->resource,
             $resourceId,

--- a/resources/views/biogmains/altname/create.blade.php
+++ b/resources/views/biogmains/altname/create.blade.php
@@ -84,8 +84,31 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
+                    <div class="col-sm-10">
+                        <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="提交提案時請簡述修改原因或補充說明"></textarea>
+                        <small class="text-muted">僅在提交提案時需要填寫，直接儲存時可略過</small>
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
-                        <button type="submit" class="btn btn-default">Submit</button>
+                        @if(Auth::check() && Auth::user()->isActive())
+                            <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                            @if(Auth::user()->canWriteDirectly())
+                                <button type="submit" name="action" value="save" class="btn btn-primary">
+                                    <i class="fa fa-save"></i> 直接儲存
+                                </button>
+                            @endif
+
+                            <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                            <button type="submit" name="action" value="proposal" class="btn btn-info">
+                                <i class="fa fa-paper-plane"></i> 提交提案
+                            </button>
+                        @endif
+
+                        <a href="{{ route('basicinformation.altnames.index', ['basicinformation' => $id]) }}" class="btn btn-default">
+                            <i class="fa fa-times"></i> 取消
+                        </a>
                     </div>
                 </div>
             </form>

--- a/resources/views/biogmains/altname/edit.blade.php
+++ b/resources/views/biogmains/altname/edit.blade.php
@@ -105,8 +105,31 @@ $row->c_notes = unionPKDef_decode_for_convert($row->c_notes);
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="__proposal_comment" class="col-sm-2 control-label">提案說明</label>
+                    <div class="col-sm-10">
+                        <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="提交提案時請簡述修改原因或補充說明"></textarea>
+                        <small class="text-muted">僅在提交提案時需要填寫，直接儲存時可略過</small>
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
-                        <button type="submit" class="btn btn-default">Submit</button>
+                        @if(Auth::check() && Auth::user()->isActive())
+                            <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                            @if(Auth::user()->canWriteDirectly())
+                                <button type="submit" name="action" value="save" class="btn btn-primary">
+                                    <i class="fa fa-save"></i> 直接儲存
+                                </button>
+                            @endif
+
+                            <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                            <button type="submit" name="action" value="proposal" class="btn btn-info">
+                                <i class="fa fa-paper-plane"></i> 提交提案
+                            </button>
+                        @endif
+
+                        <a href="{{ route('basicinformation.altnames.index', ['basicinformation' => $id]) }}" class="btn btn-default">
+                            <i class="fa fa-times"></i> 取消
+                        </a>
                     </div>
                 </div>
             </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,6 +52,12 @@ Route::resource('basicinformation.possession', 'BasicInformationPossessionContro
 Route::resource('basicinformation.socialinst', 'BasicInformationSocialInstController');
 Route::resource('basicinformation.sources', 'BasicInformationSourcesController');
 
+// BiogMain 提案路由
+Route::post('basicinformation/{personid}/{resource}/proposal', 'BasicInformationProposalController@proposalStore')
+    ->name('basicinformation.proposal.store');
+Route::post('basicinformation/{personid}/{resource}/{id}/proposal', 'BasicInformationProposalController@proposalUpdate')
+    ->name('basicinformation.proposal.update');
+
 Route::get('codes', 'CodesController@index')->name('codes.index');
 Route::get('codes/{table_name}', 'CodesController@show')->name('codes.show');
 Route::get('codes/{table_name}/{id}/edit', 'CodesController@edit')->name('codes.edit');

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -1,0 +1,552 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Operation;
+use App\Repositories\BiogMainRepository;
+use App\Repositories\OperationRepository;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class BasicInformationProposalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock BiogMainRepository
+        $this->app->instance(BiogMainRepository::class, \Mockery::mock(BiogMainRepository::class, function ($mock) {
+            $mock->shouldReceive('unionPKDef')->andReturnUsing(function ($value) {
+                if ($value === null || $value === '') {
+                    return 'NULL';
+                }
+                return str_replace('-', 'minus', (string) $value);
+            });
+            $mock->shouldReceive('unionPKDef_decode')->andReturnUsing(function ($value) {
+                // Decode composite ID string back to its original form
+                return str_replace('minus', '-', (string) $value);
+            });
+        }));
+
+        // Mock OperationRepository
+        $this->app->instance(OperationRepository::class, \Mockery::mock(OperationRepository::class, function ($mock) {
+            $mock->shouldReceive('store')->andReturnUsing(function ($userId, $personId, $opType, $resource, $resourceId, $resourceData, $original = '', $crowdsourcingStatus = 0) {
+                $operation = new Operation();
+                $operation->user_id = $userId;
+                $operation->c_personid = $personId;
+                $operation->op_type = $opType;
+                $operation->resource = $resource;
+                $operation->resource_id = $resourceId;
+                $operation->resource_data = json_encode($resourceData, JSON_UNESCAPED_UNICODE);
+                if (!empty($original)) {
+                    $operation->resource_original = json_encode($original, JSON_UNESCAPED_UNICODE);
+                }
+                if ($crowdsourcingStatus !== 0) {
+                    $operation->crowdsourcing_status = $crowdsourcingStatus;
+                }
+                $operation->save();
+
+                return $operation;
+            });
+            $mock->shouldReceive('getArrDiff')->andReturnUsing(function ($new, $old, $original) {
+                return (new OperationRepository())->getArrDiff($new, $old, $original);
+            });
+        }));
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->boolean('is_active')->default(0);
+            $table->boolean('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('operations');
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('ALTNAME_DATA');
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->nullable();
+            $table->string('c_alt_name_chn');
+            $table->string('c_alt_name')->nullable();
+            $table->integer('c_alt_name_type_code');
+            $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('ALTNAME_DATA');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    protected function makeActiveUser(): User
+    {
+        $user = User::factory()->create([
+            'name' => 'activeuser',
+            'email' => 'active@example.com',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => 0,
+        ]);
+
+        return $user;
+    }
+
+    protected function makeAdmin(): User
+    {
+        $user = User::factory()->create([
+            'name' => 'admin',
+            'email' => 'admin@example.com',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => 1,
+        ]);
+
+        return $user;
+    }
+
+    protected function makeInactiveUser(): User
+    {
+        $user = User::factory()->create([
+            'name' => 'inactive',
+            'email' => 'inactive@example.com',
+            'is_active' => 0,
+            'is_admin' => 0,
+        ]);
+
+        return $user;
+    }
+
+    public function testProposalStoreRequiresAuthentication()
+    {
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '測試別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '新增測試',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testProposalStoreRequiresActiveUser()
+    {
+        $user = $this->makeInactiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '測試別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '新增測試',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testProposalStoreCreatesNewProposal()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '測試別名',
+            'c_alt_name' => 'Test Name',
+            'c_alt_name_type_code' => 1,
+            'c_source' => 100,
+            'c_pages' => '第1頁',
+            'c_notes' => '這是測試筆記',
+            '__proposal_comment' => '新增測試別名',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已提交新增提案', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('operations', [
+            'user_id' => $user->id,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'ALTNAME_DATA',
+        ]);
+
+        $operation = Operation::where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE)
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('測試別名', $payload['c_alt_name_chn']);
+        $this->assertSame('pending', $payload['__review_status']);
+        $this->assertSame('新增測試別名', $payload['__proposal_meta']['comment']);
+        $this->assertSame(['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'], $payload['__key_columns']);
+    }
+
+    public function testProposalStoreRejectsDuplicateData()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '已存在別名',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '已存在別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '嘗試重複新增',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('資料已存在', $flash[0]['message'] ?? '');
+    }
+
+    public function testProposalStoreDetectsConflictingProposal()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 先創建一個待審核的新增提案
+        $operation = new Operation();
+        $operation->user_id = $user->id;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-衝突別名-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '衝突別名',
+            'c_alt_name_type_code' => 1,
+            '__review_status' => 'pending',
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        // 嘗試提交相同主鍵的新增提案
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '衝突別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '嘗試衝突提案',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已有其他新增提案', $flash[0]['message'] ?? '');
+    }
+
+    public function testProposalUpdateCreatesUpdateProposal()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '原始別名',
+            'c_alt_name' => 'Original Name',
+            'c_alt_name_type_code' => 1,
+            'c_source' => 100,
+            'c_pages' => '第1頁',
+            'c_notes' => '原始筆記',
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'altnames',
+            'id' => '1-1-原始別名-1',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '原始別名',
+            'c_alt_name' => 'Updated Name',
+            'c_alt_name_type_code' => 1,
+            'c_source' => 200,
+            'c_pages' => '第2頁',
+            'c_notes' => '更新後筆記',
+            '__proposal_comment' => '修改別名資訊',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已提交修改提案', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('operations', [
+            'user_id' => $user->id,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+        ]);
+
+        $operation = Operation::where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('Updated Name', $payload['c_alt_name']);
+        $this->assertSame('第2頁', $payload['c_pages']);
+        $this->assertSame('pending', $payload['__review_status']);
+    }
+
+    public function testProposalUpdateRejectsNoChanges()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '無變更別名',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'altnames',
+            'id' => '1-1-無變更別名-1',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '無變更別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '嘗試無變更提交',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('未偵測到任何修改', $flash[0]['message'] ?? '');
+    }
+
+    public function testApproveCreateProposalInsertsRow()
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $resourceData = [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '核准別名',
+            'c_alt_name' => 'Approved Name',
+            'c_alt_name_type_code' => 1,
+            'c_source' => 100,
+            'c_pages' => '第1頁',
+            'c_notes' => '核准的別名',
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+            '__proposal_meta' => ['submitted_by' => 'tester', 'submitted_at' => Carbon::now()->format('Y-m-d H:i:s')],
+        ];
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-核准別名-1';
+        $operation->resource_data = json_encode($resourceData, JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode([], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '核准通過',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已核准', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '核准別名',
+            'c_alt_name' => 'Approved Name',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+        $this->assertSame('核准通過', $payload['__review_comment']);
+        $this->assertSame($admin->name, $payload['__reviewed_by']);
+
+        // 驗證正式操作記錄
+        $this->assertDatabaseHas('operations', [
+            'resource' => 'ALTNAME_DATA',
+            'op_type' => Operation::TYPE_CREATE,
+            'c_personid' => 1,
+        ]);
+    }
+
+    public function testApproveUpdateProposalUpdatesRow()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '修改前別名',
+            'c_alt_name' => 'Before',
+            'c_alt_name_type_code' => 1,
+            'c_notes' => '修改前筆記',
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $resourceData = [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '修改前別名',
+            'c_alt_name' => 'After',
+            'c_alt_name_type_code' => 1,
+            'c_notes' => '修改後筆記',
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ];
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_UPDATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-修改前別名-1';
+        $operation->resource_data = json_encode($resourceData, JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '修改前別名',
+            'c_alt_name' => 'Before',
+            'c_alt_name_type_code' => 1,
+            'c_notes' => '修改前筆記',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '修改合理',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '修改前別名',
+            'c_alt_name' => 'After',
+            'c_notes' => '修改後筆記',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+        $this->assertSame('修改合理', $payload['__review_comment']);
+
+        // 驗證正式操作記錄
+        $this->assertDatabaseHas('operations', [
+            'resource' => 'ALTNAME_DATA',
+            'op_type' => Operation::TYPE_UPDATE,
+            'c_personid' => 1,
+        ]);
+    }
+
+    public function testRejectProposalUpdatesStatus()
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $resourceData = [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '退回別名',
+            'c_alt_name_type_code' => 1,
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ];
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-退回別名-1';
+        $operation->resource_data = json_encode($resourceData, JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.reject', $operation), [
+            'review_comment' => '資料不完整',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已退回', $flash[0]['message'] ?? '');
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('rejected', $payload['__review_status']);
+        $this->assertSame('資料不完整', $payload['__review_comment']);
+
+        // 驗證沒有插入實際資料
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_alt_name_chn' => '退回別名',
+        ]);
+    }
+}

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -549,4 +549,291 @@ class BasicInformationProposalTest extends TestCase
             'c_alt_name_chn' => '退回別名',
         ]);
     }
+
+    public function testApproveRequiresReviewerPermission()
+    {
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-無權-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '無權',
+            'c_alt_name_type_code' => 1,
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertStatus(403);
+    }
+
+    public function testApproveRejectsNonProposalOperation()
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-非提案-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '非提案',
+            'c_alt_name_type_code' => 1,
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertStatus(404);
+    }
+
+    public function testApproveFailsWhenKeyColumnsMissing()
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-缺主鍵-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '缺主鍵',
+            'c_alt_name_type_code' => 1,
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('提案缺少主鍵資訊', $flash[0]['message'] ?? '');
+    }
+
+    public function testApproveCreateFailsWhenRowAlreadyExists()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '已存在',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-已存在-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '已存在',
+            'c_alt_name_type_code' => 1,
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('資料已存在', $flash[0]['message'] ?? '');
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('pending', $payload['__review_status']);
+        $this->assertSame(1, Operation::count());
+    }
+
+    public function testApproveUpdateFailsWithoutOriginalData()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '缺少原始',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_UPDATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-缺少原始-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '缺少原始',
+            'c_alt_name_type_code' => 1,
+            'c_notes' => '新的備註',
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode([]);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('缺少原始資料', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '缺少原始',
+            'c_notes' => null,
+        ]);
+    }
+
+    public function testApproveUpdateRejectsPrimaryKeyChange()
+    {
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '不可改主鍵',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_UPDATE;
+        $operation->resource = 'ALTNAME_DATA';
+        $operation->resource_id = '1-1-不可改主鍵-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '新主鍵值',
+            'c_alt_name_type_code' => 1,
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '不可改主鍵',
+            'c_alt_name_type_code' => 1,
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('提案不可修改主鍵欄位', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '不可改主鍵',
+        ]);
+    }
+
+    public function testProposalStoreFailsWhenPrimaryKeyMissing()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_alt_name_chn' => '缺少主鍵欄位',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '主鍵缺失',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('主鍵欄位已填寫完整', $flash[0]['message'] ?? '');
+        $this->assertSame(0, Operation::count());
+    }
+
+    public function testProposalUpdateFailsWhenRowMissing()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'altnames',
+            'id' => '1-1-不存在-1',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '不存在',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '不存在的資料列',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('找不到對應的資料列', $flash[0]['message'] ?? '');
+        $this->assertSame(0, Operation::count());
+    }
+
+    public function testUnknownResourceTypeReturnsNotFound()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'unknown',
+        ]), [
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '未知',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function testCompositeIdEncodesHyphenInResourceId()
+    {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '名-字',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '連字號測試',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::first();
+        $this->assertNotNull($operation);
+        $this->assertSame('1-1-名minus字-1', $operation->resource_id);
+    }
 }


### PR DESCRIPTION
完整实现 BiogMain 别名数据的提案审批工作流，支持新增和修改提案的提交、审核和管理。

## 核心功能

### 1. 提案控制器 (BasicInformationProposalController)
- proposalStore(): 处理新增提案提交
- proposalUpdate(): 处理修改提案提交
- 支持 5 种资源类型配置（altnames, addresses, texts, statuses, possessions）
- 复合主键编码/解码处理
- 提案冲突检测
- 权限验证（isActive, canWriteDirectly）

### 2. 路由配置
新增两条提案路由：
- POST basicinformation/{personid}/{resource}/proposal
- POST basicinformation/{personid}/{resource}/{id}/proposal

### 3. 控制器修改
修改 BasicInformationAltnamesController：
- store() 和 update() 方法支持双模式（直接保存 vs 提案）
- 根据 action 参数分发请求
- 过滤提案相关参数（action, __proposal_comment）

### 4. 审核控制器增强
修改 OperationsProposalController：
- logFinalOperation() 方法支持 BiogMain 提案的 c_personid
- 兼容 Codes 提案（personId = 0）

### 5. 视图层改进
修改 create.blade.php 和 edit.blade.php：
- 添加「提案說明」字段
- 根据用户权限显示不同按钮：
  * canWriteDirectly: 显示「直接儲存」+「提交提案」
  * 其他活跃用户: 仅显示「提交提案」
- 添加「取消」按钮

### 6. 完整测试覆盖 (BasicInformationProposalTest)
10 个测试用例覆盖：
- 权限检查（未登录、非活跃用户返回 403）
- 新增提案创建
- 重复数据检测
- 提案冲突检测
- 修改提案创建
- 无变更检测
- 审核通过流程（新增和修改）
- 审核退回流程

测试基础设施：
- 模拟 BiogMainRepository（unionPKDef, unionPKDef_decode）
- 模拟 OperationRepository（store, getArrDiff）
- SQLite 内存数据库
- 手动创建测试用户（使用 User::STATUS_ACTIVE 常量）

## 技术实现

### 权限模型
- isActive(): 用户是否激活
- canWriteDirectly(): 是否可直接写入
- canRestoreOperations(): 是否可审核提案

### 提案数据结构
```json
{
  "c_personid": 1,
  "c_sequence": 1,
  "c_alt_name_chn": "别名",
  "c_alt_name_type_code": 1,
  "__key_columns": ["c_personid", "c_sequence", "c_alt_name_chn", "c_alt_name_type_code"],
  "__review_status": "pending",
  "__proposal_meta": {
    "comment": "提案说明",
    "submitted_by": "user",
    "submitted_at": "2025-12-04 00:00:00"
  }
}
```

### 复合主键处理
- 特殊字符编码：'-' → 'minus'
- 空值编码：null/'' → 'NULL'
- 格式：{personid}-{sequence}-{name}-{type}

## 文件变更

**新增：**
- app/Http/Controllers/BasicInformationProposalController.php (433 行)
- tests/Feature/BasicInformationProposalTest.php (530 行)

**修改：**
- app/Http/Controllers/BasicInformationAltnamesController.php
- app/Http/Controllers/OperationsProposalController.php
- resources/views/biogmains/altname/create.blade.php
- resources/views/biogmains/altname/edit.blade.php
- routes/web.php
- .gitignore (添加 .phpunit.cache/)

## 相关文档
- BIOGMAIN_APPROVAL_FLOWS_PLAN.md: 详细实施计划
- AGENTS.md: 开发指引
- APPROVAL_FLOWS.md: 审批流程文档

## 下一步
- 扩展到其他 BiogMain 子资源
- 在 Operations 页面添加提案筛选
- 考虑批量审核功能