### PR TITLE
doc: 更新所有 AdminLTE 2、Mix/webpack 與 resources/assets 相關文檔

### DIFF
--- a/ADMINLTE.md
+++ b/ADMINLTE.md
@@ -1,6 +1,6 @@
 # AdminLTE 在 CBDB Online 項目中的現況與指引
 
-本文件針對本分支最新狀態更新，已剔除不再存在的 AdminLTE 2 / Bower / Laravel Mix 內容。
+本文件記錄專案前端技術棧現況。專案已完成從 AdminLTE 2 / Bower / Laravel Mix 到 AdminLTE 3 / Vite 的完整遷移。
 
 ## 現況總覽（v3.2 + Vite）
 - 全站已切換至 AdminLTE v3.2（Bootstrap 4、Font Awesome 5），所有使用 dashboard 佈局的頁面都走 `layouts/dashboard-v3.blade.php`，專案中不存在 `layouts/dashboard.blade.php`。
@@ -14,9 +14,13 @@
 - 登入/註冊等 Auth 頁面也改用 Vite 入口與 Bootstrap 4 表單樣式，不再載入 AdminLTE 2 資產。
 - `resources/views/layouts/app.blade.php`（Auth 用）與 `resources/views/layouts/dashboard-v3.blade.php`（主站）均透過 `@vite(['resources/js/app.js'])`。
 
-## 遺留檔案說明（不再生產）
-- `resources/assets/js/bootstrap.js`、`resources/assets/sass/app.scss` 仍保留，但內部引用 `resources/bower_components/AdminLTE` 與 Laravel Mix；倉庫沒有 `resources/bower_components` 目錄，也沒有 `public/js` / `public/css` 輸出，這條管線已停用。
-- `resources/assets/css/styles.css` 為舊版樣式，現行頁面未透過 Vite 引用；若需保留其中的實用樣式，請將必要段落移植到 Vite 入口後再刪除 legacy 檔。
+## 遺留檔案清理狀態
+Laravel Mix 時期的 `resources/assets/` 目錄及相關檔案**已完全移除**：
+- ~~`resources/assets/js/bootstrap.js`~~、~~`resources/assets/sass/app.scss`~~ - 原 Mix 入口
+- ~~`resources/assets/css/styles.css`~~ - 舊版樣式檔
+- 相關的 Mix 配置檔案（`webpack.mix.js`）也已移除
+
+所有前端資源現由 **Vite** 統一管理，入口位於 `resources/js/` 目錄。
 
 ## 類名對照（歷史備查）
 升版時常用的 v2 → v3 對照，供查漏用：
@@ -33,5 +37,8 @@
 - 若有前端改動，使用 `npm run dev`（或 `npm run build`）重建 `public/build`。
 
 ## 後續工作方向
-- 移除未使用的 legacy 檔（`resources/assets/*`、舊 Mix 設定）以避免誤導。
-- 準備 AdminLTE 4（Bootstrap 5）升級時，重點關注 `data-toggle` → `data-bs-toggle`、`float-*` → `d-flex`/utilities、Font Awesome 6 對照，以及 Vite 產物測試。
+- **AdminLTE 4 升級準備**（Bootstrap 5）：
+  - Data attributes：`data-toggle` → `data-bs-toggle`
+  - 工具類：`float-*` → `d-flex` / Flexbox utilities
+  - 圖標：Font Awesome 5 → Font Awesome 6
+  - 測試重點：Vite 構建產物、響應式佈局、JavaScript 插件兼容性

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 本文件彙整 AI 代理在此專案工作時必備的背景知識、流程與測試指引，請在開始作業前閱讀並依循。
 
 ## 專案速覽
-- **技術棧**：Laravel 10.0（PHP 8.1+，建議 8.4）、MariaDB 10.3.39、Blade、Vue 3。前端存在兩條管線：舊版 AdminLTE 2/Bootstrap 3 仍用 `laravel-mix`，新版 AdminLTE 3+（`layouts/dashboard-v3` 及其頁面如 `/codes`、`/operations`、`/view` 等）改用 Vite 並內建 `resources/js/jquery-global.js`、Bootstrap 4 bundle 與 modal 焦點修復。
+- **技術棧**：Laravel 10.0（PHP 8.1+，建議 8.4）、MariaDB 10.3.39、Blade、Vue 3。前端已完成 **AdminLTE 3** (Bootstrap 4) 升級，使用 **Vite** 構建系統。所有頁面均透過 `layouts/dashboard-v3.blade.php` 佈局，使用 Vite 載入前端資源（`resources/js/jquery-global.js` 將 jQuery 暴露到全局，Bootstrap 4、AdminLTE 3、Select2 等在 `app.js` 中實現）。
 - **數據庫環境**：
   - **生產環境**：MariaDB 10.3.39 (Debian)
   - **重要原則**：避免使用特定數據庫專屬功能（如 MySQL 的 ngram parser、MariaDB 專屬插件），以保持未來遷移至其他數據庫實現的可能性
@@ -17,7 +17,7 @@
   - `app/Http/Controllers`：Laravel 控制器（如 `OperationsController`）。
   - `app/Repositories`：資料存取與封裝邏輯（如 `OperationRepository`）。
   - `resources/views`：Blade 模板與各模組頁面。
-  - `resources/assets/js`：Vue 元件與前端入口（代碼提交前需跑 `npm run prod` 重新編譯）。
+  - `resources/js`：Vue 元件與前端入口（使用 Vite 構建，代碼提交前需跑 `npm run build`）。
   - `tests/Feature`、`tests/Unit`：PHPUnit 測試。
 - **重要設定**：
   - `config/codes.php`：`/codes/*` 白名單。
@@ -211,7 +211,7 @@
    - 嚴禁在未授權情況下直接修改資料庫結構或大量資料。
    - 避免在 Controller 中直接寫 SQL；如需操作資料庫，優先利用 Repository。對於**單一主鍵**的表可以使用 Eloquent 模型，但對於**複合主鍵**的表（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA` 等）必須使用 Query Builder（`DB::table()`）而非 Eloquent 模型。
    - 所有新路由需通過授權檢查，避免只靠前端限制。
-  - 目前前端樣式與互動高度依賴 AdminLTE（`resources/assets/sass/app.scss`、`resources/assets/js/bootstrap.js` 持續匯入相關資產）；`/codes` 已改用 `layouts/dashboard-v3`（AdminLTE 3 CDN、未載入 Mix 產物），其他頁面仍是 AdminLTE 2。若要移除舊資產需先規畫替代的樣式框架、重構 Blade 樣板與 JS 初始化流程，並逐頁驗證後才能刪除舊資產，避免界面崩壞。
+  - 全站已完成 AdminLTE 3 升級，所有頁面使用 `layouts/dashboard-v3.blade.php` 佈局，透過 Vite 載入前端資源（入口位於 `resources/js/`）。請勿引入外部 CDN 的 jQuery/Bootstrap，以免與 Vite bundle 產生版本衝突。Laravel Mix 時期的 `resources/assets/` 目錄及相關檔案已完全移除。
 5. **文檔更新建議**：
    - 有任何 UI／流程重大調整時，請同步更新 `README.md` 與 `CHANGELOG.md`。
    - 若整理出新的知識或踩坑，務必補充至 `AGENTS.md`，讓後續代理能快速掌握背景。
@@ -223,7 +223,6 @@
 - Feature 測試手動建立資料表時，記得設置必要的 primary key 與時間戳；否則模型邏輯可能出錯。
 - Vue/JS 變更未重新編譯會導致前端顯示舊版本，部署前請確認產物最新。
 - dashboard-v3 佈局改用 Vite 打包（`@vite` 載入），共用 `resources/js/jquery-global.js` 並內建 Bootstrap 4 bundle；不要再引用外部 CDN 的 jQuery/Bootstrap/Datatables 以免載入順序衝突。modal 關閉的焦點修復也在 Vite 入口內，全站共用。
-- `package-lock.json` 為長期歷史產物，當前難以乾淨重建；若非必要請勿刪除重生，待全站切換到 Vite + AdminLTE 3 後再集中清理。
 - **測試數據庫依賴陷阱**：避免依賴完整 MySQL schema 或複雜遷移文件，這會導致 CI 失敗和測試不穩定。
 - **PHPUnit 版本兼容性**：專案使用 PHPUnit 10.1，注意使用相容的斷言方法（如 `assertStringContainsString` 替代舊版 `assertContains`）。
 - **用戶模型測試**：記得為 `users` 表的 `confirmation_token` 字段提供值，避免 NOT NULL 約束錯誤。

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@
 - **Node.js**: 12.x
 
 ### 前端構建現況
-- 併存兩條管線：舊版 AdminLTE 2/Bootstrap 3 仍用 `laravel-mix`；新版 AdminLTE 3（`layouts/dashboard-v3` 及其頁面）使用 Vite，內建共用的 `resources/js/jquery-global.js`（提供 jQuery/Bootstrap/Datatables 與 modal 焦點修復），請勿再引入外部 CDN 的 jQuery/Bootstrap。
-- `package-lock.json` 目前為歷史積累，尚難乾淨重建；在全站切換至 Vite + AdminLTE 3 後再統一清理。
+- 全站已完成 **AdminLTE 3** (Bootstrap 4) 升級，使用 **Vite** 構建系統。
+- 主要入口：`resources/js/app.js`（UI 組件）、`resources/js/datatables.js`（DataTables）、`resources/js/passport.js`（Laravel Passport）。
+- `resources/js/jquery-global.js` 將 jQuery 暴露到全局；Bootstrap 4、AdminLTE 3、Select2 等在 `app.js` 中實現。
+- 所有頁面均使用 `@vite` 載入前端資源，**請勿引入外部 CDN 的 jQuery/Bootstrap**，以免版本衝突。
 
 ⚠️ **重要**：本專案現已升級到 Laravel 10.0 並要求 PHP 8.1+。**建議使用 PHP 8.4** 以獲得最佳性能和安全性。雖然 Laravel 10.0 官方僅測試到 PHP 8.2，但經測試表明 PHP 8.4 可正常運行。
 
@@ -119,15 +121,28 @@ php artisan make:request BiogBasicInformationRequest
 
 参考文档：[Laravel 10.x Controllers](https://laravel.com/docs/10.x/controllers)
 
-### webpack打包
+### 前端資源構建
 
-修改resource/assets/js/bootstrape和resource/assets/css/app.scss
-执行npm run dev
+本專案已從 Laravel Mix/webpack 遷移至 **Vite**。
 
-### vue
-vue模板放在`resource\assets\js\components`
-在`bootstrap.js`注册
-npm run dev
+**開發環境**：
+```bash
+npm run dev    # 啟動 Vite 開發伺服器
+```
+
+**生產環境**：
+```bash
+npm run build  # 或 npm run prod，編譯並優化前端資源
+```
+
+**入口文件**：
+- `resources/js/app.js` - 主要 UI 組件
+- `resources/js/datatables.js` - DataTables 功能
+- `resources/js/passport.js` - Laravel Passport
+
+**Vue 元件**：
+- Vue 3 模板放在 `resources/js/components/`
+- 在對應的 JS 入口文件中引入並註冊
 
 ### 已处理数据库表格
 BIOG_MAIN
@@ -310,26 +325,30 @@ Contributed by [Yawei SUN](https://github.com/yaweisun)
 
 https://github.com/cbdb-project/cbdb-online-main-server/issues/116
 
-### rebuild vue 的前端（感謝盧建安先生貢獻）
+### 前端依賴問題排查
 
-`npm run dev`如果出現錯誤訊息：`error code ELIFECYCLE`
+如果 `npm run dev` 或 `npm run build` 出現錯誤（如 `error code ELIFECYCLE`），可嘗試以下步驟：
 
-執行命令：
-```
+**步驟 1：清理並重裝依賴**
+```bash
 rm -rf node_modules
-rm package-lock.json
 npm cache clear --force
 npm install
 ```
 
-詳細說明：
+**步驟 2：重新執行構建**
+```bash
+npm run dev    # 開發環境
+# 或
+npm run build  # 生產環境
+```
 
-* rm -rf node_modules 是將node_modules資料夾整個刪除
-* rm package-lock.json 是將最低需求的版本控制資訊移除，直接取得最新版本，這可能會在較新的主機遇到。
-* npm cache clear –force 清除快取
-* npm install 重新安裝
+**說明**：
+- `rm -rf node_modules` - 刪除所有已安裝的依賴
+- `npm cache clear --force` - 清除 npm 緩存
+- `npm install` - 根據 `package-lock.json` 重新安裝依賴
 
-之後再執行 `npm run dev` 就可以通過了。
+⚠️ **注意**：一般情況下**不需要**刪除 `package-lock.json`，該檔案確保依賴版本一致性。僅在確認鎖定檔案損壞時才考慮刪除。
 
 ### Install the proper version of node and npm in ubuntu
 


### PR DESCRIPTION
完整更新專案文檔以反映前端技術棧已從 AdminLTE 2 + Laravel Mix 遷移到 AdminLTE 3 + Vite 的現況。

主要變更：

1. README.md
   - 更新"前端構建現況"：移除"併存兩條管線"的過時描述
   - 替換 webpack 章節為 Vite 構建指引
   - 修正 jquery-global.js 職責說明（僅負責全局暴露 jQuery）

2. AGENTS.md
   - 更新"專案速覽"技術棧說明
   - 修正 jquery-global.js 功能描述
   - 更新主要資料夾說明（resources/assets/js → resources/js）
   - 更新開發注意事項，說明 resources/assets/ 已完全移除

3. ADMINLTE.md
   - 更新文檔標題說明，記錄完整遷移成果
   - 重寫"遺留檔案清理狀態"章節，反映 resources/assets/ 已完全移除
   - 優化"後續工作方向"，移除已完成的清理任務
   - 詳細列出 AdminLTE 4 升級準備要點

技術細節：
- Laravel Mix 時期的 resources/assets/ 目錄及相關檔案已完全移除
- 所有前端資源現由 Vite 統一管理（入口：resources/js/）
- jquery-global.js 僅負責將 jQuery 暴露到全局
- Bootstrap 4、AdminLTE 3、Select2 等在 app.js 中實現
- 所有頁面使用 layouts/dashboard-v3.blade.php 佈局