### PR TITLE
重構：使用 OpenAI 兼容的 Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ PUSHER_APP_SECRET=
 # Google Gemini API for Natural Language Query
 # Get your API key from: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=
+# OpenAI-compatible API endpoint
+GEMINI_API_ENDPOINT=https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+# Model name (e.g., gemini-3-flash-preview, gemini-2.0-flash-exp)
+GEMINI_MODEL=gemini-3-flash-preview

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -10,11 +10,14 @@ use Illuminate\Support\Facades\Log;
 class NaturalLanguageQueryService {
     protected DatabaseSchemaService $schemaService;
     protected string $apiKey;
-    protected string $apiEndpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent';
+    protected string $apiEndpoint;
+    protected string $model;
 
     public function __construct(DatabaseSchemaService $schemaService) {
         $this->schemaService = $schemaService;
         $this->apiKey = config('services.gemini.api_key', '');
+        $this->apiEndpoint = config('services.gemini.api_endpoint', 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
+        $this->model = config('services.gemini.model', 'gemini-3-flash-preview');
     }
 
     /**
@@ -50,42 +53,54 @@ class NaturalLanguageQueryService {
         try {
             $schemaPrompt = $this->schemaService->generateSchemaPrompt($tableNames);
             $systemPrompt = $this->buildSystemPrompt($schemaPrompt);
-            $fullPrompt = $systemPrompt . "\n\n用户问题：{$question}";
 
             // 记录发送给 LLM 的提示词
-            $logData['llm_prompt'] = $fullPrompt;
+            $logData['llm_prompt'] = $systemPrompt . "\n\n用户问题：{$question}";
 
             $response = Http::timeout(30)
                 ->withHeaders([
                     'Content-Type' => 'application/json',
+                    'Authorization' => 'Bearer ' . $this->apiKey,
                 ])
-                ->post($this->apiEndpoint . '?key=' . $this->apiKey, [
-                    'contents' => [
+                ->post($this->apiEndpoint, [
+                    'model' => $this->model,
+                    'messages' => [
                         [
-                            'parts' => [
-                                ['text' => $fullPrompt],
-                            ],
+                            'role' => 'system',
+                            'content' => $systemPrompt,
+                        ],
+                        [
+                            'role' => 'user',
+                            'content' => $question,
                         ],
                     ],
-                    'generationConfig' => [
-                        'temperature' => 0.1,
-                        'topK' => 40,
-                        'topP' => 0.95,
-                        'maxOutputTokens' => 8192, // 增加输出 token 限制以支持复杂查询
-                        'responseMimeType' => 'application/json',
-                        'responseSchema' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'sql' => [
-                                    'type' => 'string',
-                                    'description' => 'The SQL SELECT query statement',
+                    'temperature' => 0.1,
+                    'top_p' => 0.95,
+                    'max_tokens' => 8192,
+                    'response_format' => [
+                        'type' => 'json_schema',
+                        'json_schema' => [
+                            'name' => 'sql_query_response',
+                            'strict' => true,
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'sql' => [
+                                        'type' => ['string', 'null'],
+                                        'description' => 'The SQL SELECT query statement (null if error)',
+                                    ],
+                                    'explanation' => [
+                                        'type' => ['string', 'null'],
+                                        'description' => 'A brief explanation of what the query does (1-2 sentences in Traditional Chinese)',
+                                    ],
+                                    'error' => [
+                                        'type' => ['string', 'null'],
+                                        'description' => 'Error message explaining why SQL cannot be generated (null if successful)',
+                                    ],
                                 ],
-                                'explanation' => [
-                                    'type' => 'string',
-                                    'description' => 'A brief explanation of what the query does (1-2 sentences in Traditional Chinese)',
-                                ],
+                                'required' => ['sql', 'explanation', 'error'],
+                                'additionalProperties' => false,
                             ],
-                            'required' => ['sql', 'explanation'],
                         ],
                     ],
                 ]);
@@ -112,7 +127,7 @@ class NaturalLanguageQueryService {
             // 记录 LLM 响应
             $logData['llm_response'] = json_encode($response->json(), JSON_UNESCAPED_UNICODE);
 
-            $result = $this->parseGeminiResponse($response->json());
+            $result = $this->parseOpenAIResponse($response->json());
 
             // 更新日志数据
             $logData['generated_sql'] = $result['sql'];
@@ -189,76 +204,117 @@ class NaturalLanguageQueryService {
 2. 不要使用 EXPLAIN、DESCRIBE、SHOW 等元查询
 3. 查询只能使用以下提供的表和字段
 4. 使用标准 SQL 语法（MySQL/MariaDB 兼容）
-5. 返回格式为 JSON，包含：
-   - sql: SQL 查询语句（纯文本，不需要代码块标记）
-   - explanation: 简短的查询解释（一到两句话，使用繁体中文）
+5. 返回格式为 JSON，包含以下字段：
+   - sql: SQL 查询语句（纯文本，不需要代码块标记）；如果无法生成则为 null
+   - explanation: 简短的查询解释（一到两句话，使用繁体中文）；如果无法生成则为 null
+   - error: 错误信息（繁体中文），说明为何无法生成 SQL；成功时为 null
+
+**何时返回 error（设置 sql 和 explanation 为 null）：**
+- 用户问题不清楚或过于模糊
+- 用户要求的表或字段不在提供的数据库结构中
+- 用户要求执行非 SELECT 操作（如修改、删除数据）
+- 用户问题无法用 SQL 查询表达
+- 用户问题涉及数据库元信息（如 SHOW、DESCRIBE）
 
 **可用的数据库表结构：**
 
 {$schemaPrompt}
 
-**示例：**
+**成功示例：**
 用户问题：显示所有朝代名称
 返回 JSON：
 {
   "sql": "SELECT c_dy FROM DYNASTIES",
-  "explanation": "此查询从 DYNASTIES 表中选择所有朝代名称字段。"
+  "explanation": "此查询从 DYNASTIES 表中选择所有朝代名称字段。",
+  "error": null
+}
+
+**错误示例：**
+用户问题：删除所有朝代
+返回 JSON：
+{
+  "sql": null,
+  "explanation": null,
+  "error": "無法執行此操作，系統僅支援查詢（SELECT）操作，不支援刪除（DELETE）操作。"
+}
+
+用户问题：查询用户表
+返回 JSON：
+{
+  "sql": null,
+  "explanation": null,
+  "error": "資料庫中沒有「用户表」，請檢查可用的表格清單並重新表述問題。"
 }
 PROMPT;
     }
 
     /**
-     * 解析 Gemini API 响应（使用 structured output）
+     * 解析 OpenAI 兼容 API 响应（使用 structured output）
      *
      * @param array $responseData
      * @return array
      */
-    protected function parseGeminiResponse(array $responseData): array {
+    protected function parseOpenAIResponse(array $responseData): array {
         try {
-            // 从 structured output 中获取 JSON 文本
-            $text = $responseData['candidates'][0]['content']['parts'][0]['text'] ?? null;
+            // 从 OpenAI 格式的响应中获取内容
+            $content = $responseData['choices'][0]['message']['content'] ?? null;
 
-            if (!$text) {
+            if (!$content) {
                 return [
                     'success' => false,
                     'sql' => null,
-                    'error' => 'Gemini API 返回的响应格式不正确',
+                    'error' => 'API 返回的响应格式不正确',
                     'explanation' => null,
                 ];
             }
 
             // 清理可能的控制字符，但保留换行符和制表符（JSON 中合法）
             // 移除其他控制字符（0x00-0x1F，除了 0x09 制表符、0x0A 换行、0x0D 回车）
-            $text = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $text);
+            $content = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $content);
 
             // 解析 JSON 响应，使用选项忽略 UTF-8 错误
-            $jsonData = json_decode($text, true, 512, JSON_INVALID_UTF8_IGNORE);
+            $jsonData = json_decode($content, true, 512, JSON_INVALID_UTF8_IGNORE);
 
             if (json_last_error() !== JSON_ERROR_NONE) {
-                Log::warning('Gemini API 返回的 JSON 解析失败', [
+                Log::warning('API 返回的 JSON 解析失败', [
                     'error' => json_last_error_msg(),
-                    'text' => mb_substr($text, 0, 500), // 只记录前 500 个字符
-                    'text_length' => strlen($text),
+                    'content' => mb_substr($content, 0, 500), // 只记录前 500 个字符
+                    'content_length' => strlen($content),
                 ]);
 
                 return [
                     'success' => false,
                     'sql' => null,
-                    'error' => 'Gemini API 返回的 JSON 格式不正确: ' . json_last_error_msg() . '。请尝试简化您的问题。',
+                    'error' => 'API 返回的 JSON 格式不正确: ' . json_last_error_msg() . '。请尝试简化您的问题。',
+                    'explanation' => null,
+                ];
+            }
+
+            // 检查 LLM 返回的 error 字段
+            if (!empty($jsonData['error'])) {
+                $llmError = trim($jsonData['error']);
+                Log::info('LLM 返回錯誤，無法生成 SQL', [
+                    'error' => $llmError,
+                ]);
+
+                return [
+                    'success' => false,
+                    'sql' => null,
+                    'error' => $llmError,
                     'explanation' => null,
                 ];
             }
 
             // 验证必需字段
             if (empty($jsonData['sql'])) {
-                Log::warning('Gemini API 返回的响应中缺少 SQL 字段', [
+                Log::warning('API 返回的响应中缺少 SQL 字段', [
                     'json_data' => $jsonData,
                 ]);
 
                 return [
                     'success' => false,
                     'sql' => null,
-                    'error' => 'Gemini API 返回的响应中缺少 SQL 字段。请尝试重新表述您的问题。',
+                    'error' => 'API 返回的响应中缺少 SQL 字段。请尝试重新表述您的问题。',
                     'explanation' => null,
                 ];
             }
@@ -274,7 +330,7 @@ PROMPT;
             ];
 
         } catch (\Exception $e) {
-            Log::error('解析 Gemini 响应时出错', [
+            Log::error('解析 API 响应时出错', [
                 'exception' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);
@@ -282,7 +338,7 @@ PROMPT;
             return [
                 'success' => false,
                 'sql' => null,
-                'error' => '解析 Gemini 响应时出错: ' . $e->getMessage(),
+                'error' => '解析 API 响应时出错: ' . $e->getMessage(),
                 'explanation' => null,
             ];
         }

--- a/config/services.php
+++ b/config/services.php
@@ -37,6 +37,8 @@ return [
 
     'gemini' => [
         'api_key' => env('GEMINI_API_KEY'),
+        'api_endpoint' => env('GEMINI_API_ENDPOINT', 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'),
+        'model' => env('GEMINI_MODEL', 'gemini-3-flash-preview'),
     ],
 
 ];

--- a/tests/Unit/NaturalLanguageQueryServiceTest.php
+++ b/tests/Unit/NaturalLanguageQueryServiceTest.php
@@ -42,21 +42,20 @@ class NaturalLanguageQueryServiceTest extends TestCase {
         $this->schemaService->method('generateSchemaPrompt')
             ->willReturn('Mock schema info');
 
-        // Mock HTTP response with structured output (JSON)
+        // Mock HTTP response with OpenAI-compatible structured output
         Http::fake([
             '*' => Http::response([
-                'candidates' => [
+                'choices' => [
                     [
-                        'content' => [
-                            'parts' => [
-                                [
-                                    'text' => json_encode([
-                                        'sql' => 'SELECT * FROM DYNASTIES',
-                                        'explanation' => '此查詢選擇所有朝代。',
-                                    ]),
-                                ],
-                            ],
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => json_encode([
+                                'sql' => 'SELECT * FROM DYNASTIES',
+                                'explanation' => '此查詢選擇所有朝代。',
+                                'error' => null,
+                            ]),
                         ],
+                        'finish_reason' => 'stop',
                     ],
                 ],
             ], 200),
@@ -72,6 +71,7 @@ class NaturalLanguageQueryServiceTest extends TestCase {
         $this->assertTrue($result['success']);
         $this->assertStringContainsString('SELECT', $result['sql']);
         $this->assertNotNull($result['explanation']);
+        $this->assertNull($result['error']);
     }
 
     /** @test */
@@ -99,18 +99,16 @@ class NaturalLanguageQueryServiceTest extends TestCase {
         $this->schemaService->method('generateSchemaPrompt')
             ->willReturn('Mock schema info');
 
-        // Mock HTTP response with invalid JSON
+        // Mock HTTP response with invalid JSON (OpenAI format)
         Http::fake([
             '*' => Http::response([
-                'candidates' => [
+                'choices' => [
                     [
-                        'content' => [
-                            'parts' => [
-                                [
-                                    'text' => 'This is not valid JSON',
-                                ],
-                            ],
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => 'This is not valid JSON',
                         ],
+                        'finish_reason' => 'stop',
                     ],
                 ],
             ], 200),
@@ -127,20 +125,20 @@ class NaturalLanguageQueryServiceTest extends TestCase {
         $this->schemaService->method('generateSchemaPrompt')
             ->willReturn('Mock schema info');
 
-        // Mock HTTP response with missing sql field
+        // Mock HTTP response with missing sql field (OpenAI format)
         Http::fake([
             '*' => Http::response([
-                'candidates' => [
+                'choices' => [
                     [
-                        'content' => [
-                            'parts' => [
-                                [
-                                    'text' => json_encode([
-                                        'explanation' => 'Some explanation',
-                                    ]),
-                                ],
-                            ],
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => json_encode([
+                                'sql' => null,
+                                'explanation' => null,
+                                'error' => null,
+                            ]),
                         ],
+                        'finish_reason' => 'stop',
                     ],
                 ],
             ], 200),
@@ -150,5 +148,38 @@ class NaturalLanguageQueryServiceTest extends TestCase {
 
         $this->assertFalse($result['success']);
         $this->assertStringContainsString('缺少 SQL 字段', $result['error']);
+    }
+
+    /** @test */
+    public function it_handles_llm_returned_error() {
+        $this->schemaService->method('generateSchemaPrompt')
+            ->willReturn('Mock schema info');
+
+        // Mock HTTP response where LLM returns an error (cannot generate SQL)
+        Http::fake([
+            '*' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => json_encode([
+                                'sql' => null,
+                                'explanation' => null,
+                                'error' => '無法執行此操作，系統僅支援查詢（SELECT）操作，不支援刪除（DELETE）操作。',
+                            ]),
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $result = $this->service->generateSQL('刪除所有朝代');
+
+        $this->assertFalse($result['success']);
+        $this->assertNull($result['sql']);
+        $this->assertNull($result['explanation']);
+        $this->assertStringContainsString('無法執行此操作', $result['error']);
+        $this->assertStringContainsString('僅支援查詢', $result['error']);
     }
 }


### PR DESCRIPTION
將自然語言查詢功能改為使用 Gemini 的 OpenAI 兼容端點，簡化代碼並提升互操作性，同時添加結構化的錯誤處理機制。

主要改動：

1. API 端點更新
   - 從 Gemini 原生 API 改為 OpenAI 兼容端點
   - 新端點：https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
   - 使用最新的 gemini-3-flash-preview 模型
   - 採用 Authorization Bearer token 認證方式

2. 請求格式改為 OpenAI 標準
   - 使用 messages 數組（system/user role）
   - 使用 OpenAI 的 response_format.json_schema 進行結構化輸出
   - 參數名稱標準化：top_p、max_tokens

3. Response Schema 增強
   - 添加 error 字段（可選，繁體中文）
   - sql 和 explanation 字段改為可空類型
   - 所有三個字段均為必填（strict mode），確保結構完整

4. 系統提示詞優化
   - 明確說明何時應返回 error 字段： * 用戶問題不清楚或過於模糊 * 要求的表或字段不存在 * 要求執行非 SELECT 操作 * 問題無法用 SQL 表達 * 涉及數據庫元信息查詢
   - 提供成功和錯誤的示例幫助 LLM 理解

5. 響應解析邏輯
   - 重命名 parseGeminiResponse 為 parseOpenAIResponse
   - 適配 OpenAI 響應格式：choices[0].message.content
   - 優先檢查 LLM 返回的 error 字段
   - 保留控制字符清理和 UTF-8 容錯處理

6. 測試完善
   - 所有 HTTP mock 更新為 OpenAI 格式
   - 更新成功測試確保 error 為 null
   - 新增 it_handles_llm_returned_error 測試
   - 驗證刪除操作等不支援場景的錯誤處理
   - 測試結果：6/6 tests passed, 17 assertions

優勢：
- 更標準的 API 介面，便於未來切換不同 LLM 提供商
- 與 OpenAI SDK 和工具生態系統相容
- 用戶能獲得更清晰的錯誤提示
- 區分系統錯誤和 LLM 判斷的無法處理情況
- 便於收集用戶問題特徵以改進提示詞
- 代碼更簡潔，維護性更好

參考文檔：https://ai.google.dev/gemini-api/docs/openai