### PR TITLE
改進： 調整基本資訊時間欄位排版及日期驗證邏輯

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -203,6 +203,36 @@ import SelectVue from './components/Select.vue';
 // Make createApp globally available for pages that need it
 window.createVueApp = createApp;
 
+// Lunar month/day validation helper for forms
+window.initLunarValidation = function(scope = document) {
+    const $scope = $(scope);
+    const validateLunarInput = ($input, max) => {
+        const value = $input.val().trim();
+        if (value === '') {
+            $input.removeClass('is-invalid');
+            return;
+        }
+        const parsed = Number(value);
+        const isInteger = Number.isInteger(parsed);
+        const isValid = isInteger && parsed >= 1 && parsed <= max;
+        $input.toggleClass('is-invalid', !isValid);
+    };
+
+    const bindInputs = (selector, max) => {
+        const $inputs = $scope.find(selector);
+        $inputs.each(function() {
+            const $input = $(this);
+            validateLunarInput($input, max);
+        });
+        $inputs.off('.lunarValidation').on('input.lunarValidation change.lunarValidation', function() {
+            validateLunarInput($(this), max);
+        });
+    };
+
+    bindInputs('.lunar-month', 12);
+    bindInputs('.lunar-day', 30);
+};
+
 // Install global modal focus guard when DOM is ready
 $(installModalFocusFix);
 $(installMobileSidebarDismiss);

--- a/resources/js/components/Select.vue
+++ b/resources/js/components/Select.vue
@@ -1,5 +1,5 @@
 <template>
-    <select class="form-control select2" v-bind:name="name" v-model="selectedid">
+    <select class="form-control select2" :id="id" v-bind:name="name" v-model="selectedid">
         <!--<option disabled value="">请选择</option>-->
         <option value="">请选择</option>
         <option v-for="item in data" v-bind:value="id(item)">{{ normalization(item) }}</option>
@@ -13,7 +13,7 @@
     const pendingRequests = {};
 
     export default {
-        props: ['name', 'model', 'selected'],
+        props: ['name', 'model', 'selected', 'id', 'idKey'],
         data() {
           return {
               data: {},
@@ -73,10 +73,53 @@
                 return str.trim();
             },
             id(item) {
-                for (let key in item) {
-//                    console.log(item[key]);
-                    return item[key];
+                const modelIdKeyMap = {
+                    ethnicity: 'c_ethnicity_code',
+                    choronym: 'c_choronym_code',
+                    dynasty: 'c_dy',
+                    nianhao: 'c_nianhao_id',
+                    biogaddr: 'c_addr_type',
+                    altcode: 'c_name_type_code',
+                    role: 'c_role_id',
+                    range: 'c_range_code',
+                    ganzhi: 'c_ganzhi_code',
+                    household: 'c_household_status_code',
+                    appttype: 'c_appt_code',
+                    assumeoffice: 'c_assume_office_code',
+                    officecate: 'c_office_category_id',
+                    parentstatus: 'c_parental_status_code',
+                    measure: 'c_measure_code',
+                    possact: 'c_possession_act_code',
+                    birole: 'c_bi_role_code',
+                    topic: 'c_topic_code',
+                    occasion: 'c_occasion_code',
+                };
+
+                const preferredKey = this.idKey || modelIdKeyMap[this.model];
+                if (preferredKey && Object.prototype.hasOwnProperty.call(item, preferredKey)) {
+                    return item[preferredKey];
                 }
+
+                if (Object.prototype.hasOwnProperty.call(item, 'id')) {
+                    return item.id;
+                }
+
+                const keys = Object.keys(item);
+                if (keys.length === 1) {
+                    return item[keys[0]];
+                }
+
+                const suffixPriority = ['_id', '_code'];
+                for (const suffix of suffixPriority) {
+                    const matches = keys.filter((key) => key.endsWith(suffix));
+                    if (matches.length > 0) {
+                        matches.sort();
+                        return item[matches[0]];
+                    }
+                }
+
+                keys.sort();
+                return keys.length > 0 ? item[keys[0]] : '';
             }
         },
     }

--- a/resources/views/biogmains/addresses/_form.blade.php
+++ b/resources/views/biogmains/addresses/_form.blade.php
@@ -51,69 +51,119 @@
 
     <div class="form-group row">
         <label for="c_firstyear" class="col-sm-2 col-form-label">始年(c_firstyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_firstyear" class="form-control" value="{{ $isEdit ? $row->c_firstyear : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_fy_nh_code">年号</label>
-            <select-vue name="c_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_fy_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_fy_nh_year" class="form-control" value="{{ $isEdit ? $row->c_fy_nh_year : '' }}">
-            <span for="">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_fy_range" model="range" selected="{{ $isEdit ? $row->c_fy_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_fy_intercalary" class="form-control select2">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_fy_intercalary == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_fy_intercalary == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_fy_month" class="form-control" value="{{ $isEdit ? $row->c_fy_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_fy_day" class="form-control" value="{{ $isEdit ? $row->c_fy_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_fy_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_fy_day_gz : '' }}"></select-vue>
+        <div class="col-sm-10">
+            <div class="d-flex align-items-center flex-wrap">
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
+                    <input type="number" name="c_firstyear" class="form-control" style="width: 12ch; min-width: 12ch;" value="{{ $isEdit ? $row->c_firstyear : '' }}">
+                </div>
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
+                    <label class="mb-0 mr-2" for="c_fy_nh_code">年号</label>
+                    <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
+                        <select-vue name="c_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_fy_nh_code : '' }}"></select-vue>
+                    </div>
+                    <input type="number" name="c_fy_nh_year" class="form-control mr-2"
+                           style="width: 8ch; min-width: 8ch;"
+                           value="{{ $isEdit ? $row->c_fy_nh_year : '' }}">
+                    <span>年</span>
+                </div>
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
+                    <label class="mb-0 mr-2" for="c_fy_range">時限</label>
+                    <div class="flex-grow-1" style="min-width: 16ch;">
+                        <select-vue name="c_fy_range" model="range" selected="{{ $isEdit ? $row->c_fy_range : '' }}"></select-vue>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+                    <div class="custom-control custom-checkbox mr-4">
+                        <input type="hidden" name="c_fy_intercalary" value="0">
+                        <input type="checkbox"
+                               class="custom-control-input"
+                               id="c_fy_intercalary"
+                               name="c_fy_intercalary"
+                               value="1"
+                               {{ ($isEdit && $row->c_fy_intercalary == 1) ? 'checked' : '' }}>
+                        <label class="custom-control-label" for="c_fy_intercalary">閏月</label>
+                    </div>
+                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                        <input type="number" name="c_fy_month" class="form-control lunar-month"
+                               min="1"
+                               max="12"
+                               value="{{ $isEdit ? $row->c_fy_month : '' }}">
+                        <div class="invalid-feedback">請輸入 1-12 或留空</div>
+                    </div>
+                    <span class="mr-2">月</span>
+                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                        <input type="number" name="c_fy_day" class="form-control lunar-day"
+                               min="1"
+                               max="30"
+                               value="{{ $isEdit ? $row->c_fy_day : '' }}">
+                        <div class="invalid-feedback">請輸入 1-30 或留空</div>
+                    </div>
+                    <span class="mr-2">日</span>
+                    <label class="mb-0 mr-2">日(干支)</label>
+                    <div class="flex-grow-1" style="min-width: 12ch;">
+                        <select-vue name="c_fy_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_fy_day_gz : '' }}"></select-vue>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
     <div class="form-group row">
         <label for="c_lastyear" class="col-sm-2 col-form-label">終年(c_lastyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_lastyear" class="form-control" value="{{ $isEdit ? $row->c_lastyear : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_ly_nh_code">年号</label>
-            <select-vue name="c_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_ly_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_ly_nh_year" class="form-control" value="{{ $isEdit ? $row->c_ly_nh_year : '' }}">
-            <span for="">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_ly_range" model="range" selected="{{ $isEdit ? $row->c_ly_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_ly_intercalary" class="form-control select2">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_ly_intercalary == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_ly_intercalary == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_ly_month" class="form-control" value="{{ $isEdit ? $row->c_ly_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_ly_day" class="form-control" value="{{ $isEdit ? $row->c_ly_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_ly_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_ly_day_gz : '' }}"></select-vue>
+        <div class="col-sm-10">
+            <div class="d-flex align-items-center flex-wrap">
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
+                    <input type="number" name="c_lastyear" class="form-control" style="width: 12ch; min-width: 12ch;" value="{{ $isEdit ? $row->c_lastyear : '' }}">
+                </div>
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
+                    <label class="mb-0 mr-2" for="c_ly_nh_code">年号</label>
+                    <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
+                        <select-vue name="c_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_ly_nh_code : '' }}"></select-vue>
+                    </div>
+                    <input type="number" name="c_ly_nh_year" class="form-control mr-2"
+                           style="width: 8ch; min-width: 8ch;"
+                           value="{{ $isEdit ? $row->c_ly_nh_year : '' }}">
+                    <span>年</span>
+                </div>
+                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
+                    <label class="mb-0 mr-2" for="c_ly_range">時限</label>
+                    <div class="flex-grow-1" style="min-width: 16ch;">
+                        <select-vue name="c_ly_range" model="range" selected="{{ $isEdit ? $row->c_ly_range : '' }}"></select-vue>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+                    <div class="custom-control custom-checkbox mr-4">
+                        <input type="hidden" name="c_ly_intercalary" value="0">
+                        <input type="checkbox"
+                               class="custom-control-input"
+                               id="c_ly_intercalary"
+                               name="c_ly_intercalary"
+                               value="1"
+                               {{ ($isEdit && $row->c_ly_intercalary == 1) ? 'checked' : '' }}>
+                        <label class="custom-control-label" for="c_ly_intercalary">閏月</label>
+                    </div>
+                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                        <input type="number" name="c_ly_month" class="form-control lunar-month"
+                               min="1"
+                               max="12"
+                               value="{{ $isEdit ? $row->c_ly_month : '' }}">
+                        <div class="invalid-feedback">請輸入 1-12 或留空</div>
+                    </div>
+                    <span class="mr-2">月</span>
+                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                        <input type="number" name="c_ly_day" class="form-control lunar-day"
+                               min="1"
+                               max="30"
+                               value="{{ $isEdit ? $row->c_ly_day : '' }}">
+                        <div class="invalid-feedback">請輸入 1-30 或留空</div>
+                    </div>
+                    <span class="mr-2">日</span>
+                    <label class="mb-0 mr-2">日(干支)</label>
+                    <div class="flex-grow-1" style="min-width: 12ch;">
+                        <select-vue name="c_ly_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_ly_day_gz : '' }}"></select-vue>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -192,6 +242,37 @@
         textperson_pair_first_load();
         $(".c_addr_id").select2(options('addr'));
         $(".c_source").select2(options('text'));
+
+        function validateLunarInput($input, max) {
+            var value = $input.val().trim();
+            if (value === '') {
+                $input.removeClass('is-invalid');
+                return;
+            }
+            var parsed = Number(value);
+            var isInteger = Number.isInteger(parsed);
+            var isValid = isInteger && parsed >= 1 && parsed <= max;
+            $input.toggleClass('is-invalid', !isValid);
+        }
+
+        function bindLunarValidation() {
+            $('.lunar-month').each(function () {
+                var $input = $(this);
+                validateLunarInput($input, 12);
+                $input.on('input change', function () {
+                    validateLunarInput($input, 12);
+                });
+            });
+            $('.lunar-day').each(function () {
+                var $input = $(this);
+                validateLunarInput($input, 30);
+                $input.on('input change', function () {
+                    validateLunarInput($input, 30);
+                });
+            });
+        }
+
+        bindLunarValidation();
 
         function formatRepo (repo) {
             if (repo.loading) {

--- a/resources/views/biogmains/addresses/_form.blade.php
+++ b/resources/views/biogmains/addresses/_form.blade.php
@@ -51,120 +51,48 @@
 
     <div class="form-group row">
         <label for="c_firstyear" class="col-sm-2 col-form-label">始年(c_firstyear)</label>
-        <div class="col-sm-10">
-            <div class="d-flex align-items-center flex-wrap">
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
-                    <input type="number" name="c_firstyear" class="form-control" style="width: 12ch; min-width: 12ch;" value="{{ $isEdit ? $row->c_firstyear : '' }}">
-                </div>
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
-                    <label class="mb-0 mr-2" for="c_fy_nh_code">年号</label>
-                    <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                        <select-vue name="c_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_fy_nh_code : '' }}"></select-vue>
-                    </div>
-                    <input type="number" name="c_fy_nh_year" class="form-control mr-2"
-                           style="width: 8ch; min-width: 8ch;"
-                           value="{{ $isEdit ? $row->c_fy_nh_year : '' }}">
-                    <span>年</span>
-                </div>
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
-                    <label class="mb-0 mr-2" for="c_fy_range">時限</label>
-                    <div class="flex-grow-1" style="min-width: 16ch;">
-                        <select-vue name="c_fy_range" model="range" selected="{{ $isEdit ? $row->c_fy_range : '' }}"></select-vue>
-                    </div>
-                </div>
-                <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
-                    <div class="custom-control custom-checkbox mr-4">
-                        <input type="hidden" name="c_fy_intercalary" value="0">
-                        <input type="checkbox"
-                               class="custom-control-input"
-                               id="c_fy_intercalary"
-                               name="c_fy_intercalary"
-                               value="1"
-                               {{ ($isEdit && $row->c_fy_intercalary == 1) ? 'checked' : '' }}>
-                        <label class="custom-control-label" for="c_fy_intercalary">閏月</label>
-                    </div>
-                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                        <input type="number" name="c_fy_month" class="form-control lunar-month"
-                               min="1"
-                               max="12"
-                               value="{{ $isEdit ? $row->c_fy_month : '' }}">
-                        <div class="invalid-feedback">請輸入 1-12 或留空</div>
-                    </div>
-                    <span class="mr-2">月</span>
-                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                        <input type="number" name="c_fy_day" class="form-control lunar-day"
-                               min="1"
-                               max="30"
-                               value="{{ $isEdit ? $row->c_fy_day : '' }}">
-                        <div class="invalid-feedback">請輸入 1-30 或留空</div>
-                    </div>
-                    <span class="mr-2">日</span>
-                    <label class="mb-0 mr-2">日(干支)</label>
-                    <div class="flex-grow-1" style="min-width: 12ch;">
-                        <select-vue name="c_fy_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_fy_day_gz : '' }}"></select-vue>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <x-inline-time-fields
+            yearName="c_firstyear"
+            :yearValue="$isEdit ? $row->c_firstyear : ''"
+            nhCodeName="c_fy_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_fy_nh_code : ''"
+            nhYearName="c_fy_nh_year"
+            :nhYearValue="$isEdit ? $row->c_fy_nh_year : ''"
+            rangeName="c_fy_range"
+            :rangeValue="$isEdit ? $row->c_fy_range : ''"
+            :showLunar="true"
+            intercalaryName="c_fy_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_fy_intercalary : ''"
+            monthName="c_fy_month"
+            :monthValue="$isEdit ? $row->c_fy_month : ''"
+            dayName="c_fy_day"
+            :dayValue="$isEdit ? $row->c_fy_day : ''"
+            dayGzName="c_fy_day_gz"
+            :dayGzValue="$isEdit ? $row->c_fy_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
         <label for="c_lastyear" class="col-sm-2 col-form-label">終年(c_lastyear)</label>
-        <div class="col-sm-10">
-            <div class="d-flex align-items-center flex-wrap">
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
-                    <input type="number" name="c_lastyear" class="form-control" style="width: 12ch; min-width: 12ch;" value="{{ $isEdit ? $row->c_lastyear : '' }}">
-                </div>
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
-                    <label class="mb-0 mr-2" for="c_ly_nh_code">年号</label>
-                    <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                        <select-vue name="c_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_ly_nh_code : '' }}"></select-vue>
-                    </div>
-                    <input type="number" name="c_ly_nh_year" class="form-control mr-2"
-                           style="width: 8ch; min-width: 8ch;"
-                           value="{{ $isEdit ? $row->c_ly_nh_year : '' }}">
-                    <span>年</span>
-                </div>
-                <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
-                    <label class="mb-0 mr-2" for="c_ly_range">時限</label>
-                    <div class="flex-grow-1" style="min-width: 16ch;">
-                        <select-vue name="c_ly_range" model="range" selected="{{ $isEdit ? $row->c_ly_range : '' }}"></select-vue>
-                    </div>
-                </div>
-                <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
-                    <div class="custom-control custom-checkbox mr-4">
-                        <input type="hidden" name="c_ly_intercalary" value="0">
-                        <input type="checkbox"
-                               class="custom-control-input"
-                               id="c_ly_intercalary"
-                               name="c_ly_intercalary"
-                               value="1"
-                               {{ ($isEdit && $row->c_ly_intercalary == 1) ? 'checked' : '' }}>
-                        <label class="custom-control-label" for="c_ly_intercalary">閏月</label>
-                    </div>
-                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                        <input type="number" name="c_ly_month" class="form-control lunar-month"
-                               min="1"
-                               max="12"
-                               value="{{ $isEdit ? $row->c_ly_month : '' }}">
-                        <div class="invalid-feedback">請輸入 1-12 或留空</div>
-                    </div>
-                    <span class="mr-2">月</span>
-                    <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                        <input type="number" name="c_ly_day" class="form-control lunar-day"
-                               min="1"
-                               max="30"
-                               value="{{ $isEdit ? $row->c_ly_day : '' }}">
-                        <div class="invalid-feedback">請輸入 1-30 或留空</div>
-                    </div>
-                    <span class="mr-2">日</span>
-                    <label class="mb-0 mr-2">日(干支)</label>
-                    <div class="flex-grow-1" style="min-width: 12ch;">
-                        <select-vue name="c_ly_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_ly_day_gz : '' }}"></select-vue>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <x-inline-time-fields
+            yearName="c_lastyear"
+            :yearValue="$isEdit ? $row->c_lastyear : ''"
+            nhCodeName="c_ly_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_ly_nh_code : ''"
+            nhYearName="c_ly_nh_year"
+            :nhYearValue="$isEdit ? $row->c_ly_nh_year : ''"
+            rangeName="c_ly_range"
+            :rangeValue="$isEdit ? $row->c_ly_range : ''"
+            :showLunar="true"
+            intercalaryName="c_ly_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_ly_intercalary : ''"
+            monthName="c_ly_month"
+            :monthValue="$isEdit ? $row->c_ly_month : ''"
+            dayName="c_ly_day"
+            :dayValue="$isEdit ? $row->c_ly_day : ''"
+            dayGzName="c_ly_day_gz"
+            :dayGzValue="$isEdit ? $row->c_ly_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -188,7 +116,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" cols="30" rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
         </div>
@@ -243,36 +171,9 @@
         $(".c_addr_id").select2(options('addr'));
         $(".c_source").select2(options('text'));
 
-        function validateLunarInput($input, max) {
-            var value = $input.val().trim();
-            if (value === '') {
-                $input.removeClass('is-invalid');
-                return;
-            }
-            var parsed = Number(value);
-            var isInteger = Number.isInteger(parsed);
-            var isValid = isInteger && parsed >= 1 && parsed <= max;
-            $input.toggleClass('is-invalid', !isValid);
+        if (window.initLunarValidation) {
+            window.initLunarValidation();
         }
-
-        function bindLunarValidation() {
-            $('.lunar-month').each(function () {
-                var $input = $(this);
-                validateLunarInput($input, 12);
-                $input.on('input change', function () {
-                    validateLunarInput($input, 12);
-                });
-            });
-            $('.lunar-day').each(function () {
-                var $input = $(this);
-                validateLunarInput($input, 30);
-                $input.on('input change', function () {
-                    validateLunarInput($input, 30);
-                });
-            });
-        }
-
-        bindLunarValidation();
 
         function formatRepo (repo) {
             if (repo.loading) {

--- a/resources/views/biogmains/altname/_form.blade.php
+++ b/resources/views/biogmains/altname/_form.blade.php
@@ -82,7 +82,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             @php
                 $c_notes_value = $isEdit ? unionPKDef_decode_for_convert($row->c_notes) : '';

--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -106,74 +106,52 @@
 
     <div class="form-group row">
         <label for="c_assoc_fy_year" class="col-sm-2 col-form-label">社會關係始年</label>
-        <div class="col-md-1">
-            <input type="number" name="c_assoc_first_year" class="form-control" value="{{ $isEdit ? $row->c_assoc_first_year : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_assoc_fy_nh_code">年号</label>
-            <select-vue name="c_assoc_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_assoc_fy_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_assoc_fy_nh_year" class="form-control" value="{{ $isEdit ? $row->c_assoc_fy_nh_year : '' }}">
-            <span for="c_assoc_fy_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_assoc_fy_range" model="range" selected="{{ $isEdit ? $row->c_assoc_fy_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_assoc_fy_intercalary" class="form-control select2">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_assoc_fy_intercalary == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_assoc_fy_intercalary == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_assoc_fy_month" class="form-control" value="{{ $isEdit ? $row->c_assoc_fy_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_assoc_fy_day" class="form-control" value="{{ $isEdit ? $row->c_assoc_fy_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_assoc_fy_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_assoc_fy_day_gz : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_assoc_first_year"
+            :yearValue="$isEdit ? $row->c_assoc_first_year : ''"
+            nhCodeName="c_assoc_fy_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_assoc_fy_nh_code : ''"
+            nhYearName="c_assoc_fy_nh_year"
+            :nhYearValue="$isEdit ? $row->c_assoc_fy_nh_year : ''"
+            rangeName="c_assoc_fy_range"
+            :rangeValue="$isEdit ? $row->c_assoc_fy_range : ''"
+            :showLunar="true"
+            intercalaryName="c_assoc_fy_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_assoc_fy_intercalary : ''"
+            monthName="c_assoc_fy_month"
+            :monthValue="$isEdit ? $row->c_assoc_fy_month : ''"
+            dayName="c_assoc_fy_day"
+            :dayValue="$isEdit ? $row->c_assoc_fy_day : ''"
+            dayGzName="c_assoc_fy_day_gz"
+            :dayGzValue="$isEdit ? $row->c_assoc_fy_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
         <label for="c_assoc_ly_year" class="col-sm-2 col-form-label">社會關係終年</label>
-        <div class="col-md-1">
-            <input type="number" name="c_assoc_last_year" class="form-control" value="{{ $isEdit ? $row->c_assoc_last_year : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_assoc_ly_nh_code">年号</label>
-            <select-vue name="c_assoc_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_assoc_ly_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_assoc_ly_nh_year" class="form-control" value="{{ $isEdit ? $row->c_assoc_ly_nh_year : '' }}">
-            <span for="c_assoc_ly_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_assoc_ly_range" model="range" selected="{{ $isEdit ? $row->c_assoc_ly_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_assoc_ly_intercalary" class="form-control select2">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_assoc_ly_intercalary == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_assoc_ly_intercalary == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_assoc_ly_month" class="form-control" value="{{ $isEdit ? $row->c_assoc_ly_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_assoc_ly_day" class="form-control" value="{{ $isEdit ? $row->c_assoc_ly_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_assoc_ly_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_assoc_ly_day_gz : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_assoc_last_year"
+            :yearValue="$isEdit ? $row->c_assoc_last_year : ''"
+            nhCodeName="c_assoc_ly_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_assoc_ly_nh_code : ''"
+            nhYearName="c_assoc_ly_nh_year"
+            :nhYearValue="$isEdit ? $row->c_assoc_ly_nh_year : ''"
+            rangeName="c_assoc_ly_range"
+            :rangeValue="$isEdit ? $row->c_assoc_ly_range : ''"
+            :showLunar="true"
+            intercalaryName="c_assoc_ly_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_assoc_ly_intercalary : ''"
+            monthName="c_assoc_ly_month"
+            :monthValue="$isEdit ? $row->c_assoc_ly_month : ''"
+            dayName="c_assoc_ly_day"
+            :dayValue="$isEdit ? $row->c_assoc_ly_day : ''"
+            dayGzName="c_assoc_ly_day_gz"
+            :dayGzValue="$isEdit ? $row->c_assoc_ly_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             @php
                 $notes_value = $isEdit ? unionPKDef_decode_for_convert($row->c_notes) : '';
@@ -379,6 +357,10 @@
         $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_source").select2(options('text'));
         $(".c_assocship_pair").select2();
+
+        if (window.initLunarValidation) {
+            window.initLunarValidation();
+        }
 
         // 绑定事件监听器
         $(".c_kin_code").on('change', function() {

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -182,80 +182,128 @@
 
                 <div class="form-group row">
                     <label for="c_firstyear" class="col-sm-2 col-form-label">生年(birth year)</label>
-                    <div class="col-md-1">
-                        <input type="number" name="c_birthyear" class="form-control"
-                               value="{{ $basicinformation->c_birthyear }}" onchange="indexYear()">
-                    </div>
-
-                    <div class="col-md-2 from-inline">
-                        <label for="c_fy_nh_code">年号</label>
-                        <select-vue name="c_by_nh_code" model="nianhao" selected="{{ $basicinformation->c_by_nh_code }}"></select-vue>
-                        <input type="number" name="c_by_nh_year" class="form-control"
-                               value="{{ $basicinformation->c_by_nh_year }}">
-                        <span for="">年</span>
-                    </div>
-                    <div class="col-md-3">
-                        <label for="">時限</label>
-                        <select-vue name="c_by_range" model="range" selected="{{ $basicinformation->c_by_range }}"></select-vue>
-                    </div>
-                    <div class="col-md-2">
-                        <label for="">閏</label>
-                        <select name="c_by_intercalary" class="form-control select2">
-                            <option disabled value="">请选择</option>
-                            <option value="0" {{ $basicinformation->c_by_intercalary == 0? 'selected': '' }}>0-否
-                            </option>
-                            <option value="1" {{ $basicinformation->c_by_intercalary == 1? 'selected': '' }}>1-是
-                            </option>
-                        </select>
-                    </div>
-                    <div class="col-sm-2">
-                        <input type="number" name="c_by_month" class="form-control"
-                               value="{{ $basicinformation->c_by_month }}">
-                        <span for="">月</span>
-                        <input type="number" name="c_by_day" class="form-control"
-                               value="{{ $basicinformation->c_by_day }}">
-                        <span for="">日</span>
-                        <label for="">日(干支) </label>
-                        <select-vue name="c_by_day_gz" model="ganzhi" selected="{{ $basicinformation->c_by_day_gz }}"></select-vue>
+                    <div class="col-sm-10">
+                        <div class="d-flex align-items-center flex-wrap">
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
+                                <input type="number" name="c_birthyear" class="form-control"
+                                       style="width: 12ch; min-width: 12ch;"
+                                       value="{{ $basicinformation->c_birthyear }}" onchange="indexYear()">
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
+                                <label class="mb-0 mr-2" for="c_fy_nh_code">年号</label>
+                                <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
+                                    <select-vue name="c_by_nh_code" model="nianhao" selected="{{ $basicinformation->c_by_nh_code }}"></select-vue>
+                                </div>
+                                <input type="number" name="c_by_nh_year" class="form-control mr-2"
+                                       style="width: 8ch; min-width: 8ch;"
+                                       value="{{ $basicinformation->c_by_nh_year }}">
+                                <span>年</span>
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
+                                <label class="mb-0 mr-2" for="c_by_range">時限</label>
+                                <div class="flex-grow-1" style="min-width: 16ch;">
+                                    <select-vue name="c_by_range" model="range" selected="{{ $basicinformation->c_by_range }}"></select-vue>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+                                <div class="custom-control custom-checkbox mr-4">
+                                    <input type="hidden" name="c_by_intercalary" value="0">
+                                    <input type="checkbox"
+                                           class="custom-control-input"
+                                           id="c_by_intercalary"
+                                           name="c_by_intercalary"
+                                           value="1"
+                                           {{ $basicinformation->c_by_intercalary == 1 ? 'checked' : '' }}>
+                                    <label class="custom-control-label" for="c_by_intercalary">閏月</label>
+                                </div>
+                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                                    <input type="number" class="form-control lunar-month intercalary-month"
+                                           data-field="c_by_month"
+                                           name="c_by_month"
+                                           min="1"
+                                           max="12"
+                                           step="1"
+                                           value="{{ $basicinformation->c_by_month }}">
+                                    <div class="invalid-feedback">請輸入 1-12 或留空</div>
+                                </div>
+                                <span class="mr-2">月</span>
+                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                                    <input type="number" name="c_by_day" class="form-control lunar-day"
+                                           min="1"
+                                           max="30"
+                                           value="{{ $basicinformation->c_by_day }}">
+                                    <div class="invalid-feedback">請輸入 1-30 或留空</div>
+                                </div>
+                                <span class="mr-2">日</span>
+                                <label class="mb-0 mr-2">日(干支)</label>
+                                <div class="flex-grow-1" style="min-width: 12ch;">
+                                    <select-vue name="c_by_day_gz" model="ganzhi" selected="{{ $basicinformation->c_by_day_gz }}"></select-vue>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="form-group row">
                     <label for="c_firstyear" class="col-sm-2 col-form-label">卒年(death year)</label>
-                    <div class="col-md-1">
-                        <input type="number" name="c_deathyear" class="form-control"
-                               value="{{ $basicinformation->c_deathyear }}" onchange="indexYear()">
-                    </div>
-
-                    <div class="col-md-2 from-inline">
-                        <label for="c_dy_nh_code">年号</label>
-                        <select-vue name="c_dy_nh_code" model="nianhao" selected="{{ $basicinformation->c_dy_nh_code }}"></select-vue>
-                        <input type="number" name="c_dy_nh_year" class="form-control"
-                               value="{{ $basicinformation->c_dy_nh_year }}">
-                        <span for="">年</span>
-                    </div>
-                    <div class="col-md-3">
-                        <label for="">時限</label>
-                        <select-vue name="c_dy_range" model="range" selected="{{ $basicinformation->c_dy_range }}"></select-vue>
-                    </div>
-                    <div class="col-md-2">
-                        <label for="">閏</label>
-                        <select name="c_dy_intercalary" class="form-control select2">
-                            <option disabled value="">请选择</option>
-                            <option value="0" {{ $basicinformation->c_dy_intercalary == 0? 'selected': '' }}>0-否
-                            </option>
-                            <option value="1" {{ $basicinformation->c_dy_intercalary == 1? 'selected': '' }}>1-是
-                            </option>
-                        </select>
-                    </div>
-                    <div class="col-sm-2">
-                        <input type="number" name="c_dy_month" class="form-control"
-                               value="{{ $basicinformation->c_dy_month }}">
-                        <span for="">月</span>
-                        <input type="number" name="c_dy_day" class="form-control"
-                               value="{{ $basicinformation->c_dy_day }}">
-                        <span for="">日</span>
-                        <label for="">日(干支) </label>
-                        <select-vue name="c_dy_day_gz" model="ganzhi" selected="{{ $basicinformation->c_dy_day_gz }}"></select-vue>
+                    <div class="col-sm-10">
+                        <div class="d-flex align-items-center flex-wrap">
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
+                                <input type="number" name="c_deathyear" class="form-control"
+                                       style="width: 12ch; min-width: 12ch;"
+                                       value="{{ $basicinformation->c_deathyear }}" onchange="indexYear()">
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
+                                <label class="mb-0 mr-2" for="c_dy_nh_code">年号</label>
+                                <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
+                                    <select-vue name="c_dy_nh_code" model="nianhao" selected="{{ $basicinformation->c_dy_nh_code }}"></select-vue>
+                                </div>
+                                <input type="number" name="c_dy_nh_year" class="form-control mr-2"
+                                       style="width: 8ch; min-width: 8ch;"
+                                       value="{{ $basicinformation->c_dy_nh_year }}">
+                                <span>年</span>
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
+                                <label class="mb-0 mr-2" for="c_dy_range">時限</label>
+                                <div class="flex-grow-1" style="min-width: 16ch;">
+                                    <select-vue name="c_dy_range" model="range" selected="{{ $basicinformation->c_dy_range }}"></select-vue>
+                                </div>
+                            </div>
+                            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+                                <div class="custom-control custom-checkbox mr-4">
+                                    <input type="hidden" name="c_dy_intercalary" value="0">
+                                    <input type="checkbox"
+                                           class="custom-control-input"
+                                           id="c_dy_intercalary"
+                                           name="c_dy_intercalary"
+                                           value="1"
+                                           {{ $basicinformation->c_dy_intercalary == 1 ? 'checked' : '' }}>
+                                    <label class="custom-control-label" for="c_dy_intercalary">閏月</label>
+                                </div>
+                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                                    <input type="number" class="form-control lunar-month intercalary-month"
+                                           data-field="c_dy_month"
+                                           name="c_dy_month"
+                                           min="1"
+                                           max="12"
+                                           step="1"
+                                           value="{{ $basicinformation->c_dy_month }}">
+                                    <div class="invalid-feedback">請輸入 1-12 或留空</div>
+                                </div>
+                                <span class="mr-2">月</span>
+                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                                    <input type="number" name="c_dy_day" class="form-control lunar-day"
+                                           min="1"
+                                           max="30"
+                                           value="{{ $basicinformation->c_dy_day }}">
+                                    <div class="invalid-feedback">請輸入 1-30 或留空</div>
+                                </div>
+                                <span class="mr-2">日</span>
+                                <label class="mb-0 mr-2">日(干支)</label>
+                                <div class="flex-grow-1" style="min-width: 12ch;">
+                                    <select-vue name="c_dy_day_gz" model="ganzhi" selected="{{ $basicinformation->c_dy_day_gz }}"></select-vue>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="form-group row">
@@ -325,9 +373,9 @@
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
                     </div>
-                    <label for="" class="col-sm-2 col-form-label">范围</label>
+                    <label for="c_death_age_range" class="col-sm-2 col-form-label">范围(c_death_age_range)</label>
                     <div class="col-sm-4">
-                        <select class="form-control select2" name="c_death_age_range">
+                        <select class="form-control select2" name="c_death_age_range" id="c_death_age_range">
                             {{--<option value="null"></option>--}}
                             @foreach($yearRange as $item )
                                 @if($item->c_range_code === $basicinformation->c_death_age_range)
@@ -343,30 +391,48 @@
                 <div class="form-group row">
                     <label for="c_fl_earliest_year"
                            class="col-sm-2 col-form-label">在世始年(fl_earliest_year)</label>
-                    <div class="col-sm-10 form-inline">
-                        <input type="text" name="c_fl_earliest_year" class="form-control"
-                               value="{{ $basicinformation->c_fl_earliest_year }}">
-                        <label for="">年号</label>
-                        <select-vue name="c_fl_ey_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ey_nh_code }}"></select-vue>
-                        <input type="text" name="c_fl_ey_nh_year" class="form-control" value="{{ $basicinformation->c_fl_ey_nh_year }}">
-                        <label for="">年</label>
-                        在世始年注
-                        <input type="text" name="c_fl_ey_notes" class="form-control" value="{{ $basicinformation->c_fl_ey_notes }}">
+                    <div class="col-sm-10">
+                        <div class="d-flex align-items-center flex-wrap">
+                            <input type="text" name="c_fl_earliest_year" class="form-control mr-3"
+                                   style="width: 120px;"
+                                   value="{{ $basicinformation->c_fl_earliest_year }}">
+                            <label class="mb-0 mr-2" for="c_fl_ey_nh_code">年号</label>
+                            <div class="mr-2" style="min-width: 140px;">
+                                <select-vue name="c_fl_ey_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ey_nh_code }}"></select-vue>
+                            </div>
+                            <input type="text" name="c_fl_ey_nh_year" class="form-control mr-2"
+                                   style="width: 80px;"
+                                   value="{{ $basicinformation->c_fl_ey_nh_year }}">
+                            <span class="mr-3">年</span>
+                            <div class="w-100 my-2"></div>
+                            <label class="mb-0 mr-2" for="c_fl_ey_notes">在世始年注</label>
+                            <input type="text" name="c_fl_ey_notes" id="c_fl_ey_notes" class="form-control"
+                                   value="{{ $basicinformation->c_fl_ey_notes }}">
+                        </div>
 
                     </div>
                 </div>
                 <div class="form-group row">
                     <label for="c_fl_latest_year"
                            class="col-sm-2 col-form-label">在世終年(fl_latest_year)</label>
-                    <div class="col-sm-10 form-inline">
-                        <input type="text" name="c_fl_latest_year" class="form-control"
-                               value="{{ $basicinformation->c_fl_latest_year }}">
-                        <label for="">年号</label>
-                        <select-vue name="c_fl_ly_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ly_nh_code }}"></select-vue>
-                        <input type="text" name="c_fl_ly_nh_year" class="form-control" value="{{ $basicinformation->c_fl_ly_nh_year }}">
-                        <label for="">年</label>
-                        在世終年注
-                        <input type="text" name="c_fl_ly_notes" class="form-control" value="{{ $basicinformation->c_fl_ly_notes }}">
+                    <div class="col-sm-10">
+                        <div class="d-flex align-items-center flex-wrap">
+                            <input type="text" name="c_fl_latest_year" class="form-control mr-3"
+                                   style="width: 120px;"
+                                   value="{{ $basicinformation->c_fl_latest_year }}">
+                            <label class="mb-0 mr-2" for="c_fl_ly_nh_code">年号</label>
+                            <div class="mr-2" style="min-width: 140px;">
+                                <select-vue name="c_fl_ly_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ly_nh_code }}"></select-vue>
+                            </div>
+                            <input type="text" name="c_fl_ly_nh_year" class="form-control mr-2"
+                                   style="width: 80px;"
+                                   value="{{ $basicinformation->c_fl_ly_nh_year }}">
+                            <span class="mr-3">年</span>
+                            <div class="w-100 my-2"></div>
+                            <label class="mb-0 mr-2" for="c_fl_ly_notes">在世終年注</label>
+                            <input type="text" name="c_fl_ly_notes" id="c_fl_ly_notes" class="form-control"
+                                   value="{{ $basicinformation->c_fl_ly_notes }}">
+                        </div>
 
                     </div>
                 </div>
@@ -480,6 +546,38 @@
         });
 
         $(".select2").select2();
+
+        function validateLunarInput($input, max) {
+            var value = $input.val().trim();
+            if (value === '') {
+                $input.removeClass('is-invalid');
+                return;
+            }
+            var parsed = Number(value);
+            var isInteger = Number.isInteger(parsed);
+            var isValid = isInteger && parsed >= 1 && parsed <= max;
+            $input.toggleClass('is-invalid', !isValid);
+        }
+
+        function bindLunarValidation() {
+            $('.lunar-month').each(function () {
+                var $input = $(this);
+                validateLunarInput($input, 12);
+                $input.on('input change', function () {
+                    validateLunarInput($input, 12);
+                });
+            });
+            $('.lunar-day').each(function () {
+                var $input = $(this);
+                validateLunarInput($input, 30);
+                $input.on('input change', function () {
+                    validateLunarInput($input, 30);
+                });
+            });
+        }
+
+        bindLunarValidation();
+
         function indexYear() {
             let birth = $('input[name=c_birthyear]').val();
             let death = $('input[name=c_deathyear]').val();

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -182,129 +182,49 @@
 
                 <div class="form-group row">
                     <label for="c_firstyear" class="col-sm-2 col-form-label">生年(birth year)</label>
-                    <div class="col-sm-10">
-                        <div class="d-flex align-items-center flex-wrap">
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
-                                <input type="number" name="c_birthyear" class="form-control"
-                                       style="width: 12ch; min-width: 12ch;"
-                                       value="{{ $basicinformation->c_birthyear }}" onchange="indexYear()">
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
-                                <label class="mb-0 mr-2" for="c_fy_nh_code">年号</label>
-                                <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                                    <select-vue name="c_by_nh_code" model="nianhao" selected="{{ $basicinformation->c_by_nh_code }}"></select-vue>
-                                </div>
-                                <input type="number" name="c_by_nh_year" class="form-control mr-2"
-                                       style="width: 8ch; min-width: 8ch;"
-                                       value="{{ $basicinformation->c_by_nh_year }}">
-                                <span>年</span>
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
-                                <label class="mb-0 mr-2" for="c_by_range">時限</label>
-                                <div class="flex-grow-1" style="min-width: 16ch;">
-                                    <select-vue name="c_by_range" model="range" selected="{{ $basicinformation->c_by_range }}"></select-vue>
-                                </div>
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
-                                <div class="custom-control custom-checkbox mr-4">
-                                    <input type="hidden" name="c_by_intercalary" value="0">
-                                    <input type="checkbox"
-                                           class="custom-control-input"
-                                           id="c_by_intercalary"
-                                           name="c_by_intercalary"
-                                           value="1"
-                                           {{ $basicinformation->c_by_intercalary == 1 ? 'checked' : '' }}>
-                                    <label class="custom-control-label" for="c_by_intercalary">閏月</label>
-                                </div>
-                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                                    <input type="number" class="form-control lunar-month intercalary-month"
-                                           data-field="c_by_month"
-                                           name="c_by_month"
-                                           min="1"
-                                           max="12"
-                                           step="1"
-                                           value="{{ $basicinformation->c_by_month }}">
-                                    <div class="invalid-feedback">請輸入 1-12 或留空</div>
-                                </div>
-                                <span class="mr-2">月</span>
-                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                                    <input type="number" name="c_by_day" class="form-control lunar-day"
-                                           min="1"
-                                           max="30"
-                                           value="{{ $basicinformation->c_by_day }}">
-                                    <div class="invalid-feedback">請輸入 1-30 或留空</div>
-                                </div>
-                                <span class="mr-2">日</span>
-                                <label class="mb-0 mr-2">日(干支)</label>
-                                <div class="flex-grow-1" style="min-width: 12ch;">
-                                    <select-vue name="c_by_day_gz" model="ganzhi" selected="{{ $basicinformation->c_by_day_gz }}"></select-vue>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <x-inline-time-fields
+                        yearName="c_birthyear"
+                        :yearValue="$basicinformation->c_birthyear"
+                        :yearAttributes="['onchange' => 'indexYear()']"
+                        nhCodeName="c_by_nh_code"
+                        :nhCodeValue="$basicinformation->c_by_nh_code"
+                        nhYearName="c_by_nh_year"
+                        :nhYearValue="$basicinformation->c_by_nh_year"
+                        rangeName="c_by_range"
+                        :rangeValue="$basicinformation->c_by_range"
+                        :showLunar="true"
+                        intercalaryName="c_by_intercalary"
+                        :intercalaryValue="$basicinformation->c_by_intercalary"
+                        monthName="c_by_month"
+                        :monthValue="$basicinformation->c_by_month"
+                        dayName="c_by_day"
+                        :dayValue="$basicinformation->c_by_day"
+                        dayGzName="c_by_day_gz"
+                        :dayGzValue="$basicinformation->c_by_day_gz"
+                    />
                 </div>
                 <div class="form-group row">
                     <label for="c_firstyear" class="col-sm-2 col-form-label">卒年(death year)</label>
-                    <div class="col-sm-10">
-                        <div class="d-flex align-items-center flex-wrap">
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
-                                <input type="number" name="c_deathyear" class="form-control"
-                                       style="width: 12ch; min-width: 12ch;"
-                                       value="{{ $basicinformation->c_deathyear }}" onchange="indexYear()">
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
-                                <label class="mb-0 mr-2" for="c_dy_nh_code">年号</label>
-                                <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                                    <select-vue name="c_dy_nh_code" model="nianhao" selected="{{ $basicinformation->c_dy_nh_code }}"></select-vue>
-                                </div>
-                                <input type="number" name="c_dy_nh_year" class="form-control mr-2"
-                                       style="width: 8ch; min-width: 8ch;"
-                                       value="{{ $basicinformation->c_dy_nh_year }}">
-                                <span>年</span>
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
-                                <label class="mb-0 mr-2" for="c_dy_range">時限</label>
-                                <div class="flex-grow-1" style="min-width: 16ch;">
-                                    <select-vue name="c_dy_range" model="range" selected="{{ $basicinformation->c_dy_range }}"></select-vue>
-                                </div>
-                            </div>
-                            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
-                                <div class="custom-control custom-checkbox mr-4">
-                                    <input type="hidden" name="c_dy_intercalary" value="0">
-                                    <input type="checkbox"
-                                           class="custom-control-input"
-                                           id="c_dy_intercalary"
-                                           name="c_dy_intercalary"
-                                           value="1"
-                                           {{ $basicinformation->c_dy_intercalary == 1 ? 'checked' : '' }}>
-                                    <label class="custom-control-label" for="c_dy_intercalary">閏月</label>
-                                </div>
-                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                                    <input type="number" class="form-control lunar-month intercalary-month"
-                                           data-field="c_dy_month"
-                                           name="c_dy_month"
-                                           min="1"
-                                           max="12"
-                                           step="1"
-                                           value="{{ $basicinformation->c_dy_month }}">
-                                    <div class="invalid-feedback">請輸入 1-12 或留空</div>
-                                </div>
-                                <span class="mr-2">月</span>
-                                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
-                                    <input type="number" name="c_dy_day" class="form-control lunar-day"
-                                           min="1"
-                                           max="30"
-                                           value="{{ $basicinformation->c_dy_day }}">
-                                    <div class="invalid-feedback">請輸入 1-30 或留空</div>
-                                </div>
-                                <span class="mr-2">日</span>
-                                <label class="mb-0 mr-2">日(干支)</label>
-                                <div class="flex-grow-1" style="min-width: 12ch;">
-                                    <select-vue name="c_dy_day_gz" model="ganzhi" selected="{{ $basicinformation->c_dy_day_gz }}"></select-vue>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <x-inline-time-fields
+                        yearName="c_deathyear"
+                        :yearValue="$basicinformation->c_deathyear"
+                        :yearAttributes="['onchange' => 'indexYear()']"
+                        nhCodeName="c_dy_nh_code"
+                        :nhCodeValue="$basicinformation->c_dy_nh_code"
+                        nhYearName="c_dy_nh_year"
+                        :nhYearValue="$basicinformation->c_dy_nh_year"
+                        rangeName="c_dy_range"
+                        :rangeValue="$basicinformation->c_dy_range"
+                        :showLunar="true"
+                        intercalaryName="c_dy_intercalary"
+                        :intercalaryValue="$basicinformation->c_dy_intercalary"
+                        monthName="c_dy_month"
+                        :monthValue="$basicinformation->c_dy_month"
+                        dayName="c_dy_day"
+                        :dayValue="$basicinformation->c_dy_day"
+                        dayGzName="c_dy_day_gz"
+                        :dayGzValue="$basicinformation->c_dy_day_gz"
+                    />
                 </div>
                 <div class="form-group row">
                     <label for="c_index_year" class="col-sm-2 col-form-label">指數年(index year)</label>
@@ -391,50 +311,36 @@
                 <div class="form-group row">
                     <label for="c_fl_earliest_year"
                            class="col-sm-2 col-form-label">在世始年(fl_earliest_year)</label>
-                    <div class="col-sm-10">
-                        <div class="d-flex align-items-center flex-wrap">
-                            <input type="text" name="c_fl_earliest_year" class="form-control mr-3"
-                                   style="width: 120px;"
-                                   value="{{ $basicinformation->c_fl_earliest_year }}">
-                            <label class="mb-0 mr-2" for="c_fl_ey_nh_code">年号</label>
-                            <div class="mr-2" style="min-width: 140px;">
-                                <select-vue name="c_fl_ey_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ey_nh_code }}"></select-vue>
-                            </div>
-                            <input type="text" name="c_fl_ey_nh_year" class="form-control mr-2"
-                                   style="width: 80px;"
-                                   value="{{ $basicinformation->c_fl_ey_nh_year }}">
-                            <span class="mr-3">年</span>
-                            <div class="w-100 my-2"></div>
-                            <label class="mb-0 mr-2" for="c_fl_ey_notes">在世始年注</label>
-                            <input type="text" name="c_fl_ey_notes" id="c_fl_ey_notes" class="form-control"
-                                   value="{{ $basicinformation->c_fl_ey_notes }}">
-                        </div>
-
-                    </div>
+                    <x-inline-time-fields
+                        yearName="c_fl_earliest_year"
+                        :yearValue="$basicinformation->c_fl_earliest_year"
+                        nhCodeName="c_fl_ey_nh_code"
+                        :nhCodeValue="$basicinformation->c_fl_ey_nh_code"
+                        nhYearName="c_fl_ey_nh_year"
+                        :nhYearValue="$basicinformation->c_fl_ey_nh_year"
+                        :showNotes="true"
+                        :showLunarPlaceholder="true"
+                        notesName="c_fl_ey_notes"
+                        :notesValue="$basicinformation->c_fl_ey_notes"
+                        notesLabel="在世始年註"
+                    />
                 </div>
                 <div class="form-group row">
                     <label for="c_fl_latest_year"
                            class="col-sm-2 col-form-label">在世終年(fl_latest_year)</label>
-                    <div class="col-sm-10">
-                        <div class="d-flex align-items-center flex-wrap">
-                            <input type="text" name="c_fl_latest_year" class="form-control mr-3"
-                                   style="width: 120px;"
-                                   value="{{ $basicinformation->c_fl_latest_year }}">
-                            <label class="mb-0 mr-2" for="c_fl_ly_nh_code">年号</label>
-                            <div class="mr-2" style="min-width: 140px;">
-                                <select-vue name="c_fl_ly_nh_code" model="nianhao" selected="{{ $basicinformation->c_fl_ly_nh_code }}"></select-vue>
-                            </div>
-                            <input type="text" name="c_fl_ly_nh_year" class="form-control mr-2"
-                                   style="width: 80px;"
-                                   value="{{ $basicinformation->c_fl_ly_nh_year }}">
-                            <span class="mr-3">年</span>
-                            <div class="w-100 my-2"></div>
-                            <label class="mb-0 mr-2" for="c_fl_ly_notes">在世終年注</label>
-                            <input type="text" name="c_fl_ly_notes" id="c_fl_ly_notes" class="form-control"
-                                   value="{{ $basicinformation->c_fl_ly_notes }}">
-                        </div>
-
-                    </div>
+                    <x-inline-time-fields
+                        yearName="c_fl_latest_year"
+                        :yearValue="$basicinformation->c_fl_latest_year"
+                        nhCodeName="c_fl_ly_nh_code"
+                        :nhCodeValue="$basicinformation->c_fl_ly_nh_code"
+                        nhYearName="c_fl_ly_nh_year"
+                        :nhYearValue="$basicinformation->c_fl_ly_nh_year"
+                        :showNotes="true"
+                        :showLunarPlaceholder="true"
+                        notesName="c_fl_ly_notes"
+                        :notesValue="$basicinformation->c_fl_ly_notes"
+                        notesLabel="在世終年註"
+                    />
                 </div>
                 <div class="form-group row">
                     <label for="c_choronym_code" class="col-sm-2 col-form-label">郡望(choronym_code)</label>
@@ -449,7 +355,7 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    <label for="c_notes" class="col-sm-2 col-form-label">注</label>
+                    <label for="c_notes" class="col-sm-2 col-form-label">註</label>
                     <div class="col-sm-10">
                         <textarea class="form-control" name="c_notes" id="" cols="30"
                                   rows="5">{{ $basicinformation->c_notes }}</textarea>
@@ -547,36 +453,9 @@
 
         $(".select2").select2();
 
-        function validateLunarInput($input, max) {
-            var value = $input.val().trim();
-            if (value === '') {
-                $input.removeClass('is-invalid');
-                return;
-            }
-            var parsed = Number(value);
-            var isInteger = Number.isInteger(parsed);
-            var isValid = isInteger && parsed >= 1 && parsed <= max;
-            $input.toggleClass('is-invalid', !isValid);
+        if (window.initLunarValidation) {
+            window.initLunarValidation();
         }
-
-        function bindLunarValidation() {
-            $('.lunar-month').each(function () {
-                var $input = $(this);
-                validateLunarInput($input, 12);
-                $input.on('input change', function () {
-                    validateLunarInput($input, 12);
-                });
-            });
-            $('.lunar-day').each(function () {
-                var $input = $(this);
-                validateLunarInput($input, 30);
-                $input.on('input change', function () {
-                    validateLunarInput($input, 30);
-                });
-            });
-        }
-
-        bindLunarValidation();
 
         function indexYear() {
             let birth = $('input[name=c_birthyear]').val();

--- a/resources/views/biogmains/entries/_form.blade.php
+++ b/resources/views/biogmains/entries/_form.blade.php
@@ -41,19 +41,17 @@
 
     <div class="form-group row">
         <label for="c_year" class="col-sm-2 col-form-label">入仕年(year)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_year" class="form-control" value="{{ $isEdit ? $row->c_year : '0' }}" {{ $isEdit ? '' : 'required' }}>
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_nianhao_id">年号</label>
-            <select-vue name="c_nianhao_id" model="nianhao" selected="{{ $isEdit ? $row->c_nianhao_id : '' }}"></select-vue>
-            <input type="text" name="c_entry_nh_year" class="form-control" value="{{ $isEdit ? $row->c_entry_nh_year : '' }}">
-            <span for="c_entry_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_entry_range">時限</label>
-            <select-vue name="c_entry_range" model="range" selected="{{ $isEdit ? $row->c_entry_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_year"
+            :yearValue="$isEdit ? $row->c_year : '0'"
+            :yearRequired="!$isEdit"
+            nhCodeName="c_nianhao_id"
+            :nhCodeValue="$isEdit ? $row->c_nianhao_id : ''"
+            nhYearName="c_entry_nh_year"
+            :nhYearValue="$isEdit ? $row->c_entry_nh_year : ''"
+            rangeName="c_entry_range"
+            :rangeValue="$isEdit ? $row->c_entry_range : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -201,7 +199,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30" rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
         </div>

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -49,40 +49,26 @@
 
     <div class="form-group row">
         <label for="c_year" class="col-sm-2 col-form-label">事件發生年</label>
-        <div class="col-md-1">
-            <input type="number" name="c_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_year : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_nh_code">事件年號</label>
-            <select-vue name="c_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_nh_year : '' }}">
-            <span for="c_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_yr_range">時限</label>
-            <select-vue name="c_yr_range" model="range" selected="{{ $isEdit ? $row->c_yr_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_intercalary" class="form-control select2">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_intercalary == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_intercalary == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_month" class="form-control"
-                   value="{{ $isEdit ? $row->c_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_day" class="form-control"
-                   value="{{ $isEdit ? $row->c_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_day_ganzhi" model="ganzhi" selected="{{ $isEdit ? $row->c_day_ganzhi : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_year"
+            :yearValue="$isEdit ? $row->c_year : ''"
+            nhCodeName="c_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_nh_code : ''"
+            nhYearName="c_nh_year"
+            :nhYearValue="$isEdit ? $row->c_nh_year : ''"
+            rangeName="c_yr_range"
+            :rangeValue="$isEdit ? $row->c_yr_range : ''"
+            :showLunar="true"
+            intercalaryName="c_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_intercalary : ''"
+            monthName="c_month"
+            :monthValue="$isEdit ? $row->c_month : ''"
+            dayName="c_day"
+            :dayValue="$isEdit ? $row->c_day : ''"
+            dayGzName="c_day_ganzhi"
+            :dayGzValue="$isEdit ? $row->c_day_ganzhi : ''"
+            nhLabel="事件年號"
+        />
     </div>
 
     <div class="form-group row">
@@ -129,7 +115,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30"
                       rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
@@ -179,6 +165,10 @@
         $(".c_source").select2(options('text'));
         $(".c_addr_id").select2(options('addr'));
         $(".c_event_code").select2(options('event'));
+
+        if (window.initLunarValidation) {
+            window.initLunarValidation();
+        }
 
         function formatRepo (repo) {
             if (repo.loading) {

--- a/resources/views/biogmains/kinship/_form.blade.php
+++ b/resources/views/biogmains/kinship/_form.blade.php
@@ -66,7 +66,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30" rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
         </div>

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -105,82 +105,48 @@
 
     <div class="form-group row">
         <label for="c_firstyear" class="col-sm-2 col-form-label">始年(firstyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_firstyear" class="form-control"
-                   value="{{ $isEdit ? $row->c_firstyear : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_fy_nh_code">年号</label>
-            <select-vue name="c_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_fy_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_fy_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_fy_nh_year : '' }}">
-            <span for="">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_fy_range" model="range" selected="{{ $isEdit ? $row->c_fy_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_fy_intercalary" class="form-control select2" name="c_natal">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_fy_intercalary == 0) ? 'selected' : ($isEdit ? '' : 'selected') }}>0-否
-                </option>
-                <option value="1" {{ ($isEdit && $row->c_fy_intercalary == 1) ? 'selected' : '' }}>1-是
-                </option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_fy_month" class="form-control"
-                   value="{{ $isEdit ? $row->c_fy_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_fy_day" class="form-control"
-                   value="{{ $isEdit ? $row->c_fy_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_fy_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_fy_day_gz : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_firstyear"
+            :yearValue="$isEdit ? $row->c_firstyear : ''"
+            nhCodeName="c_fy_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_fy_nh_code : ''"
+            nhYearName="c_fy_nh_year"
+            :nhYearValue="$isEdit ? $row->c_fy_nh_year : ''"
+            rangeName="c_fy_range"
+            :rangeValue="$isEdit ? $row->c_fy_range : ''"
+            :showLunar="true"
+            intercalaryName="c_fy_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_fy_intercalary : ''"
+            monthName="c_fy_month"
+            :monthValue="$isEdit ? $row->c_fy_month : ''"
+            dayName="c_fy_day"
+            :dayValue="$isEdit ? $row->c_fy_day : ''"
+            dayGzName="c_fy_day_gz"
+            :dayGzValue="$isEdit ? $row->c_fy_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
         <label for="c_lastyear" class="col-sm-2 col-form-label">終年(lastyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_lastyear" class="form-control"
-                   value="{{ $isEdit ? $row->c_lastyear : '' }}">
-        </div>
-
-        <div class="col-md-2 from-inline">
-            <label for="c_ly_nh_code">年号</label>
-            <select-vue name="c_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_ly_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_ly_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_ly_nh_year : '' }}">
-            <span for="">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="">時限</label>
-            <select-vue name="c_ly_range" model="range" selected="{{ $isEdit ? $row->c_ly_range : '' }}"></select-vue>
-        </div>
-        <div class="col-md-2">
-            <label for="">閏</label>
-            <select name="c_ly_intercalary" class="form-control select2" name="c_natal">
-                <option disabled value="">请选择</option>
-                <option value="0" {{ ($isEdit && $row->c_ly_intercalary == 0) ? 'selected' : ($isEdit ? '' : 'selected') }}>0-否
-                </option>
-                <option value="1" {{ ($isEdit && $row->c_ly_intercalary == 1) ? 'selected' : '' }}>1-是
-                </option>
-            </select>
-        </div>
-        <div class="col-sm-2">
-            <input type="number" name="c_ly_month" class="form-control"
-                   value="{{ $isEdit ? $row->c_ly_month : '' }}">
-            <span for="">月</span>
-            <input type="number" name="c_ly_day" class="form-control"
-                   value="{{ $isEdit ? $row->c_ly_day : '' }}">
-            <span for="">日</span>
-            <label for="">日(干支) </label>
-            <select-vue name="c_ly_day_gz" model="ganzhi" selected="{{ $isEdit ? $row->c_ly_day_gz : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_lastyear"
+            :yearValue="$isEdit ? $row->c_lastyear : ''"
+            nhCodeName="c_ly_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_ly_nh_code : ''"
+            nhYearName="c_ly_nh_year"
+            :nhYearValue="$isEdit ? $row->c_ly_nh_year : ''"
+            rangeName="c_ly_range"
+            :rangeValue="$isEdit ? $row->c_ly_range : ''"
+            :showLunar="true"
+            intercalaryName="c_ly_intercalary"
+            :intercalaryValue="$isEdit ? $row->c_ly_intercalary : ''"
+            monthName="c_ly_month"
+            :monthValue="$isEdit ? $row->c_ly_month : ''"
+            dayName="c_ly_day"
+            :dayValue="$isEdit ? $row->c_ly_day : ''"
+            dayGzName="c_ly_day_gz"
+            :dayGzValue="$isEdit ? $row->c_ly_day_gz : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -205,7 +171,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30"
                       rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
@@ -306,6 +272,10 @@
         $(".c_source").select2(options('text'));
         $(".c_inst_code").select2(options('socialinstcode'));
         $(".c_addr").select2(options('addr'));
+
+        if (window.initLunarValidation) {
+            window.initLunarValidation();
+        }
 
         function formatRepo (repo) {
             if (repo.loading) {

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -61,21 +61,16 @@
 
     <div class="form-group row">
         <label for="c_possession_yr" class="col-sm-2 col-form-label">年份(possession_yr)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_possession_yr" class="form-control"
-                   value="{{ $isEdit ? $row->c_possession_yr : '' }}">
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_possession_nh_code">年号</label>
-            <select-vue name="c_possession_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_possession_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_possession_nh_yr" class="form-control"
-                   value="{{ $isEdit ? $row->c_possession_nh_yr : '' }}">
-            <span for="c_possession_nh_yr">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_possession_yr_range">時限</label>
-            <select-vue name="c_possession_yr_range" model="range" selected="{{ $isEdit ? $row->c_possession_yr_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_possession_yr"
+            :yearValue="$isEdit ? $row->c_possession_yr : ''"
+            nhCodeName="c_possession_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_possession_nh_code : ''"
+            nhYearName="c_possession_nh_yr"
+            :nhYearValue="$isEdit ? $row->c_possession_nh_yr : ''"
+            rangeName="c_possession_yr_range"
+            :rangeValue="$isEdit ? $row->c_possession_yr_range : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -114,7 +109,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30"
                       rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>

--- a/resources/views/biogmains/socialinst/_form.blade.php
+++ b/resources/views/biogmains/socialinst/_form.blade.php
@@ -44,40 +44,30 @@
 
     <div class="form-group row">
         <label for="c_bi_begin_year" class="col-sm-2 col-form-label">始年(firstyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_bi_begin_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_bi_begin_year : '' }}">
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_bi_by_nh_code">年号</label>
-            <select-vue name="c_bi_by_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_bi_by_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_bi_by_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_bi_by_nh_year : '' }}">
-            <span for="c_bi_by_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_bi_by_range">時限</label>
-            <select-vue name="c_bi_by_range" model="range" selected="{{ $isEdit ? $row->c_bi_by_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_bi_begin_year"
+            :yearValue="$isEdit ? $row->c_bi_begin_year : ''"
+            nhCodeName="c_bi_by_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_bi_by_nh_code : ''"
+            nhYearName="c_bi_by_nh_year"
+            :nhYearValue="$isEdit ? $row->c_bi_by_nh_year : ''"
+            rangeName="c_bi_by_range"
+            :rangeValue="$isEdit ? $row->c_bi_by_range : ''"
+        />
     </div>
 
     <div class="form-group row">
         <label for="c_bi_end_year" class="col-sm-2 col-form-label">終年(lastyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_bi_end_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_bi_end_year : '' }}">
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_bi_ey_nh_code">年号</label>
-            <select-vue name="c_bi_ey_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_bi_ey_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_bi_ey_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_bi_ey_nh_year : '' }}">
-            <span for="c_bi_ey_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_bi_ey_range">時限</label>
-            <select-vue name="c_bi_ey_range" model="range" selected="{{ $isEdit ? $row->c_bi_ey_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_bi_end_year"
+            :yearValue="$isEdit ? $row->c_bi_end_year : ''"
+            nhCodeName="c_bi_ey_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_bi_ey_nh_code : ''"
+            nhYearName="c_bi_ey_nh_year"
+            :nhYearValue="$isEdit ? $row->c_bi_ey_nh_year : ''"
+            rangeName="c_bi_ey_range"
+            :rangeValue="$isEdit ? $row->c_bi_ey_range : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -101,7 +91,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30"
                       rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>

--- a/resources/views/biogmains/sources/_form.blade.php
+++ b/resources/views/biogmains/sources/_form.blade.php
@@ -61,7 +61,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             @php
                 $notes_value = $isEdit ? unionPKDef_decode_for_convert($row->c_notes) : '';

--- a/resources/views/biogmains/statuses/_form.blade.php
+++ b/resources/views/biogmains/statuses/_form.blade.php
@@ -49,40 +49,30 @@
 
     <div class="form-group row">
         <label for="c_firstyear" class="col-sm-2 col-form-label">始年(c_firstyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_firstyear" class="form-control"
-                   value="{{ $isEdit ? $row->c_firstyear : '' }}">
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_fy_nh_code">年号</label>
-            <select-vue name="c_fy_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_fy_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_fy_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_fy_nh_year : '' }}">
-            <span for="c_fy_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_fy_range">時限</label>
-            <select-vue name="c_fy_range" model="range" selected="{{ $isEdit ? $row->c_fy_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_firstyear"
+            :yearValue="$isEdit ? $row->c_firstyear : ''"
+            nhCodeName="c_fy_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_fy_nh_code : ''"
+            nhYearName="c_fy_nh_year"
+            :nhYearValue="$isEdit ? $row->c_fy_nh_year : ''"
+            rangeName="c_fy_range"
+            :rangeValue="$isEdit ? $row->c_fy_range : ''"
+        />
     </div>
 
     <div class="form-group row">
         <label for="c_lastyear" class="col-sm-2 col-form-label">終年(c_lastyear)</label>
-        <div class="col-md-1">
-            <input type="number" name="c_lastyear" class="form-control"
-                   value="{{ $isEdit ? $row->c_lastyear : '' }}">
-        </div>
-        <div class="col-md-2 from-inline">
-            <label for="c_ly_nh_code">年号</label>
-            <select-vue name="c_ly_nh_code" model="nianhao" selected="{{ $isEdit ? $row->c_ly_nh_code : '' }}"></select-vue>
-            <input type="number" name="c_ly_nh_year" class="form-control"
-                   value="{{ $isEdit ? $row->c_ly_nh_year : '' }}">
-            <span for="c_ly_nh_year">年</span>
-        </div>
-        <div class="col-md-3">
-            <label for="c_ly_range">時限</label>
-            <select-vue name="c_ly_range" model="range" selected="{{ $isEdit ? $row->c_ly_range : '' }}"></select-vue>
-        </div>
+        <x-inline-time-fields
+            yearName="c_lastyear"
+            :yearValue="$isEdit ? $row->c_lastyear : ''"
+            nhCodeName="c_ly_nh_code"
+            :nhCodeValue="$isEdit ? $row->c_ly_nh_code : ''"
+            nhYearName="c_ly_nh_year"
+            :nhYearValue="$isEdit ? $row->c_ly_nh_year : ''"
+            rangeName="c_ly_range"
+            :rangeValue="$isEdit ? $row->c_ly_range : ''"
+        />
     </div>
 
     <div class="form-group row">
@@ -106,7 +96,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30"
                       rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>

--- a/resources/views/biogmains/texts/_form.blade.php
+++ b/resources/views/biogmains/texts/_form.blade.php
@@ -60,7 +60,7 @@
     </div>
 
     <div class="form-group row">
-        <label for="c_notes" class="col-sm-2 col-form-label">注(c_notes)</label>
+        <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             <textarea class="form-control" name="c_notes" id="" cols="30" rows="5">{{ $isEdit ? $row->c_notes : '' }}</textarea>
         </div>

--- a/resources/views/components/inline-time-fields.blade.php
+++ b/resources/views/components/inline-time-fields.blade.php
@@ -44,7 +44,7 @@
         <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
             <label class="mb-0 mr-2" for="{{ $nhCodeName }}">{{ $nhLabel }}</label>
             <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                <select-vue name="{{ $nhCodeName }}" model="nianhao" selected="{{ $nhCodeValue }}"></select-vue>
+                <select-vue id="{{ $nhCodeName }}" name="{{ $nhCodeName }}" model="nianhao" id-key="c_nianhao_id" selected="{{ $nhCodeValue }}"></select-vue>
             </div>
             <input type="number"
                    name="{{ $nhYearName }}"
@@ -57,7 +57,7 @@
             <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
                 <label class="mb-0 mr-2" for="{{ $rangeName }}">{{ $rangeLabel }}</label>
                 <div class="flex-grow-1" style="min-width: 16ch;">
-                    <select-vue name="{{ $rangeName }}" model="range" selected="{{ $rangeValue }}"></select-vue>
+                    <select-vue id="{{ $rangeName }}" name="{{ $rangeName }}" model="range" id-key="c_range_code" selected="{{ $rangeValue }}"></select-vue>
                 </div>
             </div>
         @endif
@@ -93,9 +93,9 @@
                     <div class="invalid-feedback">請輸入 1-30 或留空</div>
                 </div>
                 <span class="mr-2">日</span>
-                <label class="mb-0 mr-2">{{ $dayGzLabel }}</label>
+                <label class="mb-0 mr-2" for="{{ $dayGzName }}">{{ $dayGzLabel }}</label>
                 <div class="flex-grow-1" style="min-width: 12ch;">
-                    <select-vue name="{{ $dayGzName }}" model="ganzhi" selected="{{ $dayGzValue }}"></select-vue>
+                    <select-vue id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
                 </div>
             </div>
         @elseif($showLunarPlaceholder)

--- a/resources/views/components/inline-time-fields.blade.php
+++ b/resources/views/components/inline-time-fields.blade.php
@@ -1,0 +1,111 @@
+@props([
+    'yearName',
+    'yearValue' => '',
+    'yearRequired' => false,
+    'yearAttributes' => [],
+    'yearInputType' => 'number',
+    'nhCodeName',
+    'nhCodeValue' => '',
+    'nhYearName',
+    'nhYearValue' => '',
+    'rangeName' => null,
+    'rangeValue' => '',
+    'showLunar' => false,
+    'intercalaryName' => null,
+    'intercalaryValue' => null,
+    'monthName' => null,
+    'monthValue' => '',
+    'dayName' => null,
+    'dayValue' => '',
+    'dayGzName' => null,
+    'dayGzValue' => '',
+    'nhLabel' => '年号',
+    'rangeLabel' => '時限',
+    'intercalaryLabel' => '閏月',
+    'dayGzLabel' => '日(干支)',
+    'showLunarPlaceholder' => false,
+    'notesName' => null,
+    'notesValue' => '',
+    'notesLabel' => '',
+    'showNotes' => false,
+])
+
+<div class="col-sm-10">
+    <div class="d-flex align-items-center flex-wrap">
+        <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 12ch; flex: 1 1 12ch;">
+            <input type="{{ $yearInputType }}"
+                   name="{{ $yearName }}"
+                   class="form-control"
+                   style="width: 12ch; min-width: 12ch;"
+                   value="{{ $yearValue }}"
+                   @if($yearRequired) required @endif
+                   @foreach($yearAttributes as $attr => $value) {{ $attr }}="{{ $value }}" @endforeach>
+        </div>
+        <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
+            <label class="mb-0 mr-2" for="{{ $nhCodeName }}">{{ $nhLabel }}</label>
+            <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
+                <select-vue name="{{ $nhCodeName }}" model="nianhao" selected="{{ $nhCodeValue }}"></select-vue>
+            </div>
+            <input type="number"
+                   name="{{ $nhYearName }}"
+                   class="form-control mr-2"
+                   style="width: 8ch; min-width: 8ch;"
+                   value="{{ $nhYearValue }}">
+            <span>年</span>
+        </div>
+        @if($rangeName)
+            <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
+                <label class="mb-0 mr-2" for="{{ $rangeName }}">{{ $rangeLabel }}</label>
+                <div class="flex-grow-1" style="min-width: 16ch;">
+                    <select-vue name="{{ $rangeName }}" model="range" selected="{{ $rangeValue }}"></select-vue>
+                </div>
+            </div>
+        @endif
+        @if($showLunar)
+            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+                <div class="custom-control custom-checkbox mr-4">
+                    <input type="hidden" name="{{ $intercalaryName }}" value="0">
+                    <input type="checkbox"
+                           class="custom-control-input"
+                           id="{{ $intercalaryName }}"
+                           name="{{ $intercalaryName }}"
+                           value="1"
+                           {{ (int) $intercalaryValue === 1 ? 'checked' : '' }}>
+                    <label class="custom-control-label" for="{{ $intercalaryName }}">{{ $intercalaryLabel }}</label>
+                </div>
+                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                    <input type="number"
+                           name="{{ $monthName }}"
+                           class="form-control lunar-month"
+                           min="1"
+                           max="12"
+                           value="{{ $monthValue }}">
+                    <div class="invalid-feedback">請輸入 1-12 或留空</div>
+                </div>
+                <span class="mr-2">月</span>
+                <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
+                    <input type="number"
+                           name="{{ $dayName }}"
+                           class="form-control lunar-day"
+                           min="1"
+                           max="30"
+                           value="{{ $dayValue }}">
+                    <div class="invalid-feedback">請輸入 1-30 或留空</div>
+                </div>
+                <span class="mr-2">日</span>
+                <label class="mb-0 mr-2">{{ $dayGzLabel }}</label>
+                <div class="flex-grow-1" style="min-width: 12ch;">
+                    <select-vue name="{{ $dayGzName }}" model="ganzhi" selected="{{ $dayGzValue }}"></select-vue>
+                </div>
+            </div>
+        @elseif($showLunarPlaceholder)
+            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;"></div>
+        @endif
+        @if($showNotes)
+            <div class="w-100 my-2"></div>
+            <label class="mb-0 mr-2" for="{{ $notesName }}">{{ $notesLabel }}</label>
+            <input type="text" name="{{ $notesName }}" id="{{ $notesName }}" class="form-control"
+                   value="{{ $notesValue }}">
+        @endif
+    </div>
+</div>


### PR DESCRIPTION
調整基本資訊與地址時間欄位排版（行內組合/彈性換行）並加入農曆月日驗證（閏月未勾選送 0）

統一年份/年號/時限/閏月欄位排版並抽出 inline-time-fields 元件，集中農曆月日驗證與註解用字

- 統一 addresses/basicinformation/offices/assoc/events/statuses/socialinst/entries/possession 的行內組合與最小寬度
- 新增共用元件 resources/views/components/inline-time-fields.blade.php，支援闰月/月日干支、註解欄位與占位
- 將月/日驗證抽到 resources/js/app.js 並於相關表單啟用
- 全站 c_notes 等欄位標籤統一為「註」

<img width="1427" height="826" alt="image" src="https://github.com/user-attachments/assets/df6b1122-5471-43fb-ac9c-fc2df7013b4e" />

<img width="1434" height="794" alt="image" src="https://github.com/user-attachments/assets/69dace12-3099-45ff-a6ee-c62a8774c72e" />
