### PR TITLE
fix: 修復並改進 /profile 頁面的 API Token 管理功能

### DIFF
--- a/app/Http/Controllers/ApiTokenController.php
+++ b/app/Http/Controllers/ApiTokenController.php
@@ -15,9 +15,9 @@ class ApiTokenController extends Controller {
                     'id' => $token->id,
                     'name' => $token->name,
                     'abilities' => $token->abilities,
-                    'last_used_at' => $token->last_used_at?->toDateTimeString(),
-                    'created_at' => $token->created_at->toDateTimeString(),
-                    'expires_at' => $token->expires_at?->toDateTimeString(),
+                    'last_used_at' => $token->last_used_at?->toIso8601String(),
+                    'created_at' => $token->created_at->toIso8601String(),
+                    'expires_at' => $token->expires_at?->toIso8601String(),
                 ];
             })
         );
@@ -52,8 +52,8 @@ class ApiTokenController extends Controller {
                     'id' => $token->accessToken->id,
                     'name' => $token->accessToken->name,
                     'abilities' => $token->accessToken->abilities,
-                    'created_at' => $token->accessToken->created_at->toDateTimeString(),
-                    'expires_at' => $token->accessToken->expires_at?->toDateTimeString(),
+                    'created_at' => $token->accessToken->created_at->toIso8601String(),
+                    'expires_at' => $token->accessToken->expires_at?->toIso8601String(),
                     // 只在創建時返回完整 token（之後無法再次查看）
                     'plainTextToken' => $token->plainTextToken,
                 ],

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -107,6 +107,8 @@ window.fetchPersonOption = fetchPersonOption;
 import axios from 'axios';
 window.axios = axios;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+window.axios.defaults.headers.common['Accept'] = 'application/json';
+window.axios.defaults.headers.post['Content-Type'] = 'application/json';
 
 // Global modal focus management to avoid aria-hidden warnings when closing
 const installModalFocusFix = () => {

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -2,13 +2,7 @@
 
 @section('content')
 
-<div class="card card-default">
-    <div class="card-header">
-        <h3 class="card-title">個人資料設定</h3>
-    </div>
-    <div class="card-body">
-
-        @if(session('success'))
+@if(session('success'))
             <div class="alert alert-success alert-dismissible">
                 <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-check"></i> 成功！</h4>
@@ -44,10 +38,10 @@
             </div>
         @endif
 
-        <!-- Container for dynamic alerts -->
-        <div id="alerts-container"></div>
+<!-- Container for dynamic alerts -->
+<div id="alerts-container"></div>
 
-        <form action="{{ route('profile.update') }}" class="form-horizontal" method="post">
+<form action="{{ route('profile.update') }}" class="form-horizontal" method="post">
             {{ method_field('PATCH') }}
             {{ csrf_field() }}
 
@@ -121,12 +115,10 @@
                     <a href="{{ url('/home') }}" class="btn btn-secondary">取消</a>
                 </div>
             </div>
-        </form>
-    </div>
-</div>
+    </form>
 
 <!-- API Token 管理 -->
-<div class="card card-info">
+<div class="card card-info mt-3">
     <div class="card-header">
         <h3 class="card-title">API 訪問令牌管理</h3>
     </div>
@@ -184,8 +176,49 @@
 
 @section('js')
 <script>
+// 時區相關變數與函數（參考 operations 頁面）
+var userTimeZone = (Intl.DateTimeFormat().resolvedOptions().timeZone) || 'UTC';
+
+function formatTimestamp(utcTimeString, targetTimeZone) {
+    try {
+        var utcDate = new Date(utcTimeString);
+        if (isNaN(utcDate.getTime())) {
+            console.warn('Invalid time:', utcTimeString);
+            return utcTimeString;
+        }
+
+        var zone = targetTimeZone || userTimeZone;
+        var parts = new Intl.DateTimeFormat(undefined, {
+            timeZone: zone,
+            timeZoneName: 'short'
+        }).formatToParts(utcDate);
+        var timeZoneName = '';
+        for (var i = 0; i < parts.length; i++) {
+            if (parts[i].type === 'timeZoneName') {
+                timeZoneName = parts[i].value || '';
+                break;
+            }
+        }
+
+        var dateTimeWithoutTZ = utcDate.toLocaleString('sv-SE', {
+            timeZone: zone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+        });
+
+        return dateTimeWithoutTZ.replace(' ', ' ') + ' (' + timeZoneName + ')';
+    } catch (e) {
+        console.error('formatTimestamp error:', e);
+        return utcTimeString;
+    }
+}
+
 // Show inline alert message
-function showMessage(message, type = 'success') {
+function showMessage(message, type = 'success', autoDismiss = true) {
     const alertsContainer = document.getElementById('alerts-container');
     const alert = document.createElement('div');
     alert.className = `alert alert-${type} alert-dismissible fade show`;
@@ -195,11 +228,13 @@ function showMessage(message, type = 'success') {
     `;
     alertsContainer.appendChild(alert);
 
-    // Auto dismiss after 5 seconds
-    setTimeout(() => {
-        alert.classList.remove('show');
-        setTimeout(() => alert.remove(), 150);
-    }, 5000);
+    // Auto dismiss after 5 seconds (unless disabled)
+    if (autoDismiss) {
+        setTimeout(() => {
+            alert.classList.remove('show');
+            setTimeout(() => alert.remove(), 150);
+        }, 5000);
+    }
 }
 
 // Copy token using modern Clipboard API
@@ -244,7 +279,7 @@ function copyToken(event) {
 
 // Load user's API tokens
 function loadTokens() {
-    axios.get('{{ route('api-tokens.index') }}')
+    axios.get('{{ route('api-tokens.index', [], false) }}')
         .then(response => {
             const tokens = response.data;
             const listDiv = document.getElementById('tokens-list');
@@ -317,7 +352,7 @@ function revokeToken(tokenId, tokenName) {
         return;
     }
 
-    axios.delete(`{{ route('api-tokens.destroy', '') }}/${tokenId}`)
+    axios.delete(`{{ route('api-tokens.destroy', '', false) }}/${tokenId}`)
         .then(response => {
             showMessage('<i class="fa fa-check"></i> Token 已撤銷', 'success');
             loadTokens();
@@ -335,7 +370,7 @@ function revokeAllTokens() {
         return;
     }
 
-    axios.delete('{{ route('api-tokens.destroy-all') }}')
+    axios.delete('{{ route('api-tokens.destroy-all', [], false) }}')
         .then(response => {
             showMessage('<i class="fa fa-check"></i> 所有 Token 已撤銷', 'success');
             loadTokens();
@@ -347,16 +382,10 @@ function revokeAllTokens() {
         });
 }
 
-// Format date to localized string
+// Format date to localized string (使用 formatTimestamp 處理 UTC 時間)
 function formatDate(dateString) {
-    const date = new Date(dateString);
-    return date.toLocaleString('zh-TW', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'
-    });
+    if (!dateString) return '';
+    return formatTimestamp(dateString);
 }
 
 // Escape HTML to prevent XSS
@@ -366,50 +395,171 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
-// 創建 Token 表單提交
-document.getElementById('create-token-form').addEventListener('submit', function(e) {
-    e.preventDefault();
-
-    const form = this;
-    const formData = new FormData(form);
-    const data = {
-        name: formData.get('name'),
-        expires_in: formData.get('expires_in') || null
-    };
-
-    axios.post('{{ route('api-tokens.store') }}', data)
-        .then(response => {
-            // 重置表單
-            form.reset();
-
-            // 更新 Token 列表
-            loadTokens();
-
-            // 顯示成功訊息和新 Token
-            const tokenValue = response.data?.token?.plainTextToken || response.data?.plainTextToken;
-            let message = '<i class="fa fa-check"></i> <strong>Token 創建成功！</strong>';
-            if (tokenValue) {
-                message += '<br><br>請妥善保存以下 Token，它只會顯示一次：<br>';
-                message += '<div class="mt-2"><code style="font-size: 14px; word-break: break-all;">' + escapeHtml(tokenValue) + '</code></div>';
-            }
-            showMessage(message, 'success');
-
-            // 收起表單
-            const card = document.querySelector('.card.card-default.collapsed-card');
-            if (card && window.$ && $.fn.CardWidget) {
-                $(card).CardWidget('collapse');
-            }
-        })
-        .catch(error => {
-            console.error('創建 Token 失敗:', error);
-            const errorMsg = error.response?.data?.message || error.message || '網絡錯誤，請檢查輸入並重試';
-            showMessage(`<i class="fa fa-ban"></i> 創建失敗：${errorMsg}`, 'danger');
-        });
-});
-
-// 頁面載入時載入 Token 列表
+// 頁面載入時初始化
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('DOMContentLoaded - initializing token management');
+
+    // 載入 Token 列表
     loadTokens();
+
+    // 創建 Token 表單提交
+    const createTokenForm = document.getElementById('create-token-form');
+    console.log('Form element found:', createTokenForm);
+
+    if (createTokenForm) {
+        console.log('Attaching submit event listener to form');
+        createTokenForm.addEventListener('submit', function(e) {
+            console.log('Form submit event triggered');
+            e.preventDefault();
+            e.stopPropagation();
+
+            const form = this;
+            const formData = new FormData(form);
+            const expiresIn = formData.get('expires_in');
+            const data = {
+                name: formData.get('name')
+            };
+            // 只有選擇了有效期限才發送 expires_in 字段
+            if (expiresIn) {
+                data.expires_in = parseInt(expiresIn, 10);
+            }
+
+            console.log('Submitting token creation:', data);
+
+            axios.post('{{ route('api-tokens.store', [], false) }}', data)
+                .then(response => {
+                    console.log('Token creation success:', response);
+                    // 重置表單
+                    form.reset();
+
+                    // 更新 Token 列表
+                    loadTokens();
+
+                    // 顯示成功訊息和新 Token
+                    const tokenValue = response.data?.token?.plainTextToken || response.data?.plainTextToken;
+                    let message = '<i class="fa fa-check"></i> <strong>Token 創建成功！</strong>';
+                    if (tokenValue) {
+                        message += '<br><br><strong class="text-danger">⚠️ 請立即複製並保存以下 Token，關閉此訊息後將無法再次查看：</strong><br>';
+                        message += '<div class="mt-2 p-2" style="background: #f8f9fa; border: 2px solid #28a745; border-radius: 4px;"><code style="font-size: 14px; word-break: break-all; user-select: all;">' + escapeHtml(tokenValue) + '</code></div>';
+                        // Token 消息不自動消失，需要用戶手動關閉
+                        showMessage(message, 'success', false);
+
+                        // 滾動到頁面頂部，讓用戶看到 Token
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    } else {
+                        // 沒有 token 的普通成功消息可以自動消失
+                        showMessage(message, 'success', true);
+                    }
+
+                    // 收起表單
+                    const card = document.querySelector('.card.card-default.collapsed-card');
+                    if (card && window.$ && $.fn.CardWidget) {
+                        $(card).CardWidget('collapse');
+                    }
+                })
+                .catch(error => {
+                    console.error('創建 Token 失敗:', error);
+                    console.error('Error response:', error.response);
+                    console.error('Error status:', error.response?.status);
+                    console.error('Error data:', error.response?.data);
+
+                    let errorMsg = '網絡錯誤，請檢查輸入並重試';
+                    if (error.response?.status === 401) {
+                        errorMsg = '未授權：請刷新頁面重新登入';
+                    } else if (error.response?.status === 419) {
+                        errorMsg = 'CSRF Token 過期，請刷新頁面後重試';
+                    } else if (error.response?.data?.message) {
+                        errorMsg = error.response.data.message;
+                    } else if (error.response?.data?.errors) {
+                        errorMsg = Object.values(error.response.data.errors).flat().join(', ');
+                    } else if (error.message) {
+                        errorMsg = error.message;
+                    }
+
+                    showMessage(`<i class="fa fa-ban"></i> 創建失敗：${errorMsg}`, 'danger');
+                });
+        });
+    } else {
+        console.error('Form element not found!');
+    }
 });
+
+// 也嘗試在 Vite ready 後再次綁定（以防萬一）
+if (window.onViteReady) {
+    window.onViteReady(function() {
+        console.log('Vite ready - checking form again');
+        const form = document.getElementById('create-token-form');
+        if (form && !form.dataset.listenerAttached) {
+            console.log('Attaching event listener via Vite ready');
+            form.dataset.listenerAttached = 'true';
+            form.addEventListener('submit', function(e) {
+                console.log('Form submit via Vite ready handler');
+                e.preventDefault();
+                e.stopPropagation();
+
+                const formData = new FormData(this);
+                const expiresIn = formData.get('expires_in');
+                const data = {
+                    name: formData.get('name')
+                };
+                // 只有選擇了有效期限才發送 expires_in 字段
+                if (expiresIn) {
+                    data.expires_in = parseInt(expiresIn, 10);
+                }
+
+                console.log('Submitting token creation:', data);
+
+                axios.post('{{ route('api-tokens.store', [], false) }}', data)
+                    .then(response => {
+                        console.log('Token creation success:', response);
+                        this.reset();
+                        loadTokens();
+
+                        const tokenValue = response.data?.token?.plainTextToken || response.data?.plainTextToken;
+                        let message = '<i class="fa fa-check"></i> <strong>Token 創建成功！</strong>';
+                        if (tokenValue) {
+                            message += '<br><br><strong class="text-danger">⚠️ 請立即複製並保存以下 Token，關閉此訊息後將無法再次查看：</strong><br>';
+                            message += '<div class="mt-2 p-2" style="background: #f8f9fa; border: 2px solid #28a745; border-radius: 4px;"><code style="font-size: 14px; word-break: break-all; user-select: all;">' + escapeHtml(tokenValue) + '</code></div>';
+                            // Token 消息不自動消失，需要用戶手動關閉
+                            showMessage(message, 'success', false);
+
+                            // 滾動到頁面頂部，讓用戶看到 Token
+                            window.scrollTo({ top: 0, behavior: 'smooth' });
+                        } else {
+                            // 沒有 token 的普通成功消息可以自動消失
+                            showMessage(message, 'success', true);
+                        }
+
+                        const card = document.querySelector('.card.card-default.collapsed-card');
+                        if (card && window.$ && $.fn.CardWidget) {
+                            $(card).CardWidget('collapse');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('創建 Token 失敗:', error);
+                        console.error('Error response:', error.response);
+                        console.error('Error status:', error.response?.status);
+                        console.error('Error data:', error.response?.data);
+
+                        let errorMsg = '網絡錯誤，請檢查輸入並重試';
+                        if (error.response?.status === 401) {
+                            errorMsg = '未授權：請刷新頁面重新登入';
+                        } else if (error.response?.status === 419) {
+                            errorMsg = 'CSRF Token 過期，請刷新頁面後重試';
+                        } else if (error.response?.data?.message) {
+                            errorMsg = error.response.data.message;
+                        } else if (error.response?.data?.errors) {
+                            errorMsg = Object.values(error.response.data.errors).flat().join(', ');
+                        } else if (error.message) {
+                            errorMsg = error.message;
+                        }
+
+                        showMessage(`<i class="fa fa-ban"></i> 創建失敗：${errorMsg}`, 'danger');
+                    });
+            });
+        }
+    });
+}
+
 </script>
 @endsection


### PR DESCRIPTION
主要修復：
- 修復路由緩存問題，確保 API token 路由正確註冊
- 配置 axios 正確的 Accept 和 Content-Type headers，使 API 返回 JSON
- 修復數據類型驗證錯誤（expires_in 需為整數或不傳遞）
- 修復表單事件監聽器綁定時機問題

用戶體驗改進：
- 創建 Token 後自動滾動到頁面頂部，確保用戶能看到新 Token
- Token 顯示不自動消失，需手動關閉，避免錯過重要信息
- 改進錯誤處理，針對 401/419/驗證錯誤提供明確提示
- 添加調試日誌，便於排查問題

時間格式改進：
- API 返回 UTC ISO 8601 格式時間
- 前端自動轉換為用戶本地時間並顯示時區
- 與 /operations 頁面保持一致的時間處理方式

頁面布局優化：
- 移除多餘的「個人資料設定」外層卡片包裝
- 調整 API Token 管理區塊位置，使頁面結構更清晰

🤖 Generated with [Claude Code](https://claude.com/claude-code)