### PR TITLE
feat: 迁移 operations 和 modified 页面到 AdminLTE v3

### DIFF
--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -330,7 +330,7 @@
 
                     <li class="nav-item">
                         <a href="{{ route('admin.unidirectional-relationship-repair') }}" class="nav-link {{ $page_title == '單向關係修復' ? 'active' : '' }}">
-                            <i class="nav-icon fa fa-exchange"></i>
+                            <i class="nav-icon fas fa-exchange-alt"></i>
                             <p>單向關係修復</p>
                         </a>
                     </li>

--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -1,9 +1,9 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
 @include('biogmains.defense')
-    <div class="panel panel-default">
-        <div class="panel-body">
+    <div class="card card-default">
+        <div class="card-body">
             <div class="table-responsive">
                 <table class="table table-bordered table-striped">
                 <p>* 修改類型 0表示crowdsourcing記錄，1表示新增，2表示整體覆寫（完整替換現有記錄，主要用於 code 表修改），3表示修改，4表示刪除，8表示記錄新增提案，9表示記錄修改提案<br />
@@ -170,11 +170,11 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @if($isProposal)
                                     <div class="proposal-status" style="margin-bottom:6px;">
                                         @if($reviewStatus === 'approved')
-                                            <span class="label label-success">已核准</span>
+                                            <span class="badge badge-success">已核准</span>
                                         @elseif($reviewStatus === 'rejected')
-                                            <span class="label label-danger">已退修</span>
+                                            <span class="badge badge-danger">已退修</span>
                                         @else
-                                            <span class="label label-warning">待審核</span>
+                                            <span class="badge badge-warning">待審核</span>
                                         @endif
                                         @if(!empty($proposalMeta['comment']))
                                             <small class="text-muted" style="display:block;">
@@ -219,7 +219,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         @include('components.key-value-table', ['data' => $resourceDataDisplay])
                                       </div>
                                       <div class="modal-footer">
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                                       </div>
                                     </div>
                                   </div>
@@ -238,7 +238,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         </div>
                                       </div>
                                       <div class="modal-footer">
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                                       </div>
                                     </div>
                                   </div>
@@ -277,7 +277,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                                 </div>
                                             </div>
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+                                                <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
                                                 <button type="submit" class="btn btn-danger">確認退修</button>
                                             </div>
                                           </form>
@@ -348,7 +348,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                 </tbody>
                 </table>
             </div>
-            <div class="pull-right">
+            <div class="float-right">
                 {{ $lists->links() }}
             </div>
         </div>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -1,9 +1,9 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
 @include('biogmains.defense')
-    <div class="panel panel-default">
-        <div class="panel-body">
+    <div class="card card-default">
+        <div class="card-body">
             @if(!empty($proposals_only))
                 @php
                     $statusOptions = [
@@ -22,7 +22,7 @@
                             {{ $label }}
                         </label>
                     @endforeach
-                    <a href="{{ route('operations.index', ['proposals_only' => 1]) }}" class="btn btn-default btn-sm" style="margin-left: 8px;">清除篩選</a>
+                    <a href="{{ route('operations.index', ['proposals_only' => 1]) }}" class="btn btn-secondary btn-sm" style="margin-left: 8px;">清除篩選</a>
                 </form>
                 <script>
                     document.addEventListener('DOMContentLoaded', function () {
@@ -213,13 +213,13 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @if($isProposal)
                                     <div class="proposal-status" style="margin-bottom:6px;">
                                         @if($reviewStatus === 'approved')
-                                            <span class="label label-success">已核准</span>
+                                            <span class="badge badge-success">已核准</span>
                                         @elseif($reviewStatus === 'rejected')
-                                            <span class="label label-danger">已退修</span>
+                                            <span class="badge badge-danger">已退修</span>
                                         @elseif($reviewStatus === 'cancelled')
-                                            <span class="label label-default">已撤回</span>
+                                            <span class="badge badge-secondary">已撤回</span>
                                         @else
-                                            <span class="label label-warning">待審核</span>
+                                            <span class="badge badge-warning">待審核</span>
                                         @endif
                                 @if(!empty($proposalMeta['comment']))
                                     <small class="text-muted" style="display:block;">
@@ -275,7 +275,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         @include('components.key-value-table', ['data' => $resourceDataDisplay])
                                       </div>
                                       <div class="modal-footer">
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                                       </div>
                                     </div>
                                   </div>
@@ -294,7 +294,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         </div>
                                       </div>
                                       <div class="modal-footer">
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                                       </div>
                                     </div>
                                   </div>
@@ -311,7 +311,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @if($canEditProposal)
                                     <div class="proposal-actions" style="margin-top:8px;">
                                         <a href="{{ route('codes.proposals.edit', ['table_name' => $item->resource, 'operation' => $item->id]) }}"
-                                           class="btn btn-default btn-sm">
+                                           class="btn btn-secondary btn-sm">
                                             修改提案
                                         </a>
                                         <form method="post"
@@ -355,7 +355,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                                 </div>
                                               </div>
                                               <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+                                                <button type="button" class="btn btn-secondary" data-dismiss="modal">取消</button>
                                                 <button type="submit" class="btn btn-danger">確認退修</button>
                                               </div>
                                           </form>
@@ -412,7 +412,7 @@ $item->resource_data = unionPKDef($item->resource_data);
 
                 </table>
             </div>
-            <div class="pull-right">
+            <div class="float-right">
                 {{ $lists->links() }}
             </div>
         </div>


### PR DESCRIPTION
迁移了两个高频使用的列表页面：

1. operations/index.blade.php（最近編輯/提案列表）
   - 更换为 dashboard-v3 布局
   - panel → card 类名转换
   - label → badge 类名转换
   - btn-default → btn-secondary
   - pull-right → float-right

2. modified/index.blade.php（最近修改記錄）
   - 相同的 v2 → v3 类名转换
   - 保持所有功能逻辑不变

这两个页面的结构和功能与原版完全一致，只是使用了 AdminLTE v3 的样式。