### PR TITLE
feat: 迁移管理员页面和用户资料页面到 AdminLTE v3

### DIFF
--- a/ADMINLTE.md
+++ b/ADMINLTE.md
@@ -302,14 +302,25 @@
 | view/list.blade.php | /view/{id} | ✅ 完成 | 检视表详情 |
 | manage/index.blade.php | /manage | ✅ 完成 | 用户管理列表 |
 | manage/edit.blade.php | /manage/{id}/edit | ✅ 完成 | 用户编辑 |
+| manage/merge-preview.blade.php | /manage/merge-preview | ✅ 完成 | 人物记录合并预览 |
 | crowdsourcing/index.blade.php | /crowdsourcing | ✅ 完成 | 众包录入记录 |
+| profile/edit.blade.php | /profile/edit | ✅ 完成 | 用户资料编辑 |
+| admin/wiki-maintenance.blade.php | /admin/wiki-maintenance | ✅ 完成 | Wiki 对照资料维护 |
+| admin/cbdb-table-maintenance.blade.php | /admin/cbdb-table-maintenance | ✅ 完成 | CBDB 内部表维护 |
+| admin/explain_sql.blade.php | /admin/explainsql | ✅ 完成 | MySQL EXPLAIN 工具 |
+| admin/unidirectional-relationship-repair.blade.php | /admin/unidirectional-relationship-repair | ✅ 完成 | 单向关系修复 |
+| admin/batch_load_book_titles.blade.php | /admin/batch-load-book-titles | ✅ 完成 | 批次汇入书稿资料 |
+| admin/batch_load_offices.blade.php | /admin/batch-load-offices | ✅ 完成 | 批次汇入官职 |
+| admin/batch_load_social_institutes.blade.php | /admin/batch-load-social-institutes | ✅ 完成 | 批次汇入社会机构 |
 
-**总计**: 12 个页面已迁移到 AdminLTE v3
+**总计**: 21 个页面已迁移到 AdminLTE v3
 
 ### 🎉 已完成模块
 - ✅ **codes 模块** - 全部 5 个页面已迁移 (2025-12-11 完成)
-- ✅ **manage 模块** - 全部 2 个页面已迁移 (2025-12-13 完成)
+- ✅ **manage 模块** - 全部 3 个页面已迁移 (2025-12-14 完成)
 - ✅ **crowdsourcing 模块** - 1 个页面已迁移 (2025-12-13 完成)
+- ✅ **profile 模块** - 1 个页面已迁移 (2025-12-14 完成)
+- ✅ **admin 模块** - 全部 8 个管理员工具页面已迁移 (2025-12-14 完成)
 
 ## 下一步计划
 

--- a/resources/views/admin/batch_load_book_titles.blade.php
+++ b/resources/views/admin/batch_load_book_titles.blade.php
@@ -1,11 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">批次匯入書稿資料</h3>
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">批次匯入書稿資料</h3>
         </div>
-        <div class="panel-body">
+        <div class="card-body">
             <p class="text-muted">
                 將作者 CBDB ID、書名、來源 <code>TEXT_ID</code> 貼在下方文字框，每行以 <code>Tab</code> 分隔三欄。
                 範例：<code>12345[TAB]某某書名[TAB]67890</code>。系統會依序建立 <code>TEXT_CODES</code>，

--- a/resources/views/admin/batch_load_offices.blade.php
+++ b/resources/views/admin/batch_load_offices.blade.php
@@ -1,11 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">批次匯入官職</h3>
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">批次匯入官職</h3>
         </div>
-        <div class="panel-body">
+        <div class="card-body">
             <p class="text-muted">
                 每行輸入 <code>中文職名</code>、<code>英文職名</code>、<code>朝代（中文）</code>、
                 <code>官職類型 ID</code>、<code>所屬單位（備註用，可空白）</code>、<code>來源 TEXT_ID</code>，

--- a/resources/views/admin/batch_load_social_institutes.blade.php
+++ b/resources/views/admin/batch_load_social_institutes.blade.php
@@ -1,11 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">批次匯入社會機構</h3>
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">批次匯入社會機構</h3>
         </div>
-        <div class="panel-body">
+        <div class="card-body">
             <p class="text-muted">
                 每行請依序輸入：<code>機構名稱</code>、<code>類型（中文）</code>、<code>朝代（中文）</code>、<code>地址名稱（可留白）</code>、
                 <code>地址 ID</code>、<code>來源 TEXT_ID</code>，以 <code>Tab</code> 分隔。

--- a/resources/views/admin/cbdb-table-maintenance.blade.php
+++ b/resources/views/admin/cbdb-table-maintenance.blade.php
@@ -1,9 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-<div class="panel panel-default">
-    <div class="panel-heading">CBDB 內部表維護</div>
-    <div class="panel-body">
+<div class="card card-default">
+    <div class="card-header">
+        <h3 class="card-title">CBDB 內部表維護</h3>
+    </div>
+    <div class="card-body">
 
         {{-- 顯示操作結果消息 --}}
         @if(session('success'))
@@ -31,14 +33,14 @@
         <div class="row" style="margin-bottom: 20px;">
             @foreach($tables as $tableName => $tableInfo)
             <div class="col-md-6">
-                <div class="panel panel-{{ $tableInfo['color'] }}">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
+                <div class="card card-{{ $tableInfo['color'] }}">
+                    <div class="card-header">
+                        <h3 class="card-title">
                             <i class="fa fa-{{ $tableInfo['icon'] }}"></i>
                             {{ $tableInfo['name_chn'] }}
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p><strong>資料表：</strong><code>{{ $tableInfo['name'] }}</code></p>
                         <p><strong>說明：</strong>{{ $tableInfo['description'] }}</p>
                         <p><strong>Artisan 命令：</strong><code>{{ $tableInfo['command'] }}</code></p>
@@ -51,7 +53,7 @@
                             </p>
                         @else
                             <p><strong>狀態：</strong>
-                                <span class="label label-warning">資料表不存在</span>
+                                <span class="badge badge-warning">資料表不存在</span>
                             </p>
                         @endif
 
@@ -128,11 +130,11 @@
         </div>
 
         {{-- 說明文字 --}}
-        <div class="panel panel-info">
-            <div class="panel-heading">
-                <h3 class="panel-title"><i class="fa fa-info-circle"></i> 說明</h3>
+        <div class="card card-info">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fa fa-info-circle"></i> 說明</h3>
             </div>
-            <div class="panel-body">
+            <div class="card-body">
                 <h4>繁簡映射表 (CBDB__TRAD_SIMP_MAP)</h4>
                 <ul>
                     <li>從 OpenCC 專案下載最新的繁簡對照資料</li>

--- a/resources/views/admin/explain_sql.blade.php
+++ b/resources/views/admin/explain_sql.blade.php
@@ -1,11 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">MySQL EXPLAIN</h3>
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">MySQL EXPLAIN</h3>
         </div>
-        <div class="panel-body">
+        <div class="card-body">
             <p class="text-muted">
                 這個工具僅供管理員用於診斷查詢效能。請輸入只讀 SQL（僅支援 SELECT / WITH），系統會送出
                 <code>EXPLAIN</code> 並顯示 MySQL 回傳的執行計畫，方便評估索引或查詢設計是否需要調整。
@@ -31,7 +31,7 @@
 
             @if(is_array($results) && count($results) > 0)
                 <div class="table-responsive" style="margin-top: 20px;">
-                    <table class="table table-bordered table-striped table-condensed">
+                    <table class="table table-bordered table-striped table-sm">
                         <thead>
                         <tr>
                             @foreach($columns as $column)

--- a/resources/views/admin/unidirectional-relationship-repair.blade.php
+++ b/resources/views/admin/unidirectional-relationship-repair.blade.php
@@ -1,21 +1,23 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-<div class="panel panel-default">
-    <div class="panel-heading">單向關係修復</div>
-    <div class="panel-body">
+<div class="card card-default">
+    <div class="card-header">
+        <h3 class="card-title">單向關係修復</h3>
+    </div>
+    <div class="card-body">
 
         {{-- 上半部分：親屬關係修復 --}}
         <div class="row" style="margin-bottom: 30px;">
             <div class="col-md-12">
-                <div class="panel panel-primary">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
+                <div class="card card-primary">
+                    <div class="card-header">
+                        <h3 class="card-title">
                             <i class="fa fa-users"></i>
                             親屬關係修復
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <div id="kinship-result-container"></div>
 
                         <form id="kinship-repair-form">
@@ -52,7 +54,7 @@
                             <button type="submit" class="btn btn-primary" id="kinship-submit-btn">
                                 <i class="fa fa-check"></i> 修復親屬關係
                             </button>
-                            <button type="reset" class="btn btn-default">
+                            <button type="reset" class="btn btn-secondary">
                                 <i class="fa fa-undo"></i> 重置
                             </button>
                         </form>
@@ -64,14 +66,14 @@
         {{-- 下半部分：社會關係修復 --}}
         <div class="row" style="margin-bottom: 30px;">
             <div class="col-md-12">
-                <div class="panel panel-success">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
+                <div class="card card-success">
+                    <div class="card-header">
+                        <h3 class="card-title">
                             <i class="fa fa-sitemap"></i>
                             社會關係修復
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <div id="assoc-result-container"></div>
 
                         <form id="assoc-repair-form">
@@ -108,7 +110,7 @@
                             <button type="submit" class="btn btn-success" id="assoc-submit-btn">
                                 <i class="fa fa-check"></i> 修復社會關係
                             </button>
-                            <button type="reset" class="btn btn-default">
+                            <button type="reset" class="btn btn-secondary">
                                 <i class="fa fa-undo"></i> 重置
                             </button>
                         </form>

--- a/resources/views/admin/wiki-maintenance.blade.php
+++ b/resources/views/admin/wiki-maintenance.blade.php
@@ -1,9 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-<div class="panel panel-default">
-    <div class="panel-heading">Wiki 對照資料維護</div>
-    <div class="panel-body">
+<div class="card card-default">
+    <div class="card-header">
+        <h3 class="card-title">Wiki 對照資料維護</h3>
+    </div>
+    <div class="card-body">
 
         {{-- 統計信息 --}}
         <div class="row" style="margin-bottom: 20px;">
@@ -28,13 +30,13 @@
         {{-- URL 導入功能 --}}
         <div class="row" style="margin-bottom: 20px;">
             <div class="col-md-12">
-                <div class="panel panel-info">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
+                <div class="card card-info">
+                    <div class="card-header">
+                        <h3 class="card-title">
                             <i class="fa fa-download"></i> 從 URL 導入 Wiki 對照資料
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <form id="import-form" method="POST" action="{{ route('admin.wiki-maintenance.import-url') }}" class="form-horizontal">
                             {{ csrf_field() }}
 
@@ -71,7 +73,7 @@
                                                 <i class="fa fa-download"></i> 下載並導入資料
                                             </button>
                                         </div>
-                                        <div class="btn-group pull-right" role="group">
+                                        <div class="btn-group float-right" role="group">
                                             <form method="POST" action="{{ route('admin.wiki-maintenance.delete-all') }}" style="display: inline;">
                                                 {{ csrf_field() }}
                                                 <input type="hidden" name="source_id" value="{{ $currentSourceId }}">
@@ -92,11 +94,11 @@
                             {{-- 進度顯示區域 --}}
                             <div id="progress-container" class="form-group" style="display: none;">
                                 <div class="col-sm-offset-2 col-sm-10">
-                                    <div class="panel panel-default">
-                                        <div class="panel-body">
+                                    <div class="card card-default">
+                                        <div class="card-body">
                                             <h4 id="progress-title">正在處理導入任務...</h4>
                                             <div class="progress">
-                                                <div id="progress-bar" class="progress-bar progress-bar-info progress-bar-striped active"
+                                                <div id="progress-bar" class="progress-bar progress-bar-info progress-bar-striped progress-bar-animated"
                                                      role="progressbar" style="width: 0%">
                                                     <span id="progress-text">0%</span>
                                                 </div>
@@ -197,18 +199,18 @@
                     </p>
                 </div>
                 <div class="col-md-6">
-                    <nav aria-label="分頁導航" class="pull-right">
+                    <nav aria-label="分頁導航" class="float-right">
                         <ul class="pagination">
                             {{-- 上一頁 --}}
                             @if($hasPrev)
-                                <li>
-                                    <a href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $page - 1]) }}">
+                                <li class="page-item">
+                                    <a class="page-link" href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $page - 1]) }}">
                                         <span aria-hidden="true">&laquo;</span>
                                     </a>
                                 </li>
                             @else
-                                <li class="disabled">
-                                    <span aria-hidden="true">&laquo;</span>
+                                <li class="page-item disabled">
+                                    <span class="page-link" aria-hidden="true">&laquo;</span>
                                 </li>
                             @endif
 
@@ -220,12 +222,12 @@
 
                             @for($i = $startPage; $i <= $endPage; $i++)
                                 @if($i == $page)
-                                    <li class="active">
-                                        <span>{{ $i }}</span>
+                                    <li class="page-item active">
+                                        <span class="page-link">{{ $i }}</span>
                                     </li>
                                 @else
-                                    <li>
-                                        <a href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $i]) }}">
+                                    <li class="page-item">
+                                        <a class="page-link" href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $i]) }}">
                                             {{ $i }}
                                         </a>
                                     </li>
@@ -234,14 +236,14 @@
 
                             {{-- 下一頁 --}}
                             @if($hasNext)
-                                <li>
-                                    <a href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $page + 1]) }}">
+                                <li class="page-item">
+                                    <a class="page-link" href="{{ route('admin.wiki-maintenance', ['source_id' => $currentSourceId, 'page' => $page + 1]) }}">
                                         <span aria-hidden="true">&raquo;</span>
                                     </a>
                                 </li>
                             @else
-                                <li class="disabled">
-                                    <span aria-hidden="true">&raquo;</span>
+                                <li class="page-item disabled">
+                                    <span class="page-link" aria-hidden="true">&raquo;</span>
                                 </li>
                             @endif
                         </ul>
@@ -289,7 +291,7 @@ a:hover {
 }
 
 @media (max-width: 768px) {
-    .btn-toolbar .btn-group.pull-right {
+    .btn-toolbar .btn-group.float-right {
         float: none !important;
         display: block;
         margin-top: 10px;
@@ -458,7 +460,7 @@ $(document).ready(function() {
             var originalText = '<i class="fa fa-download"></i> 下載並導入資料';
 
             if (progress.status === 'completed') {
-                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped active')
+                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped progress-bar-animated')
                     .addClass('progress-bar-success');
                 $('#progress-title').text('導入完成！').addClass('text-success');
 
@@ -469,7 +471,7 @@ $(document).ready(function() {
                 }, 1000);
 
             } else if (progress.status === 'cancelled') {
-                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped active')
+                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped progress-bar-animated')
                     .addClass('progress-bar-warning');
                 $('#progress-title').text('導入已取消').addClass('text-warning');
 
@@ -480,7 +482,7 @@ $(document).ready(function() {
                 }, 1000);
 
             } else {
-                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped active')
+                $('#progress-bar').removeClass('progress-bar-info progress-bar-striped progress-bar-animated')
                     .addClass('progress-bar-danger');
                 $('#progress-title').text('導入失敗').addClass('text-danger');
 

--- a/resources/views/admin/wiki-maintenance.blade.php
+++ b/resources/views/admin/wiki-maintenance.blade.php
@@ -14,7 +14,7 @@
                 <a href="{{ route('admin.wiki-maintenance', ['source_id' => $id]) }}" style="text-decoration: none;">
                     <div class="info-box{{ $currentSourceId == $id ? ' info-box-selected' : '' }}">
                         <span class="info-box-icon bg-{{ $id == 60795 ? 'blue' : ($id == 68942 ? 'green' : 'orange') }}">
-                            <i class="fa fa-{{ $id == 68942 ? 'globe' : 'wikipedia-w' }}"></i>
+                            <i class="{{ $id == 68942 ? 'fas fa-globe' : 'fab fa-wikipedia-w' }}"></i>
                         </span>
                         <div class="info-box-content">
                             <span class="info-box-text">{{ $sourceNames[$id] }}</span>

--- a/resources/views/manage/merge-preview.blade.php
+++ b/resources/views/manage/merge-preview.blade.php
@@ -1,9 +1,11 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
-    <div class="panel panel-default">
-        <div class="panel-heading">人物記錄合併</div>
-        <div class="panel-body">
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">人物記錄合併</h3>
+        </div>
+        <div class="card-body">
             <form method="post" action="{{ route('merge-preview.index') }}" class="form-horizontal">
                 {{ csrf_field() }}
                 <div class="form-group">
@@ -49,7 +51,7 @@
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
                         <button type="submit" class="btn btn-primary" id="preview-button">預覽合併結果</button>
-                        <button type="button" class="btn btn-default" id="copy_merge_link" data-base="{{ route('merge-preview.index') }}">複製連結</button>
+                        <button type="button" class="btn btn-secondary" id="copy_merge_link" data-base="{{ route('merge-preview.index') }}">複製連結</button>
                     </div>
                 </div>
             </form>
@@ -65,7 +67,7 @@
                 <div class="row">
                     <div class="col-md-6">
                         <h5>保留人物</h5>
-                        <table class="table table-bordered table-condensed">
+                        <table class="table table-bordered table-sm">
                             <tr>
                                 <th>ID</th>
                                 <td>
@@ -110,7 +112,7 @@
                     </div>
                     <div class="col-md-6">
                         <h5>合併來源</h5>
-                        <table class="table table-bordered table-condensed">
+                        <table class="table table-bordered table-sm">
                             <tr>
                                 <th>ID</th>
                                 <td>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,10 +1,12 @@
-@extends('layouts.dashboard')
+@extends('layouts.dashboard-v3')
 
 @section('content')
 
-<div class="panel panel-default">
-    <div class="panel-heading">個人資料設定</div>
-    <div class="panel-body">
+<div class="card card-default">
+    <div class="card-header">
+        <h3 class="card-title">個人資料設定</h3>
+    </div>
+    <div class="card-body">
 
         @if(session('success'))
             <div class="alert alert-success alert-dismissible">
@@ -30,11 +32,11 @@
             {{ method_field('PATCH') }}
             {{ csrf_field() }}
 
-            <div class="box box-primary">
-                <div class="box-header with-border">
-                    <h3 class="box-title">基本資料</h3>
+            <div class="card card-primary">
+                <div class="card-header">
+                    <h3 class="card-title">基本資料</h3>
                 </div>
-                <div class="box-body">
+                <div class="card-body">
                     <div class="form-group">
                         <label for="name" class="col-sm-2 control-label">姓名 <span class="text-red">*</span></label>
                         <div class="col-sm-10">
@@ -61,14 +63,14 @@
                 </div>
             </div>
 
-            <div class="box box-warning">
-                <div class="box-header with-border">
-                    <h3 class="box-title">修改密碼</h3>
-                    <div class="box-tools">
+            <div class="card card-warning">
+                <div class="card-header">
+                    <h3 class="card-title">修改密碼</h3>
+                    <div class="card-tools">
                         <p class="help-block" style="margin: 0;">如果不需要修改密碼，請留空以下欄位</p>
                     </div>
                 </div>
-                <div class="box-body">
+                <div class="card-body">
                     <div class="form-group">
                         <label for="current_password" class="col-sm-2 control-label">當前密碼</label>
                         <div class="col-sm-10">
@@ -97,7 +99,7 @@
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
                     <button type="submit" class="btn btn-primary">儲存變更</button>
-                    <a href="{{ url('/home') }}" class="btn btn-default">取消</a>
+                    <a href="{{ url('/home') }}" class="btn btn-secondary">取消</a>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
本次迁移包含以下页面：

1. profile/edit.blade.php - 用户资料编辑页面
2. admin/wiki-maintenance.blade.php - Wiki 对照资料维护
3. admin/cbdb-table-maintenance.blade.php - CBDB 内部表维护
4. admin/explain_sql.blade.php - MySQL EXPLAIN 工具
5. admin/unidirectional-relationship-repair.blade.php - 单向关系修复
6. admin/batch_load_book_titles.blade.php - 批次汇入书稿资料
7. admin/batch_load_offices.blade.php - 批次汇入官职
8. admin/batch_load_social_institutes.blade.php - 批次汇入社会机构
9. manage/merge-preview.blade.php - 人物记录合并预览

主要变更：
- 替换布局：layouts.dashboard → layouts.dashboard-v3
- 组件更新：panel → card, box → card
- 样式类名：pull-right → float-right, table-condensed → table-sm
- 按钮样式：btn-default → btn-secondary
- 分页组件：Bootstrap 3 pagination → Bootstrap 4 pagination
- 进度条：progress-bar active → progress-bar progress-bar-animated

已完成模块统计：
- admin 模块：8 个管理员工具页面 ✅
- profile 模块：1 个用户资料页面 ✅
- manage 模块：3 个页面（含合并预览）✅

累计已迁移 21 个页面到 AdminLTE v3