### PR TITLE
fix: 修正 CBDB_NAME_LIST 遷移檔案的最佳實踐問題

### DIFF
--- a/database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php
+++ b/database/migrations/2025_12_12_000000_drop_cbdb_name_list_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class DropCbdbNameListTable extends Migration {
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -28,6 +28,11 @@ class DropCbdbNameListTable extends Migration {
             // Add indexes
             $table->index('c_personid', 'idx_c_personid');
             $table->index('name', 'idx_name');
+
+            // Explicitly set table properties to match original schema
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_general_ci';
+            $table->engine = 'InnoDB';
         });
     }
-}
+};


### PR DESCRIPTION
## 概述
修正 `drop_cbdb_name_list_table` 遷移檔案，使其符合 Laravel 10+ 最佳實踐並確保跨環境一致性。

## 變更內容

### 1. 轉換為匿名類別 (Laravel 10+ 最佳實踐)
- ✅ 將命名類別 `DropCbdbNameListTable` 轉換為匿名類別 `return new class extends Migration`
- ✅ 避免載入歷史遷移時可能的類別名稱衝突
- ✅ 符合 Laravel 10 官方遷移檔案產生器的預設格式

### 2. 顯式設定資料庫屬性
- ✅ 在 `down()` 方法中新增明確的字符集、排序規則和引擎設定
  - `charset = 'utf8mb4'`
  - `collation = 'utf8mb4_general_ci'`
  - `engine = 'InnoDB'`
- ✅ 確保回滾時與原始模式定義一致 ([2025_01_01_000000_import_cbdb_schema.php:687](database/migrations/2025_01_01_000000_import_cbdb_schema.php#L687))

## 解決的問題

### Minor Issue
使用匿名類別避免遷移類別名稱衝突。Laravel 10 的遷移檔案產生器預設使用匿名類別，以防止在載入歷史遷移時出現意外的類別名稱碰撞。

### Nit Issue
明確指定字符集、排序規則和引擎，確保 `down()` 回滾操作在不同環境下都能正確重建資料表，與原始模式定義保持一致。

## 影響範圍

- **影響文件**: 1 個檔案
- **程式碼變更**: 
  - 類別定義轉換為匿名類別
  - 新增 3 行資料庫屬性設定
- **破壞性變更**: 無

## 測試驗證

- ✅ 遷移檔案語法正確
- ✅ PHP CS Fixer 格式檢查通過
- ✅ 符合 Laravel 10+ 最佳實踐

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>