### PR TITLE
新增 operations 缺漏使用者補齊腳本

### DIFF
--- a/scripts/backfill_missing_operation_users.php
+++ b/scripts/backfill_missing_operation_users.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$app = require __DIR__ . '/../bootstrap/app.php';
+$app->make(Kernel::class)->bootstrap();
+
+$missingIds = DB::table('operations')
+    ->leftJoin('users', 'operations.user_id', '=', 'users.id')
+    ->whereNull('users.id')
+    ->select('operations.user_id')
+    ->distinct()
+    ->orderBy('operations.user_id')
+    ->pluck('operations.user_id');
+
+if ($missingIds->isEmpty()) {
+    echo "No missing users found.\n";
+    exit(0);
+}
+
+$now = now();
+$rows = [];
+
+foreach ($missingIds as $userId) {
+    $label = (string) $userId;
+
+    $rows[] = [
+        'id' => $userId,
+        'name' => 'User ' . $label,
+        'email' => 'user-' . $label . '@example.com',
+        'password' => Hash::make(Str::random(32)),
+        'confirmation_token' => Str::random(32),
+        'created_at' => $now,
+        'updated_at' => $now,
+    ];
+}
+
+DB::table('users')->insert($rows);
+
+echo 'Inserted ' . count($rows) . " placeholder users.\n";


### PR DESCRIPTION
提供一次性 PHP 腳本，補齊 operations.user_id 在 users 表不存在的紀錄。

以 user-<id>@example.com 與 User <id> 建立 placeholder 帳號，僅供 local development backfill 使用。