### PR TITLE
改進：將基本資訊導航改為支援自動換行的 Bootstrap nav-tabs 樣式

### DIFF
--- a/resources/views/biogmains/banner.blade.php
+++ b/resources/views/biogmains/banner.blade.php
@@ -1,46 +1,75 @@
+@php
+    $currentRoute = request()->route()->getName();
+@endphp
 
-<div class="text-center">
-    <h3>{{ $basicinformation->c_name_chn.'（'.$basicinformation->c_name.'）- '.$basicinformation->c_personid }}</h3>
-    <div class="row text-left">
-        <div class="offset-sm-1 col-sm-2">
-            <a href="/basicinformation/{{ $basicinformation->c_personid }}/edit"><i class="fas fa-user" aria-hidden="true"></i>&nbsp;&nbsp;基本資料</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.addresses.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-map-marker-alt" aria-hidden="true"></i>&nbsp;&nbsp;地址({{ $basicinformation->biog_addresses_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.altnames.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-id-card"></i>&nbsp;&nbsp;别名({{ $basicinformation->altnames_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.texts.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-book"></i>&nbsp;&nbsp;著述({{ $basicinformation->texts_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.offices.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-briefcase"></i>&nbsp;&nbsp;官名({{ $basicinformation->offices_count }})</a>
-        </div>
-        <div class="offset-sm-1 col-sm-2">
-            <a href="{{ route('basicinformation.entries.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-door-open"></i>&nbsp;&nbsp;入仕({{ $basicinformation->entries_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.events.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-calendar-alt"></i>&nbsp;&nbsp;事件({{ $basicinformation->events_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.statuses.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-users"></i>&nbsp;&nbsp;社會區分({{ $basicinformation->statuses_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.kinship.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-user-friends"></i>&nbsp;&nbsp;親屬({{ $basicinformation->kinship_count }})</a>
-        </div>
-        <div class="col-sm-3">
-            <a href="{{ route('basicinformation.assoc.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-network-wired"></i>&nbsp;&nbsp;社會關係({{ $basicinformation->assoc_count }})</a>
-        </div>
-        <div class="offset-sm-1 col-sm-2">
-            <a href="{{ route('basicinformation.possession.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-coins"></i>&nbsp;&nbsp;財產({{ $basicinformation->possession_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.socialinst.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-building"></i>&nbsp;&nbsp;社交機構({{ $basicinformation->inst_count }})</a>
-        </div>
-        <div class="col-sm-2">
-            <a href="{{ route('basicinformation.sources.index', ['basicinformation' => $basicinformation->c_personid]) }}"><i class="fas fa-file-alt"></i>&nbsp;&nbsp;出處({{ $basicinformation->sources_count }})</a>
-        </div>
-    </div>
-    <br>
+<div class="mb-4">
+    <h3 class="text-center mb-3">{{ $basicinformation->c_name_chn.'（'.$basicinformation->c_name.'）- '.$basicinformation->c_personid }}</h3>
+
+    <ul class="nav nav-tabs" style="flex-wrap: wrap;">
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.edit' ? 'active' : '' }}" href="/basicinformation/{{ $basicinformation->c_personid }}/edit">
+                <i class="fas fa-user" aria-hidden="true"></i> 基本資料
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.addresses.index' ? 'active' : '' }}" href="{{ route('basicinformation.addresses.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-map-marker-alt" aria-hidden="true"></i> 地址<span class="badge badge-light ml-1">{{ $basicinformation->biog_addresses_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.altnames.index' ? 'active' : '' }}" href="{{ route('basicinformation.altnames.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-id-card"></i> 别名<span class="badge badge-light ml-1">{{ $basicinformation->altnames_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.texts.index' ? 'active' : '' }}" href="{{ route('basicinformation.texts.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-book"></i> 著述<span class="badge badge-light ml-1">{{ $basicinformation->texts_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.offices.index' ? 'active' : '' }}" href="{{ route('basicinformation.offices.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-briefcase"></i> 官名<span class="badge badge-light ml-1">{{ $basicinformation->offices_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.entries.index' ? 'active' : '' }}" href="{{ route('basicinformation.entries.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-door-open"></i> 入仕<span class="badge badge-light ml-1">{{ $basicinformation->entries_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.events.index' ? 'active' : '' }}" href="{{ route('basicinformation.events.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-calendar-alt"></i> 事件<span class="badge badge-light ml-1">{{ $basicinformation->events_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.statuses.index' ? 'active' : '' }}" href="{{ route('basicinformation.statuses.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-users"></i> 社會區分<span class="badge badge-light ml-1">{{ $basicinformation->statuses_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.kinship.index' ? 'active' : '' }}" href="{{ route('basicinformation.kinship.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-user-friends"></i> 親屬<span class="badge badge-light ml-1">{{ $basicinformation->kinship_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.assoc.index' ? 'active' : '' }}" href="{{ route('basicinformation.assoc.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-network-wired"></i> 社會關係<span class="badge badge-light ml-1">{{ $basicinformation->assoc_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.possession.index' ? 'active' : '' }}" href="{{ route('basicinformation.possession.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-coins"></i> 財產<span class="badge badge-light ml-1">{{ $basicinformation->possession_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.socialinst.index' ? 'active' : '' }}" href="{{ route('basicinformation.socialinst.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-building"></i> 社交機構<span class="badge badge-light ml-1">{{ $basicinformation->inst_count }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ $currentRoute === 'basicinformation.sources.index' ? 'active' : '' }}" href="{{ route('basicinformation.sources.index', ['basicinformation' => $basicinformation->c_personid]) }}">
+                <i class="fas fa-file-alt"></i> 出處<span class="badge badge-light ml-1">{{ $basicinformation->sources_count }}</span>
+            </a>
+        </li>
+    </ul>
 </div>


### PR DESCRIPTION
- 將原本的栅格佈局改為標準的 nav nav-tabs 樣式
- 添加 flex-wrap 樣式支持自動換行，窗口寬度不足時標籤自動換行
- 根據當前路由自動高亮激活的標籤頁
- 將計數改為使用 badge 樣式顯示，更加美觀
- 保留所有圖標和功能
- 優化間距和佈局

<img width="1012" height="605" alt="image" src="https://github.com/user-attachments/assets/af0aa190-c9a2-45a7-a007-fd8e0d4ebad4" />