### PR TITLE
fix: Operations 頁面錯誤並為代碼表資源添加編輯連結

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -406,6 +406,21 @@ class OperationsController extends Controller {
                             }
 
                         }
+
+                        // 檢查陣列長度是否足夠（BIOG_SOURCE_DATA 需要 3 個欄位）
+                        if (count($source_1) < 3) {
+                            // 記錄錯誤並跳過此筆資料
+                            \Log::warning("BIOG_SOURCE_DATA resource_id 格式不正確: {$resource_id}", [
+                                'parsed' => $source_1,
+                                'expected_count' => 3,
+                                'actual_count' => count($source_1),
+                                'operation_id' => $listsArr['data'][$x]['id'] ?? null,
+                            ]);
+                            $arr3 = null;
+
+                            break;
+                        }
+
                         $arr3 = DB::table('BIOG_SOURCE_DATA')->where([
                             ['c_personid', '=', $source_1[0]],
                             ['c_textid', '=', $source_1[1]],
@@ -424,8 +439,8 @@ class OperationsController extends Controller {
                 $arr3 = [];
             }
 
-            $arr1Decoded = json_decode($arr1, true);
-            $arr2Decoded = json_decode($arr2, true);
+            $arr1Decoded = $arr1 ? json_decode($arr1, true) : null;
+            $arr2Decoded = $arr2 ? json_decode($arr2, true) : null;
             $arr1Decoded = is_array($arr1Decoded) ? $arr1Decoded : [];
             $arr2Decoded = is_array($arr2Decoded) ? $arr2Decoded : [];
 

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -51,7 +51,8 @@
                 </thead>
                 <tbody>
                     @php
-                        $codeTables = array_map('strtoupper', config('codes.tables', []));
+                        $codeTableKeys = array_keys(config('codes.tables', []));
+                        $codeTables = array_map('strtoupper', $codeTableKeys);
                     @endphp
                     @foreach($lists as $item)
 @php
@@ -124,10 +125,14 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 $hasPersonLink = $personLink && !empty($item->biogmain);
                                 $isCodeResource = in_array(strtoupper($item->resource), $codeTables, true);
                                 $resourceLink = null;
-                                if (!$hasPersonLink && $isCodeResource) {
-                                    $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $originalResourceId], false);
-                                } elseif ($hasPersonLink && $resourceSpecificLink) {
+
+                                // 优先使用人物相关的特定资源链接
+                                if ($hasPersonLink && $resourceSpecificLink) {
                                     $resourceLink = $resourceSpecificLink;
+                                }
+                                // 对于代码表资源（无论是否涉及人物），如果没有特定资源链接，则使用 codes 路由
+                                elseif ($isCodeResource && $item->op_type != 4) {
+                                    $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $originalResourceId], false);
                                 }
                             @endphp
                             @if(!$hasPersonLink)

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Operation;
+use App\Repositories\OperationRepository;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class OperationsIndexLinksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 使用 SQLite 内存数据库
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // 创建测试所需的最小化表结构
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('BIOG_MAIN', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function test_operations_index_generates_links_for_non_person_code_resources()
+    {
+        // 创建测试用户
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 创建不涉及人物的 TEXT_CODES 操作记录
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => 2, // 整體覆寫
+            'resource' => 'TEXT_CODES',
+            'resource_id' => '68942',
+            'resource_data' => json_encode(['c_textid' => 68942, 'c_text_name' => 'Test Text']),
+            'resource_original' => json_encode(['c_textid' => 68942, 'c_text_name' => 'Old Text']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        // 访问 operations 页面
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+
+        // 验证页面包含正确的链接
+        $response->assertSee('/codes/TEXT_CODES/68942/edit', false);
+        $response->assertSee('(本修改不涉及人物)');
+    }
+
+    public function test_code_resource_link_generation_logic()
+    {
+        // 测试 codes 表配置是否正确
+        $codeTableKeys = array_keys(config('codes.tables', []));
+        $codeTables = array_map('strtoupper', $codeTableKeys);
+
+        // 验证常见的代码表都在配置中
+        $this->assertTrue(in_array('TEXT_CODES', $codeTables));
+        $this->assertTrue(in_array('OFFICE_CODES', $codeTables));
+        $this->assertTrue(in_array('OFFICE_CODE_TYPE_REL', $codeTables));
+        $this->assertTrue(in_array('ADDR_CODES', $codeTables));
+        $this->assertTrue(in_array('ALTNAME_DATA', $codeTables));
+
+        // 验证链接生成逻辑
+        $resourceId = '803819';
+        $resource = 'OFFICE_CODES';
+        $isCodeResource = in_array(strtoupper($resource), $codeTables);
+
+        $this->assertTrue($isCodeResource);
+
+        // 验证可以生成正确的路由
+        $expectedLink = route('codes.edit', ['table_name' => $resource, 'id' => $resourceId], false);
+        $this->assertEquals('/codes/OFFICE_CODES/803819/edit', $expectedLink);
+    }
+
+    public function test_person_specific_link_priority_logic()
+    {
+        // 测试链接优先级逻辑：人物特定链接优先于代码表链接
+
+        $codeTableKeys = array_keys(config('codes.tables', []));
+        $codeTables = array_map('strtoupper', $codeTableKeys);
+
+        // 模拟一个涉及人物的 ALTNAME_DATA 操作
+        $resource = 'ALTNAME_DATA';
+        $resourceId = '115470-0-馬可·波羅-17';
+        $personId = 115470;
+        $opType = 3;
+
+        $isCodeResource = in_array(strtoupper($resource), $codeTables);
+        $this->assertTrue($isCodeResource, 'ALTNAME_DATA should be a code resource');
+
+        // 模拟视图逻辑
+        $hasPersonLink = $personId && $personId != 0;
+        $resourceSpecificLink = null;
+
+        if ($hasPersonLink) {
+            $resourceSpecificLink = "/basicinformation/{$personId}/altnames/{$resourceId}/edit";
+        }
+
+        $resourceLink = null;
+        // 优先使用人物相关的特定资源链接
+        if ($hasPersonLink && $resourceSpecificLink) {
+            $resourceLink = $resourceSpecificLink;
+        }
+        // 对于代码表资源，如果没有特定资源链接，则使用 codes 路由
+        elseif ($isCodeResource && $opType != 4) {
+            $resourceLink = route('codes.edit', ['table_name' => $resource, 'id' => $resourceId], false);
+        }
+
+        // 验证应该使用人物特定链接
+        $this->assertEquals('/basicinformation/115470/altnames/115470-0-馬可·波羅-17/edit', $resourceLink);
+        $this->assertStringNotContainsString('/codes/ALTNAME_DATA/', $resourceLink);
+    }
+
+    public function test_operations_index_does_not_generate_links_for_deleted_operations()
+    {
+        // 创建测试用户
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 创建删除类型的操作记录 (op_type = 4)
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => 4, // 刪除
+            'resource' => 'TEXT_CODES',
+            'resource_id' => '68942',
+            'resource_data' => json_encode(['c_textid' => 68942, 'c_text_name' => 'Deleted Text']),
+            'resource_original' => null,
+            'crowdsourcing_status' => 0,
+        ]);
+
+        // 访问 operations 页面
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+
+        // 验证删除操作不生成编辑链接
+        $response->assertDontSee('/codes/TEXT_CODES/68942/edit', false);
+        // 但应该显示 resource_id
+        $response->assertSee('68942');
+    }
+}

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -3,17 +3,12 @@
 namespace Tests\Feature;
 
 use App\Operation;
-use App\Repositories\OperationRepository;
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
-class OperationsIndexLinksTest extends TestCase
-{
-    protected function setUp(): void
-    {
+class OperationsIndexLinksTest extends TestCase {
+    protected function setUp(): void {
         parent::setUp();
 
         // 使用 SQLite 内存数据库
@@ -57,8 +52,7 @@ class OperationsIndexLinksTest extends TestCase
         });
     }
 
-    public function test_operations_index_generates_links_for_non_person_code_resources()
-    {
+    public function test_operations_index_generates_links_for_non_person_code_resources() {
         // 创建测试用户
         $user = User::create([
             'name' => 'Test User',
@@ -91,8 +85,7 @@ class OperationsIndexLinksTest extends TestCase
         $response->assertSee('(本修改不涉及人物)');
     }
 
-    public function test_code_resource_link_generation_logic()
-    {
+    public function test_code_resource_link_generation_logic() {
         // 测试 codes 表配置是否正确
         $codeTableKeys = array_keys(config('codes.tables', []));
         $codeTables = array_map('strtoupper', $codeTableKeys);
@@ -116,8 +109,7 @@ class OperationsIndexLinksTest extends TestCase
         $this->assertEquals('/codes/OFFICE_CODES/803819/edit', $expectedLink);
     }
 
-    public function test_person_specific_link_priority_logic()
-    {
+    public function test_person_specific_link_priority_logic() {
         // 测试链接优先级逻辑：人物特定链接优先于代码表链接
 
         $codeTableKeys = array_keys(config('codes.tables', []));
@@ -155,8 +147,7 @@ class OperationsIndexLinksTest extends TestCase
         $this->assertStringNotContainsString('/codes/ALTNAME_DATA/', $resourceLink);
     }
 
-    public function test_operations_index_does_not_generate_links_for_deleted_operations()
-    {
+    public function test_operations_index_does_not_generate_links_for_deleted_operations() {
         // 创建测试用户
         $user = User::create([
             'name' => 'Test User',


### PR DESCRIPTION
## 修復的問題

1. **OperationsController.php:411 陣列索引錯誤**
   - 問題：當 BIOG_SOURCE_DATA 的 resource_id 格式不完整時（如刪除操作只有 personid），嘗試訪問不存在的陣列索引導致 "Undefined array key 1" 錯誤
   - 修復：添加陣列長度檢查，在訪問陣列元素前驗證長度是否足夠
   - 對於格式不正確的 resource_id，記錄警告日誌並跳過處理

2. **PHP 8.1+ Deprecation 警告**
   - 問題：當 resource_original 為 null 時，json_decode(null) 會觸發 deprecation 警告
   - 修復：在調用 json_decode 前檢查參數是否為 null

## 新增功能

**為不涉及人物的代碼表資源添加編輯連結**

- 在 /operations 頁面的「資源 TTS」欄位，為 TEXT_CODES、OFFICE_CODES、OFFICE_CODE_TYPE_REL 等代碼表資源添加指向 /codes/{table}/{id}/edit 的連結
- 修復 config('codes.tables') 解析錯誤：正確使用陣列鍵而非值進行比對
- 鏈接優先級邏輯：
  1. 優先使用人物特定的編輯連結（如 /basicinformation/{id}/altnames/{res_id}/edit）
  2. 對於代碼表資源（無特定連結時），使用 codes 路由
  3. 刪除操作（op_type=4）不生成編輯連結

## 測試

- 添加 OperationsIndexLinksTest 測試套件
- 驗證不涉及人物的代碼表資源正確生成連結
- 驗證人物相關資源優先使用特定連結
- 驗證刪除操作不生成編輯連結
- 所有測試通過 (4 tests, 16 assertions)