### PR TITLE
feat: 添加臨時時間戳欄位並轉換現有日期資料

### DIFF
--- a/database/migrations/2025_12_09_000000_add_timestamp_temporary_columns.php
+++ b/database/migrations/2025_12_09_000000_add_timestamp_temporary_columns.php
@@ -1,0 +1,137 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add temporary timestamp columns and convert YYYYMMDD dates to proper timestamps.
+ *
+ * Note on transactions:
+ * - DDL operations (ALTER TABLE) in MySQL are auto-committed and cannot be rolled back
+ * - DML operations (UPDATE) are wrapped in a transaction for atomicity
+ * - If the migration fails during data conversion, columns will exist but some may be empty
+ * - This is safe because the original data in c_created_date/c_modified_date is preserved
+ */
+class AddTimestampTemporaryColumns extends Migration
+{
+    /**
+     * The tables that need timestamp conversion.
+     *
+     * @var array
+     */
+    protected $tables = [
+        'ALTNAME_DATA',
+        'ASSOC_DATA',
+        'BIOG_ADDR_DATA',
+        'BIOG_INST_DATA',
+        'BIOG_MAIN',
+        'BIOG_TEXT_DATA',
+        'ENTRY_DATA',
+        'EVENTS_DATA',
+        'KIN_DATA',
+        'MERGED_PERSON_DATA',
+        'POSSESSION_DATA',
+        'POSTED_TO_OFFICE_DATA',
+        'STATUS_DATA',
+        'TEXT_CODES',
+        'TEXT_INSTANCE_DATA',
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Step 1: Add all columns first (DDL operations - cannot be rolled back in MySQL)
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            // Add the new timestamp columns
+            if (!Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->timestamp('c_created_date_timestamp_temporary')->nullable();
+                });
+            }
+
+            if (!Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->timestamp('c_modified_date_timestamp_temporary')->nullable();
+                });
+            }
+        }
+
+        // Step 2: Convert and populate the data (DML operations - wrapped in transaction)
+        DB::transaction(function () {
+            foreach ($this->tables as $table) {
+                if (!Schema::hasTable($table)) {
+                    continue;
+                }
+
+                $this->convertDates($table);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            if (Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->dropColumn('c_created_date_timestamp_temporary');
+                });
+            }
+
+            if (Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->dropColumn('c_modified_date_timestamp_temporary');
+                });
+            }
+        }
+    }
+
+    /**
+     * Convert YYYYMMDD format dates to timestamps.
+     *
+     * @param string $table
+     * @return void
+     */
+    protected function convertDates(string $table): void
+    {
+        // Update c_created_date_timestamp_temporary
+        if (Schema::hasColumn($table, 'c_created_date')) {
+            DB::statement("
+                UPDATE `{$table}`
+                SET `c_created_date_timestamp_temporary` = STR_TO_DATE(`c_created_date`, '%Y%m%d')
+                WHERE `c_created_date` IS NOT NULL
+                  AND `c_created_date` != ''
+                  AND `c_created_date` REGEXP '^[0-9]{8}$'
+            ");
+        }
+
+        // Update c_modified_date_timestamp_temporary
+        if (Schema::hasColumn($table, 'c_modified_date')) {
+            DB::statement("
+                UPDATE `{$table}`
+                SET `c_modified_date_timestamp_temporary` = STR_TO_DATE(`c_modified_date`, '%Y%m%d')
+                WHERE `c_modified_date` IS NOT NULL
+                  AND `c_modified_date` != ''
+                  AND `c_modified_date` REGEXP '^[0-9]{8}$'
+            ");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

新增 15 個資料表的臨時時間戳欄位，並將現有的 YYYYMMDD 格式日期轉換為正確的時間戳格式。

### 變更內容

- 新增 migration：`2025_12_09_000000_add_timestamp_temporary_columns.php`
- 為以下資料表新增兩個欄位：
  - `c_created_date_timestamp_temporary`
  - `c_modified_date_timestamp_temporary`

### 影響的資料表

1. ALTNAME_DATA
2. ASSOC_DATA
3. BIOG_ADDR_DATA
4. BIOG_INST_DATA
5. BIOG_MAIN
6. BIOG_TEXT_DATA
7. ENTRY_DATA
8. EVENTS_DATA
9. KIN_DATA
10. MERGED_PERSON_DATA
11. POSSESSION_DATA
12. POSTED_TO_OFFICE_DATA
13. STATUS_DATA
14. TEXT_CODES
15. TEXT_INSTANCE_DATA

### 技術細節

- 將 YYYYMMDD 格式（例如 `20080122`）轉換為 MySQL 時間戳
- 使用 `STR_TO_DATE()` 進行格式轉換
- 資料轉換使用交易保護，確保原子性操作
- 包含正則表達式驗證，只處理有效的 8 位數日期
- 原始資料保持不變，確保資料安全

### 交易安全性

- DDL 操作（ALTER TABLE）：MySQL 自動提交，無法回滾
- DML 操作（UPDATE）：包裹在交易中，確保全部成功或全部回滾
- 若轉換失敗，新欄位將保持空值，原始資料不受影響

## Test plan

- [ ] 執行 migration：`php artisan migrate`
- [ ] 驗證所有 15 個資料表都新增了兩個欄位
- [ ] 檢查日期轉換是否正確（抽查部分資料）
- [ ] 測試 rollback：`php artisan migrate:rollback`
- [ ] 驗證欄位已被移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)