### PR TITLE
feat: 新增系統總覽頁面 (/dashboard)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,13 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 
-class DashboardController extends Controller
-{
-    public function index()
-    {
+class DashboardController extends Controller {
+    public function index() {
         // 基础统计
         $totalPersons = DB::table('BIOG_MAIN')->count();
         $totalAltnames = DB::table('ALTNAME_DATA')->count();
@@ -62,6 +60,7 @@ class DashboardController extends Controller
                     3 => '刪除',
                     4 => '提案',
                 ];
+
                 return [$typeNames[$item->op_type] ?? '未知' => $item->count];
             });
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        // 基础统计
+        $totalPersons = DB::table('BIOG_MAIN')->count();
+        $totalAltnames = DB::table('ALTNAME_DATA')->count();
+        $totalOffices = DB::table('POSTED_TO_OFFICE_DATA')->count();
+        $totalTexts = DB::table('BIOG_TEXT_DATA')->count();
+        $totalUsers = DB::table('users')->count();
+        $totalOperations = DB::table('operations')->count();
+
+        // 近期修改统计（按提交人）
+        $oneDayAgo = Carbon::now()->subDay();
+        $oneWeekAgo = Carbon::now()->subWeek();
+        $oneMonthAgo = Carbon::now()->subMonth();
+
+        // 过去一天的修改统计
+        $dailyStats = DB::table('operations')
+            ->join('users', 'operations.user_id', '=', 'users.id')
+            ->select('users.name as user_name', DB::raw('COUNT(*) as count'))
+            ->where('operations.created_at', '>=', $oneDayAgo)
+            ->groupBy('users.name')
+            ->orderByDesc('count')
+            ->get();
+
+        // 过去一周的修改统计
+        $weeklyStats = DB::table('operations')
+            ->join('users', 'operations.user_id', '=', 'users.id')
+            ->select('users.name as user_name', DB::raw('COUNT(*) as count'))
+            ->where('operations.created_at', '>=', $oneWeekAgo)
+            ->groupBy('users.name')
+            ->orderByDesc('count')
+            ->get();
+
+        // 过去一个月的修改统计
+        $monthlyStats = DB::table('operations')
+            ->join('users', 'operations.user_id', '=', 'users.id')
+            ->select('users.name as user_name', DB::raw('COUNT(*) as count'))
+            ->where('operations.created_at', '>=', $oneMonthAgo)
+            ->groupBy('users.name')
+            ->orderByDesc('count')
+            ->get();
+
+        // 操作类型统计（过去一个月）
+        $operationTypeStats = DB::table('operations')
+            ->select('op_type', DB::raw('COUNT(*) as count'))
+            ->where('created_at', '>=', $oneMonthAgo)
+            ->groupBy('op_type')
+            ->get()
+            ->mapWithKeys(function ($item) {
+                $typeNames = [
+                    1 => '新增',
+                    2 => '修改',
+                    3 => '刪除',
+                    4 => '提案',
+                ];
+                return [$typeNames[$item->op_type] ?? '未知' => $item->count];
+            });
+
+        return view('dashboard.index', [
+            'page_title' => '系統總覽',
+            'breadcrumb_home' => 'Home',
+            'totalPersons' => $totalPersons,
+            'totalAltnames' => $totalAltnames,
+            'totalOffices' => $totalOffices,
+            'totalTexts' => $totalTexts,
+            'totalUsers' => $totalUsers,
+            'totalOperations' => $totalOperations,
+            'dailyStats' => $dailyStats,
+            'weeklyStats' => $weeklyStats,
+            'monthlyStats' => $monthlyStats,
+            'operationTypeStats' => $operationTypeStats,
+        ]);
+    }
+}

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,192 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+    <!-- Info boxes -->
+    <div class="row">
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-info elevation-1"><i class="fas fa-user"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">人物記錄</span>
+                    <span class="info-box-number">{{ number_format($totalPersons) }}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-success elevation-1"><i class="fas fa-id-card"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">別名記錄</span>
+                    <span class="info-box-number">{{ number_format($totalAltnames) }}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-warning elevation-1"><i class="fas fa-briefcase"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">任官記錄</span>
+                    <span class="info-box-number">{{ number_format($totalOffices) }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-primary elevation-1"><i class="fas fa-book"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">著作記錄</span>
+                    <span class="info-box-number">{{ number_format($totalTexts) }}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-secondary elevation-1"><i class="fas fa-users"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">系統用戶</span>
+                    <span class="info-box-number">{{ number_format($totalUsers) }}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="info-box">
+                <span class="info-box-icon bg-danger elevation-1"><i class="fas fa-history"></i></span>
+                <div class="info-box-content">
+                    <span class="info-box-text">操作記錄</span>
+                    <span class="info-box-number">{{ number_format($totalOperations) }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 操作类型统计 -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">操作類型統計（過去一個月）</h3>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        @foreach($operationTypeStats as $type => $count)
+                            <div class="col-6 col-md-3">
+                                <div class="small-box bg-light">
+                                    <div class="inner">
+                                        <h3>{{ number_format($count) }}</h3>
+                                        <p>{{ $type }}</p>
+                                    </div>
+                                    <div class="icon">
+                                        <i class="fas fa-edit"></i>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 近期修改统计 -->
+    <div class="row">
+        <!-- 过去一天 -->
+        <div class="col-12 col-md-4">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">過去一天修改統計</h3>
+                </div>
+                <div class="card-body p-0">
+                    @if($dailyStats->count() > 0)
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>提交人</th>
+                                    <th class="text-right">操作次數</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($dailyStats as $stat)
+                                    <tr>
+                                        <td>{{ $stat->user_name ?? '未知' }}</td>
+                                        <td class="text-right">{{ number_format($stat->count) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @else
+                        <div class="p-3 text-muted">暫無數據</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <!-- 过去一周 -->
+        <div class="col-12 col-md-4">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">過去一週修改統計</h3>
+                </div>
+                <div class="card-body p-0">
+                    @if($weeklyStats->count() > 0)
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>提交人</th>
+                                    <th class="text-right">操作次數</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($weeklyStats as $stat)
+                                    <tr>
+                                        <td>{{ $stat->user_name ?? '未知' }}</td>
+                                        <td class="text-right">{{ number_format($stat->count) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @else
+                        <div class="p-3 text-muted">暫無數據</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <!-- 过去一个月 -->
+        <div class="col-12 col-md-4">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">過去一個月修改統計</h3>
+                </div>
+                <div class="card-body p-0">
+                    @if($monthlyStats->count() > 0)
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>提交人</th>
+                                    <th class="text-right">操作次數</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($monthlyStats as $stat)
+                                    <tr>
+                                        <td>{{ $stat->user_name ?? '未知' }}</td>
+                                        <td class="text-right">{{ number_format($stat->count) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @else
+                        <div class="p-3 text-muted">暫無數據</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -35,6 +35,13 @@
                 <li class="nav-header">MAIN NAVIGATION</li>
 
                 <li class="nav-item">
+                    <a href="{{ route('dashboard') }}" class="nav-link {{ $page_title == '系統總覽' ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-tachometer-alt"></i>
+                        <p>系統總覽</p>
+                    </a>
+                </li>
+
+                <li class="nav-item">
                     <a href="{{ route('basicinformation.index') }}" class="nav-link {{ $page_title == 'Basicinformation' ? 'active' : '' }}">
                         <i class="nav-icon ion ion-ios-people-outline"></i>
                         <p>個人基本信息</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ Route::get('operations', ['as' => 'operations.index', 'uses' => 'OperationsContr
 Route::get('crowdsourcing', ['as' => 'crowdsourcing.index', 'uses' => 'CrowdsourcingController@index']);
 
 Route::get('home', 'HomeController@index')->name('home');
+Route::get('dashboard', 'DashboardController@index')->middleware('auth')->name('dashboard');
 Route::get('cbdbapi/person.php', 'CbdbApiController@person')->name('cbdbapi.v1.person');
 Route::get('cbdbapi/person', 'CbdbApiController@person');
 Route::get('view', 'ViewTableController@index')->middleware('auth')->name('view.index');


### PR DESCRIPTION
創建全新的系統儀表板頁面，使用 AdminLTE v3 布局展示系統核心統計數據。

## 新增功能

### 1. 系統總覽頁面 (/dashboard)
- 路由: `/dashboard` (需要登錄認證)
- 控制器: `DashboardController`
- 視圖: `resources/views/dashboard/index.blade.php`

### 2. 核心統計數據 (6 個 Info Boxes)

**第一行**：
- 人物記錄數 (BIOG_MAIN)
- 別名記錄數 (ALTNAME_DATA)
- 任官記錄數 (POSTED_TO_OFFICE_DATA)

**第二行**：
- 著作記錄數 (BIOG_TEXT_DATA)
- 系統用戶數 (users)
- 操作記錄數 (operations)

### 3. 操作類型統計 (過去一個月)
- 新增、修改、刪除、提案等操作類型分佈
- 使用 Small Boxes 展示

### 4. 近期修改統計 (按提交人)
三個並排的表格卡片，分別顯示：
- 過去一天的修改統計
- 過去一週的修改統計
- 過去一個月的修改統計

每個統計表顯示提交人姓名和操作次數，按操作次數降序排列。

## 技術實現

### DashboardController
- 使用 Query Builder 查詢各表記錄總數
- 使用 JOIN users 表獲取操作記錄的提交人姓名
- 使用 Carbon 處理時間範圍查詢
- 統計操作類型分佈並映射中文名稱

### 視圖設計
- 使用 AdminLTE v3 組件:
  - Info Boxes: 核心統計數據展示
  - Small Boxes: 操作類型統計
  - Cards + Tables: 近期修改統計
- 響應式布局:
  - 桌面 (md+): 每行 3 個
  - 平板 (sm): 每行 2 個
  - 手機 (xs): 每行 1 個

### 側邊欄導航
- 在 sidebar-v3 的 "MAIN NAVIGATION" 頂部添加「系統總覽」鏈接
- 使用 tachometer-alt 圖標
- 支援 active 狀態高亮

## Breadcrumb
- Home / 系統總覽

## 修改文件
- `app/Http/Controllers/DashboardController.php` (新建)
- `resources/views/dashboard/index.blade.php` (新建)
- `resources/views/layouts/sidebar-v3.blade.php` (添加導航鏈接)
- `routes/web.php` (添加 /dashboard 路由)

🤖 Generated with [Claude Code](https://claude.com/claude-code)