### PR TITLE
refactor: 完成時間戳欄位重構，移除臨時欄位名稱

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,10 @@ DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 # Database timezone - MUST match APP_TIMEZONE (config/app.php) to prevent TIMESTAMP conversion issues
-# Use '+08:00' for GMT+8 or 'Asia/Shanghai'
+# IMPORTANT: Use numeric offset format (e.g., '+08:00') instead of named timezones
+# Named timezones (e.g., 'Asia/Shanghai') require MySQL time zone tables to be loaded
+# and will cause "Unknown or incorrect time zone" errors if not available.
+# For GMT+8 (Asia/Shanghai equivalent), use: +08:00
 DB_TIMEZONE=+08:00
 
 BROADCAST_DRIVER=log

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ DB_PORT=3306
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
+# Database timezone - MUST match APP_TIMEZONE (config/app.php) to prevent TIMESTAMP conversion issues
+# Use '+08:00' for GMT+8 or 'Asia/Shanghai'
+DB_TIMEZONE=+08:00
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
   - **時區設定**：統一使用 GMT+8 時區（Asia/Shanghai）。
   - **CRITICAL 配置要求**：`.env` 中的 `DB_TIMEZONE` **必須**與 `config/app.php` 的 `timezone` 匹配！
     - 正確設定：`DB_TIMEZONE=+08:00`（對應 `APP_TIMEZONE=Asia/Shanghai`）
+    - **必須使用數字偏移格式**（如 `+08:00`），不可使用命名時區（如 `Asia/Shanghai`）
+    - 原因：MySQL 命名時區需要載入 time zone tables，否則會導致 "Unknown or incorrect time zone" 錯誤並中斷所有資料庫連線
     - 如果不匹配：MySQL TIMESTAMP 欄位會產生 8 小時時區偏移（字串看起來相同，但底層 UNIX timestamp 錯誤）
     - 詳細說明請參考 `app/Repositories/ToolsRepository.php` 中的註釋
 - **主要資料夾**：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,11 @@
   - `CBDB__NAME_FTS`：姓名搜尋倒排索引，支援高效能後綴匹配查詢
   - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射，基於 OpenCC 標準，使用 VARBINARY(4) 支援非BMP字符
 - **日期/時間處理**：使用 Carbon 2.x。
-  - **時區設定**：目前 database 內部分表格欄位出現 datetime 與 timestamp 混用的情況。為避免日期衝突，統一使用 GMT+8 時區。
+  - **時區設定**：統一使用 GMT+8 時區（Asia/Shanghai）。
+  - **CRITICAL 配置要求**：`.env` 中的 `DB_TIMEZONE` **必須**與 `config/app.php` 的 `timezone` 匹配！
+    - 正確設定：`DB_TIMEZONE=+08:00`（對應 `APP_TIMEZONE=Asia/Shanghai`）
+    - 如果不匹配：MySQL TIMESTAMP 欄位會產生 8 小時時區偏移（字串看起來相同，但底層 UNIX timestamp 錯誤）
+    - 詳細說明請參考 `app/Repositories/ToolsRepository.php` 中的註釋
 - **主要資料夾**：
   - `app/Http/Controllers`：Laravel 控制器（如 `OperationsController`）。
   - `app/Repositories`：資料存取與封裝邏輯（如 `OperationRepository`）。

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -1001,12 +1001,12 @@ class CodesController extends Controller {
 
         foreach ($row as $key => $value) {
             if (in_array($key, $auditFieldOrder, true)) {
-                // 时间戳字段转换为本地时区（Asia/Taipei, GMT+8）
+                // 时间戳字段转换为应用配置的时区
                 if (in_array($key, $timestampFields, true) && $value !== null && $value !== '') {
                     try {
                         $carbon = Carbon::parse($value);
-                        // 转换为 Asia/Taipei 时区（GMT+8）
-                        $carbon->setTimezone('Asia/Taipei');
+                        // 转换为应用配置的时区（与写入时保持一致）
+                        $carbon->setTimezone(config('app.timezone'));
                         $auditFields[$key] = $carbon->format('Y-m-d H:i:s');
                     } catch (\Exception $e) {
                         // 如果解析失败，保持原值

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -965,7 +965,8 @@ class CodesController extends Controller {
 
         // 更新 c_modified_date
         if (array_key_exists('c_modified_date', $data)) {
-            $data['c_modified_date'] = $now->format('Y-m-d H:i:s');
+            // Store as Carbon object (Laravel will convert to TIMESTAMP in DB)
+            $data['c_modified_date'] = $now;
         } elseif (array_key_exists('c_modified_date', $original)) {
             $data['c_modified_date'] = $original['c_modified_date'];
         }

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -871,13 +871,9 @@ class CodesController extends Controller {
             $data['c_created_by'] = Auth::user()->name;
         }
 
-        // Dual write: c_created_date (Ymd format) 和 c_created_date_timestamp_temporary (Y-m-d H:i:s format)
         if (in_array('c_created_date', $columns, true)) {
-            $data['c_created_date'] = $now->format('Ymd');
-        }
-
-        if (in_array('c_created_date_timestamp_temporary', $columns, true)) {
-            $data['c_created_date_timestamp_temporary'] = $now->format('Y-m-d H:i:s');
+            // Store as Carbon object (Laravel will convert to TIMESTAMP in DB)
+            $data['c_created_date'] = $now;
         }
 
         return $data;
@@ -952,7 +948,7 @@ class CodesController extends Controller {
         $now = Carbon::now();
 
         // 保护 created_* 字段不被修改
-        foreach (['c_created_by', 'c_created_date', 'c_created_date_timestamp_temporary'] as $field) {
+        foreach (['c_created_by', 'c_created_date'] as $field) {
             if (array_key_exists($field, $data) && array_key_exists($field, $original)) {
                 $data[$field] = $original[$field];
             }
@@ -967,18 +963,11 @@ class CodesController extends Controller {
             }
         }
 
-        // Dual write: c_modified_date (Ymd format) 和 c_modified_date_timestamp_temporary (Y-m-d H:i:s format)
-        // 使用同一个时间戳确保两者完全一致
+        // 更新 c_modified_date
         if (array_key_exists('c_modified_date', $data)) {
-            $data['c_modified_date'] = $now->format('Ymd');
+            $data['c_modified_date'] = $now->format('Y-m-d H:i:s');
         } elseif (array_key_exists('c_modified_date', $original)) {
             $data['c_modified_date'] = $original['c_modified_date'];
-        }
-
-        if (array_key_exists('c_modified_date_timestamp_temporary', $data)) {
-            $data['c_modified_date_timestamp_temporary'] = $now->format('Y-m-d H:i:s');
-        } elseif (array_key_exists('c_modified_date_timestamp_temporary', $original)) {
-            $data['c_modified_date_timestamp_temporary'] = $original['c_modified_date_timestamp_temporary'];
         }
 
         return $data;
@@ -995,16 +984,14 @@ class CodesController extends Controller {
         $auditFieldOrder = [
             'c_created_by',
             'c_created_date',
-            'c_created_date_timestamp_temporary',
             'c_modified_by',
             'c_modified_date',
-            'c_modified_date_timestamp_temporary',
         ];
 
         // 时间戳字段需要转换时区
         $timestampFields = [
-            'c_created_date_timestamp_temporary',
-            'c_modified_date_timestamp_temporary',
+            'c_created_date',
+            'c_modified_date',
         ];
 
         // 分离审计字段和其他字段

--- a/app/Repositories/ToolsRepository.php
+++ b/app/Repositories/ToolsRepository.php
@@ -19,9 +19,13 @@ class ToolsRepository {
     public function timestamp(array $data, $isCreat = false) {
         if ($isCreat) {
             $data['c_created_by'] = Auth::user()->name;
-            // Store as Carbon object in local timezone (Asia/Shanghai)
-            // Laravel will convert to MySQL TIMESTAMP which stores UTC internally
-            // but displays in system timezone, giving us the correct local time
+            // Store as Carbon object in server's configured timezone (config('app.timezone'))
+            // Behavior:
+            // 1. Carbon::now() returns current time in server timezone (e.g., Asia/Shanghai GMT+8)
+            // 2. Laravel Query Builder converts to string: '2025-12-22 20:08:00'
+            // 3. MySQL TIMESTAMP stores this value directly
+            // 4. Display uses same timezone (config('app.timezone')) for consistency
+            // Result: All users see unified server time, not their browser's local time
             $data['c_created_date'] = Carbon::now();
         } else {
             $data['c_modified_by'] = Auth::user()->name;

--- a/app/Repositories/ToolsRepository.php
+++ b/app/Repositories/ToolsRepository.php
@@ -20,12 +20,23 @@ class ToolsRepository {
         if ($isCreat) {
             $data['c_created_by'] = Auth::user()->name;
             // Store as Carbon object in server's configured timezone (config('app.timezone'))
-            // Behavior:
-            // 1. Carbon::now() returns current time in server timezone (e.g., Asia/Shanghai GMT+8)
-            // 2. Laravel Query Builder converts to string: '2025-12-22 20:08:00'
-            // 3. MySQL TIMESTAMP stores this value directly
-            // 4. Display uses same timezone (config('app.timezone')) for consistency
-            // Result: All users see unified server time, not their browser's local time
+            //
+            // CRITICAL: DB_TIMEZONE (.env) MUST match APP_TIMEZONE (config/app.php)!
+            //
+            // Behavior with correct config (DB_TIMEZONE=+08:00, APP_TIMEZONE=Asia/Shanghai):
+            // 1. Carbon::now() returns current time in Asia/Shanghai (GMT+8): '2025-12-22 20:08:00'
+            // 2. Laravel Query Builder converts Carbon to string: '2025-12-22 20:08:00'
+            // 3. MySQL interprets this string in session timezone (+08:00), converts to UTC for storage
+            // 4. On read, MySQL converts UTC back to +08:00, returns: '2025-12-22 20:08:00'
+            // 5. Carbon::parse() interprets in Asia/Shanghai timezone
+            // 6. Result: UNIX timestamps match perfectly, no 8-hour drift
+            //
+            // Without DB_TIMEZONE (or if mismatched):
+            // - MySQL uses SYSTEM timezone (often UTC)
+            // - Causes 8-hour drift in stored UNIX timestamp (string looks same, but timestamp differs)
+            // - Queries still work but stored values are semantically wrong
+            //
+            // Result: All users see unified server time (not browser's local time)
             $data['c_created_date'] = Carbon::now();
         } else {
             $data['c_modified_by'] = Auth::user()->name;

--- a/app/Repositories/ToolsRepository.php
+++ b/app/Repositories/ToolsRepository.php
@@ -19,10 +19,9 @@ class ToolsRepository {
     public function timestamp(array $data, $isCreat = false) {
         if ($isCreat) {
             $data['c_created_by'] = Auth::user()->name;
-            // Store as Carbon object (UTC), which Laravel will:
-            // 1. Convert to TIMESTAMP in database (UTC stored, no timezone info in column)
-            // 2. Serialize to ISO-8601 in JSON (e.g., "2024-12-22T12:00:00.000000Z")
-            // Display logic (CodesController) will convert to Asia/Taipei when showing to users
+            // Store as Carbon object in local timezone (Asia/Shanghai)
+            // Laravel will convert to MySQL TIMESTAMP which stores UTC internally
+            // but displays in system timezone, giving us the correct local time
             $data['c_created_date'] = Carbon::now();
         } else {
             $data['c_modified_by'] = Auth::user()->name;

--- a/app/Repositories/ToolsRepository.php
+++ b/app/Repositories/ToolsRepository.php
@@ -19,15 +19,14 @@ class ToolsRepository {
     public function timestamp(array $data, $isCreat = false) {
         if ($isCreat) {
             $data['c_created_by'] = Auth::user()->name;
-            #20251217更新 create 和 modify 欄位時間的寫入方式
-            # 同時更新新舊兩個欄位以保持相容性
-            $data['c_created_date'] = Carbon::now()->format('Ymd');
-            $data['c_created_date_timestamp_temporary'] = Carbon::now();
+            // Store as Carbon object (UTC), which Laravel will:
+            // 1. Convert to TIMESTAMP in database (UTC stored, no timezone info in column)
+            // 2. Serialize to ISO-8601 in JSON (e.g., "2024-12-22T12:00:00.000000Z")
+            // Display logic (CodesController) will convert to Asia/Taipei when showing to users
+            $data['c_created_date'] = Carbon::now();
         } else {
             $data['c_modified_by'] = Auth::user()->name;
-            # 同時更新新舊兩個欄位以保持相容性
-            $data['c_modified_date'] = Carbon::now()->format('Ymd');
-            $data['c_modified_date_timestamp_temporary'] = Carbon::now();
+            $data['c_modified_date'] = Carbon::now();
         }
 
         return $data;

--- a/config/database.php
+++ b/config/database.php
@@ -52,6 +52,7 @@ return [
             'prefix' => '',
             'strict' => false,
             'engine' => null,
+            'timezone' => env('DB_TIMEZONE', '+08:00'),
             'options' => extension_loaded('pdo_mysql') ? [
                 PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
             ] : [],

--- a/config/database.php
+++ b/config/database.php
@@ -52,6 +52,10 @@ return [
             'prefix' => '',
             'strict' => false,
             'engine' => null,
+            // CRITICAL: DB_TIMEZONE must match config('app.timezone') to prevent TIMESTAMP drift
+            // Default '+08:00' corresponds to 'Asia/Shanghai' (GMT+8)
+            // MUST use numeric offset format (e.g., '+08:00'), NOT named timezones (e.g., 'Asia/Shanghai')
+            // If APP_TIMEZONE is changed, DB_TIMEZONE must be updated accordingly in .env
             'timezone' => env('DB_TIMEZONE', '+08:00'),
             'options' => extension_loaded('pdo_mysql') ? [
                 PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",

--- a/database/migrations/2025_12_22_000000_rename_timestamp_temporary_columns.php
+++ b/database/migrations/2025_12_22_000000_rename_timestamp_temporary_columns.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -102,10 +101,19 @@ class RenameTimestampTemporaryColumns extends Migration {
     /**
      * Reverse the migrations.
      *
-     * WARNING: This rollback involves DATA LOSS.
-     * - Time components (H:i:s) will be permanently lost during rollback
-     * - Only date components (Y-m-d) are preserved in Ymd format
-     * - Consider this a destructive emergency-only operation
+     * CRITICAL WARNING: This rollback is STRUCTURE-ONLY.
+     *
+     * Due to composite primary keys in most tables (e.g., ALTNAME_DATA has
+     * c_alt_name_chn + c_alt_name_type_code + c_personid), automatic data
+     * conversion is unsafe and could cause data corruption.
+     *
+     * This rollback will:
+     * 1. Rename TIMESTAMP columns back to temporary names
+     * 2. Re-create empty VARCHAR columns
+     * 3. Leave data conversion as a MANUAL operation
+     *
+     * If you need to populate the VARCHAR columns, you must manually run
+     * UPDATE statements with proper WHERE clauses for each table's composite key.
      *
      * @return void
      */
@@ -128,7 +136,8 @@ class RenameTimestampTemporaryColumns extends Migration {
                 });
             }
 
-            // Step 2: Re-create VARCHAR columns
+            // Step 2: Re-create empty VARCHAR columns
+            // NOTE: Data conversion is NOT performed automatically due to composite key complexity
             if (!Schema::hasColumn($table, 'c_created_date')) {
                 Schema::table($table, function ($blueprint) {
                     $blueprint->string('c_created_date', 255)->nullable();
@@ -141,72 +150,7 @@ class RenameTimestampTemporaryColumns extends Migration {
                 });
             }
 
-            // Step 3: Convert timestamp data back to VARCHAR Ymd format
-            // Use database-agnostic approach with Query Builder for portability
-            // Time components will be permanently lost during this conversion
-            if (Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
-                // Process in chunks to handle large tables without memory issues
-                $primaryKey = $this->getPrimaryKeyColumn($table);
-                DB::table($table)
-                    ->whereNotNull('c_created_date_timestamp_temporary')
-                    ->orderBy($primaryKey)
-                    ->chunk(1000, function ($rows) use ($table, $primaryKey) {
-                        foreach ($rows as $row) {
-                            $timestamp = $row->c_created_date_timestamp_temporary;
-                            if ($timestamp) {
-                                try {
-                                    $ymd = \Carbon\Carbon::parse($timestamp)->format('Ymd');
-                                    DB::table($table)
-                                        ->where($primaryKey, $row->{$primaryKey})
-                                        ->update(['c_created_date' => $ymd]);
-                                } catch (\Exception $e) {
-                                    // Skip unparseable timestamps
-                                    continue;
-                                }
-                            }
-                        }
-                    });
-            }
-
-            if (Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
-                $primaryKey = $this->getPrimaryKeyColumn($table);
-                DB::table($table)
-                    ->whereNotNull('c_modified_date_timestamp_temporary')
-                    ->orderBy($primaryKey)
-                    ->chunk(1000, function ($rows) use ($table, $primaryKey) {
-                        foreach ($rows as $row) {
-                            $timestamp = $row->c_modified_date_timestamp_temporary;
-                            if ($timestamp) {
-                                try {
-                                    $ymd = \Carbon\Carbon::parse($timestamp)->format('Ymd');
-                                    DB::table($table)
-                                        ->where($primaryKey, $row->{$primaryKey})
-                                        ->update(['c_modified_date' => $ymd]);
-                                } catch (\Exception $e) {
-                                    // Skip unparseable timestamps
-                                    continue;
-                                }
-                            }
-                        }
-                    });
-            }
+            // Data conversion is intentionally skipped - see docblock for details
         }
-    }
-
-    /**
-     * Get the primary key column for a table.
-     * Most tables use c_personid, but some have different primary keys.
-     *
-     * @param string $table
-     * @return string
-     */
-    protected function getPrimaryKeyColumn(string $table): string {
-        // Map of tables to their primary key columns
-        $primaryKeys = [
-            'TEXT_CODES' => 'c_textid',
-            'TEXT_INSTANCE_DATA' => 'c_inst_id',
-        ];
-
-        return $primaryKeys[$table] ?? 'c_personid';
     }
 }

--- a/database/migrations/2025_12_22_000000_rename_timestamp_temporary_columns.php
+++ b/database/migrations/2025_12_22_000000_rename_timestamp_temporary_columns.php
@@ -1,0 +1,212 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Rename timestamp temporary columns to their final names.
+ *
+ * This migration completes the timestamp refactoring by:
+ * 1. Dropping the old VARCHAR date columns (c_created_date, c_modified_date)
+ * 2. Renaming temporary timestamp columns to their final names
+ *
+ * Note: This is a breaking change that requires all code to be updated.
+ */
+class RenameTimestampTemporaryColumns extends Migration {
+    /**
+     * The tables that need timestamp column renaming.
+     *
+     * @var array
+     */
+    protected $tables = [
+        'ALTNAME_DATA',
+        'ASSOC_DATA',
+        'BIOG_ADDR_DATA',
+        'BIOG_INST_DATA',
+        'BIOG_MAIN',
+        'BIOG_TEXT_DATA',
+        'ENTRY_DATA',
+        'EVENTS_DATA',
+        'KIN_DATA',
+        'MERGED_PERSON_DATA',
+        'POSSESSION_DATA',
+        'POSTED_TO_OFFICE_DATA',
+        'STATUS_DATA',
+        'TEXT_CODES',
+        'TEXT_INSTANCE_DATA',
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        // Pre-flight validation: Ensure temporary columns exist before we drop old columns
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            // Verify that temporary columns exist (they contain our data)
+            if (!Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
+                throw new \RuntimeException(
+                    "Table {$table} is missing required column 'c_created_date_timestamp_temporary'. "
+                    . "This column must exist before running this migration to prevent data loss."
+                );
+            }
+
+            if (!Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
+                throw new \RuntimeException(
+                    "Table {$table} is missing required column 'c_modified_date_timestamp_temporary'. "
+                    . "This column must exist before running this migration to prevent data loss."
+                );
+            }
+        }
+
+        // All validation passed, proceed with migration
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            // Step 1: Drop old VARCHAR columns to avoid naming conflicts
+            if (Schema::hasColumn($table, 'c_created_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->dropColumn('c_created_date');
+                });
+            }
+
+            if (Schema::hasColumn($table, 'c_modified_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->dropColumn('c_modified_date');
+                });
+            }
+
+            // Step 2: Rename temporary columns to final names
+            if (Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->renameColumn('c_created_date_timestamp_temporary', 'c_created_date');
+                });
+            }
+
+            if (Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->renameColumn('c_modified_date_timestamp_temporary', 'c_modified_date');
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * WARNING: This rollback involves DATA LOSS.
+     * - Time components (H:i:s) will be permanently lost during rollback
+     * - Only date components (Y-m-d) are preserved in Ymd format
+     * - Consider this a destructive emergency-only operation
+     *
+     * @return void
+     */
+    public function down() {
+        foreach ($this->tables as $table) {
+            if (!Schema::hasTable($table)) {
+                continue;
+            }
+
+            // Step 1: Rename back to temporary names
+            if (Schema::hasColumn($table, 'c_created_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->renameColumn('c_created_date', 'c_created_date_timestamp_temporary');
+                });
+            }
+
+            if (Schema::hasColumn($table, 'c_modified_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->renameColumn('c_modified_date', 'c_modified_date_timestamp_temporary');
+                });
+            }
+
+            // Step 2: Re-create VARCHAR columns
+            if (!Schema::hasColumn($table, 'c_created_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->string('c_created_date', 255)->nullable();
+                });
+            }
+
+            if (!Schema::hasColumn($table, 'c_modified_date')) {
+                Schema::table($table, function ($blueprint) {
+                    $blueprint->string('c_modified_date', 255)->nullable();
+                });
+            }
+
+            // Step 3: Convert timestamp data back to VARCHAR Ymd format
+            // Use database-agnostic approach with Query Builder for portability
+            // Time components will be permanently lost during this conversion
+            if (Schema::hasColumn($table, 'c_created_date_timestamp_temporary')) {
+                // Process in chunks to handle large tables without memory issues
+                $primaryKey = $this->getPrimaryKeyColumn($table);
+                DB::table($table)
+                    ->whereNotNull('c_created_date_timestamp_temporary')
+                    ->orderBy($primaryKey)
+                    ->chunk(1000, function ($rows) use ($table, $primaryKey) {
+                        foreach ($rows as $row) {
+                            $timestamp = $row->c_created_date_timestamp_temporary;
+                            if ($timestamp) {
+                                try {
+                                    $ymd = \Carbon\Carbon::parse($timestamp)->format('Ymd');
+                                    DB::table($table)
+                                        ->where($primaryKey, $row->{$primaryKey})
+                                        ->update(['c_created_date' => $ymd]);
+                                } catch (\Exception $e) {
+                                    // Skip unparseable timestamps
+                                    continue;
+                                }
+                            }
+                        }
+                    });
+            }
+
+            if (Schema::hasColumn($table, 'c_modified_date_timestamp_temporary')) {
+                $primaryKey = $this->getPrimaryKeyColumn($table);
+                DB::table($table)
+                    ->whereNotNull('c_modified_date_timestamp_temporary')
+                    ->orderBy($primaryKey)
+                    ->chunk(1000, function ($rows) use ($table, $primaryKey) {
+                        foreach ($rows as $row) {
+                            $timestamp = $row->c_modified_date_timestamp_temporary;
+                            if ($timestamp) {
+                                try {
+                                    $ymd = \Carbon\Carbon::parse($timestamp)->format('Ymd');
+                                    DB::table($table)
+                                        ->where($primaryKey, $row->{$primaryKey})
+                                        ->update(['c_modified_date' => $ymd]);
+                                } catch (\Exception $e) {
+                                    // Skip unparseable timestamps
+                                    continue;
+                                }
+                            }
+                        }
+                    });
+            }
+        }
+    }
+
+    /**
+     * Get the primary key column for a table.
+     * Most tables use c_personid, but some have different primary keys.
+     *
+     * @param string $table
+     * @return string
+     */
+    protected function getPrimaryKeyColumn(string $table): string {
+        // Map of tables to their primary key columns
+        $primaryKeys = [
+            'TEXT_CODES' => 'c_textid',
+            'TEXT_INSTANCE_DATA' => 'c_inst_id',
+        ];
+
+        return $primaryKeys[$table] ?? 'c_personid';
+    }
+}

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -4,7 +4,6 @@
 
     @php
         $currentUserName = optional(Auth::user())->name;
-        $currentDateYmd = \Carbon\Carbon::now()->format('Ymd');
         $currentTimestampTaipei = \Carbon\Carbon::now('Asia/Taipei')->format('Y-m-d H:i:s');
     @endphp
 
@@ -29,8 +28,8 @@
                     @endif
                     @foreach($row as $key => $value)
                         @php
-                            $isCreatedField = in_array($key, ['c_created_by', 'c_created_date', 'c_created_date_timestamp_temporary'], true);
-                            $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date', 'c_modified_date_timestamp_temporary'], true);
+                            $isCreatedField = in_array($key, ['c_created_by', 'c_created_date'], true);
+                            $isModifiedField = in_array($key, ['c_modified_by', 'c_modified_date'], true);
                             // 显示原始值而不是替换后的值
                             $inputValue = $value;
                             $shouldDisable = $isCreatedField || $isModifiedField;
@@ -41,8 +40,6 @@
                                 if ($key === 'c_modified_by' && $currentUserName !== null) {
                                     $helpText = '欄位內容提交後會被替換為：' . $currentUserName;
                                 } elseif ($key === 'c_modified_date') {
-                                    $helpText = '欄位內容提交後會被替換為：' . $currentDateYmd;
-                                } elseif ($key === 'c_modified_date_timestamp_temporary') {
                                     $helpText = '欄位內容提交後會被替換為：' . $currentTimestampTaipei . ' (GMT+8)';
                                 }
                             }

--- a/resources/views/codes/edit.blade.php
+++ b/resources/views/codes/edit.blade.php
@@ -4,7 +4,8 @@
 
     @php
         $currentUserName = optional(Auth::user())->name;
-        $currentTimestampTaipei = \Carbon\Carbon::now('Asia/Taipei')->format('Y-m-d H:i:s');
+        // Use application timezone (consistent with write operations)
+        $currentTimestamp = \Carbon\Carbon::now(config('app.timezone'))->format('Y-m-d H:i:s');
     @endphp
 
     <div class="card card-default">
@@ -40,7 +41,7 @@
                                 if ($key === 'c_modified_by' && $currentUserName !== null) {
                                     $helpText = '欄位內容提交後會被替換為：' . $currentUserName;
                                 } elseif ($key === 'c_modified_date') {
-                                    $helpText = '欄位內容提交後會被替換為：' . $currentTimestampTaipei . ' (GMT+8)';
+                                    $helpText = '欄位內容提交後會被替換為：' . $currentTimestamp;
                                 }
                             }
                         @endphp

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -40,13 +40,9 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
             $table->string('c_source')->nullable();
             $table->longText('c_notes')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('BIOG_MAIN', function (Blueprint $table) {

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -47,13 +47,9 @@ class BasicInformationAltnamesControllerTest extends TestCase {
             $table->string('c_alt_name_type_code');
             $table->integer('c_source')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         // 創建 TEXT_CODES 表

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -79,13 +79,9 @@ class BasicInformationPagesLoadTest extends TestCase {
             $table->integer('c_index_year')->nullable();
             $table->integer('c_index_addr_id')->nullable();  // 指数地址ID
             $table->string('c_created_by', 50)->nullable();
-            $table->string('c_created_date', 50)->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by', 50)->nullable();
-            $table->string('c_modified_date', 50)->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
             $table->timestamps();
         });
 

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -100,13 +100,9 @@ class BasicInformationProposalTest extends TestCase {
             $table->string('c_pages')->nullable();
             $table->text('c_notes')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
     }
 

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -39,12 +39,8 @@ class BasicInformationSourcesControllerTest extends TestCase {
             $table->tinyInteger('c_self_bio')->default(0);
             $table->string('c_created_by')->nullable();
             $table->timestamp('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
             $table->string('c_modified_by')->nullable();
             $table->timestamp('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {

--- a/tests/Feature/BasicInformationUpdateTest.php
+++ b/tests/Feature/BasicInformationUpdateTest.php
@@ -62,13 +62,9 @@ class BasicInformationUpdateTest extends TestCase {
             $table->integer('c_by_intercalary')->default(0);
             $table->integer('c_dy_intercalary')->default(0);
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         // 創建 operations 表

--- a/tests/Feature/BiogMainBasicInfoNameMergeTest.php
+++ b/tests/Feature/BiogMainBasicInfoNameMergeTest.php
@@ -68,13 +68,9 @@ class BiogMainBasicInfoNameMergeTest extends TestCase {
             $table->smallInteger('c_by_intercalary')->default(0);
             $table->smallInteger('c_dy_intercalary')->default(0);
             $table->string('c_created_by', 50)->nullable();
-            $table->string('c_created_date', 8)->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by', 50)->nullable();
-            $table->string('c_modified_date', 8)->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
             // BiogMain 模型不使用 Laravel timestamps
         });
 

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -98,13 +98,9 @@ class CbdbApiPersonTest extends TestCase {
             $table->integer('c_source')->nullable();
             $table->string('c_pages')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('ADDR_CODES', function (Blueprint $table) {

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -219,14 +219,20 @@ class CodesControllerTest extends TestCase {
         $this->assertCount(1, $this->fakeDb->tables['TEXT_CODES']);
         $row = $this->fakeDb->tables['TEXT_CODES'][0];
         $this->assertSame('audit-user', $row['c_created_by']);
-        $this->assertSame(Carbon::now()->format('Ymd'), $row['c_created_date']);
+        // Carbon object is stored directly in fake DB (real DB would convert to TIMESTAMP)
+        $this->assertInstanceOf(Carbon::class, $row['c_created_date']);
+        $this->assertEquals(Carbon::now()->timestamp, $row['c_created_date']->timestamp, '', 1);
         $this->assertSame('Sample', $row['c_title']);
         $this->assertSame('範例', $row['c_title_chn']);
 
         $this->assertCount(1, $this->operationSpy->calls);
         $call = $this->operationSpy->calls[0];
         $this->assertSame('audit-user', $call['resource_data']['c_created_by']);
-        $this->assertSame(Carbon::now()->format('Ymd'), $call['resource_data']['c_created_date']);
+        // After DB round-trip, Laravel Query Builder returns TIMESTAMP as ISO-8601 string
+        $this->assertIsString($call['resource_data']['c_created_date']);
+        // Parse the ISO-8601 string and verify it matches expected time
+        $parsedTime = Carbon::parse($call['resource_data']['c_created_date']);
+        $this->assertEquals(Carbon::now()->timestamp, $parsedTime->timestamp, '', 1);
 
         Carbon::setTestNow();
     }
@@ -630,9 +636,9 @@ class CodesControllerTest extends TestCase {
                 'c_title' => 'Sample Title',
                 'c_title_chn' => 'Sample Title CHN',
                 'c_created_by' => 'origin',
-                'c_created_date' => '20200101',
+                'c_created_date' => '2020-01-01 00:00:00',
                 'c_modified_by' => 'previous',
-                'c_modified_date' => '20200102',
+                'c_modified_date' => '2020-01-02 00:00:00',
             ],
         ]);
 
@@ -659,7 +665,7 @@ class CodesControllerTest extends TestCase {
         // c_created_date 应显示原始值并且 readonly
         $createdDatePos = strpos($content, 'name="c_created_date"');
         $this->assertNotFalse($createdDatePos);
-        $this->assertNotFalse(strpos($content, 'value="20200101"', $createdDatePos));
+        $this->assertNotFalse(strpos($content, 'value="2020-01-01 00:00:00"', $createdDatePos));
         $this->assertNotFalse(strpos($content, 'readonly', $createdDatePos));
 
         // c_modified_by 应显示原始值（"previous"）而非当前用户，并且 readonly
@@ -668,15 +674,17 @@ class CodesControllerTest extends TestCase {
         $this->assertNotFalse(strpos($content, 'value="previous"', $modifiedByPos));
         $this->assertNotFalse(strpos($content, 'readonly', $modifiedByPos));
 
-        // c_modified_date 应显示原始值（"20200102"）而非当前日期，并且 readonly
+        // c_modified_date 应显示原始值（"2020-01-02 00:00:00"）而非当前日期，并且 readonly
         $modifiedDatePos = strpos($content, 'name="c_modified_date"');
         $this->assertNotFalse($modifiedDatePos);
-        $this->assertNotFalse(strpos($content, 'value="20200102"', $modifiedDatePos));
+        $this->assertNotFalse(strpos($content, 'value="2020-01-02 00:00:00"', $modifiedDatePos));
         $this->assertNotFalse(strpos($content, 'readonly', $modifiedDatePos));
 
         // 应该有提示文字说明提交后会被替换的值
         $response->assertSee('欄位內容提交後會被替換為：text-admin', false);
-        $response->assertSee('欄位內容提交後會被替換為：'.Carbon::now()->format('Ymd'), false);
+        // Use Carbon to derive the expected timestamp in Asia/Taipei timezone
+        $expectedTimestamp = Carbon::now()->timezone('Asia/Taipei')->format('Y-m-d H:i:s');
+        $response->assertSee('欄位內容提交後會被替換為：'.$expectedTimestamp.' (GMT+8)', false);
 
         Carbon::setTestNow();
     }

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -682,9 +682,9 @@ class CodesControllerTest extends TestCase {
 
         // 应该有提示文字说明提交后会被替换的值
         $response->assertSee('欄位內容提交後會被替換為：text-admin', false);
-        // Use Carbon to derive the expected timestamp in Asia/Taipei timezone
-        $expectedTimestamp = Carbon::now()->timezone('Asia/Taipei')->format('Y-m-d H:i:s');
-        $response->assertSee('欄位內容提交後會被替換為：'.$expectedTimestamp.' (GMT+8)', false);
+        // Use config timezone (consistent with write operations)
+        $expectedTimestamp = Carbon::now()->timezone(config('app.timezone'))->format('Y-m-d H:i:s');
+        $response->assertSee('欄位內容提交後會被替換為：'.$expectedTimestamp, false);
 
         Carbon::setTestNow();
     }

--- a/tests/Feature/NameSearchIndexAutoSyncTest.php
+++ b/tests/Feature/NameSearchIndexAutoSyncTest.php
@@ -85,13 +85,9 @@ class NameSearchIndexAutoSyncTest extends TestCase {
             $table->string('c_alt_name_chn')->nullable();
             $table->integer('c_source')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
 
             // 實際資料庫使用復合主鍵，但 SQLite 測試環境簡化處理
             $table->index(['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'], 'idx_altname_pk');

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -39,8 +39,6 @@ class OfficeAddressOperationLoggingTest extends TestCase {
             $table->integer('c_source')->default(0);
             $table->string('c_modified_by')->nullable();
             $table->timestamp('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
         });
 
         Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
@@ -50,12 +48,8 @@ class OfficeAddressOperationLoggingTest extends TestCase {
             $table->integer('c_addr_id');
             $table->string('c_created_by')->nullable();
             $table->timestamp('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
             $table->string('c_modified_by')->nullable();
             $table->timestamp('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
         });
 
         Schema::create('POSTING_DATA', function (Blueprint $table) {
@@ -63,12 +57,8 @@ class OfficeAddressOperationLoggingTest extends TestCase {
             $table->integer('c_posting_id')->primary();
             $table->string('c_created_by')->nullable();
             $table->timestamp('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
             $table->string('c_modified_by')->nullable();
             $table->timestamp('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -23,13 +23,9 @@ class OfficePostingStoreTest extends TestCase {
             $table->integer('c_posting_id')->primary();
             $table->integer('c_personid');
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
@@ -40,13 +36,9 @@ class OfficePostingStoreTest extends TestCase {
             $table->integer('c_ly_intercalary')->default(0);
             $table->integer('c_source')->default(0);
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
@@ -55,13 +47,9 @@ class OfficePostingStoreTest extends TestCase {
             $table->integer('c_office_id');
             $table->integer('c_addr_id');
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
         });
 
         Schema::create('operations', function (Blueprint $table) {

--- a/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
+++ b/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
@@ -143,13 +143,9 @@ class UnidirectionalRelationshipRepairControllerTest extends TestCase {
             $table->text('c_notes')->nullable();
             $table->text('c_autogen_notes')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
             $table->primary(['c_kin_code', 'c_kin_id', 'c_personid']);
 
             // 添加外键约束
@@ -213,13 +209,9 @@ class UnidirectionalRelationshipRepairControllerTest extends TestCase {
             $table->string('c_pages')->nullable();
             $table->text('c_notes')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->string('c_created_date')->nullable();
-
-            $table->timestamp('c_created_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->string('c_modified_date')->nullable();
-
-            $table->timestamp('c_modified_date_timestamp_temporary')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
 
             // 添加外键约束
             $table->foreign('c_assoc_code')->references('c_assoc_code')->on('ASSOC_CODES');


### PR DESCRIPTION
## 概要

完成時間戳欄位的重構工作，將臨時欄位 `c_created_date_timestamp_temporary` 和 `c_modified_date_timestamp_temporary` 重命名為正式名稱 `c_created_date` 和 `c_modified_date`，並刪除舊的 VARCHAR 格式欄位。

## 主要變更

### 📊 資料庫層 (Migration)

**新增 Migration**: `2025_12_22_000000_rename_timestamp_temporary_columns.php`

- ✅ 重命名 15 個表格的時間戳欄位
- ✅ 刪除舊的 VARCHAR 格式欄位 (YYYYMMDD 格式)
- ✅ 包含 pre-flight 驗證防止資料遺失
- ✅ **僅結構回退（structure-only rollback）**，避免複合主鍵資料損毀風險

**受影響的表格** (15 個):
- ALTNAME_DATA, ASSOC_DATA, BIOG_ADDR_DATA, BIOG_INST_DATA
- BIOG_MAIN, BIOG_TEXT_DATA, ENTRY_DATA, EVENTS_DATA
- KIN_DATA, MERGED_PERSON_DATA, POSSESSION_DATA
- POSTED_TO_OFFICE_DATA, STATUS_DATA, TEXT_CODES, TEXT_INSTANCE_DATA

### 🔧 核心邏輯更新

1. **ToolsRepository** (`app/Repositories/ToolsRepository.php`)
   - 簡化 `timestamp()` 方法，統一使用 `Carbon::now()` 物件
   - Laravel 自動處理格式轉換（資料庫 TIMESTAMP / JSON 序列化）

2. **CodesController** (`app/Http/Controllers/CodesController.php`)
   - **Create**: `enforceAuditFieldsForCreate()` 使用 Carbon 物件
   - **Update**: `enforceAuditFieldsForUpdate()` 統一使用 Carbon 物件（修正型別不一致）
   - 移除臨時欄位的特殊處理邏輯
   - 簡化審計欄位排序與時區轉換

3. **Blade 模板** (`resources/views/codes/edit.blade.php`)
   - 更新審計欄位陣列，移除 `_timestamp_temporary` 引用
   - 移除不再使用的 Ymd 格式變數

### 🧪 測試更新

**修正 12 個測試檔案**:
- 移除 schema 定義中的重複欄位聲明
- 更新日期格式斷言（Ymd → Y-m-d H:i:s）
- 修正 CodesControllerTest 以處理資料庫往返後的字串格式

## 技術細節

### 時間戳儲存與顯示策略

```
寫入流程:
Carbon::now() (UTC 物件)
    ↓
Laravel Query Builder
    ↓
MySQL TIMESTAMP (Y-m-d H:i:s 格式)

讀取流程:
MySQL TIMESTAMP
    ↓
Laravel 返回字串 (Y-m-d H:i:s)
    ↓
CodesController 轉換為 Asia/Taipei 時區
    ↓
顯示為本地時間
```

### Migration Rollback 策略（修正複合主鍵問題）

**問題**: 原設計使用單一主鍵更新資料，但多數表格使用複合主鍵：
- `ALTNAME_DATA`: c_alt_name_chn + c_alt_name_type_code + c_personid
- `KIN_DATA`: c_kin_code + c_kin_id + c_personid  
- `POSTED_TO_OFFICE_DATA`: c_office_id + c_posting_id

**解決方案**: 改為僅執行結構回退（structure-only rollback）
- ✅ 重命名 TIMESTAMP 欄位回臨時名稱
- ✅ 重建空的 VARCHAR 欄位
- ✅ **不自動轉換資料**（避免複合主鍵衝突導致資料損毀）
- ✅ 在 docblock 明確說明需手動處理資料轉換
- ✅ 移除 `getPrimaryKeyColumn()` 等不安全的單一主鍵假設

### 型別一致性修正

**問題**: Create 使用 Carbon 物件，Update 使用字串格式，可能導致時區漂移

**解決方案**: 統一使用 Carbon 物件
```php
// Before (不一致):
enforceAuditFieldsForCreate():  $data['c_created_date'] = $now;  // Carbon 物件
enforceAuditFieldsForUpdate():  $data['c_modified_date'] = $now->format('Y-m-d H:i:s');  // 字串

// After (一致):
enforceAuditFieldsForCreate():  $data['c_created_date'] = $now;  // Carbon 物件
enforceAuditFieldsForUpdate():  $data['c_modified_date'] = $now;  // Carbon 物件
```

### 向下相容性

- ✅ 現有資料格式（Y-m-d H:i:s）完全相容
- ✅ `Carbon::parse()` 可正確解析資料庫返回的字串
- ✅ 顯示邏輯保持不變（Asia/Taipei 時區轉換）

## 驗證步驟

### Migration 驗證
```bash
php artisan migrate
php artisan tinker
>>> Schema::getColumnListing('BIOG_MAIN')
>>> DB::select('DESCRIBE BIOG_MAIN')
```

### 測試驗證
```bash
./vendor/bin/phpunit
```

## 測試結果

```
✅ 298/298 測試通過 (100%)
✅ 1066 個斷言全部成功
⏱️ 執行時間: 55.085 秒
💾 記憶體使用: 114 MB
```

## Commits

1. **refactor: 完成時間戳欄位重構，移除臨時欄位名稱** (645d134)
   - 初始重構實作
   - Migration、Repository、Controller、Blade 模板更新
   - 12 個測試檔案修正

2. **fix: 修正 migration rollback 與 update 時間戳不一致問題** (61f7a3f)
   - 修正 migration down() 複合主鍵資料損毀風險（High Priority）
   - 統一 CodesController create/update 使用 Carbon 物件（Medium Priority）

## 檢查清單

- [x] Migration 包含 pre-flight 驗證
- [x] Migration down() 修正為 structure-only，避免資料損毀
- [x] 核心 Repository 邏輯更新
- [x] Controller create/update 型別一致性修正
- [x] Blade 模板審計欄位陣列更新
- [x] 所有測試檔案更新並通過
- [x] php-cs-fixer 格式化通過
- [x] 完整測試套件通過（298/298）

## 相關議題

此 PR 完成之前規劃的時間戳欄位重構工作，移除雙寫邏輯，簡化代碼維護。

🤖 Generated with [Claude Code](https://claude.com/claude-code)