### PR TITLE
fix: 修复 /modified 页面中已撤回提案显示为「待審核」的问题

### DIFF
--- a/resources/views/modified/index.blade.php
+++ b/resources/views/modified/index.blade.php
@@ -155,6 +155,19 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         $reviewedUtc = $reviewedAt;
                                     }
                                 }
+                                $cancelledDisplay = '';
+                                $cancelledUtc = '';
+                                if (!empty($proposalMeta['cancelled_at'])) {
+                                    try {
+                                        $cancelledCarbon = \Carbon\Carbon::parse($proposalMeta['cancelled_at'], config('app.timezone', 'Asia/Shanghai'));
+                                        $cancelledDisplay = $cancelledCarbon;
+                                        $cancelledUtc = $cancelledCarbon->copy()->setTimezone('UTC')->toIso8601String();
+                                    } catch (\Exception $e) {
+                                        $cancelledDisplay = $proposalMeta['cancelled_at'];
+                                        $cancelledUtc = $proposalMeta['cancelled_at'];
+                                    }
+                                }
+                                $cancelledBy = $proposalMeta['cancelled_by'] ?? null;
                                 $isProposal = in_array((int) $item->op_type, [\App\Operation::TYPE_PROPOSAL_CREATE, \App\Operation::TYPE_PROPOSAL_UPDATE], true);
                                 $resourceDataDisplay = $resourceDataParsed;
                                 if (is_array($resourceDataDisplay)) {
@@ -173,6 +186,8 @@ $item->resource_data = unionPKDef($item->resource_data);
                                             <span class="badge badge-success">已核准</span>
                                         @elseif($reviewStatus === 'rejected')
                                             <span class="badge badge-danger">已退修</span>
+                                        @elseif($reviewStatus === 'cancelled')
+                                            <span class="badge badge-secondary">已撤回</span>
                                         @else
                                             <span class="badge badge-warning">待審核</span>
                                         @endif
@@ -188,6 +203,17 @@ $item->resource_data = unionPKDef($item->resource_data);
                                                     （<span class="js-utc-datetime" data-utc="{{ $submittedUtc }}">{{ $submittedDisplay }}</span>）
                                                 @endif
                                             </small>
+                                        @endif
+                                        @if($reviewStatus === 'cancelled')
+                                            <small class="text-muted" style="display:block;">
+                                                撤回者：{{ $cancelledBy ?? '（未知）' }}
+                                                @if($cancelledUtc)
+                                                    （<span class="js-utc-datetime" data-utc="{{ $cancelledUtc }}">{{ $cancelledDisplay }}</span>）
+                                                @endif
+                                            </small>
+                                            @if(!empty($proposalMeta['cancel_reason']))
+                                                <small class="text-muted" style="display:block;">撤回原因：{{ $proposalMeta['cancel_reason'] }}</small>
+                                            @endif
                                         @endif
                                         @if($reviewComment)
                                             <small class="text-muted" style="display:block;">審核備註：{{ $reviewComment }}</small>


### PR DESCRIPTION
问题：
- 在 /operations?proposals_only=1 页面中显示为「已撤回」的提案
- 在 /modified 页面中却显示为「待審核」

根本原因：
- /modified/index.blade.php 的提案状态显示逻辑缺少对 cancelled 状态的处理
- 导致已撤回的提案 fallback 到 else 分支，错误显示为「待審核」

修复内容：
1. 添加对 cancelled 状态的检查，显示「已撤回」badge
2. 添加撤回者、撤回时间和撤回原因的显示
3. 与 /operations 页面保持一致的显示逻辑