### PR TITLE
chore: 移除引用已刪除控制器的死代碼路由

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -67,10 +67,6 @@ Route::group(['prefix' => 'code'], function () {
 });
 
 Route::middleware('guest')->post('v1/user/login', 'Api\LoginController@login');
-Route::group(['prefix' => 'v1', 'middleware' => ['auth:api']], function () {
-    Route::resource('biog', 'Api\BiogMainController');
-    Route::resource('biog.addr', 'Api\BiogAddressController');
-});
 
 //20181105建安新增
 Route::group(['prefix' => 'v1'], function () {


### PR DESCRIPTION
BiogMainController 和 BiogAddressController 已在 #600 (e3c86b6) 中刪除， 但 routes/api.php 中仍引用這兩個不存在的控制器，導致訪問這些路由會產生 500 錯誤。

刪除的路由：
- Route::resource('biog', 'Api\BiogMainController')
- Route::resource('biog.addr', 'Api\BiogAddressController')

相關 commit: e3c86b6 - 20251215移除tts_sysno相關程式 (#600)