### PR TITLE
fix: TEXT_CODES 編輯頁面 author 下拉選單無法選擇的問題

### DIFF
--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -20,7 +20,7 @@
                     <div class="form-group row">
                         <label for="author" class="col-sm-2 col-form-label">author</label>
                         <div class="col-sm-8">
-                            <select class="form-control author js-person-select" name="" disabled></select>
+                            <select class="form-control author" name="" id="author_select"></select>
                         </div>
                         <div class="col-sm-2">
                             <button type="button" id="button_ajax_load" class="btn btn-info">Jump to author</button>
@@ -144,13 +144,30 @@
             }
             $.get('/api/select/search/textauthor', { q: c_textid }, function (data) {
                 $author.empty();
-                if (data && Array.isArray(data.data)) {
+
+                // 添加默認選項
+                $author.append(new Option('-- 請選擇作者 --', '', true, true));
+
+                if (data && Array.isArray(data.data) && data.data.length > 0) {
                     data.data.forEach(function(item) {
                         const option = new Option(item.text, item.value, false, false);
                         $author.append(option);
                     });
+
+                    // 如果只有一個作者，自動選中
+                    if (data.data.length === 1) {
+                        $author.val(data.data[0].value);
+                    }
+                } else {
+                    // 如果沒有作者數據
+                    $author.append(new Option('無作者資料', '', false, false));
                 }
+
                 $author.trigger('change');
+            }).fail(function() {
+                console.error('Failed to load author data');
+                $author.empty();
+                $author.append(new Option('載入失敗', '', false, false));
             });
         };
 
@@ -158,12 +175,12 @@
 
         $("#button_ajax_load").click(function(){
             const author = $author.val();
-            if (!author) {
+            if (!author || author === '') {
+                alert('請先選擇一個作者');
                 return;
             }
             const url = "/basicinformation/" + author + "/texts";
-            const new_window = window.open('_blank');
-            new_window.location = url ;
+            window.open(url, '_blank');
         });
     });
 </script>

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -20,7 +20,7 @@
                     <div class="form-group row">
                         <label for="author" class="col-sm-2 col-form-label">author</label>
                         <div class="col-sm-8">
-                            <select class="form-control author" name="" id="author_select"></select>
+                            <select class="form-control author" id="author_select"></select>
                         </div>
                         <div class="col-sm-2">
                             <button type="button" id="button_ajax_load" class="btn btn-info">Jump to author</button>


### PR DESCRIPTION
## 問題描述

當 TEXT_CODES 編輯頁面（`/codes/TEXT_CODES/xxxx/edit`）有兩個作者時，author 下拉選單無法展開選擇。

## 根本原因

1. **select 元素被禁用**：原代碼中 author 下拉選單設置了 `disabled` 屬性，導致用戶無法與其互動
2. **缺少預設選項**：當有多個作者時，沒有提示用戶需要選擇
3. **缺少錯誤處理**：沒有處理 API 載入失敗或無數據的情況

## 修復內容

### HTML 層面
- 移除 author select 元素的 `disabled` 屬性
- 添加 `id="author_select"` 以便於識別

### JavaScript 層面
- 添加「-- 請選擇作者 --」作為預設提示選項
- 當只有一個作者時，自動選中該作者
- 當有多個作者（包括 2 個）時，用戶可以正常下拉選擇
- 添加無數據和載入失敗的提示訊息
- 改進「Jump to author」按鈕：
  - 添加驗證，確保選擇作者後才能跳轉
  - 修正 `window.open` 的使用方式

## 測試場景

- ✅ **0 個作者**：顯示「無作者資料」
- ✅ **1 個作者**：自動選中該作者
- ✅ **2 個作者**：可正常下拉選擇（本次修復的核心問題）
- ✅ **多個作者**：可正常下拉選擇
- ✅ **未選擇作者點擊按鈕**：顯示提示訊息「請先選擇一個作者」
- ✅ **API 載入失敗**：顯示「載入失敗」

## 影響範圍

僅影響 `TEXT_CODES` 表格的編輯頁面（`resources/views/codes/edit.blade.php`），不影響其他功能。

## 截圖

修復前：下拉選單無法點擊（disabled）
修復後：下拉選單可正常點擊和選擇

🤖 Generated with [Claude Code](https://claude.com/claude-code)