### PR TITLE
feat: 在 /codes/* 編輯頁面完整顯示原始記錄內容; 支援新的時間戳審計字段

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -269,6 +269,7 @@ class CodesController extends Controller {
                 }
 
                 $rowArray = $this->convertRowToArray($data);
+                $rowArray = $this->orderAuditFieldsForDisplay($rowArray);
                 $compositeId = $this->buildCompositeId($keyColumns, $rowArray);
 
                 return view('codes.edit', [
@@ -976,6 +977,47 @@ class CodesController extends Controller {
         }
 
         return $data;
+    }
+
+    /**
+     * Reorder fields to display audit columns in a logical sequence.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    protected function orderAuditFieldsForDisplay(array $row): array {
+        // 定义审计字段的理想顺序
+        $auditFieldOrder = [
+            'c_created_by',
+            'c_created_date',
+            'c_created_date_timestamp_temporary',
+            'c_modified_by',
+            'c_modified_date',
+            'c_modified_date_timestamp_temporary',
+        ];
+
+        // 分离审计字段和其他字段
+        $auditFields = [];
+        $otherFields = [];
+
+        foreach ($row as $key => $value) {
+            if (in_array($key, $auditFieldOrder, true)) {
+                $auditFields[$key] = $value;
+            } else {
+                $otherFields[$key] = $value;
+            }
+        }
+
+        // 按照定义的顺序重新排列审计字段
+        $orderedAuditFields = [];
+        foreach ($auditFieldOrder as $field) {
+            if (array_key_exists($field, $auditFields)) {
+                $orderedAuditFields[$field] = $auditFields[$field];
+            }
+        }
+
+        // 合并：其他字段在前，审计字段在后（按顺序）
+        return array_merge($otherFields, $orderedAuditFields);
     }
 
     protected function buildConditionsFromRow(array $keyColumns, array $row): array {

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -268,7 +268,7 @@ class CodesController extends Controller {
                     return redirect()->back();
                 }
 
-                $rowArray = $this->prepareAuditFieldsForDisplay($this->convertRowToArray($data));
+                $rowArray = $this->convertRowToArray($data);
                 $compositeId = $this->buildCompositeId($keyColumns, $rowArray);
 
                 return view('codes.edit', [
@@ -935,24 +935,6 @@ class CodesController extends Controller {
         }
 
         return null;
-    }
-
-    /**
-     * Prepare immutable/mutable audit columns before rendering edit form.
-     *
-     * @param array<string, mixed> $row
-     * @return array<string, mixed>
-     */
-    protected function prepareAuditFieldsForDisplay(array $row): array {
-        if (array_key_exists('c_modified_by', $row) && Auth::check()) {
-            $row['c_modified_by'] = Auth::user()->name;
-        }
-
-        if (array_key_exists('c_modified_date', $row)) {
-            $row['c_modified_date'] = Carbon::now()->format('Ymd');
-        }
-
-        return $row;
     }
 
     /**

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -876,6 +876,10 @@ class CodesController extends Controller {
             $data['c_created_date'] = Carbon::now()->format('Ymd');
         }
 
+        if (in_array('c_created_date_timestamp_temporary', $columns, true)) {
+            $data['c_created_date_timestamp_temporary'] = Carbon::now()->format('Y-m-d H:i:s');
+        }
+
         return $data;
     }
 
@@ -945,7 +949,7 @@ class CodesController extends Controller {
      * @return array<string, mixed>
      */
     protected function enforceAuditFieldsForUpdate(array $data, array $original): array {
-        foreach (['c_created_by', 'c_created_date'] as $field) {
+        foreach (['c_created_by', 'c_created_date', 'c_created_date_timestamp_temporary'] as $field) {
             if (array_key_exists($field, $data) && array_key_exists($field, $original)) {
                 $data[$field] = $original[$field];
             }
@@ -963,6 +967,12 @@ class CodesController extends Controller {
             $data['c_modified_date'] = Carbon::now()->format('Ymd');
         } elseif (array_key_exists('c_modified_date', $original)) {
             $data['c_modified_date'] = $original['c_modified_date'];
+        }
+
+        if (array_key_exists('c_modified_date_timestamp_temporary', $data)) {
+            $data['c_modified_date_timestamp_temporary'] = Carbon::now()->format('Y-m-d H:i:s');
+        } elseif (array_key_exists('c_modified_date_timestamp_temporary', $original)) {
+            $data['c_modified_date_timestamp_temporary'] = $original['c_modified_date_timestamp_temporary'];
         }
 
         return $data;

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -1004,13 +1004,32 @@ class CodesController extends Controller {
             'c_modified_date_timestamp_temporary',
         ];
 
+        // 时间戳字段需要转换时区
+        $timestampFields = [
+            'c_created_date_timestamp_temporary',
+            'c_modified_date_timestamp_temporary',
+        ];
+
         // 分离审计字段和其他字段
         $auditFields = [];
         $otherFields = [];
 
         foreach ($row as $key => $value) {
             if (in_array($key, $auditFieldOrder, true)) {
-                $auditFields[$key] = $value;
+                // 时间戳字段转换为本地时区（Asia/Taipei, GMT+8）
+                if (in_array($key, $timestampFields, true) && $value !== null && $value !== '') {
+                    try {
+                        $carbon = Carbon::parse($value);
+                        // 转换为 Asia/Taipei 时区（GMT+8）
+                        $carbon->setTimezone('Asia/Taipei');
+                        $auditFields[$key] = $carbon->format('Y-m-d H:i:s');
+                    } catch (\Exception $e) {
+                        // 如果解析失败，保持原值
+                        $auditFields[$key] = $value;
+                    }
+                } else {
+                    $auditFields[$key] = $value;
+                }
             } else {
                 $otherFields[$key] = $value;
             }

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -868,17 +868,19 @@ class CodesController extends Controller {
      */
     protected function enforceAuditFieldsForCreate(string $table, array $data): array {
         $columns = $this->getTableColumns($table);
+        $now = Carbon::now();
 
         if (in_array('c_created_by', $columns, true) && Auth::check()) {
             $data['c_created_by'] = Auth::user()->name;
         }
 
+        // Dual write: c_created_date (Ymd format) 和 c_created_date_timestamp_temporary (Y-m-d H:i:s format)
         if (in_array('c_created_date', $columns, true)) {
-            $data['c_created_date'] = Carbon::now()->format('Ymd');
+            $data['c_created_date'] = $now->format('Ymd');
         }
 
         if (in_array('c_created_date_timestamp_temporary', $columns, true)) {
-            $data['c_created_date_timestamp_temporary'] = Carbon::now()->format('Y-m-d H:i:s');
+            $data['c_created_date_timestamp_temporary'] = $now->format('Y-m-d H:i:s');
         }
 
         return $data;
@@ -950,12 +952,16 @@ class CodesController extends Controller {
      * @return array<string, mixed>
      */
     protected function enforceAuditFieldsForUpdate(array $data, array $original): array {
+        $now = Carbon::now();
+
+        // 保护 created_* 字段不被修改
         foreach (['c_created_by', 'c_created_date', 'c_created_date_timestamp_temporary'] as $field) {
             if (array_key_exists($field, $data) && array_key_exists($field, $original)) {
                 $data[$field] = $original[$field];
             }
         }
 
+        // 更新 c_modified_by
         if (array_key_exists('c_modified_by', $data)) {
             if (Auth::check()) {
                 $data['c_modified_by'] = Auth::user()->name;
@@ -964,14 +970,16 @@ class CodesController extends Controller {
             }
         }
 
+        // Dual write: c_modified_date (Ymd format) 和 c_modified_date_timestamp_temporary (Y-m-d H:i:s format)
+        // 使用同一个时间戳确保两者完全一致
         if (array_key_exists('c_modified_date', $data)) {
-            $data['c_modified_date'] = Carbon::now()->format('Ymd');
+            $data['c_modified_date'] = $now->format('Ymd');
         } elseif (array_key_exists('c_modified_date', $original)) {
             $data['c_modified_date'] = $original['c_modified_date'];
         }
 
         if (array_key_exists('c_modified_date_timestamp_temporary', $data)) {
-            $data['c_modified_date_timestamp_temporary'] = Carbon::now()->format('Y-m-d H:i:s');
+            $data['c_modified_date_timestamp_temporary'] = $now->format('Y-m-d H:i:s');
         } elseif (array_key_exists('c_modified_date_timestamp_temporary', $original)) {
             $data['c_modified_date_timestamp_temporary'] = $original['c_modified_date_timestamp_temporary'];
         }

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -29,15 +29,19 @@
                         @php
                             $isCreatedField = in_array($key, ['c_created_by', 'c_created_date'], true);
                             $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date'], true);
+                            // 显示原始值而不是替换后的值
                             $inputValue = $value;
-                            if ($isModifiedField) {
+                            $shouldDisable = $isCreatedField || $isModifiedField;
+
+                            // 为 modified_* 字段准备提示文字
+                            $helpText = null;
+                            if ($isModifiedField && Auth::check() && Auth::user()->isActive()) {
                                 if ($key === 'c_modified_by' && $currentUserName !== null) {
-                                    $inputValue = $currentUserName;
+                                    $helpText = '欄位內容提交後會被替換為：' . $currentUserName;
                                 } elseif ($key === 'c_modified_date') {
-                                    $inputValue = $currentDateYmd;
+                                    $helpText = '欄位內容提交後會被替換為：' . $currentDateYmd;
                                 }
                             }
-                            $shouldDisable = $isCreatedField || $isModifiedField;
                         @endphp
                         <div class="form-group">
                             <label for="{{ $key }}" class="col-sm-2 control-label">{{ $key }}</label>
@@ -57,17 +61,26 @@
                                 <input type="text" name="{{ $key }}" class="form-control"
                                        value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
                                 <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                                @if($helpText)
+                                <p class="help-block text-info"><strong>{{ $helpText }}</strong></p>
+                                @endif
                             </div>
                             @elseif($table === 'ADDR_BELONGS_DATA' && $key === 'c_belongs_to')
                             <div class="col-sm-10">
                                 <input type="text" name="{{ $key }}" class="form-control"
                                        value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
                                 <p class="help-block text-muted">請從 <a href="/codes/ADDR_CODES" target="_blank">ADDR_CODES</a> 表中複製 c_addr_id 填入</p>
+                                @if($helpText)
+                                <p class="help-block text-info"><strong>{{ $helpText }}</strong></p>
+                                @endif
                             </div>
                             @else
                             <div class="col-sm-10">
                                 <input type="text" name="{{ $key }}" class="form-control"
                                        value="{{ old($key, $inputValue) }}" @if($shouldDisable) readonly @endif>
+                                @if($helpText)
+                                <p class="help-block text-info"><strong>{{ $helpText }}</strong></p>
+                                @endif
                             </div>
                             @endif
                         </div>

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -5,6 +5,7 @@
     @php
         $currentUserName = optional(Auth::user())->name;
         $currentDateYmd = \Carbon\Carbon::now()->format('Ymd');
+        $currentTimestampTaipei = \Carbon\Carbon::now('Asia/Taipei')->format('Y-m-d H:i:s');
     @endphp
 
     <div class="panel panel-default">
@@ -41,7 +42,7 @@
                                 } elseif ($key === 'c_modified_date') {
                                     $helpText = '欄位內容提交後會被替換為：' . $currentDateYmd;
                                 } elseif ($key === 'c_modified_date_timestamp_temporary') {
-                                    $helpText = '欄位內容提交後會被替換為：' . \Carbon\Carbon::now()->format('Y-m-d H:i:s');
+                                    $helpText = '欄位內容提交後會被替換為：' . $currentTimestampTaipei . ' (GMT+8)';
                                 }
                             }
                         @endphp

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -27,8 +27,8 @@
                     @endif
                     @foreach($row as $key => $value)
                         @php
-                            $isCreatedField = in_array($key, ['c_created_by', 'c_created_date'], true);
-                            $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date'], true);
+                            $isCreatedField = in_array($key, ['c_created_by', 'c_created_date', 'c_created_date_timestamp_temporary'], true);
+                            $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date', 'c_modified_date_timestamp_temporary'], true);
                             // 显示原始值而不是替换后的值
                             $inputValue = $value;
                             $shouldDisable = $isCreatedField || $isModifiedField;
@@ -40,6 +40,8 @@
                                     $helpText = '欄位內容提交後會被替換為：' . $currentUserName;
                                 } elseif ($key === 'c_modified_date') {
                                     $helpText = '欄位內容提交後會被替換為：' . $currentDateYmd;
+                                } elseif ($key === 'c_modified_date_timestamp_temporary') {
+                                    $helpText = '欄位內容提交後會被替換為：' . \Carbon\Carbon::now()->format('Y-m-d H:i:s');
                                 }
                             }
                         @endphp

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -648,27 +648,34 @@ class CodesControllerTest extends TestCase {
 
         $response->assertStatus(200);
         $content = $response->getContent();
+
+        // c_created_by 应显示原始值并且 readonly
         $createdByPos = strpos($content, 'name="c_created_by"');
         $this->assertNotFalse($createdByPos);
         $this->assertNotFalse(strpos($content, 'value="origin"', $createdByPos));
         $this->assertNotFalse(strpos($content, 'readonly', $createdByPos));
 
+        // c_created_date 应显示原始值并且 readonly
         $createdDatePos = strpos($content, 'name="c_created_date"');
         $this->assertNotFalse($createdDatePos);
         $this->assertNotFalse(strpos($content, 'value="20200101"', $createdDatePos));
         $this->assertNotFalse(strpos($content, 'readonly', $createdDatePos));
 
+        // c_modified_by 应显示原始值（"previous"）而非当前用户，并且 readonly
         $modifiedByPos = strpos($content, 'name="c_modified_by"');
         $this->assertNotFalse($modifiedByPos);
-        $this->assertNotFalse(strpos($content, 'value="text-admin"', $modifiedByPos));
+        $this->assertNotFalse(strpos($content, 'value="previous"', $modifiedByPos));
         $this->assertNotFalse(strpos($content, 'readonly', $modifiedByPos));
 
+        // c_modified_date 应显示原始值（"20200102"）而非当前日期，并且 readonly
         $modifiedDatePos = strpos($content, 'name="c_modified_date"');
         $this->assertNotFalse($modifiedDatePos);
-        $this->assertNotFalse(strpos($content, 'value="'.Carbon::now()->format('Ymd').'"', $modifiedDatePos));
+        $this->assertNotFalse(strpos($content, 'value="20200102"', $modifiedDatePos));
         $this->assertNotFalse(strpos($content, 'readonly', $modifiedDatePos));
-        $response->assertDontSee('value="previous"', false);
-        $response->assertDontSee('value="20200102"', false);
+
+        // 应该有提示文字说明提交后会被替换的值
+        $response->assertSee('欄位內容提交後會被替換為：text-admin', false);
+        $response->assertSee('欄位內容提交後會被替換為：'.Carbon::now()->format('Ymd'), false);
 
         Carbon::setTestNow();
     }


### PR DESCRIPTION
用戶登入後會顯示

<img width="706" height="916" alt="image" src="https://github.com/user-attachments/assets/13aec461-d00c-44cb-87db-17aa5c535ab6" />

未登入時顯示

<img width="729" height="914" alt="image" src="https://github.com/user-attachments/assets/53360c62-da03-4dfd-b7cf-8ef24c42a7d3" />
