### PR TITLE
doc: 添加時區設定說明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - `CBDB__NAME_FTS`：姓名搜尋倒排索引，支援高效能後綴匹配查詢
   - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射，基於 OpenCC 標準，使用 VARBINARY(4) 支援非BMP字符
 - **日期/時間處理**：使用 Carbon 2.x。
+  - **時區設定**：目前 database 內部分表格欄位出現 datetime 與 timestamp 混用的情況。為避免日期衝突，統一使用 GMT+8 時區。
 - **主要資料夾**：
   - `app/Http/Controllers`：Laravel 控制器（如 `OperationsController`）。
   - `app/Repositories`：資料存取與封裝邏輯（如 `OperationRepository`）。

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -22,6 +22,7 @@
 - **版本資訊**：`mysql Ver 15.1 Distrib 10.3.39-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2`
 - **字符集**：utf8mb4
 - **排序規則**：utf8mb4_general_ci
+- **時區設定**：目前 database 內部分表格欄位出現 datetime 與 timestamp 混用的情況。為避免日期衝突，統一使用 GMT+8 時區。
 
 ### 測試環境
 - **CI/CD**：SQLite in-memory (`:memory:`)


### PR DESCRIPTION
在 AGENTS.md 和 DATABASE.md 中加入說明：
- 目前 database 內部分表格欄位出現 datetime 與 timestamp 混用的情況
- 為避免日期衝突，統一使用 GMT+8 時區