### PR TITLE
fix: 修復 Select.vue 組件的 prop 和 method 命名衝突

### DIFF
--- a/resources/js/components/Select.vue
+++ b/resources/js/components/Select.vue
@@ -1,5 +1,5 @@
 <template>
-    <select class="form-control select2" :id="id" v-bind:name="name" v-model="selectedid">
+    <select class="form-control select2" :id="elementId" v-bind:name="name" v-model="selectedid">
         <!--<option disabled value="">请选择</option>-->
         <option value="">请选择</option>
         <option v-for="item in data" v-bind:value="id(item)">{{ normalization(item) }}</option>
@@ -13,7 +13,7 @@
     const pendingRequests = {};
 
     export default {
-        props: ['name', 'model', 'selected', 'id', 'idKey'],
+        props: ['name', 'model', 'selected', 'elementId', 'idKey'],
         data() {
           return {
               data: {},

--- a/resources/views/components/inline-time-fields.blade.php
+++ b/resources/views/components/inline-time-fields.blade.php
@@ -44,7 +44,7 @@
         <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
             <label class="mb-0 mr-2" for="{{ $nhCodeName }}">{{ $nhLabel }}</label>
             <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                <select-vue id="{{ $nhCodeName }}" name="{{ $nhCodeName }}" model="nianhao" id-key="c_nianhao_id" selected="{{ $nhCodeValue }}"></select-vue>
+                <select-vue element-id="{{ $nhCodeName }}" name="{{ $nhCodeName }}" model="nianhao" id-key="c_nianhao_id" selected="{{ $nhCodeValue }}"></select-vue>
             </div>
             <input type="number"
                    name="{{ $nhYearName }}"
@@ -57,7 +57,7 @@
             <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
                 <label class="mb-0 mr-2" for="{{ $rangeName }}">{{ $rangeLabel }}</label>
                 <div class="flex-grow-1" style="min-width: 16ch;">
-                    <select-vue id="{{ $rangeName }}" name="{{ $rangeName }}" model="range" id-key="c_range_code" selected="{{ $rangeValue }}"></select-vue>
+                    <select-vue element-id="{{ $rangeName }}" name="{{ $rangeName }}" model="range" id-key="c_range_code" selected="{{ $rangeValue }}"></select-vue>
                 </div>
             </div>
         @endif
@@ -95,7 +95,7 @@
                 <span class="mr-2">日</span>
                 <label class="mb-0 mr-2" for="{{ $dayGzName }}">{{ $dayGzLabel }}</label>
                 <div class="flex-grow-1" style="min-width: 12ch;">
-                    <select-vue id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
+                    <select-vue element-id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
                 </div>
             </div>
         @elseif($showLunarPlaceholder)


### PR DESCRIPTION
問題分析：
- commit f9bff97 中新增了 'id' prop 用於設置 select 元素的 id 屬性
- 但組件中已有 'id()' method 用於提取選項的值
- Vue 中 props 和 methods 共享同一命名空間，造成嚴重衝突
- 導致 id(item) 無法正確調用 method，select 選項值獲取失敗

修復方案：
- 將 prop 'id' 重命名為 'elementId'
- 更新 inline-time-fields.blade.php 中的三處使用：
  - 年號選單（nianhao）
  - 時限選單（range）
  - 日干支選單（ganzhi）
- 重新編譯前端資源

影響範圍：
- resources/js/components/Select.vue
- resources/views/components/inline-time-fields.blade.php