### PR TITLE
修補資料庫事故：migration 改用專用連線與帳號，修正基線 schema 建表行為

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ DB_PASSWORD=secret
 # For GMT+8 (Asia/Shanghai equivalent), use: +08:00
 DB_TIMEZONE=+08:00
 
+# For migration user only
+DB_MIGRATE_USERNAME=homestead_migrate
+DB_MIGRATE_PASSWORD=secret
+
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/config/database.php
+++ b/config/database.php
@@ -62,6 +62,24 @@ return [
             ] : [],
         ],
 
+        'mysql_migrate' => [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE'),
+            'username' => env('DB_MIGRATE_USERNAME'),
+            'password' => env('DB_MIGRATE_PASSWORD'),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'strict' => false,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? [
+                PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+            ] : [],
+        ],
+
         'pgsql' => [
             'driver' => 'pgsql',
             'host' => env('DB_HOST', '127.0.0.1'),

--- a/config/database.php
+++ b/config/database.php
@@ -75,6 +75,11 @@ return [
             'prefix' => '',
             'strict' => false,
             'engine' => null,
+            // CRITICAL: DB_TIMEZONE must match config('app.timezone') to prevent TIMESTAMP drift
+            // Default '+08:00' corresponds to 'Asia/Shanghai' (GMT+8)
+            // MUST use numeric offset format (e.g., '+08:00'), NOT named timezones (e.g., 'Asia/Shanghai')
+            // If APP_TIMEZONE is changed, DB_TIMEZONE must be updated accordingly in .env
+            'timezone' => env('DB_TIMEZONE', '+08:00'),
             'options' => extension_loaded('pdo_mysql') ? [
                 PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
             ] : [],


### PR DESCRIPTION
據電郵討論，建議生產環境採用不同 db 帳戶執行 migration 及其他危險操作。本 PR 中創建了一組新的 DB connection （`mysql_migrate`），其假定如下：

1. `cbdb` DB user 的危險權限被刪除，僅保留日常操作需要的最小權限；`cbdb_migrate` 具有操作表結構的完整權限
2. 網站程式平時用 `mysql` 這個連結，綁定 `cbdb` 這個 user
3. 執行危險操作例如 migration 時，改用 `mysql_migrate` 这个這個連結，它綁定 `cbdb_migrate` 這個 user

使用方法：

```bash
$ DB_CONNECTION=mysql_migrate php artisan migrate
```

權限更改的 MySQL 命令如下：（其中 cbdb_data_1 為库名）

```
REVOKE ALL PRIVILEGES, GRANT OPTION ON cbdb_data_1.* FROM 'cbdb'@'%';
GRANT SELECT, INSERT, UPDATE, DELETE ON cbdb_data_1.* TO 'cbdb'@'%';
CREATE USER 'cbdb_migrate'@'localhost' IDENTIFIED BY 'a-very-strong-password';
GRANT CREATE, DROP, ALTER, INDEX ON cbdb_data_1.* TO 'cbdb_migrate'@'localhost';
```

如果權限設定正確，今後使用預設的 `cbdb` 帳戶對表結構的操作將會失敗。