### PR TITLE
chore: 清理 Passport 遺留配置，完成 Sanctum 遷移

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Laravel\Passport\Passport;
 
 class AuthServiceProvider extends ServiceProvider {
     /**
@@ -22,8 +21,5 @@ class AuthServiceProvider extends ServiceProvider {
      */
     public function boot() {
         $this->registerPolicies();
-
-        // Passport routes are now automatically registered in Passport 11.x
-        // If you need to customize routes, publish the config and enable them there
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -42,7 +42,7 @@ return [
         ],
 
         'api' => [
-            'driver' => 'passport',
+            'driver' => 'sanctum',
             'provider' => 'users',
         ],
     ],


### PR DESCRIPTION
- 移除 AuthServiceProvider 中的 Passport 導入和註釋
- 將 API guard 驅動從 passport 改為 sanctum
- 完成從 Laravel Passport 到 Sanctum 的配置遷移

這是 #622 (將 Laravel Passport 完全替換為 Laravel Sanctum) 的後續清理工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)