### PR TITLE
確保 manage-user 建立帳號時寫入狀態與角色

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -36,6 +36,8 @@ class User extends Authenticatable {
         'password',
         'avatar',
         'confirmation_token',
+        'is_active',
+        'is_admin',
     ];
 
     /**

--- a/tests/Feature/ManageUserCommandTest.php
+++ b/tests/Feature/ManageUserCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ManageUserCommandTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->default('avatar5.png');
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function testInteractiveUserCreationSetsStatusAndRole() {
+        $this->artisan('cbdb:manage-user')
+            ->expectsQuestion('請輸入用戶 Email', 'interactive@example.com')
+            ->expectsQuestion('請輸入用戶名稱', 'Interactive User')
+            ->expectsQuestion('請輸入密碼（至少 6 個字符）', 'password123')
+            ->expectsChoice('請選擇激活狀態', '2', ['0' => '未激活', '1' => '激活', '2' => '預留'])
+            ->expectsChoice('請選擇用戶角色', 'expert', [
+                'crowdsourcing',
+                'expert',
+                'regular',
+                'super-admin',
+                '一般用戶',
+                '專家',
+                '眾包用戶',
+                '系統管理員',
+            ])
+            ->assertExitCode(0);
+
+        $user = User::where('email', 'interactive@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertEquals('Interactive User', $user->name);
+        $this->assertEquals(User::STATUS_RESERVED, $user->is_active);
+        $this->assertEquals(User::ROLE_EXPERT, $user->is_admin);
+        $this->assertTrue(Hash::check('password123', $user->password));
+    }
+
+    public function testUserCreationWithOptionsDoesNotSkipStatusOrRole() {
+        $this->artisan('cbdb:manage-user', [
+            '--email' => 'options@example.com',
+            '--name' => 'Options User',
+            '--password' => 'optionpass',
+            '--active' => (string)User::STATUS_ACTIVE,
+            '--role' => 'super-admin',
+        ])->assertExitCode(0);
+
+        $user = User::where('email', 'options@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertEquals(User::STATUS_ACTIVE, $user->is_active);
+        $this->assertEquals(User::ROLE_SUPER_ADMIN, $user->is_admin);
+        $this->assertTrue(Hash::check('optionpass', $user->password));
+    }
+}


### PR DESCRIPTION
## Summary
- 將 User 模型的可批量賦值欄位加入 is_active 與 is_admin，避免透過 manage-user 命令建立帳號時忽略狀態與角色
- 新增 ManageUserCommandTest 覆蓋互動與選項輸入，驗證 cbdb:manage-user 能建立指定狀態與角色的帳號

## Testing
- ./vendor/bin/php-cs-fixer fix
- APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') ./vendor/bin/phpunit --filter ManageUserCommandTest
- ./vendor/bin/phpunit *(因未預先設定 APP_KEY 導致多數案例拋出 MissingAppKeyException)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b5a80300832e86fdc423c3fd40d7)