### PR TITLE
feat: 刪除代碼和文檔中對 CBDB_NAME_LIST 表的所有引用

### DIFF
--- a/CODES.md
+++ b/CODES.md
@@ -10,7 +10,6 @@
   - 自動排序主鍵欄位並預估下一個編號（含複合鍵組合）。
   - 在新增／編輯時計入 `c_created_*`、`c_modified_*` 與 `operations` 日誌。
 - **只讀表**：部分表格設為只讀模式，僅供查詢，禁止新增、修改或刪除：
-  - `CBDB_NAME_LIST`：姓名列表（無主鍵定義，為確保數據完整性設為只讀）
   - `CBDB__NAME_FTS`：姓名搜尋倒排索引（內部輔助表，由系統自動維護）
   - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射表（內部輔助表，透過 `cbdb:import-trad-simp-map` 指令匯入）
     - ⚠️ **授權例外**：此表數據來自 [OpenCC 項目](https://github.com/BYVoid/OpenCC) 的字典文件，以 **Apache 2.0 License** 授權，而非 CBDB 其他部分使用的 CC BY-NC-SA 4.0 International 授權

--- a/CODES_PERFORMANCE.md
+++ b/CODES_PERFORMANCE.md
@@ -84,7 +84,6 @@ $thead = $this->buildTableHead($table, $sampleRow);
 **影響的表（有 `tableColumnOverrides` 配置）**：
 - `CBDB__NAME_FTS` ✅
 - `CBDB__TRAD_SIMP_MAP` ✅
-- `CBDB_NAME_LIST` ✅
 - `ADDR_BELONGS_DATA` ✅
 - `ADDR_CODES` ✅
 - `ADDRESSES` ✅
@@ -136,7 +135,6 @@ if (empty($keys)) {
 **影響的表（有 `tablePrimaryKeyOverrides` 配置）**：
 - `CBDB__NAME_FTS` ✅
 - `CBDB__TRAD_SIMP_MAP` ✅
-- `CBDB_NAME_LIST` ✅
 - `TEXT_CODES` ✅
 
 **效能提升**：

--- a/CODES_TABLES.md
+++ b/CODES_TABLES.md
@@ -38,68 +38,66 @@
 |21 | BIOG_MAIN | 人物主表 |
 |22 | BIOG_SOURCE_DATA | 人物來源資料 |
 |23 | BIOG_TEXT_DATA | 人物文獻資料 |
-|24 | CBDB_NAME_LIST | 姓名列表 |
-|25 | CBDB__NAME_FTS | 姓名搜尋倒排索引（內部表）|
-|26 | CBDB__TRAD_SIMP_MAP | 繁簡字符映射表（內部表，⚠️ Apache 2.0 授權）|
-|27 | CHORONYM_CODES | 地名類型代碼 |
-|28 | COUNTRY_CODES | 國家代碼 |
-|29 | DYNASTIES | 朝代代碼 |
-|30 | ENTRY_CODES | 入仕類型代碼 |
-|31 | ENTRY_CODE_TYPE_REL | 入仕代碼類型關聯 |
-|32 | ENTRY_DATA | 入仕資料 |
-|33 | ENTRY_TYPES | 入仕類型 |
-|34 | ETHNICITY_TRIBE_CODES | 民族/部落代碼 |
-|35 | EVENTS_ADDR | 事件地址 |
-|36 | EVENTS_DATA | 事件資料 |
-|37 | EVENT_CODES | 事件類型代碼 |
-|38 | EXTANT_CODES | 存世狀態代碼 |
-|39 | GANZHI_CODES | 干支代碼 |
-|40 | HOUSEHOLD_STATUS_CODES | 戶籍狀態代碼 |
-|41 | INDEXYEAR_TYPE_CODES | 年份索引類型代碼 |
-|42 | KINSHIP_CODES | 親屬關係代碼 |
-|43 | KIN_DATA | 親屬資料 |
-|44 | KIN_MOURNING | 親屬喪服 |
-|45 | KIN_MOURNING_STEPS | 親屬喪服等級 |
-|46 | LITERARYGENRE_CODES | 文學體裁代碼 |
-|47 | MEASURE_CODES | 度量衡代碼 |
-|48 | MERGED_PERSON_DATA | 人物合併資料 |
-|49 | NIAN_HAO | 年號 |
-|50 | OCCASION_CODES | 場合類型代碼 |
-|51 | OFFICE_CATEGORIES | 官職分類 |
-|52 | OFFICE_CODES | 官職代碼 |
-|53 | OFFICE_CODE_TYPE_REL | 官職代碼類型關聯 |
-|54 | OFFICE_TYPE_TREE | 官職類型樹 |
-|55 | PARENTAL_STATUS_CODES | 父母狀態代碼 |
-|56 | POSSESSION_ACT_CODES | 財產行為代碼 |
-|57 | POSSESSION_ADDR | 財產地址 |
-|58 | POSTED_TO_ADDR_DATA | 任官地址資料 |
-|59 | POSTED_TO_OFFICE_DATA | 任官資料 |
-|60 | POSTING_DATA | 任官主表 |
-|61 | SCHOLARLYTOPIC_CODES | 學術主題代碼 |
-|62 | SOCIAL_INSTITUTION_ADDR | 社會機構地址 |
-|63 | SOCIAL_INSTITUTION_ADDR_TYPES | 社會機構地址類型 |
-|64 | SOCIAL_INSTITUTION_ALTNAME_CODES | 社會機構別名類型代碼 |
-|65 | SOCIAL_INSTITUTION_ALTNAME_DATA | 社會機構別名資料 |
-|66 | SOCIAL_INSTITUTION_CODES | 社會機構代碼 |
-|67 | SOCIAL_INSTITUTION_NAME_CODES | 社會機構名稱類型代碼 |
-|68 | SOCIAL_INSTITUTION_TYPES | 社會機構類型 |
-|69 | STATUS_CODES | 狀態代碼 |
-|70 | STATUS_CODE_TYPE_REL | 狀態代碼類型關聯 |
-|71 | STATUS_DATA | 狀態資料 |
-|72 | STATUS_TYPES | 狀態類型 |
-|73 | TEXT_BIBLCAT_CODES | 文獻分類代碼 |
-|74 | TEXT_BIBLCAT_CODE_TYPE_REL | 文獻分類代碼類型關聯 |
-|75 | TEXT_BIBLCAT_TYPES | 文獻分類類型 |
-|76 | TEXT_CODES | 文獻代碼 |
-|77 | TEXT_INSTANCE_DATA | 文獻版本資料 |
-|78 | TEXT_ROLE_CODES | 文獻角色代碼 |
-|79 | TEXT_TYPE | 文獻類型 |
-|80 | YEAR_RANGE_CODES | 年份範圍代碼 |
+|24 | CBDB__NAME_FTS | 姓名搜尋倒排索引（內部表）|
+|25 | CBDB__TRAD_SIMP_MAP | 繁簡字符映射表（內部表，⚠️ Apache 2.0 授權）|
+|26 | CHORONYM_CODES | 地名類型代碼 |
+|27 | COUNTRY_CODES | 國家代碼 |
+|28 | DYNASTIES | 朝代代碼 |
+|29 | ENTRY_CODES | 入仕類型代碼 |
+|30 | ENTRY_CODE_TYPE_REL | 入仕代碼類型關聯 |
+|31 | ENTRY_DATA | 入仕資料 |
+|32 | ENTRY_TYPES | 入仕類型 |
+|33 | ETHNICITY_TRIBE_CODES | 民族/部落代碼 |
+|34 | EVENTS_ADDR | 事件地址 |
+|35 | EVENTS_DATA | 事件資料 |
+|36 | EVENT_CODES | 事件類型代碼 |
+|37 | EXTANT_CODES | 存世狀態代碼 |
+|38 | GANZHI_CODES | 干支代碼 |
+|39 | HOUSEHOLD_STATUS_CODES | 戶籍狀態代碼 |
+|40 | INDEXYEAR_TYPE_CODES | 年份索引類型代碼 |
+|41 | KINSHIP_CODES | 親屬關係代碼 |
+|42 | KIN_DATA | 親屬資料 |
+|43 | KIN_MOURNING | 親屬喪服 |
+|44 | KIN_MOURNING_STEPS | 親屬喪服等級 |
+|45 | LITERARYGENRE_CODES | 文學體裁代碼 |
+|46 | MEASURE_CODES | 度量衡代碼 |
+|47 | MERGED_PERSON_DATA | 人物合併資料 |
+|48 | NIAN_HAO | 年號 |
+|49 | OCCASION_CODES | 場合類型代碼 |
+|50 | OFFICE_CATEGORIES | 官職分類 |
+|51 | OFFICE_CODES | 官職代碼 |
+|52 | OFFICE_CODE_TYPE_REL | 官職代碼類型關聯 |
+|53 | OFFICE_TYPE_TREE | 官職類型樹 |
+|54 | PARENTAL_STATUS_CODES | 父母狀態代碼 |
+|55 | POSSESSION_ACT_CODES | 財產行為代碼 |
+|56 | POSSESSION_ADDR | 財產地址 |
+|57 | POSTED_TO_ADDR_DATA | 任官地址資料 |
+|58 | POSTED_TO_OFFICE_DATA | 任官資料 |
+|59 | POSTING_DATA | 任官主表 |
+|60 | SCHOLARLYTOPIC_CODES | 學術主題代碼 |
+|61 | SOCIAL_INSTITUTION_ADDR | 社會機構地址 |
+|62 | SOCIAL_INSTITUTION_ADDR_TYPES | 社會機構地址類型 |
+|63 | SOCIAL_INSTITUTION_ALTNAME_CODES | 社會機構別名類型代碼 |
+|64 | SOCIAL_INSTITUTION_ALTNAME_DATA | 社會機構別名資料 |
+|65 | SOCIAL_INSTITUTION_CODES | 社會機構代碼 |
+|66 | SOCIAL_INSTITUTION_NAME_CODES | 社會機構名稱類型代碼 |
+|67 | SOCIAL_INSTITUTION_TYPES | 社會機構類型 |
+|68 | STATUS_CODES | 狀態代碼 |
+|69 | STATUS_CODE_TYPE_REL | 狀態代碼類型關聯 |
+|70 | STATUS_DATA | 狀態資料 |
+|71 | STATUS_TYPES | 狀態類型 |
+|72 | TEXT_BIBLCAT_CODES | 文獻分類代碼 |
+|73 | TEXT_BIBLCAT_CODE_TYPE_REL | 文獻分類代碼類型關聯 |
+|74 | TEXT_BIBLCAT_TYPES | 文獻分類類型 |
+|75 | TEXT_CODES | 文獻代碼 |
+|76 | TEXT_INSTANCE_DATA | 文獻版本資料 |
+|77 | TEXT_ROLE_CODES | 文獻角色代碼 |
+|78 | TEXT_TYPE | 文獻類型 |
+|79 | YEAR_RANGE_CODES | 年份範圍代碼 |
 
 > 建議：若新增或移除代碼表，請同步更新本文件與 `config/codes.php`，並在部署環境重新執行 `php artisan config:cache` 以確保新設定生效。
 
 > 備註：以下表格在泛用 `/codes` 介面中為只讀表，僅允許瀏覽與搜尋：
-> - `CBDB_NAME_LIST`：姓名列表（無主鍵定義）
 > - `CBDB__NAME_FTS`：姓名搜尋倒排索引（內部輔助表，由系統自動維護）
 > - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射表（內部輔助表，透過 `php artisan cbdb:import-trad-simp-map` 指令匯入）
 >   - ⚠️ **授權例外**：此表數據來自 [OpenCC 項目](https://github.com/BYVoid/OpenCC) 的字典文件，以 **Apache 2.0 License** 授權，而非 CBDB 其他部分使用的 CC BY-NC-SA 4.0 International 授權

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -255,43 +255,7 @@ DB::table('ALTNAME_DATA')
 
 ## 具體場景指南
 
-### 場景 1：中文姓名搜索優化
-
-**需求**：加速 CBDB_NAME_LIST 表的姓名搜索
-
-**❌ 錯誤方案**：使用 MySQL ngram 全文索引
-```sql
--- 問題：MariaDB 10.3 不支持 ngram parser
-ALTER TABLE CBDB_NAME_LIST
-ADD FULLTEXT INDEX idx_name_fulltext (name) WITH PARSER ngram;
-```
-
-**✅ 正確方案**：使用標準 B-Tree 索引 + 前綴匹配
-```php
-// 現有的 B-Tree 索引 (idx_name) 已足夠
-// 性能測試結果：
-// - 單字查詢 "張%"：88ms
-// - 2字查詢 "張三%"：3ms ⭐ 極快
-// - 全名查詢 "蘇軾%"：2ms ⭐ 極快
-
-// 根據查詢長度選擇策略
-if (mb_strlen($query) >= 2) {
-    // 2+ 字符：使用前綴匹配（毫秒級）
-    $personIds = DB::table('CBDB_NAME_LIST')
-        ->where('name', 'like', $query . '%')
-        ->distinct()
-        ->limit(500)
-        ->pluck('c_personid');
-} else {
-    // 單字查詢：使用 BIOG_MAIN（避免過多結果）
-    $results = DB::table('BIOG_MAIN')
-        ->where('c_name_chn', 'like', '%' . $query . '%')
-        ->limit(20)
-        ->get();
-}
-```
-
-### 場景 2：複雜查詢優化
+### 場景 1：複雜查詢優化
 
 **❌ 錯誤方案**：使用數據庫特定的查詢優化器提示
 ```sql
@@ -308,7 +272,7 @@ CREATE INDEX idx_name ON users(name);
 SELECT * FROM users WHERE name = 'John';
 ```
 
-### 場景 3：JSON 數據存儲
+### 場景 2：JSON 數據存儲
 
 **⚠️ 謹慎使用**：JSON 功能在不同數據庫中差異較大
 

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -32,7 +32,6 @@ class CodesController extends Controller {
      * @var array<int, string>
      */
     protected $readOnlyTables = [
-        'CBDB_NAME_LIST',
         'CBDB__NAME_FTS',
         'CBDB__TRAD_SIMP_MAP',
         'DYNASTIES',
@@ -54,7 +53,6 @@ class CodesController extends Controller {
     protected $tableColumnOverrides = [
         'ADDR_BELONGS_DATA' => ['c_addr_id', 'c_belongs_to', 'c_firstyear', 'c_lastyear'],
         'ADDR_CODES' => ['c_addr_id', 'c_name_chn', 'c_name', 'c_firstyear', 'c_lastyear', 'c_admin_type'],
-        'CBDB_NAME_LIST' => ['c_personid', 'name', 'source'],
         'CBDB__NAME_FTS' => [
             'id',
             'c_personid',
@@ -130,7 +128,6 @@ class CodesController extends Controller {
      * @var array<string, array<int, string>>
      */
     protected $tablePrimaryKeyOverrides = [
-        'CBDB_NAME_LIST' => ['c_personid', 'name', 'source'],
         'CBDB__NAME_FTS' => ['id'],
         'CBDB__TRAD_SIMP_MAP' => ['trad_char'],
         'TEXT_CODES' => ['c_textid'],

--- a/config/codes.php
+++ b/config/codes.php
@@ -28,7 +28,6 @@ return [
         'BIOG_MAIN' => '人物傳記主表',
         'BIOG_SOURCE_DATA' => '傳記資料來源資料表',
         'BIOG_TEXT_DATA' => '傳記文本資料表',
-        'CBDB_NAME_LIST' => '人名索引（現以被 CBDB__NAME_FTS 代替）',
         'CBDB__NAME_FTS' => '人名全文檢索表',
         'CBDB__TRAD_SIMP_MAP' => '繁簡字對照表',
         'CHORONYM_CODES' => '地名類型代碼表',


### PR DESCRIPTION
配合先前的 migration 刪除 CBDB_NAME_LIST 表，清理代碼中的只讀表配置、欄位覆寫配置、主鍵配置，以及文檔中的相關說明。CBDB_NAME_LIST 已被 CBDB__NAME_FTS 取代。

🤖 Generated with [Claude Code](https://claude.com/claude-code)