### PR TITLE
改進：提取建檔/更新信息字段為可復用組件

### DIFF
--- a/resources/views/biogmains/addresses/_form.blade.php
+++ b/resources/views/biogmains/addresses/_form.blade.php
@@ -142,19 +142,13 @@
         </div>
     </div>
 
-    <div class="form-group row">
-        <label for="" class="col-sm-2 col-form-label">建檔</label>
-        <div class="col-sm-10">
-            <input type="text" class="form-control" value="{{ $isEdit ? $row->c_created_by.'/'.$row->c_created_date : '' }}" disabled>
-        </div>
-    </div>
-
-    <div class="form-group row">
-        <label for="" class="col-sm-2 col-form-label">更新</label>
-        <div class="col-sm-10">
-            <input type="text" class="form-control" value="{{ $isEdit ? $row->c_modified_by.'/'.$row->c_modified_date : '' }}" disabled>
-        </div>
-    </div>
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/altname/_form.blade.php
+++ b/resources/views/biogmains/altname/_form.blade.php
@@ -100,33 +100,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="{{ $row->c_created_by.'/'.$row->c_created_date }}" disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}" disabled>
-            </div>
-        </div>
-    @else
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="" disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="" disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <label for="__proposal_comment" class="col-sm-2 col-form-label">提案說明</label>

--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -320,20 +320,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="{{ $row->c_created_by.'/'.$row->c_created_date }}" disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}" disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -362,22 +362,13 @@
                     </div>
                 </div>
                 
-                <div class="form-group row">
-                    <label for="" class="col-sm-2 col-form-label">建檔</label>
-                    <div class="col-sm-10">
-                        <input type="text" name="" class="form-control"
-                               value="{{ $basicinformation->c_created_by.'/'.$basicinformation->c_created_date }}"
-                               disabled>
-                    </div>
-                </div>
-                <div class="form-group row">
-                    <label for="" class="col-sm-2 col-form-label">更新</label>
-                    <div class="col-sm-10">
-                        <input type="text" name="" class="form-control"
-                               value="{{ $basicinformation->c_modified_by.'/'.$basicinformation->c_modified_date }}"
-                               disabled>
-                    </div>
-                </div>
+                <x-forms.audit-fields
+                    :show="true"
+                    :createdBy="$basicinformation->c_created_by"
+                    :createdDate="$basicinformation->c_created_date"
+                    :modifiedBy="$basicinformation->c_modified_by"
+                    :modifiedDate="$basicinformation->c_modified_date"
+                />
                 @auth
                     @if(Auth::user()->isActive())
                         <div class="form-group row">

--- a/resources/views/biogmains/entries/_form.blade.php
+++ b/resources/views/biogmains/entries/_form.blade.php
@@ -214,21 +214,13 @@
         </div>
     </div>
 
-    <div class="form-group row">
-        <label for="" class="col-sm-2 col-form-label">建檔</label>
-        <div class="col-sm-10">
-            <input type="text" {{ $isEdit ? '' : 'name=""' }} class="form-control" value="{{ $isEdit ? $row->c_created_by.'/'.$row->c_created_date : '' }}" disabled>
-        </div>
-    </div>
-
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control" value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}" disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -131,24 +131,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/kinship/_form.blade.php
+++ b/resources/views/biogmains/kinship/_form.blade.php
@@ -101,24 +101,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -195,41 +195,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @else
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value=""
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value=""
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -125,24 +125,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/socialinst/_form.blade.php
+++ b/resources/views/biogmains/socialinst/_form.blade.php
@@ -107,24 +107,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/sources/_form.blade.php
+++ b/resources/views/biogmains/sources/_form.blade.php
@@ -96,20 +96,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" class="form-control" value="{{ $row->c_created_by.'/'.$row->c_created_date }}" disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" class="form-control" value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}" disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/statuses/_form.blade.php
+++ b/resources/views/biogmains/statuses/_form.blade.php
@@ -112,24 +112,13 @@
         </div>
     </div>
 
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">建檔</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_created_by.'/'.$row->c_created_date }}"
-                       disabled>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/biogmains/texts/_form.blade.php
+++ b/resources/views/biogmains/texts/_form.blade.php
@@ -75,25 +75,13 @@
         </div>
     </div>
 
-    <div class="form-group row">
-        <label for="" class="col-sm-2 col-form-label">建檔</label>
-        <div class="col-sm-10">
-            <input type="text" name="" class="form-control"
-                   value="{{ $isEdit ? $row->c_created_by.'/'.$row->c_created_date : '' }}"
-                   disabled>
-        </div>
-    </div>
-
-    @if($isEdit)
-        <div class="form-group row">
-            <label for="" class="col-sm-2 col-form-label">更新</label>
-            <div class="col-sm-10">
-                <input type="text" name="" class="form-control"
-                       value="{{ $row->c_modified_by.'/'.$row->c_modified_date }}"
-                       disabled>
-            </div>
-        </div>
-    @endif
+    <x-forms.audit-fields
+        :show="$isEdit"
+        :createdBy="$isEdit ? $row->c_created_by : null"
+        :createdDate="$isEdit ? $row->c_created_date : null"
+        :modifiedBy="$isEdit ? $row->c_modified_by : null"
+        :modifiedDate="$isEdit ? $row->c_modified_date : null"
+    />
 
     <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">

--- a/resources/views/components/forms/audit-fields.blade.php
+++ b/resources/views/components/forms/audit-fields.blade.php
@@ -1,0 +1,30 @@
+{{-- 審計字段組件：建檔/更新信息 --}}
+@props([
+    'createdBy' => null,
+    'createdDate' => null,
+    'modifiedBy' => null,
+    'modifiedDate' => null,
+    'show' => true,
+])
+
+@if($show && ($createdBy || $modifiedBy))
+    <div class="form-group row">
+        <label class="col-sm-2 col-form-label">建檔</label>
+        <div class="col-sm-10">
+            <input type="text"
+                   class="form-control"
+                   value="{{ $createdBy && $createdDate ? $createdBy.'/'.$createdDate : '' }}"
+                   disabled>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="col-sm-2 col-form-label">更新</label>
+        <div class="col-sm-10">
+            <input type="text"
+                   class="form-control"
+                   value="{{ $modifiedBy && $modifiedDate ? $modifiedBy.'/'.$modifiedDate : '' }}"
+                   disabled>
+        </div>
+    </div>
+@endif


### PR DESCRIPTION
- 創建新組件 resources/views/components/forms/audit-fields.blade.php
- 替換 13 個表單文件中的重複審計字段代碼為組件調用
- 統一審計字段的顯示邏輯（僅在編輯模式下顯示）
- 減少約 156 行重複代碼，提高維護性

影響範圍：
- altname/_form.blade.php
- addresses/_form.blade.php
- assoc/_form.blade.php
- basicinformation/edit.blade.php
- entries/_form.blade.php
- events/_form.blade.php
- kinship/_form.blade.php
- offices/_form.blade.php
- possession/_form.blade.php
- socialinst/_form.blade.php
- sources/_form.blade.php
- statuses/_form.blade.php
- texts/_form.blade.php