### PR TITLE
docs: 重構文檔體系，新增 AI 代理 Skills 並精簡核心文檔

### DIFF
--- a/.claude/skills/database-schema.md
+++ b/.claude/skills/database-schema.md
@@ -1,0 +1,387 @@
+# 數據庫表格 Schema 查詢指南
+
+## 何時使用此技能
+
+當你需要了解數據庫表格的結構（字段、類型、索引等）時，使用此指南。
+
+## 查詢步驟
+
+### 1. 查找 Baseline Migration (主要來源)
+
+數據庫表格的基礎結構定義在 **2025-01-01 的 baseline migration** 中：
+
+```bash
+# 查找 baseline migration 文件
+ls -la database/migrations/2025_01_01_*
+```
+
+Baseline migration 文件包含了大部分表格的初始定義，包括：
+- 字段名稱和數據類型
+- 主鍵和索引
+- 外鍵約束
+- 默認值
+
+### 2. 檢查後續的表格修改
+
+表格可能在 baseline 之後有增量修改，需要使用 `grep` 確認：
+
+```bash
+# 搜索特定表格的後續修改
+grep -r "table('TABLE_NAME'" database/migrations/
+
+# 或搜索 Schema 建表語句
+grep -r "Schema::create('TABLE_NAME'" database/migrations/
+grep -r "Schema::table('TABLE_NAME'" database/migrations/
+```
+
+### 3. 使用 artisan tinker 驗證
+
+使用 Laravel 的 tinker 命令可以：
+- 讀取實際數據庫記錄
+- 驗證 schema 定義是否與實際一致
+- 了解數據的實際用法
+
+```bash
+# 啟動 tinker
+php artisan tinker
+
+# 在 tinker 中執行：
+# 查看表格結構
+DB::select("DESCRIBE TABLE_NAME");
+
+# 或使用 Schema facade
+Schema::getColumnListing('TABLE_NAME');
+
+# 查看示例數據
+DB::table('TABLE_NAME')->limit(5)->get();
+
+# 退出 tinker
+exit
+```
+
+## 複合主鍵的注意事項
+
+根據 `AGENTS.md`，項目中的複合主鍵表格（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA`）：
+- **不使用 Eloquent 模型**，僅使用 Query Builder (`DB::table()`)
+- 在 migration 中會明確定義複合主鍵
+- 需要特別注意主鍵字段的組合
+
+## 內部表格標識
+
+以 `CBDB__` 前綴開頭的表格為內部輔助表，例如：
+- `CBDB__NAME_FTS` - 姓名搜索倒排索引，支援高效能後綴匹配查詢
+- `CBDB__TRAD_SIMP_MAP` - 繁簡字符映射，基於 OpenCC 標準，使用 VARBINARY(4) 支援非BMP字符
+
+這些表格通常在 `/codes` 頁面中為只讀模式。
+
+## 內部表格維護
+
+### 繁簡映射表（CBDB__TRAD_SIMP_MAP）
+
+使用專用 Artisan 命令從 OpenCC 匯入最新繁簡對照：
+
+```bash
+# 匯入繁簡映射（清空舊數據後重新匯入）
+php artisan cbdb:import-trad-simp-map --truncate
+
+# 調整批次大小（預設 1000）
+php artisan cbdb:import-trad-simp-map --truncate --batch=500
+```
+
+**重要說明**：
+- `--truncate` 選項會先清空表格再匯入，確保數據最新
+- 映射數據基於 [OpenCC](https://github.com/BYVoid/OpenCC) 標準
+- 使用 `VARBINARY(4)` 類型以支援非 BMP（Basic Multilingual Plane）字符
+
+### 檢視內部表
+
+可以透過 `/codes` 頁面檢視內部表內容（只讀模式）：
+
+- 訪問 `/codes/CBDB__NAME_FTS` - 查看姓名搜索倒排索引
+- 訪問 `/codes/CBDB__TRAD_SIMP_MAP` - 查看繁簡字符映射
+
+**注意**：內部表在 `/codes` 頁面中為只讀模式，僅供查詢不可編輯。
+
+### 项目未用表格
+
+以下表格在當前系統中未使用，僅供特定目的保留：
+
+- **ADDRESSES** - 僅供 CBDB Public API 使用
+- **CBDB_NAME_SEARCH** - 僅供舊版 CBDB API 姓名搜索功能使用，其功能現已被 `CBDB__NAME_FTS` 替代
+
+## 索引策略
+
+### B-Tree 索引（推薦）
+
+B-Tree 是所有數據庫都支持的標準索引類型，適用於大多數查詢場景。
+
+**優勢**：
+- ✅ 所有數據庫都支持（MySQL、MariaDB、PostgreSQL、SQLite）
+- ✅ 前綴匹配高效（`LIKE 'prefix%'`）
+- ✅ 排序和範圍查詢優秀
+- ✅ 等值查詢性能優異
+
+**創建索引**：
+```php
+Schema::table('users', function (Blueprint $table) {
+    // 單列索引
+    $table->index('name');
+
+    // 複合索引
+    $table->index(['last_name', 'first_name']);
+
+    // 唯一索引
+    $table->unique('email');
+});
+```
+
+### 複合索引使用規則
+
+**重要原則**：查詢必須包含索引的**前導列**才能使用索引。
+
+假設有複合索引：`['last_name', 'first_name']`
+
+**✅ 可以使用索引的查詢**：
+```php
+// 使用前導列 last_name
+DB::table('users')
+    ->where('last_name', 'Smith')
+    ->get();
+
+// 使用全部索引列
+DB::table('users')
+    ->where('last_name', 'Smith')
+    ->where('first_name', 'John')
+    ->get();
+```
+
+**❌ 無法使用索引的查詢**：
+```php
+// 跳過前導列 last_name，直接使用 first_name
+DB::table('users')
+    ->where('first_name', 'John')
+    ->get();
+```
+
+**索引順序設計建議**：
+- 將**最常用於篩選**的列放在前面
+- 將**選擇性高**（不重複值多）的列放在前面
+- 考慮實際查詢模式
+
+### 全文索引（謹慎使用）
+
+**⚠️ 警告**：全文索引在不同數據庫中實現差異很大，不建議使用。
+
+**問題**：
+- MySQL/MariaDB 使用 `FULLTEXT` 索引
+- PostgreSQL 使用 `GIN` 索引和 `tsvector`
+- SQLite 需要 FTS 擴展
+- 語法完全不兼容
+
+**建議的替代方案**：
+1. **應用層全文搜索**（推薦）：
+   - Elasticsearch
+   - Meilisearch
+   - Algolia
+
+2. **B-Tree 索引 + 前綴匹配**（適用於簡單場景）：
+   ```php
+   DB::table('users')
+       ->where('name', 'like', 'John%')
+       ->get();
+   ```
+
+3. **自定義倒排索引表**（本專案方案）：
+   - `CBDB__NAME_FTS` - 姓名搜索倒排索引
+   - 支援高效能後綴匹配查詢
+
+## 查詢優化
+
+### 索引友好的查詢
+
+**✅ 好的查詢（可使用索引）**：
+```php
+// 前綴匹配 - B-Tree 索引高效
+DB::table('users')
+    ->where('name', 'like', 'John%')
+    ->get();
+
+// 等值查詢 - B-Tree 索引高效
+DB::table('users')
+    ->where('name', 'John')
+    ->get();
+
+// 範圍查詢 - B-Tree 索引高效
+DB::table('users')
+    ->where('created_at', '>=', '2025-01-01')
+    ->get();
+```
+
+**❌ 不佳的查詢（無法有效使用索引）**：
+```php
+// 中間匹配或後綴匹配 - 無法使用 B-Tree 索引
+DB::table('users')
+    ->where('name', 'like', '%John%')
+    ->get();
+
+DB::table('users')
+    ->where('name', 'like', '%son')
+    ->get();
+
+// 函數處理後的欄位 - 無法使用索引
+DB::table('users')
+    ->whereRaw('LOWER(name) = ?', ['john'])
+    ->get();
+```
+
+**優化建議**：
+- 如需中間/後綴匹配，考慮全文搜索方案或自定義倒排索引
+- 避免在 WHERE 條件中對索引欄位使用函數
+- 如需不區分大小寫查詢，考慮添加專門的小寫欄位並建立索引
+
+### 使用 EXPLAIN 分析查詢
+
+**查看查詢執行計劃**：
+```php
+// 在 tinker 中
+php artisan tinker
+>>> DB::table('users')->where('name', 'John')->toSql();
+>>> DB::select('EXPLAIN ' . DB::table('users')->where('name', 'John')->toSql());
+```
+
+**使用專案提供的 SQL 分析工具**：
+- 訪問 `/admin/explainsql`（僅限活躍管理員）
+- 輸入 SELECT 語句並查看 MySQL `EXPLAIN` 計畫
+- 用於調校索引或查詢效能
+
+### 避免 N+1 查詢問題
+
+**❌ 不佳：N+1 查詢**：
+```php
+$users = User::all(); // 1 次查詢
+
+foreach ($users as $user) {
+    echo $user->posts->count(); // N 次查詢
+}
+```
+
+**✅ 好的：預加載**：
+```php
+$users = User::with('posts')->get(); // 2 次查詢（users + posts）
+
+foreach ($users as $user) {
+    echo $user->posts->count(); // 不產生額外查詢
+}
+```
+
+### 分頁大數據集
+
+**✅ 使用分頁而非 get()**：
+```php
+// 好：分頁加載
+$users = DB::table('users')
+    ->orderBy('id')
+    ->paginate(50);
+
+// 不佳：一次加載所有數據
+$users = DB::table('users')->get(); // 可能有數百萬條記錄
+```
+
+### 選擇必要的欄位
+
+**✅ 只選擇需要的欄位**：
+```php
+// 好：只選擇需要的欄位
+DB::table('users')
+    ->select('id', 'name', 'email')
+    ->get();
+
+// 不佳：選擇所有欄位（包括大型 TEXT/BLOB 欄位）
+DB::table('users')->get();
+```
+
+## 性能調優技巧
+
+### 1. 使用查詢緩存（Redis）
+
+```php
+use Illuminate\Support\Facades\Cache;
+
+// 緩存查詢結果
+$users = Cache::remember('users_active', 3600, function () {
+    return DB::table('users')
+        ->where('is_active', 1)
+        ->get();
+});
+```
+
+### 2. 批量操作
+
+```php
+// ✅ 好：批量插入
+DB::table('users')->insert([
+    ['name' => 'John', 'email' => 'john@example.com'],
+    ['name' => 'Jane', 'email' => 'jane@example.com'],
+    // ... 更多記錄
+]);
+
+// ❌ 不佳：循環插入
+foreach ($data as $item) {
+    DB::table('users')->insert($item); // N 次數據庫操作
+}
+```
+
+### 3. 使用索引提示（謹慎）
+
+**⚠️ 警告**：索引提示是數據庫特定功能，影響可移植性。
+
+```php
+// MySQL 特定 - 不推薦
+DB::select('SELECT /*+ INDEX(users idx_name) */ * FROM users WHERE name = ?', ['John']);
+
+// ✅ 推薦：優化索引設計和查詢結構
+```
+
+### 4. 監控慢查詢
+
+**Laravel 查詢日誌**：
+```php
+// 在 AppServiceProvider.php 中
+use Illuminate\Support\Facades\DB;
+
+public function boot()
+{
+    DB::listen(function ($query) {
+        if ($query->time > 1000) { // 超過 1 秒的查詢
+            \Log::warning('Slow query', [
+                'sql' => $query->sql,
+                'bindings' => $query->bindings,
+                'time' => $query->time,
+            ]);
+        }
+    });
+}
+```
+
+## 示例工作流程
+
+```bash
+# 1. 查找 baseline migration
+ls database/migrations/2025_01_01_*
+
+# 2. 讀取 migration 文件了解表格結構
+cat database/migrations/2025_01_01_000000_baseline_schema.php
+
+# 3. 搜索該表格的後續修改
+grep -r "POSTED_TO_OFFICE_DATA" database/migrations/
+
+# 4. 使用 tinker 驗證和查看示例數據
+php artisan tinker
+>>> DB::table('POSTED_TO_OFFICE_DATA')->limit(3)->get();
+>>> exit
+```
+
+## 參考資料
+
+- `AGENTS.md` - 項目的數據庫使用規範
+- `database/migrations/` - 所有數據庫結構定義

--- a/.claude/skills/migration-guide.md
+++ b/.claude/skills/migration-guide.md
@@ -1,0 +1,572 @@
+# Laravel Migration 編寫指南
+
+## 何時使用此技能
+
+當你需要創建或修改數據庫結構時，使用此指南編寫兼容性良好的 Laravel Migration。
+
+## 核心原則
+
+### ✅ 要做的事情
+- 使用 Laravel Schema Builder
+- 使用標準 SQL 語法
+- 使用 B-Tree 索引（默認）
+- 保持數據庫無關性
+
+### ❌ 避免的事情
+- 數據庫專屬功能（ngram parser、專屬插件）
+- 供應商特定語法（REGEXP、優化器提示）
+- 直接執行原始 SQL（除非必要）
+- 修改基線 migration 文件
+
+## 創建新 Migration
+
+### 使用 Artisan 命令
+
+```bash
+# 創建新表 migration
+php artisan make:migration create_example_table
+
+# 修改現有表 migration
+php artisan make:migration add_column_to_example_table --table=example
+
+# 查看 migration 狀態
+php artisan migrate:status
+```
+
+## Migration 基本模板
+
+### 創建新表
+
+```php
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateExampleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('example', function (Blueprint $table) {
+            // ✅ 主鍵
+            $table->bigIncrements('id');
+
+            // ✅ 基本字段
+            $table->string('name', 255);
+            $table->string('email', 255)->unique();
+            $table->text('description')->nullable();
+            $table->integer('status')->default(0);
+
+            // ✅ 時間戳
+            $table->timestamps();
+
+            // ✅ 軟刪除（可選）
+            // $table->softDeletes();
+
+            // ✅ 標準索引
+            $table->index('name');
+            $table->index('status');
+
+            // ✅ 複合索引
+            $table->index(['name', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('example');
+    }
+}
+```
+
+### 修改現有表
+
+```php
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnsToExampleTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('example', function (Blueprint $table) {
+            // ✅ 添加新欄位
+            $table->string('phone', 20)->nullable()->after('email');
+
+            // ✅ 添加索引
+            $table->index('phone');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('example', function (Blueprint $table) {
+            // ✅ 先刪除索引
+            $table->dropIndex(['phone']);
+
+            // ✅ 再刪除欄位
+            $table->dropColumn('phone');
+        });
+    }
+}
+```
+
+## 複合主鍵表的 Migration
+
+**重要**：Laravel Eloquent 官方不支持複合主鍵，使用 Query Builder (`DB::table()`) 操作這些表。
+
+```php
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class CreateCompositeKeyTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('altname_data', function (Blueprint $table) {
+            // ✅ 定義字段
+            $table->integer('c_personid');
+            $table->integer('c_sequence');
+            $table->string('c_alt_name_chn', 255);
+            $table->string('c_alt_name_type_code', 10);
+            $table->text('c_notes')->nullable();
+            $table->timestamps();
+
+            // ✅ 定義複合主鍵
+            $table->primary([
+                'c_personid',
+                'c_sequence',
+                'c_alt_name_chn',
+                'c_alt_name_type_code'
+            ], 'altname_pk'); // 指定主鍵名稱
+
+            // ✅ 添加索引
+            $table->index('c_personid');
+            $table->index('c_alt_name_type_code');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('altname_data');
+    }
+}
+```
+
+**操作複合主鍵表**：
+```php
+// ✅ 使用 Query Builder
+DB::table('altname_data')
+    ->where('c_personid', $personId)
+    ->where('c_sequence', $sequence)
+    ->update(['c_alt_name_chn' => $name]);
+
+// ❌ 不要為複合主鍵表創建 Eloquent 模型
+// Eloquent 的 find()、delete() 等方法無法正確處理複合主鍵
+```
+
+## 常用字段類型
+
+### 字符串類型
+```php
+$table->string('name', 255);           // VARCHAR(255)
+$table->text('description');            // TEXT
+$table->char('code', 10);              // CHAR(10)
+$table->binary('data');                 // BLOB
+```
+
+### 數字類型
+```php
+$table->integer('count');               // INT
+$table->bigInteger('big_count');        // BIGINT
+$table->tinyInteger('is_active');       // TINYINT
+$table->decimal('price', 10, 2);        // DECIMAL(10,2)
+$table->float('rating', 8, 2);          // FLOAT
+```
+
+### 日期時間類型
+```php
+$table->timestamp('created_at');        // TIMESTAMP
+$table->datetime('published_at');       // DATETIME
+$table->date('birth_date');             // DATE
+$table->time('start_time');             // TIME
+$table->timestamps();                   // created_at, updated_at
+```
+
+### JSON 類型（謹慎使用）
+```php
+// ✅ 基本 JSON 存儲是安全的
+$table->json('settings');
+
+// ❌ 避免複雜的 JSON 查詢（不同數據庫語法差異大）
+// 如需頻繁查詢 JSON 內部欄位，考慮拆分為獨立列
+```
+
+## 索引策略
+
+### B-Tree 索引（推薦）
+
+```php
+Schema::table('users', function (Blueprint $table) {
+    // ✅ 單列索引
+    $table->index('name');
+
+    // ✅ 複合索引（注意順序）
+    $table->index(['last_name', 'first_name']);
+
+    // ✅ 唯一索引
+    $table->unique('email');
+
+    // ✅ 指定索引名稱
+    $table->index('status', 'idx_users_status');
+});
+```
+
+**複合索引使用規則**：
+- 查詢必須包含索引的**前導列**才能使用索引
+- 索引 `['last_name', 'first_name']`：
+  - ✅ 可用：`WHERE last_name = 'Smith'`
+  - ✅ 可用：`WHERE last_name = 'Smith' AND first_name = 'John'`
+  - ❌ 不可用：`WHERE first_name = 'John'`（跳過前導列）
+
+### 刪除索引
+
+```php
+Schema::table('users', function (Blueprint $table) {
+    // 刪除普通索引
+    $table->dropIndex(['name']); // 使用列名
+    $table->dropIndex('idx_users_status'); // 使用索引名稱
+
+    // 刪除唯一索引
+    $table->dropUnique(['email']);
+});
+```
+
+## 避免的模式
+
+### ❌ 不要：使用數據庫專屬功能
+
+```php
+public function up()
+{
+    // ❌ 壞：MySQL 專屬的 ngram parser
+    DB::statement('
+        CREATE FULLTEXT INDEX idx_name
+        ON table_name(name) WITH PARSER ngram
+    ');
+
+    // ❌ 壞：MariaDB 專屬插件
+    DB::statement("INSTALL SONAME 'ha_spider'");
+
+    // ❌ 壞：MySQL 特定的 ENGINE
+    DB::statement('
+        CREATE TABLE logs (
+            id INT PRIMARY KEY
+        ) ENGINE=ARCHIVE
+    ');
+}
+```
+
+### ❌ 不要：使用數據庫特定函數
+
+```php
+public function up()
+{
+    // ❌ 壞：MySQL 特定的生成列
+    DB::statement('
+        ALTER TABLE users
+        ADD COLUMN full_name VARCHAR(255)
+        GENERATED ALWAYS AS (CONCAT(first_name, " ", last_name))
+    ');
+
+    // ✅ 好：在應用層處理
+    // 使用 Eloquent Accessor 或在查詢時拼接
+}
+```
+
+### ❌ 不要：依賴複雜的 JSON 查詢
+
+```php
+public function up()
+{
+    // ❌ 壞：不同數據庫的 JSON 查詢語法差異很大
+    // MySQL:  JSON_EXTRACT(settings, '$.theme')
+    // PostgreSQL: settings->>'theme'
+
+    // ✅ 好：如需頻繁查詢 JSON 內部欄位，拆分為獨立列
+    Schema::table('configs', function (Blueprint $table) {
+        $table->string('theme', 50)->nullable();
+    });
+}
+```
+
+### ❌ 不要：修改基線 Migration
+
+```php
+// ❌ 壞：直接修改已執行的基線 migration
+// 文件：2025_01_01_000000_import_cbdb_schema.php
+
+// ✅ 好：創建新的增量 migration
+php artisan make:migration add_column_to_example_table
+```
+
+## Migration 檢查清單
+
+在執行 `php artisan migrate` 之前，請檢查：
+
+### 基本檢查
+- [ ] 是否使用了 Laravel Schema Builder？
+- [ ] 是否避免了數據庫專屬語法？
+- [ ] 欄位類型是否合適？
+- [ ] 是否正確處理了 nullable 和 default 值？
+
+### 索引檢查
+- [ ] 索引是否使用標準類型（B-Tree、UNIQUE）？
+- [ ] 複合索引的順序是否合理？
+- [ ] 是否避免了過多的索引（影響寫入性能）？
+
+### 回滾檢查
+- [ ] `down()` 方法是否能正確回滾？
+- [ ] 刪除索引時是否在刪除欄位之前？
+- [ ] 是否處理了外鍵約束？
+
+### 兼容性檢查
+- [ ] 是否在 SQLite 測試環境中測試過？
+- [ ] 功能是否在 MySQL 5.7+ 和 MariaDB 10.3+ 上都能運行？
+- [ ] 是否避免了 PostgreSQL 不支持的語法？
+
+### 安全檢查
+- [ ] 是否避免了修改基線 migration 文件？
+- [ ] Migration 是否冪等（可重複執行）？
+- [ ] 是否考慮了生產環境的數據遷移？
+
+## 常見場景範例
+
+### 場景 1：添加可空欄位
+
+```php
+public function up()
+{
+    Schema::table('users', function (Blueprint $table) {
+        // ✅ 新欄位設為 nullable，避免現有數據報錯
+        $table->string('phone', 20)->nullable()->after('email');
+    });
+}
+
+public function down()
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->dropColumn('phone');
+    });
+}
+```
+
+### 場景 2：修改欄位（需要 doctrine/dbal）
+
+```bash
+# 安裝依賴
+composer require doctrine/dbal
+```
+
+```php
+public function up()
+{
+    Schema::table('users', function (Blueprint $table) {
+        // ✅ 修改欄位長度
+        $table->string('name', 500)->change();
+
+        // ✅ 修改欄位為 nullable
+        $table->string('phone', 20)->nullable()->change();
+    });
+}
+
+public function down()
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->string('name', 255)->change();
+        $table->string('phone', 20)->nullable(false)->change();
+    });
+}
+```
+
+### 場景 3：重命名欄位/表
+
+```php
+// 重命名欄位
+public function up()
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->renameColumn('name', 'full_name');
+    });
+}
+
+// 重命名表
+public function up()
+{
+    Schema::rename('old_table', 'new_table');
+}
+```
+
+### 場景 4：添加外鍵（謹慎使用）
+
+```php
+public function up()
+{
+    Schema::table('posts', function (Blueprint $table) {
+        // ✅ 添加外鍵
+        $table->unsignedBigInteger('user_id');
+        $table->foreign('user_id')
+              ->references('id')
+              ->on('users')
+              ->onDelete('cascade');
+    });
+}
+
+public function down()
+{
+    Schema::table('posts', function (Blueprint $table) {
+        // ✅ 先刪除外鍵約束
+        $table->dropForeign(['user_id']);
+        // ✅ 再刪除欄位
+        $table->dropColumn('user_id');
+    });
+}
+```
+
+## 運行 Migration
+
+```bash
+# 執行所有待處理的 migration
+php artisan migrate
+
+# 查看 migration 狀態
+php artisan migrate:status
+
+# 回滾最後一批 migration
+php artisan migrate:rollback
+
+# 回滾所有 migration
+php artisan migrate:reset
+
+# 回滾並重新運行所有 migration
+php artisan migrate:refresh
+
+# 刪除所有表並重新運行 migration（危險！）
+php artisan migrate:fresh
+```
+
+## 測試 Migration
+
+### 在測試環境測試
+
+```bash
+# 1. 使用 SQLite 測試
+php artisan migrate --database=sqlite
+
+# 2. 回滾測試
+php artisan migrate:rollback --database=sqlite
+
+# 3. 重新運行測試
+php artisan migrate --database=sqlite
+```
+
+### 在 PHPUnit 測試中
+
+```php
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class MigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_migration_creates_table()
+    {
+        // RefreshDatabase trait 會自動運行 migration
+        $this->assertTrue(
+            Schema::hasTable('example')
+        );
+    }
+
+    public function test_migration_creates_columns()
+    {
+        $this->assertTrue(
+            Schema::hasColumn('example', 'name')
+        );
+    }
+}
+```
+
+## 常見錯誤和解決方案
+
+### 錯誤 1：索引名稱太長
+
+```php
+// ❌ 錯誤：自動生成的索引名稱可能太長
+$table->index(['very_long_column_name', 'another_long_column']);
+
+// ✅ 解決：手動指定較短的索引名稱
+$table->index(
+    ['very_long_column_name', 'another_long_column'],
+    'idx_short_name'
+);
+```
+
+### 錯誤 2：刪除欄位前未刪除索引
+
+```php
+// ❌ 錯誤順序
+public function down()
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->dropColumn('email'); // 錯誤：email 上有 unique 索引
+    });
+}
+
+// ✅ 正確順序
+public function down()
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->dropUnique(['email']); // 先刪除索引
+        $table->dropColumn('email');    // 再刪除欄位
+    });
+}
+```
+
+### 錯誤 3：Migration 順序問題
+
+```bash
+# 如果 migration B 依賴 migration A
+# 確保 A 的時間戳早於 B
+
+# 正確：
+2025_01_01_000001_create_users_table.php
+2025_01_01_000002_create_posts_table.php  # 依賴 users
+
+# 錯誤：
+2025_01_02_000001_create_posts_table.php  # 依賴 users
+2025_01_01_000001_create_users_table.php
+```
+
+## 參考資料
+
+- [Laravel 10.x Migrations 文檔](https://laravel.com/docs/10.x/migrations)
+- [Laravel Schema Builder 文檔](https://laravel.com/docs/10.x/migrations#tables)
+- `DATABASE.md` - 項目數據庫完整指南
+- `database-schema.md` - Schema 查詢指南
+- `AGENTS.md` - AI 代理開發指南

--- a/.claude/skills/pre-commit-checks.md
+++ b/.claude/skills/pre-commit-checks.md
@@ -1,0 +1,157 @@
+# 代碼提交前檢查規範
+
+## 何時使用此技能
+
+在提交任何代碼變更到 Git 之前，**必須**執行此檢查流程以確保代碼質量和項目規範。
+
+## 必要檢查項目
+
+### 1. 代碼格式化 (PHP-CS-Fixer)
+
+使用 PHP-CS-Fixer 確保代碼符合項目的編碼規範：
+
+```bash
+# 格式化所有 PHP 文件
+./vendor/bin/php-cs-fixer fix
+
+# 僅檢查而不修改（dry-run）
+./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+# 格式化特定目錄
+./vendor/bin/php-cs-fixer fix app/
+./vendor/bin/php-cs-fixer fix tests/
+```
+
+**重要提醒：**
+- 格式化後的文件需要重新 `git add`
+- 確保所有格式化變更都已加入 commit
+
+### 2. 運行測試套件 (PHPUnit)
+
+確保所有測試通過，避免引入回歸問題：
+
+```bash
+# 運行完整測試套件
+./vendor/bin/phpunit
+
+# 運行特定測試文件
+./vendor/bin/phpunit tests/Feature/CodesControllerTest.php
+
+# 運行特定測試方法
+./vendor/bin/phpunit --filter testMethodName
+
+# 運行測試並顯示詳細輸出
+./vendor/bin/phpunit --verbose
+```
+
+**測試失敗處理：**
+- ❌ **禁止**在測試失敗時提交代碼
+- ✅ 修復失敗的測試或調整測試以匹配新的行為
+- ✅ 如果是預期的行為變更，更新相應的測試
+
+### 3. 前端資源編譯（如適用）
+
+如果修改了 Vue/JS 或 SCSS 文件：
+
+```bash
+# 生產環境編譯
+npm run prod
+
+# 開發環境編譯
+npm run dev
+```
+
+**注意：**
+- `public/js/app.js` 和 `public/css/app.css` 需要一同提交
+- AdminLTE v3 頁面使用 CDN，不受此影響
+
+## 完整的提交前工作流程
+
+### 標準流程
+
+```bash
+# 1. 檢查當前狀態
+git status
+
+# 2. 格式化代碼
+./vendor/bin/php-cs-fixer fix
+
+# 3. 運行測試
+./vendor/bin/phpunit
+
+# 4. 如修改了前端資源
+npm run prod
+
+# 5. 查看變更
+git diff
+
+# 6. 添加文件
+git add .
+
+# 7. 提交（使用繁體中文）
+git commit -m "feat: 新增功能描述
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+```
+
+### 快速檢查（適用於小改動）
+
+```bash
+# 組合命令：格式化 + 測試
+./vendor/bin/php-cs-fixer fix && ./vendor/bin/phpunit
+```
+
+## 常見問題
+
+### PHP-CS-Fixer 失敗
+
+```bash
+# 查看具體錯誤
+./vendor/bin/php-cs-fixer fix --verbose
+
+# 清除緩存後重試
+rm -rf .php-cs-fixer.cache
+./vendor/bin/php-cs-fixer fix
+```
+
+### PHPUnit 測試失敗
+
+```bash
+# 查看詳細錯誤信息
+./vendor/bin/phpunit --verbose --stop-on-failure
+
+# 清除測試緩存
+php artisan cache:clear
+php artisan config:clear
+```
+
+### Git Hooks（如果配置）
+
+如果項目配置了 pre-commit hooks，這些檢查可能會自動執行。如果被 hook 阻止：
+- **不要**使用 `--no-verify` 跳過檢查
+- **應該**修復 hook 指出的問題後再提交
+
+## 提交規範補充
+
+根據 `AGENTS.md` 第 161 行：
+- ✅ 所有 Git commit message **必須使用繁體中文**
+- ✅ 使用者介面使用繁體中文
+- ✅ commit message 需包含 Claude Code 署名（如適用）
+
+## 檢查清單
+
+提交前確認：
+- [ ] 運行 `./vendor/bin/php-cs-fixer fix` 並通過
+- [ ] 運行 `./vendor/bin/phpunit` 所有測試通過
+- [ ] 如修改前端，運行 `npm run prod` 並提交編譯產物
+- [ ] `git diff` 確認只包含預期改動
+- [ ] commit message 使用繁體中文
+- [ ] 沒有遺留的 `dd()`, `dump()`, `console.log()` 等調試代碼
+
+## 參考資料
+
+- `AGENTS.md` 第 143-161 行 - 迭代流程與守則
+- `phpunit.xml` - 測試配置
+- `.php-cs-fixer.php` 或 `.php-cs-fixer.dist.php` - 代碼風格配置

--- a/.claude/skills/testing-guide.md
+++ b/.claude/skills/testing-guide.md
@@ -1,0 +1,444 @@
+# PHPUnit 測試指南
+
+## 何時使用此技能
+
+當你需要編寫或運行測試時，使用此指南了解項目的測試策略和最佳實踐。
+
+## PHPUnit 基本原則
+
+### 測試環境配置
+
+- **預設數據庫**：使用 SQLite 內存資料庫（若測試自行切換，記得還原）
+- **CSRF 中間件**：Feature 測試已停用 CSRF middleware
+- **測試隔離**：每個測試方法都應該獨立運行，不依賴其他測試
+
+### 運行測試
+
+```bash
+# 運行完整測試套件
+./vendor/bin/phpunit
+
+# 運行特定測試文件
+./vendor/bin/phpunit tests/Feature/CodesControllerTest.php
+
+# 運行特定測試方法
+./vendor/bin/phpunit --filter testMethodName
+
+# 運行測試並顯示詳細輸出
+./vendor/bin/phpunit --verbose
+
+# 運行測試並在第一次失敗時停止
+./vendor/bin/phpunit --stop-on-failure
+```
+
+## In-Memory 數據庫測試模式（⭐ 推薦標準做法）
+
+這是本項目推薦的測試方式，具有快速、可靠、不依賴外部數據庫的優勢。
+
+### 基本設置
+
+在測試類的 `setUp()` 方法中配置：
+
+```php
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+
+class ExampleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 配置 SQLite 內存數據庫
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // 創建測試所需的最小化表結構
+        $this->createTestTables();
+
+        // 預填充必要的測試數據
+        $this->seedTestData();
+    }
+
+    private function createTestTables(): void
+    {
+        // 創建測試所需的表
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('name');
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        // 根據需要創建其他表...
+    }
+
+    private function seedTestData(): void
+    {
+        // 使用 DB::table()->insert() 預填充測試數據
+        DB::table('users')->insert([
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}
+```
+
+### In-Memory 測試的優勢
+
+1. ✅ **速度快**：內存數據庫性能優異
+2. ✅ **可靠**：不依賴外部數據庫配置
+3. ✅ **隔離性**：每個測試方法都有獨立的數據庫
+4. ✅ **CI 友好**：在 CI 環境中無需配置數據庫
+5. ✅ **簡潔**：只創建測試所需的最小化結構
+
+### 遵循現有模式
+
+參考項目中的標準範例：
+
+- `tests/Feature/UserIpLoggingTest.php` - 標準 in-memory 測試範例
+- `tests/Feature/WikiMaintenanceControllerTest.php` - In-memory SQLite 測試
+- `tests/Feature/CodesControllerTest.php` - `/codes/*` 功能測試
+
+## 避免複雜數據庫依賴
+
+### ❌ 不要做的事情
+
+1. **不要**依賴完整的 MySQL 數據庫遷移
+   ```php
+   // ❌ 錯誤：依賴完整 migration
+   $this->artisan('migrate');
+   ```
+
+2. **不要**依賴複雜的外鍵約束和大型 schema
+   ```php
+   // ❌ 錯誤：創建不必要的複雜關聯
+   Schema::create('complex_table', function (Blueprint $table) {
+       $table->foreign('user_id')->references('id')->on('users')
+           ->onDelete('cascade')->onUpdate('cascade');
+       // ...大量複雜約束
+   });
+   ```
+
+3. **不要**依賴真實的生產數據結構
+   ```php
+   // ❌ 錯誤：依賴完整表結構
+   // 測試只需要驗證的字段即可
+   ```
+
+### ✅ 要做的事情
+
+1. **要**創建測試所需的最小化表結構
+   ```php
+   // ✅ 正確：只創建測試需要的字段
+   Schema::create('operations', function (Blueprint $table) {
+       $table->id();
+       $table->string('op_type');
+       $table->text('resource_data');
+       $table->timestamps();
+   });
+   ```
+
+2. **要**模擬業務邏輯而非數據庫結構
+   ```php
+   // ✅ 正確：專注於業務邏輯測試
+   $response = $this->actingAs($admin)
+       ->post('/operations/restore/123');
+
+   $this->assertDatabaseHas('operations', [
+       'op_type' => '3', // 復原操作
+   ]);
+   ```
+
+3. **要**使用 Factory 創建測試數據
+   ```php
+   // ✅ 正確：使用 Factory
+   $user = User::factory()->active()->create();
+   ```
+
+## 測試編寫建議
+
+### 測試覆蓋重點
+
+1. **授權測試**：驗證權限控制
+   ```php
+   public function test_regular_user_cannot_restore_operations()
+   {
+       $user = User::factory()->create(); // 普通用戶
+
+       $response = $this->actingAs($user)
+           ->post('/operations/restore/123');
+
+       $response->assertStatus(403);
+   }
+   ```
+
+2. **Side Effect 測試**：驗證數據變動
+   ```php
+   public function test_restore_creates_new_operation_record()
+   {
+       $admin = User::factory()->active()->superAdmin()->create();
+
+       $this->actingAs($admin)
+           ->post('/operations/restore/123');
+
+       $this->assertDatabaseHas('operations', [
+           'op_type' => '3',
+           'resource_id' => '123',
+       ]);
+   }
+   ```
+
+3. **例外情境測試**：測試資料缺失或查不到的情況
+   ```php
+   public function test_restore_non_existent_operation_returns_404()
+   {
+       $admin = User::factory()->active()->superAdmin()->create();
+
+       $response = $this->actingAs($admin)
+           ->post('/operations/restore/99999');
+
+       $response->assertStatus(404);
+   }
+   ```
+
+### Mock DB Transaction
+
+如需 mock 數據庫事務：
+
+```php
+use Illuminate\Support\Facades\DB;
+use Mockery;
+
+public function test_transaction_rollback_on_error()
+{
+    // 創建假的 DB connection
+    $mockConnection = Mockery::mock('connection');
+    $mockConnection->shouldReceive('beginTransaction')->once();
+    $mockConnection->shouldReceive('rollBack')->once();
+
+    DB::swap($mockConnection);
+
+    // 測試代碼...
+}
+```
+
+## 常見測試場景範例
+
+### 1. Controller 授權測試
+
+```php
+use Tests\TestCase;
+use App\Models\User;
+
+class CodesControllerTest extends TestCase
+{
+    public function test_guest_cannot_access_codes()
+    {
+        $response = $this->get('/codes');
+        $response->assertRedirect('/login');
+    }
+
+    public function test_authenticated_user_can_access_codes()
+    {
+        $user = User::factory()->active()->create();
+
+        $response = $this->actingAs($user)->get('/codes');
+        $response->assertStatus(200);
+    }
+}
+```
+
+### 2. Repository 測試
+
+```php
+use Tests\TestCase;
+use App\Repositories\OperationRepository;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+class OperationRepositoryTest extends TestCase
+{
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->id();
+            $table->string('op_type');
+            $table->string('resource_id');
+            $table->text('resource_data');
+            $table->timestamps();
+        });
+
+        $this->repository = new OperationRepository();
+    }
+
+    public function test_store_creates_operation_record()
+    {
+        $data = [
+            'op_type' => '1',
+            'resource_id' => 'test-123',
+            'resource_data' => json_encode(['test' => 'data']),
+        ];
+
+        $operation = $this->repository->store($data);
+
+        $this->assertDatabaseHas('operations', [
+            'op_type' => '1',
+            'resource_id' => 'test-123',
+        ]);
+    }
+}
+```
+
+### 3. 測試時提供用戶信息
+
+某些功能需要登入用戶資訊（如 `ToolsRepository::timestamp()`）：
+
+```php
+public function test_office_update_requires_authenticated_user()
+{
+    $user = User::factory()->active()->create([
+        'name' => '測試用戶',
+    ]);
+
+    // 使用 actingAs() 提供用戶資訊
+    $this->actingAs($user);
+
+    // 執行需要用戶資訊的操作
+    // ToolsRepository::timestamp() 將能取得登入者姓名
+}
+```
+
+## 測試數據庫常見陷阱
+
+### 1. 遺忘字段約束
+
+```php
+// ❌ 錯誤：遺忘 NOT NULL 字段
+Schema::create('users', function (Blueprint $table) {
+    $table->id();
+    $table->string('email');
+    $table->string('confirmation_token'); // NOT NULL，但測試中可能為空
+});
+
+// ✅ 正確：設為 nullable 或提供預設值
+Schema::create('users', function (Blueprint $table) {
+    $table->id();
+    $table->string('email');
+    $table->string('confirmation_token')->nullable();
+});
+```
+
+### 2. 遺忘主鍵
+
+```php
+// ❌ 錯誤：手動創建表時遺忘主鍵
+Schema::create('custom_table', function (Blueprint $table) {
+    $table->integer('id'); // 沒有設為主鍵
+    $table->string('name');
+});
+
+// ✅ 正確：設定主鍵
+Schema::create('custom_table', function (Blueprint $table) {
+    $table->id(); // 自動設為主鍵
+    $table->string('name');
+});
+```
+
+### 3. 遺忘 timestamps
+
+```php
+// ❌ 錯誤：Model 期望有 timestamps，但表沒有
+Schema::create('operations', function (Blueprint $table) {
+    $table->id();
+    $table->string('op_type');
+    // 沒有 timestamps
+});
+
+// ✅ 正確：加入 timestamps
+Schema::create('operations', function (Blueprint $table) {
+    $table->id();
+    $table->string('op_type');
+    $table->timestamps();
+});
+```
+
+## PHPUnit 版本兼容性
+
+本項目使用 **PHPUnit 10.1**，注意使用相容的斷言方法：
+
+```php
+// ✅ PHPUnit 10 正確用法
+$this->assertStringContainsString('needle', $haystack);
+
+// ❌ 舊版用法（已棄用）
+$this->assertContains('needle', $haystack);
+```
+
+## 常用斷言方法
+
+```php
+// HTTP 響應斷言
+$response->assertStatus(200);
+$response->assertRedirect('/login');
+$response->assertJson(['key' => 'value']);
+$response->assertViewHas('variable', $value);
+
+// 數據庫斷言
+$this->assertDatabaseHas('users', ['email' => 'test@example.com']);
+$this->assertDatabaseMissing('users', ['email' => 'deleted@example.com']);
+$this->assertDatabaseCount('users', 5);
+
+// 通用斷言
+$this->assertTrue($condition);
+$this->assertEquals($expected, $actual);
+$this->assertStringContainsString('substring', $string);
+$this->assertNull($value);
+$this->assertInstanceOf(User::class, $object);
+```
+
+## 測試清單
+
+編寫測試時，確保覆蓋：
+
+- [ ] ✅ 授權：不同角色的權限測試
+- [ ] ✅ 正常流程：功能正常運作
+- [ ] ✅ 例外情況：資料不存在、無效輸入
+- [ ] ✅ Side effects：數據庫變更、事件觸發
+- [ ] ✅ 邊界條件：空值、極端值
+- [ ] ✅ 錯誤處理：異常捕獲和回滾
+
+## 參考資料
+
+- `tests/Feature/CodesControllerTest.php` - `/codes/*` 功能測試範例
+- `tests/Feature/OperationsRestoreAuthorizeTest.php` - 操作復原授權測試
+- `tests/Feature/WikiMaintenanceControllerTest.php` - In-memory SQLite 標準範例
+- `tests/Feature/UserIpLoggingTest.php` - In-memory 測試範例
+- `phpunit.xml` - 測試環境設定
+- `AGENTS.md` - 項目開發規範

--- a/.claude/skills/user-management.md
+++ b/.claude/skills/user-management.md
@@ -1,0 +1,252 @@
+# 用戶管理指南
+
+## 何時使用此技能
+
+當你需要創建、更新用戶帳號，或在測試中使用 User Factory 創建測試用戶時，使用此指南。
+
+## 管理用戶命令
+
+使用 `php artisan cbdb:manage-user` 創建或更新用戶。適用於環境初始設置和日常用戶管理。
+
+### 交互式模式
+
+直接運行命令，系統會逐步詢問所需信息：
+
+```bash
+php artisan cbdb:manage-user
+```
+
+系統會提示輸入：
+- Email（必填）
+- 姓名（必填）
+- 密碼（創建新用戶時必填）
+- 激活狀態
+- 角色
+
+### 命令行模式（適合腳本自動化）
+
+使用選項直接指定參數：
+
+```bash
+# 創建系統管理員
+php artisan cbdb:manage-user \
+  --email=admin@example.com \
+  --name="系統管理員" \
+  --password=secret123 \
+  --active=1 \
+  --role=super-admin
+
+# 更新現有用戶角色
+php artisan cbdb:manage-user --email=user@example.com --role=expert
+
+# 列出所有用戶
+php artisan cbdb:manage-user --list
+```
+
+### 支持的角色
+
+| 角色代碼 | 說明 | 權限級別 |
+|---------|------|---------|
+| `regular` | 一般用戶 | 基本查詢和編輯 |
+| `expert` | 專家用戶 | 擴展編輯權限 |
+| `crowdsourcing` | 眾包用戶 | 眾包錄入功能 |
+| `super-admin` | 系統管理員 | 完整管理權限 |
+
+### 激活狀態
+
+| 狀態值 | 說明 |
+|-------|------|
+| `0` | 未激活 |
+| `1` | 激活 |
+| `2` | 預留 |
+
+## User Factory（測試和開發用）
+
+在測試代碼和內部工具中，可使用 `User::factory()` 創建測試用戶。
+
+### 基本用法
+
+```php
+// 創建普通用戶
+$user = User::factory()->create();
+
+// 創建活躍的系統管理員
+$admin = User::factory()->active()->superAdmin()->create();
+
+// 批量創建用戶
+$users = User::factory()->count(5)->create();
+
+// 創建但不保存到數據庫
+$user = User::factory()->make();
+```
+
+### 自定義屬性
+
+```php
+// 自定義特定字段
+$user = User::factory()->create([
+    'email' => 'custom@example.com',
+    'name' => '自定義用戶',
+]);
+
+// 使用狀態方法
+$activeExpert = User::factory()
+    ->active()
+    ->state(['role' => 'expert'])
+    ->create();
+```
+
+### 常用組合
+
+```php
+// 測試：創建活躍管理員
+$admin = User::factory()->active()->superAdmin()->create();
+
+// 測試：創建普通用戶
+$user = User::factory()->create();
+
+// 測試：創建多個眾包用戶
+$crowdsourcingUsers = User::factory()
+    ->count(3)
+    ->state(['role' => 'crowdsourcing'])
+    ->create();
+```
+
+### 向後兼容語法
+
+舊版 Laravel 語法仍然支持：
+
+```php
+// 舊語法（仍可用）
+$user = factory(User::class)->create();
+
+// 新語法（推薦）
+$user = User::factory()->create();
+```
+
+## 測試中的用戶管理
+
+### Feature 測試中的用戶認證
+
+```php
+use Tests\TestCase;
+use App\Models\User;
+
+class ExampleTest extends TestCase
+{
+    public function test_admin_can_access_page()
+    {
+        // 創建並登入管理員
+        $admin = User::factory()->active()->superAdmin()->create();
+
+        $response = $this->actingAs($admin)
+            ->get('/admin/dashboard');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_regular_user_cannot_access_admin_page()
+    {
+        // 創建普通用戶
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->get('/admin/dashboard');
+
+        $response->assertStatus(403);
+    }
+}
+```
+
+### 設置測試數據庫中的用戶表
+
+如果使用 in-memory SQLite 測試：
+
+```php
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+protected function setUp(): void
+{
+    parent::setUp();
+
+    // 配置 SQLite
+    config()->set('database.default', 'sqlite');
+    config()->set('database.connections.sqlite', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+
+    // 創建 users 表
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('email')->unique();
+        $table->string('name');
+        $table->string('password');
+        $table->string('confirmation_token')->nullable();
+        $table->tinyInteger('is_active')->default(0);
+        $table->tinyInteger('is_admin')->default(0);
+        $table->string('role')->default('regular');
+        $table->timestamps();
+    });
+}
+```
+
+**注意**：記得為 `confirmation_token` 字段提供值或設為 nullable，避免 NOT NULL 約束錯誤。
+
+## 常見場景
+
+### 1. 環境初始設置
+
+```bash
+# 創建第一個系統管理員
+php artisan cbdb:manage-user \
+  --email=admin@cbdb.example.com \
+  --name="CBDB 系統管理員" \
+  --password=secure_password_here \
+  --active=1 \
+  --role=super-admin
+```
+
+### 2. 批量創建測試用戶（開發環境）
+
+```php
+// 在 seeder 或 tinker 中執行
+User::factory()->count(10)->create();
+
+// 創建不同角色的用戶
+User::factory()->state(['role' => 'expert'])->count(3)->create();
+User::factory()->state(['role' => 'crowdsourcing'])->count(5)->create();
+```
+
+### 3. 更新用戶角色
+
+```bash
+# 將用戶提升為專家
+php artisan cbdb:manage-user --email=user@example.com --role=expert
+
+# 激活用戶
+php artisan cbdb:manage-user --email=user@example.com --active=1
+```
+
+### 4. 列出所有用戶
+
+```bash
+php artisan cbdb:manage-user --list
+```
+
+## 注意事項
+
+1. **密碼安全**：生產環境中使用強密碼，避免在命令歷史中暴露密碼
+2. **Email 唯一性**：Email 必須唯一，重複的 Email 會導致錯誤
+3. **角色權限**：確保理解不同角色的權限差異，避免過度授權
+4. **測試隔離**：測試中使用 Factory 創建的用戶會在測試後自動清理（使用 RefreshDatabase trait）
+5. **confirmation_token**：在測試中創建用戶表時，記得處理此字段（nullable 或提供值）
+
+## 參考資料
+
+- `app/Console/Commands/ManageUser.php` - 用戶管理命令實現
+- `database/factories/UserFactory.php` - User Factory 定義
+- `app/Models/User.php` - User 模型
+- `AGENTS.md` - 項目開發規範

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 - `POSTED_TO_ADDR_DATA` 操作紀錄的 `resource_id`（列表上標示為「資源tts」）會沿用對應 `POSTED_TO_OFFICE_DATA` 的 `{c_office_id}-{c_posting_id}` 值，以共用 `/basicinformation/{personid}/offices/{pk}/edit` 編輯介面；實際資料表主鍵為 `c_personid`、`c_posting_id`、`c_office_id` 三欄，完整變更內容紀錄在 `resource_data['rows']` 中。
 
 ## 常用命令
+
 | 操作 | 指令 |
 |------|------|
 | 安裝 PHP 依賴 | `composer install` |
@@ -48,96 +49,87 @@
 | 編譯前端資源 | `npm run prod`（或 `npm run dev` 用於調試）|
 | 執行完整測試 | `./vendor/bin/phpunit` |
 | 執行單一測試 | `./vendor/bin/phpunit --filter TestName` |
+| 代碼格式化 | `./vendor/bin/php-cs-fixer fix` |
 | 匯入繁簡映射 | `php artisan cbdb:import-trad-simp-map --truncate` |
-| 管理用戶 | `php artisan cbdb:manage-user` （交互式）或帶選項創建/更新 |
+| 管理用戶 | `php artisan cbdb:manage-user` |
 
 > 若修改 Vue/JS，記得在本機跑 `npm run prod` 產出 `public/js/app.js`；專案不會自動編譯。
+> 詳細的用戶管理、測試、數據庫 schema 查詢等操作指南，請參考 [AI 代理專用 Skills](#ai-代理專用-skills)。
 
-### 用戶管理
-- **管理用戶命令**：使用 `php artisan cbdb:manage-user` 創建或更新用戶。適用於環境初始設置和日常用戶管理。
-  - **交互式模式**：直接運行 `php artisan cbdb:manage-user`，系統會逐步詢問所需信息。
-  - **命令行模式**：使用選項直接指定參數，適合腳本自動化：
-    ```bash
-    # 創建系統管理員
-    php artisan cbdb:manage-user \
-      --email=admin@example.com \
-      --name="系統管理員" \
-      --password=secret123 \
-      --active=1 \
-      --role=super-admin
-
-    # 更新現有用戶角色
-    php artisan cbdb:manage-user --email=user@example.com --role=expert
-
-    # 列出所有用戶
-    php artisan cbdb:manage-user --list
-    ```
-  - **支持的角色**：`regular`（一般）、`expert`（專家）、`crowdsourcing`（眾包）、`super-admin`（系統管理員）
-  - **激活狀態**：`0`（未激活）、`1`（激活）、`2`（預留）
-- **User Factory**：測試和內部工具可使用 `User::factory()` 創建測試用戶：
-  ```php
-  // 創建普通用戶
-  $user = User::factory()->create();
-
-  // 創建活躍的系統管理員
-  $admin = User::factory()->active()->superAdmin()->create();
-
-  // 批量創建用戶
-  $users = User::factory()->count(5)->create();
-
-  // 舊語法仍然支持（向後兼容）
-  $user = factory(User::class)->create();
-  ```
-
-### 內部表維護
-- **繁簡映射表**：使用 `php artisan cbdb:import-trad-simp-map --truncate` 從 OpenCC 匯入最新繁簡對照。支援 `--batch=N` 參數調整批次大小（預設 1000）。
-- **檢視內部表**：可透過 `/codes/CBDB__NAME_FTS` 和 `/codes/CBDB__TRAD_SIMP_MAP` 檢視表內容（只讀）。
-- **项目未用表格**：`ADDRESSES` 表僅供 CBDB Public API 使用。`CBDB_NAME_SEARCH` 表格僅供舊版 CBDB API 姓名搜索功能使用，其功能現已被 `CBDB__NAME_FTS` 替代。
-
-### 檢視表 ViewTable 模組補充
+## 檢視表 ViewTable 模組補充
 - 新增或調整檢視請更新 `config/view_tables.php`（欄位標題、描述、每頁筆數、對應 builder）。
 - 搜尋欄位維護在 `config/view_table_searchable.php`，欄位名稱必須與查詢 builder 中使用的資料表別名一致。
 - 查詢邏輯集中在 `app/ViewTables/ViewTableQueries.php`。若需透過資料庫 view，請確保 migration 會建立對應 View_*，否則改以查詢組合實作。
 - `/view` 首頁會列出所有檢視；如需逐一查看別名、說明，建議參考 `VIEWS.md`，並保持此文件與設定內容同步。
 - 頁面右上角的「顯示 SQL」會呈現實際執行語句及 bindings，可用來對照 `ViewTableQueries` 或資料庫查詢。
 
-## 測試策略
-1. **PHPUnit 基本原則**
-   - 預設使用 SQLite 內存資料庫（若測試自行切換，記得還原）。
-   - Feature 測試已停用 CSRF middleware；若需要真正驗證 CSRF，請額外撰寫整合測試。
+## AI 代理專用 Skills
 
-2. **In-Memory 數據庫測試模式**（⭐ 推薦標準做法）
-   - **遵循現有模式**：參考 `tests/Feature/UserIpLoggingTest.php` 等現有測試
-   - **配置方式**：在 `setUp()` 方法中設置：
-     ```php
-     config()->set('database.default', 'sqlite');
-     config()->set('database.connections.sqlite', [
-         'driver' => 'sqlite',
-         'database' => ':memory:',
-         'prefix' => '',
-     ]);
-     ```
-   - **表結構創建**：使用 `Schema::create()` 創建測試所需的最小化表結構
-   - **測試數據**：使用 `DB::table()->insert()` 預填充必要的測試數據
-   - **隔離性**：每個測試方法都有獨立的內存數據庫，完全隔離
-   - **優勢**：快速、可靠、不依賴外部數據庫，CI 環境友好
+本專案在 `.claude/skills/` 目錄下提供了專門的技能指南，供 AI 代理（如 Claude Code）在特定場景下參考使用。這些 skills 整合了專案的最佳實踐和規範，可提高工作效率並確保代碼質量。
 
-3. **避免複雜數據庫依賴**
-   - ❌ **不要**：依賴完整的 MySQL 數據庫遷移
-   - ❌ **不要**：依賴複雜的外鍵約束和大型 schema
-   - ✅ **要**：創建測試所需的最小化表結構
-   - ✅ **要**：模擬業務邏輯而非數據庫結構
+### 可用的 Skills
 
-4. **範例測試**
-   - `tests/Feature/CodesControllerTest.php`：涵蓋 `/codes/*` 授權、搜尋、操作記錄等行為。
-   - `tests/Feature/OperationsRestoreAuthorizeTest.php`：驗證操作復原的授權與記錄流程。
-   - `tests/Feature/WikiMaintenanceControllerTest.php`：In-memory SQLite 測試的標準範例
+#### 1. **database-schema.md** - 數據庫表格 Schema 查詢與維護
+**何時使用**：需要了解數據庫表格結構、字段類型、索引，或維護內部表格時。
 
-5. **撰寫測試建議**
-   - 覆蓋授權、Side effect（資料變動）、例外情境（資料缺失或查不到）。
-   - 優先使用 in-memory 數據庫模式，避免外部依賴
-   - 測試邏輯而非數據庫結構，保持測試簡潔和可維護
-   - 需 mock DB transaction 時，可使用 `DB::swap()` 注入假交易器。
+**主要內容**：
+- 從 `database/migrations/2025_01_01_*` 找到 baseline migration
+- 使用 `grep` 搜索表格的後續修改
+- 使用 `php artisan tinker` 驗證 schema 並查看示例數據
+- 複合主鍵表格的特殊處理說明
+- 內部輔助表（`CBDB__` 前綴）的識別和維護
+- 繁簡映射表的匯入和更新
+
+#### 2. **pre-commit-checks.md** - 代碼提交前檢查規範
+**何時使用**：在提交任何代碼變更到 Git 之前（必須執行）。
+
+**必要檢查項目**：
+- ✅ 代碼格式化：`./vendor/bin/php-cs-fixer fix`
+- ✅ 測試驗證：`./vendor/bin/phpunit`（必須全部通過）
+- ✅ 前端編譯：`npm run prod`（如修改了 Vue/JS/SCSS）
+- ✅ 提交信息使用繁體中文
+
+#### 3. **user-management.md** - 用戶管理操作指南
+**何時使用**：需要創建、更新用戶帳號，或在測試中使用 User Factory 時。
+
+**主要內容**：
+- `php artisan cbdb:manage-user` 命令的交互式和命令行模式
+- 支持的角色：`regular`、`expert`、`crowdsourcing`、`super-admin`
+- User Factory 在測試中的使用方法
+- Feature 測試中的用戶認證設置
+- 常見用戶管理場景和最佳實踐
+
+#### 4. **testing-guide.md** - PHPUnit 測試編寫指南
+**何時使用**：編寫或運行測試時，了解項目的測試策略和最佳實踐。
+
+**主要內容**：
+- PHPUnit 基本原則和運行方法
+- ⭐ In-Memory 數據庫測試模式（推薦標準做法）
+- 避免複雜數據庫依賴的策略
+- 測試編寫建議（授權、Side effect、例外情境）
+- 常見測試場景範例（Controller、Repository）
+- 測試數據庫常見陷阱和解決方案
+- PHPUnit 10.1 版本兼容性說明
+
+#### 5. **migration-guide.md** - Laravel Migration 編寫指南
+**何時使用**：需要創建或修改數據庫結構時。
+
+**主要內容**：
+- Migration 編寫核心原則（數據庫兼容性）
+- 創建新表和修改現有表的完整模板
+- 複合主鍵表的 Migration 處理
+- 常用字段類型和索引策略
+- 避免的模式（數據庫專屬功能）
+- Migration 檢查清單
+- 常見錯誤和解決方案
+
+### 如何使用 Skills
+
+- **AI 代理**：在需要時直接讀取對應的 skill 文件（如 `.claude/skills/database-schema.md`）
+- **開發者**：可以作為快速參考指南查閱
+- **擴展**：如發現新的通用場景，可以添加新的 skill 文件並更新此列表
+
+> **注意**：Skills 的內容會隨專案演進持續更新，請以 `.claude/skills/` 目錄中的最新版本為準。
 
 ## 迭代流程與守則
 1. **變更前**：檢查 `git status`，確認工作樹是否乾淨；若不乾淨，先理解現存修改，避免誤刪。

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -131,80 +131,34 @@ php artisan migrate
 
 ## 最佳實踐
 
-### 索引策略
+> 💡 **詳細的索引策略、查詢優化和性能調優技巧**，請參考 [database-schema.md skill](./.claude/skills/database-schema.md)。
+
+### 索引策略概述
 
 #### B-Tree 索引（推薦）
+- ✅ 所有數據庫都支持
+- ✅ 前綴匹配高效（`LIKE 'prefix%'`）
+- ✅ 排序和範圍查詢優秀
 
 ```php
 Schema::table('users', function (Blueprint $table) {
-    // ✅ 單列索引
-    $table->index('name');
-
-    // ✅ 複合索引
-    $table->index(['last_name', 'first_name']);
-
-    // ✅ 唯一索引
-    $table->unique('email');
+    $table->index('name');                      // 單列索引
+    $table->index(['last_name', 'first_name']); // 複合索引
+    $table->unique('email');                    // 唯一索引
 });
 ```
-
-**優勢**：
-- 所有數據庫都支持
-- 前綴匹配高效（`LIKE 'prefix%'`）
-- 排序和範圍查詢優秀
 
 #### 全文索引（謹慎使用）
+⚠️ 不同數據庫實現差異大，建議使用應用層全文搜索方案（Elasticsearch、Meilisearch）。
 
-```php
-// ⚠️ 謹慎：不同數據庫實現差異大
-Schema::table('articles', function (Blueprint $table) {
-    // MySQL/MariaDB 特定
-    DB::statement('ALTER TABLE articles ADD FULLTEXT(content)');
+### 查詢優化概述
 
-    // PostgreSQL 需要完全不同的語法
-    // DB::statement('CREATE INDEX ... USING GIN(to_tsvector(...))');
-});
-```
+**索引友好的查詢**：
+- ✅ 前綴匹配：`WHERE name LIKE 'John%'`
+- ✅ 等值查詢：`WHERE name = 'John'`
+- ❌ 中間匹配：`WHERE name LIKE '%John%'`（無法使用 B-Tree 索引）
 
-**建議**：未來如需全文搜索，使用應用層方案
-
-### 查詢優化
-
-#### 索引友好的查詢
-
-```php
-// ✅ 好：前綴匹配，可使用索引
-DB::table('users')
-    ->where('name', 'like', 'John%')
-    ->get();
-
-// ❌ 壞：中間匹配，無法使用索引
-DB::table('users')
-    ->where('name', 'like', '%John%')
-    ->get();
-```
-
-#### 複合索引使用
-
-```php
-// 假設有複合索引：['last_name', 'first_name']
-
-// ✅ 好：使用索引前導列
-$users = DB::table('users')
-    ->where('last_name', 'Smith')
-    ->get();
-
-// ✅ 好：使用索引全部列
-$users = DB::table('users')
-    ->where('last_name', 'Smith')
-    ->where('first_name', 'John')
-    ->get();
-
-// ❌ 壞：跳過索引前導列，無法使用索引
-$users = DB::table('users')
-    ->where('first_name', 'John')
-    ->get();
-```
+**複合索引規則**：查詢必須包含索引的**前導列**才能有效使用索引。
 
 ### ORM 使用策略
 
@@ -300,40 +254,40 @@ DB::table('configs')->insert([
 
 ## Migration 指南
 
-### 基本模板
+> 💡 **詳細的 Migration 編寫指南、模板和檢查清單**，請參考 [migration-guide.md skill](./.claude/skills/migration-guide.md)。
+
+### 核心原則
+
+✅ **要做的事情**：
+- 使用 Laravel Schema Builder
+- 使用標準 SQL 語法
+- 使用 B-Tree 索引（默認）
+- `down()` 方法能正確回滾
+
+❌ **避免的事情**：
+- 數據庫專屬功能（ngram parser、專屬插件）
+- 供應商特定語法（REGEXP、優化器提示）
+- 直接執行原始 SQL（除非必要）
+- 修改基線 migration 文件
+
+### 快速示例
 
 ```php
-<?php
-
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class CreateExampleTable extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
     public function up()
     {
         Schema::create('example', function (Blueprint $table) {
-            // ✅ 使用 Laravel Schema Builder
             $table->bigIncrements('id');
             $table->string('name', 255);
-            $table->text('description')->nullable();
             $table->timestamps();
-
-            // ✅ 標準索引
             $table->index('name');
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists('example');
@@ -341,120 +295,49 @@ class CreateExampleTable extends Migration
 }
 ```
 
-### 避免的模式
+### 常用命令
 
-```php
-public function up()
-{
-    // ❌ 壞：直接執行數據庫特定 SQL
-    DB::statement('
-        CREATE FULLTEXT INDEX idx_name
-        ON table_name(name) WITH PARSER ngram
-    ');
-
-    // ❌ 壞：使用數據庫特定函數
-    DB::statement('
-        ALTER TABLE users
-        ADD COLUMN full_name VARCHAR(255)
-        GENERATED ALWAYS AS (CONCAT(first_name, " ", last_name))
-    ');
-
-    // ❌ 壞：使用 MySQL 特定的 ENGINE
-    DB::statement('
-        CREATE TABLE logs (
-            id INT PRIMARY KEY
-        ) ENGINE=ARCHIVE
-    ');
-}
+```bash
+php artisan make:migration create_example_table  # 創建 migration
+php artisan migrate                               # 執行 migration
+php artisan migrate:status                        # 查看狀態
+php artisan migrate:rollback                      # 回滾
 ```
-
-### Migration 檢查清單
-
-在執行 `php artisan migrate` 之前，請檢查：
-
-- [ ] 是否使用了 Laravel Schema Builder？
-- [ ] 是否避免了數據庫專屬語法？
-- [ ] 索引是否使用標準類型（B-Tree、UNIQUE）？
-- [ ] `down()` 方法是否能正確回滾？
-- [ ] 是否在 SQLite 測試環境中測試過？
-- [ ] 功能是否在 MySQL 5.7+ 和 MariaDB 10.3+ 上都能運行？
 
 ---
 
 ## 測試策略
 
-### In-Memory SQLite 測試（推薦）
+> 💡 **詳細的 PHPUnit 測試編寫指南、In-Memory 數據庫測試和最佳實踐**，請參考 [testing-guide.md skill](./.claude/skills/testing-guide.md)。
 
+### 推薦方法：In-Memory SQLite 測試
+
+**核心原則**：
+1. ✅ **隔離性**：每個測試使用獨立的 in-memory 數據庫
+2. ✅ **最小化**：只創建測試所需的表結構
+3. ✅ **快速**：避免依賴完整的 schema migration
+4. ✅ **可靠**：不依賴外部數據庫服務
+
+**基本設置**：
 ```php
-<?php
-
-namespace Tests\Feature;
-
-use Tests\TestCase;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
-
-class ExampleTest extends TestCase
+protected function setUp(): void
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
+    parent::setUp();
 
-        // 配置 SQLite in-memory
-        config()->set('database.default', 'sqlite');
-        config()->set('database.connections.sqlite.database', ':memory:');
+    // 配置 SQLite in-memory
+    config()->set('database.default', 'sqlite');
+    config()->set('database.connections.sqlite.database', ':memory:');
 
-        // 創建測試所需的最小化表結構
-        Schema::create('users', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamps();
-        });
-
-        // 插入測試數據
-        DB::table('users')->insert([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
-    }
-
-    public function test_can_query_users()
-    {
-        $user = DB::table('users')->first();
-        $this->assertEquals('Test User', $user->name);
-    }
+    // 創建最小化表結構
+    Schema::create('users', function (Blueprint $table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->timestamps();
+    });
 }
 ```
 
-### 多數據庫兼容性測試
-
-```php
-// phpunit.xml 配置
-<php>
-    <env name="DB_CONNECTION" value="sqlite"/>
-    <env name="DB_DATABASE" value=":memory:"/>
-</php>
-
-// 如需測試真實數據庫
-public function test_works_on_mariadb()
-{
-    if (env('DB_CONNECTION') !== 'mysql') {
-        $this->markTestSkipped('MariaDB test');
-    }
-
-    // 測試代碼...
-}
-```
-
-### 測試原則
-
-1. **隔離性**：每個測試使用獨立的 in-memory 數據庫
-2. **最小化**：只創建測試所需的表結構
-3. **快速**：避免依賴完整的 schema migration
-4. **可靠**：不依賴外部數據庫服務
-
-參考範例：
+**參考範例**：
 - `tests/Feature/CodesControllerTest.php`
 - `tests/Feature/WikiMaintenanceControllerTest.php`
 - `tests/Feature/UserIpLoggingTest.php`
@@ -484,6 +367,12 @@ public function test_works_on_mariadb()
 ---
 
 ## 參考資源
+
+### 項目 Skills（操作指南）
+- [database-schema.md](./.claude/skills/database-schema.md) - 數據庫 Schema 查詢、索引策略、查詢優化
+- [migration-guide.md](./.claude/skills/migration-guide.md) - Migration 編寫完整指南
+- [testing-guide.md](./.claude/skills/testing-guide.md) - PHPUnit 測試編寫指南
+- [pre-commit-checks.md](./.claude/skills/pre-commit-checks.md) - 代碼提交前檢查規範
 
 ### 官方文檔
 - [Laravel 10.x Database](https://laravel.com/docs/10.x/database)


### PR DESCRIPTION
## 主要改動

### 新增 Skills（.claude/skills/）
- database-schema.md - 數據庫 Schema 查詢、索引策略、查詢優化
- migration-guide.md - Laravel Migration 編寫完整指南
- testing-guide.md - PHPUnit 測試編寫指南
- user-management.md - 用戶管理操作指南
- pre-commit-checks.md - 代碼提交前檢查規範

### 精簡核心文檔
- AGENTS.md: 245 行 → 175 行（-29%）
  - 移除詳細操作指南至 skills
  - 保留核心背景知識和規範
  - 新增 Skills 索引章節

- DATABASE.md: 544 行 → 432 行（-21%）
  - 移除重複的測試策略內容
  - 精簡 Migration 和最佳實踐的詳細示例
  - 添加對 skills 的引用
  - 保留核心概念和快速參考

## 改進效果

1. **文檔定位更清晰**
   - 核心文檔：提供概念和原則（給人類快速理解）
   - Skills：提供詳細操作指南（給 AI 代理和開發者參考）

2. **避免內容重複**
   - 測試策略集中在 testing-guide.md
   - Migration 指南集中在 migration-guide.md
   - 數據庫優化集中在 database-schema.md

3. **易於維護和查找**
   - 清晰的引用關係
   - 專注於特定任務的 skill 文件
   - 統一的索引系統

🤖 Generated with [Claude Code](https://claude.com/claude-code)