### PR TITLE
feat: 新增刪除 CBDB_NAME_LIST 表的遷移檔案

### DIFF
--- a/database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php
+++ b/database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropCbdbNameListTable extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::dropIfExists('CBDB_NAME_LIST');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::create('CBDB_NAME_LIST', function (Blueprint $table) {
+            $table->integer('c_personid')->nullable();
+            $table->string('name', 255)->nullable();
+            $table->string('source', 255)->nullable();
+
+            // Add indexes
+            $table->index('c_personid', 'idx_c_personid');
+            $table->index('name', 'idx_name');
+        });
+    }
+}


### PR DESCRIPTION
## 概述
新增資料庫遷移檔案以移除不再使用的 CBDB_NAME_LIST 資料表。

## 變更內容

### 新增遷移檔案
- ✅ [database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php](database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php)
  - `up()`: 使用 `Schema::dropIfExists()` 刪除 CBDB_NAME_LIST 表
  - `down()`: 提供回滾功能，重建原始表結構（包含欄位和索引）

## 遷移詳情

### 刪除的表結構
- `c_personid` (integer, nullable)
- `name` (varchar 255, nullable) 
- `source` (varchar 255, nullable)
- 索引: `idx_c_personid`, `idx_name`

## 執行方式

```bash
# 執行遷移
php artisan migrate

# 如需回滾
php artisan migrate:rollback
```

## 影響範圍

- **新增檔案**: 1 個遷移檔案
- **資料庫變更**: 刪除 CBDB_NAME_LIST 表
- **破壞性變更**: 是（會刪除表及其資料，但提供回滾功能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)