### PR TITLE
feat(playground): 新增 SQL 查詢練習場功能

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class QueryPlaygroundController extends Controller {
+    public function __construct() {
+        $this->middleware('auth');
+    }
+
+    /**
+     * Forbidden keywords (case-insensitive checking in logic).
+     */
+    protected $forbiddenKeywords = [
+        'UPDATE', 'DELETE', 'INSERT', 'ALTER', 'DROP', 'TRUNCATE',
+        'CREATE', 'GRANT', 'REVOKE', 'REPLACE', 'LOCK', 'UNLOCK',
+        'COMMIT', 'ROLLBACK', 'SAVEPOINT', 'SET', 'EXECUTE', 'CALL',
+        'SHOW', 'DESCRIBE', 'USE', 'EXPLAIN',
+    ];
+
+    public function index(Request $request) {
+        if (!Auth::user()->isAdmin()) {
+            abort(403, 'Unauthorized. Expert access required.');
+        }
+
+        $initialSql = $request->input('sql', 'SELECT * FROM DYNASTIES');
+
+        return view('query_playground.index', [
+            'page_title' => 'SQL 查詢練習場',
+            'page_title_key' => 'Query Playground',
+            'page_description' => '本功能目前處於測試階段，請適度使用以維護系統穩定',
+            'page_url' => route('query-playground.index'),
+            'initial_sql' => $initialSql,
+        ]);
+    }
+
+    public function run(Request $request) {
+        if (!Auth::user()->isAdmin()) {
+            return response()->json(['error' => 'Unauthorized. Expert access required.'], 403);
+        }
+
+        $request->validate([
+            'sql' => 'required|string|max:5000',
+            'page' => 'nullable|integer|min:1',
+        ]);
+
+        $sql = trim($request->input('sql'));
+
+        // Remove trailing semicolons to allow "SELECT ...;"
+        $sql = rtrim($sql, "; \t\n\r\0\x0B");
+
+        // Check for multiple statements (semicolon inside query)
+        if (strpos($sql, ';') !== false) {
+            return response()->json([
+               'error' => "Forbidden character detected: ';'. Multiple statements are not allowed.",
+            ], 403);
+        }
+
+        // Remove trailing semicolons to allow "SELECT ...;"
+        $sql = rtrim($sql, "; \t\n\r\0\x0B");
+
+        // Check for multiple statements (semicolon inside query)
+        if (strpos($sql, ';') !== false) {
+            return response()->json([
+               'error' => "Forbidden character detected: ';'. Multiple statements are not allowed.",
+            ], 403);
+        }
+
+        $page = (int) $request->input('page', 1);
+        $perPage = 20;
+        $offset = ($page - 1) * $perPage;
+
+        // 1. Basic security check: forbidden keywords
+        foreach ($this->forbiddenKeywords as $keyword) {
+            // Use word boundary to avoid false positives (e.g., "USE" inside "USERS")
+            if (preg_match('/\b' . preg_quote($keyword, '/') . '\b/i', $sql)) {
+                return response()->json([
+                    'error' => "Forbidden keyword detected: $keyword",
+                ], 403);
+            }
+        }
+
+        // 2. Table whitelist check
+        $allowedTables = array_keys(config('codes.tables', []));
+        // Add internal allowed tables if not in codes.tables but deemed safe?
+        // For now strict adherence to codes.tables as requested.
+
+        $tablesInQuery = $this->extractTableNames($sql);
+
+        if (empty($tablesInQuery)) {
+            return response()->json([
+               'error' => "Could not detect any table names. Please ensure your query is standard SQL.",
+            ], 400);
+        }
+
+        foreach ($tablesInQuery as $table) {
+            // Case-insensitive check against allowed list
+            $found = false;
+            foreach ($allowedTables as $allowed) {
+                if (strcasecmp($allowed, $table) === 0) {
+                    $found = true;
+
+                    break;
+                }
+            }
+            if (!$found) {
+                return response()->json([
+                    'error' => "Table '$table' is not allowed. (Not in codes whitelist)",
+                ], 403);
+            }
+        }
+
+        // 3. Execution with pagination limit
+        // Wrap user query: SELECT * FROM (UserSQL) as T LIMIT 21 OFFSET X
+        // Fetch 21 rows to know if there is a next page.
+
+        // Remove trailing semicolon if strictly at end (though regex might catch it)
+        $sql = rtrim($sql, ';');
+
+        $wrappedSql = "SELECT * FROM ($sql) AS subquery_wrapper LIMIT " . ($perPage + 1) . " OFFSET $offset";
+
+        try {
+            $results = DB::select($wrappedSql);
+
+            $hasMore = count($results) > $perPage;
+            if ($hasMore) {
+                array_pop($results); // Remove the 21st item
+            }
+
+            $columns = [];
+            if (!empty($results)) {
+                $columns = array_keys((array) $results[0]);
+            }
+
+            return response()->json([
+                'data' => $results,
+                'columns' => $columns,
+                'page' => $page,
+                'has_more' => $hasMore,
+                'usage_note' => 'Results are capped at 20 per page for performance.',
+            ]);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'error' => 'Database Error: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Heuristic to extract table names from SQL queries.
+     * Supports FROM/JOIN clauses and comma-separated tables.
+     */
+    protected function extractTableNames($sql) {
+        // 1. Remove strings and comments to avoid false positives
+        $sqlClean = preg_replace("/'[^']*'/", '', $sql);
+        $sqlClean = preg_replace('/"[^"]*"/', '', $sqlClean);
+        $sqlClean = preg_replace('/`[^`]*`/', '', $sqlClean); // We shouldn't remove backticks blindly as they contain validation targets, but we can treat them as delimiters.
+        // Actually, let's keep backticks but just strip the ticks later.
+
+        // Better approach: Normalize whitespace
+        $sql = preg_replace('/\s+/', ' ', $sql);
+
+        // 2. Find "FROM ... [WHERE|GROUP|ORDER|LIMIT|;]" blocks
+        // This is complex regex. Let's iterate through keywords.
+        // We look for patterns starting with FROM or JOIN, ending at the next reserved keyword.
+
+        // Keywords that end a FROM/JOIN clause
+        $stoppers = 'WHERE|GROUP|HAVING|ORDER|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|;|LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL|JOIN';
+
+        preg_match_all("/(?:FROM|JOIN)\s+(.*?)(?=(?:\s+(?:$stoppers))|$)/i", $sql, $matches);
+
+        $candidates = [];
+        foreach ($matches[1] as $block) {
+            // Block contains "table1, table2 alias, table3"
+            $parts = explode(',', $block);
+            foreach ($parts as $part) {
+                $part = trim($part);
+                if (empty($part)) {
+                    continue;
+                }
+
+                // Get the first word (table name) ignoring optional parenthesis for subqueries?
+                // Subqueries "(SELECT...)" break this.
+                // We should BLOCK subqueries in FROM check if they are not just aliased valid tables?
+                // No, "FROM (SELECT * FROM whitelisted)" is safe.
+                // "FROM (SELECT * FROM forbidden)" is unsafe.
+                // Our regex logic above will see "SELECT" as a table name if we are not careful?
+                // Wait, logic: "FROM (SELECT..." -> match block "(SELECT..."
+                // first word is "(".
+
+                // If it starts with (, it's a subquery. Recursion needed?
+                // For Playground MVP: simple table names only?
+                // Users might want complex queries.
+
+                // Let's rely on checking ALL words found in the FROM/JOIN block.
+                // If any word looks like a table name (alphanumeric), check it against whitelist?
+                // No, aliases will flag false positives. "FROM allowed AS forbidden_name" -> Error.
+
+                // Keep it simple: Extract first token of each comma-segment.
+                // If token starts with (, ignore (it effectively recurses via the global regex search for FROM inside).
+
+                // Remove opening parenthesis
+                $part = ltrim($part, '(');
+
+                // Get first token
+                $token = preg_split('/\s+/', $part)[0] ?? '';
+
+                // Strip quotes/backticks
+                $token = trim($token, "`'\"");
+
+                if (!empty($token)) {
+                    $candidates[] = $token;
+                }
+            }
+        }
+
+        // Also run a global simple match for standard "FROM table" just in case the block logic missed something
+        // due to nested parens structure.
+        preg_match_all('/(?:FROM|JOIN)\s+[`\'"]?([a-zA-Z0-9_]+)[`\'"]?/i', $sql, $fallbackMatches);
+        $candidates = array_merge($candidates, $fallbackMatches[1] ?? []);
+
+        return array_unique($candidates);
+    }
+}

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -329,6 +329,7 @@
                             'CBDB 內部表維護',
                             '單向關係修復',
                             'MergePreview',
+                            'Query Playground',
                         ];
                         $adminMenuOpen = in_array($activePage, $adminPages, true);
                     @endphp
@@ -345,6 +346,12 @@
                                 <a href="{{ route('manage.index') }}" class="nav-link {{ in_array($activePage, ['用戶管理'], true) ? 'active' : '' }}">
                                     <i class="nav-icon fas fa-user-cog"></i>
                                     <p>用戶管理</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('query-playground.index') }}" class="nav-link {{ $activePage == 'Query Playground' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-terminal"></i>
+                                    <p>SQL 查詢練習場</p>
                                 </a>
                             </li>
                             <li class="nav-item">

--- a/resources/views/query_playground/index.blade.php
+++ b/resources/views/query_playground/index.blade.php
@@ -1,0 +1,202 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fas fa-terminal mr-1"></i> {{ $page_title }}</h3>
+            </div>
+            <div class="card-body">
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle"></i> {{ $page_description }}。每頁限制 20 筆。
+                </div>
+                
+                <div class="form-group">
+                    <label for="sqlInput">SQL Query:</label>
+                    <textarea class="form-control" id="sqlInput" rows="5" style="font-family: monospace;">{{ $initial_sql ?? 'SELECT * FROM DYNASTIES' }}</textarea>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                        <button class="btn btn-primary" id="btnRun">
+                            <i class="fas fa-play"></i> 執行查詢 (Run)
+                        </button>
+                        <button class="btn btn-default ml-2" id="btnShare" title="複製分享連結">
+                            <i class="fas fa-share-alt"></i> 複製連結
+                        </button>
+                    </div>
+                    <div id="loadingIndicator" style="display:none;">
+                        <div class="spinner-border text-primary spinner-border-sm" role="status"></div> 查詢中...
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card" id="resultCard" style="display: none;">
+            <div class="card-header">
+                <h3 class="card-title">查詢結果</h3>
+                <div class="card-tools">
+                    <button class="btn btn-sm btn-secondary" id="btnPrev" disabled><i class="fas fa-chevron-left"></i> 上一頁</button>
+                    <span class="px-2" id="pageDisplay">Page 1</span>
+                    <button class="btn btn-sm btn-secondary" id="btnNext" disabled>下一頁 <i class="fas fa-chevron-right"></i></button>
+                </div>
+            </div>
+            <div class="card-body table-responsive p-0">
+                <table class="table table-hover text-nowrap" id="resultTable">
+                    <thead>
+                        <tr id="tableHead"></tr>
+                    </thead>
+                    <tbody id="tableBody"></tbody>
+                </table>
+                <div id="noResults" class="p-3 text-center text-muted" style="display:none;">無資料 (No data found)</div>
+            </div>
+        </div>
+        
+        <div class="alert alert-danger mt-3" id="errorAlert" style="display: none;"></div>
+    </div>
+</div>
+@endsection
+
+@section('js')
+<script>
+onViteReady(function() {
+    let currentPage = 1;
+
+    // Check if initial SQL provided via URL param (already populated in UI by controller), maybe auto-run?
+    // User didn't strictly ask for auto-run, but it's often expected. Let's stick to manual run for safety first.
+
+    function updateUrl(sql) {
+        const url = new URL(window.location);
+        url.searchParams.set('sql', sql);
+        window.history.pushState({path: url.href}, '', url.href);
+    }
+
+    function runQuery(page = 1) {
+        const sql = $('#sqlInput').val();
+        if (!sql.trim()) return;
+
+        // Update URL on run
+        updateUrl(sql);
+
+        $('#btnRun').prop('disabled', true);
+        $('#loadingIndicator').show();
+        $('#errorAlert').hide();
+        $('#resultCard').hide();
+        
+        // Reset table
+        $('#tableHead').empty();
+        $('#tableBody').empty();
+
+        $.ajax({
+            url: "{{ route('query-playground.run', [], false) }}",
+            method: 'POST',
+            data: {
+                _token: $('meta[name="csrf-token"]').attr('content'),
+                sql: sql,
+                page: page
+            },
+            success: function(response) {
+                renderResults(response);
+                currentPage = page;
+                updatePagination(response);
+                $('#resultCard').show();
+            },
+            error: function(xhr) {
+                let msg = '發生錯誤';
+                if (xhr.responseJSON && xhr.responseJSON.error) {
+                    msg = xhr.responseJSON.error;
+                } else if (xhr.status === 403) {
+                    msg = '禁止的查詢 (403 Forbidden)';
+                }
+                const errorHtml = `<strong>Error:</strong> ${msg}`;
+                $('#errorAlert').html(errorHtml).show();
+            },
+            complete: function() {
+                $('#btnRun').prop('disabled', false);
+                $('#loadingIndicator').hide();
+            }
+        });
+    }
+
+    function renderResults(data) {
+        const rows = data.data;
+        const columns = data.columns;
+
+        if (!rows || rows.length === 0) {
+            $('#noResults').show();
+            $('#resultTable').hide();
+            return;
+        }
+
+        $('#noResults').hide();
+        $('#resultTable').show();
+
+        // Render Head
+        let theadHtml = '';
+        columns.forEach(col => {
+            theadHtml += `<th>${col}</th>`;
+        });
+        $('#tableHead').html(theadHtml);
+
+        // Render Body
+        let tbodyHtml = '';
+        rows.forEach(row => {
+            tbodyHtml += '<tr>';
+            columns.forEach(col => {
+                let val = row[col];
+                let displayVal = '';
+
+                if (val === null) {
+                    displayVal = '<span class="text-muted">NULL</span>';
+                } else {
+                    // Basic XSS protection for display
+                    displayVal = $('<div>').text(val).html(); 
+                }
+
+                tbodyHtml += `<td>${displayVal}</td>`;
+            });
+            tbodyHtml += '</tr>';
+        });
+        $('#tableBody').html(tbodyHtml);
+    }
+
+    function updatePagination(data) {
+        $('#pageDisplay').text(`Page ${data.page}`);
+        
+        $('#btnPrev').prop('disabled', data.page <= 1);
+        $('#btnNext').prop('disabled', !data.has_more);
+        
+        // Unbind previous clicks to avoid accumulation
+        $('#btnPrev').off('click').on('click', function() {
+            if (currentPage > 1) runQuery(currentPage - 1);
+        });
+        
+        $('#btnNext').off('click').on('click', function() {
+            if (data.has_more) runQuery(currentPage + 1);
+        });
+    }
+
+    $('#btnRun').click(function() {
+        runQuery(1);
+    });
+
+    $('#btnShare').click(function() {
+        const sql = $('#sqlInput').val();
+         updateUrl(sql);
+        
+        navigator.clipboard.writeText(window.location.href).then(function() {
+            // Simple visual feedback
+            const originalText = $('#btnShare').html();
+            $('#btnShare').html('<i class="fas fa-check"></i> 已複製');
+            setTimeout(() => {
+                $('#btnShare').html(originalText);
+            }, 2000);
+        }, function(err) {
+            console.error('Could not copy text: ', err);
+            alert('複製失敗，請手動複製網址列');
+        });
+    });
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -140,5 +140,9 @@ Route::middleware('auth')->group(function () {
         ->name('admin.cbdb-table-maintenance.progress');
     Route::get('admin/unidirectional-relationship-repair', 'UnidirectionalRelationshipRepairController@index')->name('admin.unidirectional-relationship-repair');
     Route::post('admin/unidirectional-relationship-repair/kinship', 'UnidirectionalRelationshipRepairController@repairKinship')->name('admin.unidirectional-relationship-repair.kinship');
+    // Query Playground
+    Route::get('query-playground', 'QueryPlaygroundController@index')->name('query-playground.index');
+    Route::post('query-playground/run', 'QueryPlaygroundController@run')->name('query-playground.run');
+
     Route::post('admin/unidirectional-relationship-repair/assoc', 'UnidirectionalRelationshipRepairController@repairAssoc')->name('admin.unidirectional-relationship-repair.assoc');
 });

--- a/tests/Feature/QueryPlaygroundTest.php
+++ b/tests/Feature/QueryPlaygroundTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class QueryPlaygroundTest extends TestCase {
+    protected $adminUser;
+    protected $regularUser;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Mock config for strict whitelist testing
+        Config::set('codes.tables', [
+            'DYNASTIES' => 'Dynasties Table',
+            'ALTNAME_DATA' => 'Altname Data',
+            'ALLOWED1' => 'A1',
+            'ALLOWED2' => 'A2',
+        ]);
+
+        // Create users if DB is available, otherwise mock Auth
+        // Assuming In-Memory SQLite usually used in Laravel tests
+        // Create users using forceFill since is_admin/is_active are not fillable
+        $this->adminUser = new User();
+        $this->adminUser->forceFill([
+            'id' => 1,
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'is_admin' => User::ROLE_EXPERT,
+            'is_active' => User::STATUS_ACTIVE,
+        ]);
+
+        $this->regularUser = new User();
+        $this->regularUser->forceFill([
+            'id' => 2,
+            'name' => 'Regular User',
+            'email' => 'reg@example.com',
+            'is_admin' => User::ROLE_REGULAR,
+            'is_active' => User::STATUS_ACTIVE,
+        ]);
+    }
+
+    /** @test */
+    public function guests_cannot_access_playground() {
+        auth()->logout();
+        $response = $this->get(route('query-playground.index'));
+        $response->assertRedirect('login');
+    }
+
+    /** @test */
+    public function regular_users_cannot_access_playground() {
+        $this->be($this->regularUser);
+        $response = $this->get(route('query-playground.index'));
+        $response->assertStatus(403);
+    }
+
+    /** @test */
+    public function expert_users_can_access_playground() {
+        $this->be($this->adminUser);
+        $response = $this->get(route('query-playground.index'));
+        $response->assertStatus(200);
+        $response->assertSee('SQL 查詢練習場');
+    }
+
+    /** @test */
+    public function regular_users_cannot_run_queries() {
+        $this->be($this->regularUser);
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM DYNASTIES',
+        ]);
+        $response->assertStatus(403);
+    }
+
+    /** @test */
+    public function it_blocks_forbidden_keywords() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'DELETE FROM DYNASTIES',
+        ]);
+
+        $response->assertStatus(403);
+        $response->assertJson([
+            'error' => 'Forbidden keyword detected: DELETE',
+        ]);
+    }
+
+    /** @test */
+    public function it_blocks_non_whitelisted_tables() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM users',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertStringContainsString('is not allowed', $response->json()['error'] ?? '');
+    }
+
+    /** @test */
+    public function it_extracts_multiple_tables_correctly() {
+        $this->be($this->adminUser);
+
+        // 1. Valid Join
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1 JOIN ALLOWED2 ON id=id',
+        ]);
+        // Expecting either 200 (if tables exist) or 500 (if tables missing).
+        // Definitely NOT 403.
+        $this->assertNotEquals(403, $response->status(), 'Should allow valid join');
+
+        // 2. Invalid Join
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1 JOIN USERS ON id=id',
+        ]);
+        $response->assertStatus(403);
+        $this->assertStringContainsString('USERS', $response->json()['error'] ?? '');
+
+        // 3. Comma Separated matches
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1, ALLOWED2',
+        ]);
+        $this->assertNotEquals(403, $response->status(), 'Should allow valid comma join');
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1, USERS',
+        ]);
+        $response->assertStatus(403);
+    }
+
+    /** @test */
+    public function it_allows_trailing_semicolon() {
+        $this->be($this->adminUser);
+
+        // Should NOT error with semicolon at end
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1;',
+        ]);
+
+        $this->assertNotEquals(403, $response->status(), 'Should allow trailing semicolon');
+    }
+
+    /** @test */
+    public function it_blocks_multiple_statements() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1; SELECT * FROM ALLOWED2',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertStringContainsString('Forbidden character detected', $response->json()['error'] ?? '');
+    }
+}


### PR DESCRIPTION
新增功能：
- 實作 QueryPlaygroundController 控制器
  - 支援唯讀 SQL 查詢，僅限 config/codes.php 白名單表格
  - 阻擋危險關鍵字（UPDATE、DELETE、INSERT、DROP 等）
  - 支援尾隨分號，同時阻擋多語句執行
  - 實作分頁機制（每頁 20 筆記錄）
  - 新增 URL 查詢參數支援，可透過連結分享查詢

- 建立查詢練習場使用者介面
  - SQL 輸入文字框，支援從 URL 預填查詢內容
  - 分頁結果表格，正確顯示 NULL 值
  - 複製連結按鈕，方便分享查詢
  - 執行查詢時自動更新 URL
  - 使用相對路徑 AJAX 請求，避免 HTTPS 混合內容問題

- 側邊欄選單整合
  - 新增「SQL 查詢練習場」選項於管理員工具區
  - 位置在「SQL EXPLAIN」上方
  - 僅限 Expert/Admin 角色可見

- 完整測試覆蓋（9 項測試全數通過）
  - 測試身份驗證與角色權限控制
  - 測試危險關鍵字阻擋機制
  - 測試表格白名單驗證
  - 測試尾隨分號支援
  - 測試多語句阻擋功能

技術細節：
- 使用正規表達式進行 SQL 表格名稱提取
- 實作詞界檢查避免誤判（如 USERS 不會觸發 USE 關鍵字）
- 前端使用 jQuery AJAX 與 History API 實現無刷新查詢
- 後端使用子查詢包裝實現安全分頁
- 使用 route() 第三參數 false 生成相對 URL，解決 Cloudflare HTTPS 代理混合內容問題