### PR TITLE
20251205製作c_created_by, c_created_date, c_modified_by, c_modified_date 欄位對應的功能實現

### DIFF
--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -126,7 +126,7 @@ class BasicInformationSourcesController extends Controller
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
             return redirect()->back();
         }
-        $data = $this->biogMainRepository->SourceUpdateById($request, $id, $id_);
+        $data = $this->biogMainRepository->sourceUpdateById($request, $id, $id_);
         $id_ = $id."-".$data['c_textid']."-".$data['c_pages'];
         flash('Update success @ '.Carbon::now(), 'success');
         //20200715引用聯合主鍵保留字弱點防禦函式

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -27,6 +27,7 @@ use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use Illuminate\Support\Facades\DB;
 use App\Repositories\Concerns\DetectsModelChanges;
+use Carbon\Carbon;
 
 //20181112建安修改
 use App\SocialInstCode;
@@ -614,7 +615,19 @@ class BiogMainRepository
                 );
             }
 
-            $shouldUpdateAddress = $hasAddressChange || $previousOfficeId !== $currentOfficeId;
+	    $shouldUpdateAddress = $hasAddressChange || $previousOfficeId !== $currentOfficeId;
+
+	    //20251204 issues-487，用戶在「修改」頁面保存時，若地名資訊（POSTED_TO_ADDR_DATA.c_addr_id）並沒有改變，用戶在保存的時候，則不會修改 POSTED_TO_ADDR_DATA 的 c_modified_by, c_modified_date 欄位。
+	    //有修改地名資訊時$shouldUpdateAddress = true
+	    //dd($shouldUpdateAddress);
+
+	    $c_created_by = Auth::user()->name;
+	    $c_created_date = Carbon::now();
+
+	    DB::table('POSTING_DATA')->where([
+                ['c_personid', '=', $_id],
+                ['c_posting_id', '=', $_postingid],
+            ])->update(['c_modified_by' => $c_created_by, 'c_modified_date' => $c_created_date]);
 
             if ($shouldUpdateAddress) {
                 $beforeRows = DB::table('POSTED_TO_ADDR_DATA')
@@ -630,18 +643,61 @@ class BiogMainRepository
                             'c_addr_id' => (int) $row->c_addr_id,
                         ];
                     })
-                    ->all();
+		    ->all();
+
+                //dd($previousOfficeId, $currentOfficeId, $beforeRows);
 
                 if ($previousOfficeId !== $currentOfficeId && !empty($beforeRows)) {
                     DB::table('POSTED_TO_ADDR_DATA')
                         ->where('c_personid', $_id)
                         ->where('c_posting_id', $_postingid)
                         ->where('c_office_id', $previousOfficeId)
-                        ->delete();
-                }
+			->delete();
+		    //如果$previousOfficeId與$currentOfficeId不相等，而且$beforeRows有資料，就先將舊的POSTED_TO_ADDR_DATA刪除乾淨。
+		}
 
-                $addressesForInsert = $incomingAddr !== null ? $incomingAddr : $existingAddresses;
-                $this->insertAddr($addressesForInsert, $_id, $_postingid, $currentOfficeId);
+		$addressesForInsert = $incomingAddr !== null ? $incomingAddr : $existingAddresses;
+
+		//比對修改前後的Addr陣列，刪除更新時被移除的addr。
+		$beforeAddressesForUpdate = [];
+		foreach($beforeRows as $addr_v) {
+			$beforeAddressesForUpdate[] = $addr_v['c_addr_id'];
+		}
+		//dd($beforeRows, $addressesForInsert);
+		//dd($beforeAddressesForUpdate, $addressesForInsert);
+		$oldHave_diff = array_diff($beforeAddressesForUpdate, $addressesForInsert);
+		$newHave_diff = array_diff($addressesForInsert, $beforeAddressesForUpdate);
+		//dd($oldHave_diff);
+		//dd($newHave_diff);
+
+		//比對結束，刪除更新時被移除的addr。
+		foreach($oldHave_diff as $addr_v) {
+			DB::table('POSTED_TO_ADDR_DATA')
+                        ->where('c_personid', $_id)
+                        ->where('c_posting_id', $_postingid)
+			->where('c_office_id', $previousOfficeId)
+			->where('c_addr_id', $addr_v)
+                        ->delete();
+		}
+
+		//比對結束，新增後來新加的addr。
+		foreach($newHave_diff as $addr_v) {
+			DB::table('POSTED_TO_ADDR_DATA')->insert(
+				[
+                                    'c_personid' => $_id,
+                                    'c_posting_id' => $_postingid,
+                                    'c_office_id' => $_officeid,
+                                    'c_addr_id' => $addr_v == -999 ? 0 : $addr_v,
+                                    'c_created_by' => $c_created_by,
+                                    'c_created_date' => $c_created_date,
+                                    'c_modified_by' => $c_created_by,
+                                    'c_modified_date' => $c_created_date,
+				]
+			);
+		}
+
+
+                $this->updateAddr($addressesForInsert, $_id, $_postingid, $currentOfficeId, $c_created_by, $c_created_date);
 
                 $afterRows = DB::table('POSTED_TO_ADDR_DATA')
                     ->where('c_personid', $_id)
@@ -691,14 +747,22 @@ class BiogMainRepository
                 ->orderByDesc('c_posting_id')
                 ->value('c_posting_id');
             $data['c_posting_id'] = ((int) $lastPostingId) + 1;
-            $data['c_personid'] = $id;
+	    $data['c_personid'] = $id;
+
+	    //將操作新增的使用者與當下時間紀錄為c_created_by與c_created_date。
+	    $c_created_by = Auth::user()->name;
+	    $c_created_date = Carbon::now();
+	    $data['c_created_by'] = $c_created_by;
+	    $data['c_created_date'] = $c_created_date;
 
             DB::table('POSTING_DATA')->insert([
                 'c_personid' => $data['c_personid'],
-                'c_posting_id' => $data['c_posting_id'],
+		'c_posting_id' => $data['c_posting_id'],
+		'c_created_by' => $data['c_created_by'],
+		'c_created_date' => $data['c_created_date'],
             ]);
 
-            $this->insertAddr($c_addr, $id, $data['c_posting_id'], $data['c_office_id']);
+            $this->insertAddr($c_addr, $id, $data['c_posting_id'], $data['c_office_id'], $c_created_by, $c_created_date);
 
             $data = (new ToolsRepository)->timestamp($data, true);
             DB::table('POSTED_TO_OFFICE_DATA')->insert($data);
@@ -1767,6 +1831,10 @@ class BiogMainRepository
         $data['c_personid'] = $id;
         $data['c_main_source'] = (int)$data['c_main_source'];
         $data['c_self_bio'] = (int)$data['c_self_bio'];
+	$c_modified_by = Auth::user()->name;
+	$c_modified_date = Carbon::now();
+	$data['c_modified_by'] = $c_modified_by;
+	$data['c_modified_date'] = $c_modified_date;
         DB::table('BIOG_SOURCE_DATA')->where([
             ['c_personid', '=', $temp_l[0]],
             ['c_textid', '=', $temp_l[1]],
@@ -1782,7 +1850,11 @@ class BiogMainRepository
         $data = Arr::except($data, ['_token']);
         $data['c_personid'] = $id;
         $data['c_main_source'] = (int)$data['c_main_source'];
-        $data['c_self_bio'] = (int)$data['c_self_bio'];
+	$data['c_self_bio'] = (int)$data['c_self_bio'];
+	$c_created_by = Auth::user()->name;
+	$c_created_date = Carbon::now();
+	$data['c_created_by'] = $c_created_by;
+	$data['c_created_date'] = $c_created_date;
         DB::table('BIOG_SOURCE_DATA')->insert($data);
         (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_SOURCE_DATA', $data['c_personid']."-".$data['c_textid']."-".$data['c_pages'], $data);
         return $data;
@@ -1843,7 +1915,7 @@ class BiogMainRepository
         return $originalText." ".$add;
     }
 
-    protected function insertAddr(Array $c_addr, $_id, $_postingid, $_officeid)
+    protected function insertAddr(Array $c_addr, $_id, $_postingid, $_officeid, $c_created_by='', $c_created_date='')
     {
         DB::table('POSTED_TO_ADDR_DATA')
             ->where('c_personid', $_id)
@@ -1856,10 +1928,37 @@ class BiogMainRepository
                     'c_personid' => $_id,
                     'c_posting_id' => $_postingid,
                     'c_office_id' => $_officeid,
-                    'c_addr_id' => $item == -999 ? 0 : $item
+		    'c_addr_id' => $item == -999 ? 0 : $item,
+		    'c_created_by' => $c_created_by,
+		    'c_created_date' => $c_created_date,
                 ]
             );
         }
+    }
+
+    protected function updateAddr(Array $c_addr, $_id, $_postingid, $_officeid, $c_created_by='', $c_created_date='')
+    {
+	    foreach ($c_addr as $item) {
+
+		    $addr = '';
+		    $addr = DB::table('POSTED_TO_ADDR_DATA')->where([
+			    ['c_personid', '=', $_id],
+			    ['c_posting_id', '=', $_postingid],
+			    ['c_office_id', '=', $_officeid],
+			    ['c_addr_id', '=', $item],
+		    ])->get();
+
+		    if(!empty($addr)) {
+			    //有資料就更新
+			    DB::table('POSTED_TO_ADDR_DATA')->where([
+                            ['c_personid', '=', $_id],
+                            ['c_posting_id', '=', $_postingid],
+                            ['c_office_id', '=', $_officeid],
+                            ['c_addr_id', '=', $item],
+                            ])
+			    ->update(['c_modified_by' => $c_created_by, 'c_modified_date' => $c_created_date]);
+		    }
+            }
     }
 
     protected function insertAddrPo(Array $c_addr_id, $c_possession_record_id, $c_personid)

--- a/resources/views/biogmains/sources/edit.blade.php
+++ b/resources/views/biogmains/sources/edit.blade.php
@@ -84,6 +84,22 @@ $row->c_notes = unionPKDef_decode_for_convert($row->c_notes);
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">建檔</label>
+                    <div class="col-sm-10">
+                        <input type="text" name="" class="form-control"
+                               value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
+                               disabled>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="" class="col-sm-2 control-label">更新</label>
+                    <div class="col-sm-10">
+                        <input type="text" name="" class="form-control"
+                               value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
+                               disabled>
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
                         <button type="submit" class="btn btn-default">Submit</button>
                     </div>

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use App\Repositories\BiogMainRepository;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class BasicInformationSourcesControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension is required for this test.');
+        }
+
+        Config::set('database.default', 'sqlite');
+        Config::set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('BIOG_SOURCE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_textid');
+            $table->string('c_pages');
+            $table->text('c_notes')->nullable();
+            $table->tinyInteger('c_main_source')->default(0);
+            $table->tinyInteger('c_self_bio')->default(0);
+            $table->string('c_created_by')->nullable();
+            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->timestamps();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->tinyInteger('rate')->default(0);
+        });
+
+        Auth::guard()->setUser($this->makeUser(9, 'Creator User'));
+    }
+
+    protected function makeUser(int $id, string $name): User
+    {
+        $user = new User();
+        $user->id = $id;
+        $user->name = $name;
+        $user->avatar = 'avatar5.png';
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $user->is_active = User::STATUS_ACTIVE;
+
+        return $user;
+    }
+
+    public function testSourceStoreWritesAuditFieldsAndOperations(): void
+    {
+        $repository = new BiogMainRepository();
+        $request = new Request([
+            'c_textid' => 500,
+            'c_pages' => 'p10',
+            'c_notes' => 'first note',
+            'c_main_source' => 1,
+            'c_self_bio' => 0,
+        ]);
+
+        $result = $repository->sourceStoreById($request, 321);
+
+        $this->assertSame('Creator User', $result['c_created_by']);
+        $this->assertNotNull($result['c_created_date']);
+
+        $row = DB::table('BIOG_SOURCE_DATA')->first();
+        $this->assertSame('Creator User', $row->c_created_by);
+        $this->assertNotNull($row->c_created_date);
+        $this->assertNull($row->c_modified_by);
+        $this->assertNull($row->c_modified_date);
+
+        $operation = DB::table('operations')->first();
+        $this->assertSame('BIOG_SOURCE_DATA', $operation->resource);
+        $this->assertSame('321-500-p10', $operation->resource_id);
+        $this->assertEquals(1, $operation->op_type);
+        $this->assertNull($operation->resource_original);
+
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('Creator User', $payload['c_created_by']);
+        $this->assertSame(321, $payload['c_personid']);
+    }
+
+    public function testSourceUpdatePreservesCreationAndSetsModification(): void
+    {
+        $repository = new BiogMainRepository();
+        $initialRequest = new Request([
+            'c_textid' => 501,
+            'c_pages' => 'p20',
+            'c_notes' => 'initial note',
+            'c_main_source' => 0,
+            'c_self_bio' => 1,
+        ]);
+        $repository->sourceStoreById($initialRequest, 654);
+
+        $original = DB::table('BIOG_SOURCE_DATA')->first();
+
+        Auth::guard()->setUser($this->makeUser(10, 'Editor User'));
+
+        $updateRequest = new Request([
+            'c_textid' => 501,
+            'c_pages' => 'p20',
+            'c_notes' => 'updated note',
+            'c_main_source' => 1,
+            'c_self_bio' => 0,
+        ]);
+
+        $repository->sourceUpdateById($updateRequest, 654, '654-501-p20');
+
+        $row = DB::table('BIOG_SOURCE_DATA')->first();
+        $this->assertSame('Creator User', $row->c_created_by);
+        $this->assertSame($original->c_created_date, $row->c_created_date);
+        $this->assertSame('Editor User', $row->c_modified_by);
+        $this->assertNotNull($row->c_modified_date);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $this->assertSame('BIOG_SOURCE_DATA', $operation->resource);
+        $this->assertSame('654-501-p20', $operation->resource_id);
+        $this->assertEquals(3, $operation->op_type);
+        $this->assertNull($operation->resource_original);
+
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('Editor User', $payload['c_modified_by']);
+        $this->assertSame('updated note', $payload['c_notes']);
+    }
+
+    public function testEditViewDisplaysCreationAndModificationInfo(): void
+    {
+        $row = (object) [
+            'c_personid' => 777,
+            'c_textid' => 888,
+            'c_pages' => 'A-1',
+            'c_notes' => 'view-note',
+            'c_main_source' => 1,
+            'c_self_bio' => 0,
+            'c_created_by' => 'Creator User',
+            'c_created_date' => '2024-02-01 12:00:00',
+            'c_modified_by' => 'Editor User',
+            'c_modified_date' => '2024-02-03 08:30:00',
+        ];
+
+        $html = view('biogmains.sources.edit', [
+            'id' => 777,
+            'row' => $row,
+            'res' => ['text_str' => 'Dummy Text'],
+            'page_title' => 'Basicinformation',
+            'page_description' => '基本信息表 出處',
+            'page_url' => '/basicinformation/777/sources',
+            'archer' => "<li><a href='#'>Sources</a></li>",
+        ])->render();
+
+        $this->assertStringContainsString('Creator User/2024-02-01 12:00:00', $html);
+        $this->assertStringContainsString('Editor User/2024-02-03 08:30:00', $html);
+    }
+}

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -3,12 +3,14 @@
 namespace Tests\Feature;
 
 use App\Repositories\BiogMainRepository;
+use Illuminate\Auth\GenericUser;
 use Illuminate\Http\Request;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
 
 class OfficeAddressOperationLoggingTest extends TestCase
@@ -47,6 +49,19 @@ class OfficeAddressOperationLoggingTest extends TestCase
             $table->integer('c_posting_id');
             $table->integer('c_office_id');
             $table->integer('c_addr_id');
+            $table->string('c_created_by')->nullable();
+            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
+        });
+
+        Schema::create('POSTING_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id')->primary();
+            $table->string('c_created_by')->nullable();
+            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {
@@ -62,6 +77,8 @@ class OfficeAddressOperationLoggingTest extends TestCase
             $table->tinyInteger('crowdsourcing_status')->default(0);
             $table->tinyInteger('rate')->default(0);
         });
+
+        Auth::guard()->setUser(new GenericUser(['id' => 1, 'name' => 'Testing Admin']));
     }
 
     public function testAddressChangeCreatesStructuredOperationRecord(): void

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -117,6 +117,7 @@ class OfficeAddressOperationLoggingTest extends TestCase
         $this->assertNotNull($operation);
         $this->assertEquals('POSTED_TO_ADDR_DATA', $operation->resource);
         $this->assertEquals('71313-312754', $operation->resource_id);
+        $this->assertNotNull($operation->resource_original);
 
         $after = json_decode($operation->resource_data, true);
         $before = json_decode($operation->resource_original, true);
@@ -142,6 +143,137 @@ class OfficeAddressOperationLoggingTest extends TestCase
                 ],
             ],
         ], $before);
+    }
+
+    public function testAddressChangeUpdatesAuditFields(): void
+    {
+        DB::table('POSTING_DATA')->insert([
+            'c_personid' => 900001,
+            'c_posting_id' => 880001,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-01-01 00:00:00',
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 900001,
+            'c_office_id' => 77771,
+            'c_posting_id' => 880001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 900001,
+            'c_posting_id' => 880001,
+            'c_office_id' => 77771,
+            'c_addr_id' => 45,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-01-02 00:00:00',
+        ]);
+
+        Auth::guard()->setUser(new GenericUser(['id' => 2, 'name' => 'Updater A']));
+
+        $request = new Request([
+            '_id' => 900001,
+            '_postingid' => 880001,
+            '_officeid' => 77771,
+            'c_office_id' => 77771,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [46],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 880001, 900001);
+
+        $posting = DB::table('POSTING_DATA')->where('c_posting_id', 880001)->first();
+        $this->assertSame('Updater A', $posting->c_modified_by);
+        $this->assertNotNull($posting->c_modified_date);
+
+        $address = DB::table('POSTED_TO_ADDR_DATA')->where([
+            'c_personid' => 900001,
+            'c_posting_id' => 880001,
+            'c_office_id' => 77771,
+            'c_addr_id' => 46,
+        ])->first();
+
+        $this->assertSame('Updater A', $address->c_created_by);
+        $this->assertSame('Updater A', $address->c_modified_by);
+        $this->assertNotNull($address->c_created_date);
+        $this->assertNotNull($address->c_modified_date);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $this->assertSame('POSTED_TO_ADDR_DATA', $operation->resource);
+        $this->assertNotNull($operation->resource_original);
+        $payload = json_decode($operation->resource_data, true);
+        $original = json_decode($operation->resource_original, true);
+
+        $this->assertSame(46, $payload['rows'][0]['c_addr_id']);
+        $this->assertSame(45, $original['rows'][0]['c_addr_id']);
+    }
+
+    public function testOfficeUpdateDoesNotResetAddressTimestampsWhenUnchanged(): void
+    {
+        DB::table('POSTING_DATA')->insert([
+            'c_personid' => 910002,
+            'c_posting_id' => 880002,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-05-01 00:00:00',
+            'c_modified_by' => 'Seeder',
+            'c_modified_date' => '2023-05-02 00:00:00',
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 910002,
+            'c_office_id' => 77772,
+            'c_posting_id' => 880002,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 910002,
+            'c_posting_id' => 880002,
+            'c_office_id' => 77772,
+            'c_addr_id' => 25,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-05-01 00:00:00',
+            'c_modified_by' => 'Seeder',
+            'c_modified_date' => '2023-05-02 00:00:00',
+        ]);
+
+        Auth::guard()->setUser(new GenericUser(['id' => 3, 'name' => 'Updater B']));
+
+        $request = new Request([
+            '_id' => 910002,
+            '_postingid' => 880002,
+            '_officeid' => 77772,
+            'c_office_id' => 77772,
+            'c_fy_intercalary' => 1,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [25],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 880002, 910002);
+
+        $address = DB::table('POSTED_TO_ADDR_DATA')->where([
+            'c_personid' => 910002,
+            'c_posting_id' => 880002,
+            'c_office_id' => 77772,
+            'c_addr_id' => 25,
+        ])->first();
+
+        $this->assertSame('2023-05-02 00:00:00', $address->c_modified_date);
+        $this->assertSame('Seeder', $address->c_modified_by);
+
+        $operations = DB::table('operations')->pluck('resource');
+        $this->assertContains('POSTED_TO_OFFICE_DATA', $operations);
+        $this->assertNotContains('POSTED_TO_ADDR_DATA', $operations);
     }
 
     public function testAddressChangeOnlyTouchesTargetOffice(): void

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -24,6 +24,10 @@ class OfficePostingStoreTest extends TestCase
         Schema::create('POSTING_DATA', function (Blueprint $table) {
             $table->integer('c_posting_id')->primary();
             $table->integer('c_personid');
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
         });
 
         Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
@@ -44,6 +48,10 @@ class OfficePostingStoreTest extends TestCase
             $table->integer('c_posting_id');
             $table->integer('c_office_id');
             $table->integer('c_addr_id');
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {


### PR DESCRIPTION
1.製作 POSTING_DATA 和 POSTED_TO_ADDR_DATA 在「新增」與「修改」 官職資訊時，把新增或修改的編輯者資訊不僅保存到 POSTED_TO_OFFICE_DATA 中（當前邏輯），也能保存到 POSTING_DATA 和 POSTED_TO_ADDR_DATA 的 c_created_by, c_created_date, c_modified_by, c_modified_date 欄位中。（實作這項功能並測試完成）

2.用戶在「修改」頁面保存時，若地名資訊（POSTED_TO_ADDR_DATA.c_addr_id）並沒有改變，用戶在保存的時候，則不會修改 POSTED_TO_ADDR_DATA 的 c_modified_by, c_modified_date 欄位。（實作這項功能並測試完成）

3.ADDR_BELONGS_DATA沒有更新，Frank已經統一製作功能了。

4.製作BIOG_SOURCE_DATA的c_created_by, c_created_date, c_modified_by, c_modified_date 欄位對應功能。

5.在「出處」的修改頁面，添加新建「建檔」與「更新」標籤。
