### PR TITLE
調整 API token 驗證邏輯使其有一定意義

### DIFF
--- a/app/Http/Middleware/OptionalAuthentication.php
+++ b/app/Http/Middleware/OptionalAuthentication.php
@@ -26,14 +26,18 @@ class OptionalAuthentication {
             }
         } else {
             // 嘗試使用 Sanctum 認證（Bearer Token）
-            // 如果有 token，嘗試認證；沒有或失敗也不報錯
-            try {
-                if ($request->bearerToken()) {
-                    Auth::shouldUse('sanctum');
-                    $request->user();
+            $token = $request->bearerToken();
+            if ($token) {
+                Auth::shouldUse('sanctum');
+
+                try {
+                    // 有帶 Bearer token 時必須驗證通過，否則直接拒絕
+                    if (!$request->user()) {
+                        abort(401, 'Invalid API token.');
+                    }
+                } catch (\Exception $e) {
+                    abort(401, 'Invalid API token.');
                 }
-            } catch (\Exception $e) {
-                // 認證失敗不報錯，繼續作為 guest 處理
             }
         }
 

--- a/tests/Feature/OptionalAuthenticationMiddlewareTest.php
+++ b/tests/Feature/OptionalAuthenticationMiddlewareTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class OptionalAuthenticationMiddlewareTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Force in-memory SQLite to avoid external DB dependency
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
+        $this->setUpInMemoryDatabase();
+
+        Route::middleware('auth.optional')->get('/testing/auth-optional', function (Request $request) {
+            return response()->json([
+                'user_id' => optional($request->user())->id,
+            ]);
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_guest_without_token_can_pass(): void {
+        $this->getJson('/testing/auth-optional')
+            ->assertStatus(200)
+            ->assertJson(['user_id' => null]);
+    }
+
+    public function test_request_with_valid_token_succeeds(): void {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token')->plainTextToken;
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/testing/auth-optional')
+            ->assertStatus(200)
+            ->assertJson(['user_id' => $user->id]);
+    }
+
+    public function test_request_with_invalid_token_is_rejected(): void {
+        $this->withHeader('Authorization', 'Bearer invalid-token')
+            ->getJson('/testing/auth-optional')
+            ->assertStatus(401);
+    }
+
+    private function setUpInMemoryDatabase(): void {
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(User::STATUS_ACTIVE);
+            $table->integer('is_admin')->default(User::ROLE_REGULAR);
+            $table->timestamps();
+        });
+
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
當 request 中包含有效 token 或未提供 token 時，正常回應，以保持兼容；
當 request 中包含無效 token 時，拒絕回應。
未來可考慮對不同類型 requests 做不同 rate limiting。

新增 OptionalAuthentication middleware 的 API token 驗證測試。