### PR TITLE
改進：增大基本資訊導航標籤的數字字體

### DIFF
--- a/resources/css/select2-overrides.css
+++ b/resources/css/select2-overrides.css
@@ -12,7 +12,7 @@
 }
 
 /* Increase font size for nav-tabs badge counts in basic information pages */
-.nav-tabs .nav-link .badge {
+.biogmain-navigation .nav-tabs .nav-link .badge {
     font-size: 1.1em;
     font-weight: 600;
     padding: 0.3em 0.5em;

--- a/resources/css/select2-overrides.css
+++ b/resources/css/select2-overrides.css
@@ -10,3 +10,10 @@
 .select2-container--default .select2-selection--single .select2-selection__arrow {
     height: 36px;
 }
+
+/* Increase font size for nav-tabs badge counts in basic information pages */
+.nav-tabs .nav-link .badge {
+    font-size: 1.1em;
+    font-weight: 600;
+    padding: 0.3em 0.5em;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,9 @@
 // Import AdminLTE v3 CSS from NPM
 import 'admin-lte/dist/css/adminlte.min.css';
 
+// Import custom CSS overrides
+import '../css/select2-overrides.css';
+
 // Import jQuery and expose globally before any plugins run
 import $ from './jquery-global';
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,9 +8,6 @@
 // Import AdminLTE v3 CSS from NPM
 import 'admin-lte/dist/css/adminlte.min.css';
 
-// Import custom CSS overrides
-import '../css/select2-overrides.css';
-
 // Import jQuery and expose globally before any plugins run
 import $ from './jquery-global';
 
@@ -25,6 +22,9 @@ import 'select2/dist/css/select2.min.css';
 import '@ttskch/select2-bootstrap4-theme/dist/select2-bootstrap4.min.css';
 import select2 from 'select2';
 select2(window, $);
+
+// Import custom CSS overrides (must come after Select2 CSS to properly override)
+import '../css/select2-overrides.css';
 
 import { formatTimestamp, getUserOffsetMinutes, getUserTimeZone } from './utils/datetime';
 

--- a/resources/views/biogmains/banner.blade.php
+++ b/resources/views/biogmains/banner.blade.php
@@ -2,7 +2,7 @@
     $currentRoute = request()->route()->getName();
 @endphp
 
-<div class="mb-4">
+<div class="mb-4 biogmain-navigation">
     <h3 class="text-center mb-3">{{ $basicinformation->c_name_chn.'（'.$basicinformation->c_name.'）- '.$basicinformation->c_personid }}</h3>
 
     <ul class="nav nav-tabs" style="flex-wrap: wrap;">


### PR DESCRIPTION
## 摘要

在基本資訊頁面的導航標籤（地址、別名、著述、官名等）中，增大旁邊顯示的數字徽章字體，提升可讀性。

## 變更內容

- ✅ 增加 badge 字體大小至 1.1em（較原始大小增加約 10%）
- ✅ 調整 font-weight 至 600，使數字更醒目清晰
- ✅ 調整 padding 至 0.3em 0.5em，保持視覺平衡
- ✅ 在 app.js 中導入 select2-overrides.css，確保樣式正確載入

## 測試計劃

- [ ] 在瀏覽器中訪問 `/basicinformation/{personid}/edit` 頁面
- [ ] 確認導航標籤中的數字（如「地址0」、「別名1」、「官名8」等）字體變大
- [ ] 檢查在不同螢幕尺寸下的顯示效果（桌面、平板、手機）
- [ ] 確認樣式不影響其他頁面的 badge 顯示

## 相關文件

- `resources/css/select2-overrides.css` - 新增 badge 樣式規則
- `resources/js/app.js` - 導入 CSS 文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)