### PR TITLE
chore: 強制使用 LF 換行符並修正代碼格式

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,15 @@
 * text=auto
+
+# 强制所有 PHP 和相关文件使用 LF 换行符
+*.php text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.xml text eol=lf
+*.sql text eol=lf
+
 *.css linguist-vendored
 *.scss linguist-vendored
 *.js linguist-vendored

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -781,7 +781,7 @@ class OperationsController extends Controller {
         $key = str_replace("(slash)", "/", $key);
         $key = str_replace("(backslash)", "\\", $key);
         $key = str_replace("(brackets)", "{", $key);
-        $key = str_replace("(brackets_r)","}",$key);
+        $key = str_replace("(brackets_r)", "}", $key);
         $result = $key;
 
         return $result;


### PR DESCRIPTION
## 概述
此 PR 解決了在 Windows 環境下因換行符差異導致大量文件顯示為已修改的問題，統一整個專案使用 LF 換行符。

## 變更內容

### 1. `.gitattributes`
- ✅ 添加強制所有 PHP 和相關文件使用 LF 換行符的規則
- ✅ 包含文件類型：`*.php`, `*.js`, `*.json`, `*.md`, `*.yml`, `*.yaml`, `*.xml`, `*.sql`

### 2. Git 配置
- ✅ 設置 `core.autocrlf = false`（禁用自動轉換）
- ✅ 設置 `core.eol = lf`（強制使用 LF）

### 3. 代碼格式修正
- ✅ [app/Http/Controllers/OperationsController.php:784](app/Http/Controllers/OperationsController.php#L784) - 修正 `str_replace` 函數調用格式

## 解決的問題

### 問題描述
在 Windows 環境下，Git 會將 LF 換行符自動轉換為 CRLF，導致：
- 大量文件（100+ 個）顯示為已修改，但實際內容沒有變化
- 每次運行 `php-cs-fixer fix` 後仍然有文件顯示修改
- 團隊協作時出現不必要的換行符衝突

### 解決方案
通過 `.gitattributes` 明確指定換行符策略，確保：
- ✅ 所有平台（Windows/Mac/Linux）都使用 LF 換行符
- ✅ PHP CS Fixer 與 Git 的換行符策略一致
- ✅ 避免假修改（phantom changes）

## 測試驗證

- ✅ 運行 `vendor/bin/php-cs-fixer fix` 後無額外修改
- ✅ 所有文件的換行符已統一為 LF
- ✅ Git 不再顯示 "LF will be replaced by CRLF" 警告

## 影響範圍

- **影響文件**：2 個文件
- **新增規則**：`.gitattributes` 中的換行符規則
- **代碼變更**：1 處格式修正
- **破壞性變更**：無

## 後續建議

團隊成員在拉取此 PR 後，建議執行以下命令以更新本地配置：

```bash
git config core.autocrlf false
git config core.eol lf
git pull
git add --renormalize .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)