### PR TITLE
refactor: 更新 Kernel 中间件配置为 Laravel 11 标准

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends HttpKernel {
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
@@ -53,13 +53,13 @@ class Kernel extends HttpKernel {
     ];
 
     /**
-     * The application's route middleware.
+     * The application's middleware aliases.
      *
-     * These middleware may be assigned to groups or used individually.
+     * Aliases may be used instead of class names to assign middleware to routes and groups.
      *
-     * @var array
+     * @var array<string, class-string|string>
      */
-    protected $routeMiddleware = [
+    protected $middlewareAliases = [
         'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'auth.optional' => \App\Http\Middleware\OptionalAuthentication::class,


### PR DESCRIPTION
- 将 CheckForMaintenanceMode 更新为 PreventRequestsDuringMaintenance
- 将 $routeMiddleware 重命名为 $middlewareAliases
- 添加现代化的类型提示注释

这些改动完全兼容 Laravel 10，同时为升级到 Laravel 11/12 做好准备。

技术说明：
- CheckForMaintenanceMode 在 Laravel 10 中是 PreventRequestsDuringMaintenance 的别名
- Laravel 11 已移除 CheckForMaintenanceMode，必须使用 PreventRequestsDuringMaintenance
- $middlewareAliases 是 Laravel 11 推荐的属性名，向后兼容 Laravel 10