### PR TITLE
修復：將 Gemini API 參數從 max_tokens 改為 max_completion_tokens

### DIFF
--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -76,7 +76,7 @@ class NaturalLanguageQueryService {
                     ],
                     'temperature' => 0.1,
                     'top_p' => 0.95,
-                    'max_tokens' => 8192,
+                    'max_completion_tokens' => 8192,
                     'response_format' => [
                         'type' => 'json_schema',
                         'json_schema' => [


### PR DESCRIPTION
## Summary
- 修正 `NaturalLanguageQueryService` 中 Gemini API 調用失敗的問題
- 將 API 請求參數從 `max_tokens` 改為 `max_completion_tokens`

## 問題描述
在使用自然語言查詢功能（`/query-playground` 路由）時，Gemini API 返回錯誤：
```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

## 解決方案
Gemini 的 OpenAI 兼容端點（`generativelanguage.googleapis.com/v1beta/openai/`）要求使用 `max_completion_tokens` 參數而非標準 OpenAI API 的 `max_tokens` 參數。

## 變更內容
- 📝 修改 `app/Services/NaturalLanguageQueryService.php` 第 79 行
- 將 `'max_tokens' => 8192` 改為 `'max_completion_tokens' => 8192`

## Test plan
- [x] 確認代碼變更符合 Gemini API 文檔要求
- [ ] 測試 `/query-playground` 的自然語言查詢功能
- [ ] 驗證 API 調用成功並返回正確的 SQL 查詢

🤖 Generated with [Claude Code](https://claude.com/claude-code)