### PR TITLE
文檔：修正 Eloquent ORM 使用說明，明確複合主鍵表應使用 Query Builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@
    - 若改了前端資源，記得提交編譯後檔案（除非專案流程另有規範）。
 4. **開發注意事項**：
    - 嚴禁在未授權情況下直接修改資料庫結構或大量資料。
-   - 避免在 Controller 中直接寫 SQL；如需操作資料庫，優先利用 Repository 或 Eloquent。
+   - 避免在 Controller 中直接寫 SQL；如需操作資料庫，優先利用 Repository。對於**單一主鍵**的表可以使用 Eloquent 模型，但對於**複合主鍵**的表（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA` 等）必須使用 Query Builder（`DB::table()`）而非 Eloquent 模型。
    - 所有新路由需通過授權檢查，避免只靠前端限制。
   - 目前前端樣式與互動高度依賴 AdminLTE（`resources/assets/sass/app.scss`、`resources/assets/js/bootstrap.js` 持續匯入相關資產）；`/codes` 已改用 `layouts/dashboard-v3`（AdminLTE 3 CDN、未載入 Mix 產物），其他頁面仍是 AdminLTE 2。若要移除舊資產需先規畫替代的樣式框架、重構 Blade 樣板與 JS 初始化流程，並逐頁驗證後才能刪除舊資產，避免界面崩壞。
 5. **文檔更新建議**：
@@ -166,11 +166,13 @@
 - **測試數據庫依賴陷阱**：避免依賴完整 MySQL schema 或複雜遷移文件，這會導致 CI 失敗和測試不穩定。
 - **PHPUnit 版本兼容性**：專案使用 PHPUnit 10.1，注意使用相容的斷言方法（如 `assertStringContainsString` 替代舊版 `assertContains`）。
 - **用戶模型測試**：記得為 `users` 表的 `confirmation_token` 字段提供值，避免 NOT NULL 約束錯誤。
-- **Eloquent 與複合主鍵的限制**：Laravel Eloquent ORM 對複合主鍵（composite primary key）支援不佳。對於擁有複合主鍵的表（如 `ALTNAME_DATA` 使用 `c_personid + c_sequence + c_alt_name_chn + c_alt_name_type_code`），建議直接使用 Query Builder（`DB::table()`）而非建立 Eloquent 模型。若需要類似 Observer 的副作用（如自動索引），應在控制器中手動調用對應服務（如 `NameSearchIndexService`）。嘗試為複合主鍵表建立 Eloquent 模型會遇到以下問題：
-  - `delete()` 方法無法正常運作（要求單一主鍵）
-  - `update()` 可能無法正確檢測變更（`getDirty()` 判斷失效）
-  - 即使覆寫 `delete()`/`update()` 方法仍會增加維護成本與複雜度
-  - Observer 無法被 Query Builder 觸發，但手動調用服務更加明確且易於測試
+- **Eloquent 與複合主鍵的限制**：Laravel Eloquent ORM **官方不支持**複合主鍵（composite primary key）。雖然社群有第三方套件（如 `laravel-composite-primary-keys`）提供支援，但引入第三方包會增加維護上的不確定性（套件的長期維護狀態難以保證）。因此，本專案決定對於擁有複合主鍵的表（如 `ALTNAME_DATA` 使用 `c_personid + c_sequence + c_alt_name_chn + c_alt_name_type_code`），直接使用 Query Builder（`DB::table()`）而非建立 Eloquent 模型。若需要類似 Observer 的副作用（如自動索引），應在 Repository 或 Service 層手動調用對應服務（如 `NameSearchIndexService`）。
+
+  使用 Query Builder 的優勢：
+  - 官方完整支援，無需依賴第三方套件
+  - 程式碼更明確，易於理解和維護
+  - 避免 Eloquent 在複合主鍵下的各種問題（`delete()`/`update()` 方法無法正常運作、`getDirty()` 判斷失效等）
+  - 手動調用服務比 Observer 更加明確且易於測試
 
 ## 快速回顧
 - 需要了解的主要模組：`CodesController`、`OperationsController`、`OperationRepository`、`resources/views/operations/*`。

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -205,6 +205,51 @@ $users = DB::table('users')
     ->get();
 ```
 
+### ORM 使用策略
+
+#### Eloquent 與複合主鍵限制
+
+**重要原則**：Laravel Eloquent ORM **官方不支持**複合主鍵（composite primary key）。雖然社群有第三方套件提供支援，但會增加維護上的不確定性（套件的長期維護狀態難以保證）。因此需根據表結構選擇合適的操作方式。
+
+```php
+// ✅ 好：單一主鍵的表使用 Eloquent
+class User extends Model {
+    protected $primaryKey = 'id';  // 單一主鍵
+}
+
+$user = User::find(1);
+$user->update(['name' => 'New Name']);
+$user->delete();
+
+// ✅ 好：複合主鍵的表使用 Query Builder
+// 例如：ALTNAME_DATA 有複合主鍵 (c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code)
+DB::table('ALTNAME_DATA')
+    ->where('c_personid', $personId)
+    ->where('c_sequence', $sequence)
+    ->update(['c_alt_name_chn' => $name]);
+
+DB::table('ALTNAME_DATA')
+    ->where('c_personid', $personId)
+    ->where('c_sequence', $sequence)
+    ->delete();
+
+// ❌ 避免：為複合主鍵表建立 Eloquent 模型
+// Eloquent 官方不支持複合主鍵，會導致以下問題：
+// - delete() 方法無法正常運作（僅支援單一主鍵）
+// - update() 無法正確檢測變更（getDirty() 判斷失效）
+// - find() 等方法無法使用
+// 雖然有第三方套件，但會增加維護負擔和不確定性
+```
+
+**本專案複合主鍵表示例**：
+- `ALTNAME_DATA`：`c_personid + c_sequence + c_alt_name_chn + c_alt_name_type_code`
+- `POSTED_TO_ADDR_DATA`：`c_personid + c_posting_id + c_office_id`
+
+**處理副作用（如索引更新）**：
+- 不要依賴 Eloquent Observer（Query Builder 不會觸發）
+- 在 Repository 或 Service 層手動調用相關服務（如 `NameSearchIndexService`）
+- 更加明確且易於測試
+
 ---
 
 ## 具體場景指南
@@ -476,9 +521,9 @@ public function test_works_on_mariadb()
 ## 參考資源
 
 ### 官方文檔
-- [Laravel 8.x Database](https://laravel.com/docs/8.x/database)
-- [Laravel 8.x Migrations](https://laravel.com/docs/8.x/migrations)
-- [Laravel 8.x Eloquent](https://laravel.com/docs/8.x/eloquent)
+- [Laravel 10.x Database](https://laravel.com/docs/10.x/database)
+- [Laravel 10.x Migrations](https://laravel.com/docs/10.x/migrations)
+- [Laravel 10.x Eloquent](https://laravel.com/docs/10.x/eloquent)
 - [MariaDB Documentation](https://mariadb.com/kb/en/)
 
 ### 兼容性指南

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ migration 是laravel提供的一个数据库迁移功能，可以方便的在新
 ```bash
 php artisan make:migration creat_tasks_table --create=tasks
 ```
-参考文档[migrations](http://d.laravel-china.org/docs/5.4/migrations)
+参考文档：[Laravel 10.x Migrations](https://laravel.com/docs/10.x/migrations)
 
 ### 用户验证
 
@@ -68,7 +68,7 @@ php artisan make:migration creat_tasks_table --create=tasks
 php artisan make:auth
 ```
 
-参考文档[authentication](http://d.laravel-china.org/docs/5.4/authentication)
+参考文档：[Laravel 10.x Authentication](https://laravel.com/docs/10.x/authentication)
 
 ### 信息提示 flash
 
@@ -78,15 +78,20 @@ php artisan make:auth
 
 表单验证会是本项目的重点之一，保证用户提交的信息准确无误
 
-参考文档[validation](http://d.laravel-china.org/docs/5.4/validation)
+参考文档：[Laravel 10.x Validation](https://laravel.com/docs/10.x/validation)
 
-### Eloquent ORM
+### Eloquent ORM 與 Query Builder
 
 Laravel 的 Eloquent ORM 提供了漂亮、简洁的 ActiveRecord 实现来和数据库进行交互。每个数据库表都有一个对应的「模型」可用来跟数据表进行交互。你可以通过模型查询数据表内的数据，以及将记录添加到数据表中。
 
-本项目的数据库操作都会采取这种方式。
+**重要原則：**
+- **單一主鍵的表**：可以使用 Eloquent 模型進行操作
+- **複合主鍵的表**（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA` 等）：必須使用 Query Builder（`DB::table()`）而非 Eloquent 模型，因為 **Eloquent 官方不支持複合主鍵**。雖然有第三方套件提供支援，但會增加維護上的不確定性，因此本專案決定在複合主鍵表上直接使用 Query Builder
 
-参考文档[eloquent](http://d.laravel-china.org/docs/5.4/eloquent)
+参考文档：
+- [Laravel 10.x Eloquent ORM](https://laravel.com/docs/10.x/eloquent)
+- [Laravel 10.x Query Builder](https://laravel.com/docs/10.x/queries)
+- [複合主鍵限制說明](./AGENTS.md#常見坑位)
 
 ### 控制器
 
@@ -108,7 +113,7 @@ php artisan make:request BiogBasicInformationRequest
 ```
 
 
-参考文档[controllers](http://d.laravel-china.org/docs/5.4/controllers)
+参考文档：[Laravel 10.x Controllers](https://laravel.com/docs/10.x/controllers)
 
 ### webpack打包
 
@@ -126,7 +131,7 @@ DYNASTIES
 CHORONYM_CODES
 
 ### passport API认证
-http://d.laravel-china.org/docs/5.4/passport#frontend-quickstart
+参考文档：[Laravel 10.x Passport](https://laravel.com/docs/10.x/passport)
 
 ### 对数据库的修改
 
@@ -142,7 +147,7 @@ http://d.laravel-china.org/docs/5.4/passport#frontend-quickstart
 
 ### 构建API资源服务
 
-参考文档[controllers](http://d.laravel-china.org/docs/5.6/eloquent-resources)
+参考文档：[Laravel 10.x Eloquent Resources](https://laravel.com/docs/10.x/eloquent-resources)
 
 创建API资源控制器，如人物主要信息
 

--- a/SQLITE_MIGRATION_PLAN.md
+++ b/SQLITE_MIGRATION_PLAN.md
@@ -426,10 +426,16 @@ php artisan migrate
 大部分情况下，Eloquent 会自动处理数据库差异：
 
 ```php
-// ✅ 好 - 自动兼容
+// ✅ 好 - 单一主键的表使用 Eloquent
 User::where('email', 'test@example.com')->first();
+
+// ✅ 好 - 复合主键的表使用 Query Builder
 DB::table('users')->where('active', 1)->get();
 ```
+
+**重要限制：**
+- **单一主键的表**：可以使用 Eloquent 模型
+- **复合主键的表**（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA`）：必须使用 Query Builder（`DB::table()`），因为 **Eloquent 官方不支持复合主键**。虽然有第三方套件提供支持，但会增加维护上的不确定性，因此本项目决定在复合主键表上直接使用 Query Builder
 
 #### 2. 避免数据库特定函数
 
@@ -617,9 +623,9 @@ if ($driver === 'mysql') {
 
 ### Laravel 文档
 
-- [数据库配置](https://laravel.com/docs/5.6/database)
-- [迁移](https://laravel.com/docs/5.6/migrations)
-- [测试](https://laravel.com/docs/5.6/testing)
+- [数据库配置](https://laravel.com/docs/10.x/database)
+- [迁移](https://laravel.com/docs/10.x/migrations)
+- [测试](https://laravel.com/docs/10.x/testing)
 
 ### 最佳实践
 


### PR DESCRIPTION
修改內容：
1. AGENTS.md：更新開發注意事項和常見坑位，說明 Eloquent 官方不支持複合主鍵
2. README.md：修正 Eloquent ORM 章節，明確說明官方限制及本專案策略，並更新所有文檔鏈接為 Laravel 10.x 官方文檔
3. DATABASE.md：新增「ORM 使用策略」章節，詳細說明複合主鍵的處理方式，並更新參考鏈接為 Laravel 10.x
4. SQLITE_MIGRATION_PLAN.md：更新編寫兼容代碼指南，說明複合主鍵表的使用限制，並更新 Laravel 文檔鏈接為 10.x 版本

文檔鏈接更新：
- 移除所有過時的 laravel-china.org 鏈接
- 統一使用 Laravel 10.x 官方文檔（https://laravel.com/docs/10.x/）
- 涵蓋：Migrations、Authentication、Validation、Eloquent、Query Builder、Controllers、Passport、Eloquent Resources 等

核心要點：
- Eloquent 官方不支持複合主鍵（非「支持不佳」）
- 雖然社群有第三方套件（如 laravel-composite-primary-keys），但引入會增加維護上的不確定性
- 本專案決定在複合主鍵表（如 ALTNAME_DATA、POSTED_TO_ADDR_DATA）上直接使用 DB::table()

使用 Query Builder 的優勢：
- 官方完整支援，無需依賴第三方套件
- 程式碼更明確，易於理解和維護
- 避免 Eloquent 在複合主鍵下的各種問題
- 手動調用服務比 Observer 更加明確且易於測試

相關問題：#565（單向關係修復工具）中涉及的複合主鍵表操作