### PR TITLE
改進：將出處表單的布爾字段改為復選框

### DIFF
--- a/resources/views/biogmains/sources/_form.blade.php
+++ b/resources/views/biogmains/sources/_form.blade.php
@@ -61,29 +61,38 @@
     </div>
 
     <div class="form-group row">
+        <label class="col-sm-2 col-form-label">選項</label>
+        <div class="col-sm-10">
+            <div class="custom-control custom-checkbox">
+                <input type="hidden" name="c_main_source" value="0">
+                <input type="checkbox"
+                       class="custom-control-input"
+                       id="c_main_source"
+                       name="c_main_source"
+                       value="1"
+                       {{ ($isEdit && $row->c_main_source == 1) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="c_main_source">主要出處</label>
+            </div>
+            <div class="custom-control custom-checkbox mt-2">
+                <input type="hidden" name="c_self_bio" value="0">
+                <input type="checkbox"
+                       class="custom-control-input"
+                       id="c_self_bio"
+                       name="c_self_bio"
+                       value="1"
+                       {{ ($isEdit && $row->c_self_bio == 1) ? 'checked' : '' }}>
+                <label class="custom-control-label" for="c_self_bio">本人傳記</label>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <label for="c_notes" class="col-sm-2 col-form-label">註(c_notes)</label>
         <div class="col-sm-10">
             @php
                 $notes_value = $isEdit ? unionPKDef_decode_for_convert($row->c_notes) : '';
             @endphp
             <textarea class="form-control" name="c_notes" cols="30" rows="5">{{ $notes_value }}</textarea>
-        </div>
-    </div>
-
-    <div class="form-group row">
-        <label for="c_main_source" class="col-sm-2 col-form-label">是主要出處</label>
-        <div class="col-sm-4">
-            <select class="form-control select2" name="c_main_source">
-                <option value="0" {{ ($isEdit && $row->c_main_source == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_main_source == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
-        </div>
-        <label for="c_self_bio" class="col-sm-2 col-form-label">是本人傳記</label>
-        <div class="col-sm-4">
-            <select class="form-control select2" name="c_self_bio">
-                <option value="0" {{ ($isEdit && $row->c_self_bio == 0) ? 'selected' : '' }}>0-否</option>
-                <option value="1" {{ ($isEdit && $row->c_self_bio == 1) ? 'selected' : '' }}>1-是</option>
-            </select>
         </div>
     </div>
 


### PR DESCRIPTION
將「主要出處」和「本人傳記」兩個字段從下拉菜單改為復選框，
提供更直觀的用戶體驗，並優化表單欄位順序。

**改進細節**：
- ✅ 使用 Bootstrap 4 custom-checkbox 樣式
- ✅ 兩個復選框垂直堆疊，使用統一標籤「選項」
- ✅ 添加 hidden input 確保未選中時提交 value="0"
- ✅ 優化欄位順序：複選框置於「註」欄位之上

**修改範圍**：
- 主要出處（c_main_source）
- 本人傳記（c_self_bio）

**最終欄位順序**：
1. person id
2. 出處 (c_textid)
3. 頁數/條目 (c_pages)
4. 選項（主要出處 + 本人傳記）← 複選框
5. 註 (c_notes)
6. 建檔/更新