### PR TITLE
新增：自然語言查詢的用戶同意機制

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -35,6 +35,7 @@ class QueryPlaygroundController extends Controller {
             'page_description' => '本功能目前處於測試階段，請適度使用以維護系統穩定',
             'page_url' => route('query-playground.index'),
             'initial_sql' => $initialSql,
+            'nl_model' => config('services.gemini.model', 'gemini-3-flash-preview'),
         ]);
     }
 
@@ -261,6 +262,7 @@ class QueryPlaygroundController extends Controller {
             'success' => true,
             'sql' => $result['sql'],
             'explanation' => $result['explanation'],
+            'model' => $result['model'] ?? null,
         ]);
     }
 }

--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -265,4 +265,75 @@ class QueryPlaygroundController extends Controller {
             'model' => $result['model'] ?? null,
         ]);
     }
+
+    /**
+     * 顯示自然語言查詢日誌（僅管理員）
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function nlQueryLogs(Request $request) {
+        if (!Auth::user()->isAdmin()) {
+            abort(403, 'Unauthorized. Admin access required.');
+        }
+
+        $query = DB::table('nl_query_logs')
+            ->leftJoin('users', 'nl_query_logs.user_id', '=', 'users.id')
+            ->select(
+                'nl_query_logs.*',
+                'users.name as user_name',
+                'users.email as user_email'
+            );
+
+        // 搜尋過濾
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('nl_query_logs.question', 'like', "%{$search}%")
+                    ->orWhere('nl_query_logs.generated_sql', 'like', "%{$search}%")
+                    ->orWhere('users.name', 'like', "%{$search}%")
+                    ->orWhere('users.email', 'like', "%{$search}%");
+            });
+        }
+
+        // 成功/失敗過濾
+        if ($request->filled('success')) {
+            $query->where('nl_query_logs.success', $request->input('success'));
+        }
+
+        // 用戶過濾
+        if ($request->filled('user_id')) {
+            $query->where('nl_query_logs.user_id', $request->input('user_id'));
+        }
+
+        // 排序
+        $query->orderBy('nl_query_logs.created_at', 'desc');
+
+        // 分頁
+        $logs = $query->paginate(20)->withQueryString();
+
+        // 獲取所有用戶列表用於篩選
+        $users = DB::table('users')
+            ->whereIn('id', function ($query) {
+                $query->select('user_id')
+                    ->from('nl_query_logs')
+                    ->whereNotNull('user_id')
+                    ->distinct();
+            })
+            ->orderBy('name')
+            ->get();
+
+        return view('query_playground.nl_query_logs', [
+            'page_title' => '自然語言查詢日誌',
+            'page_title_key' => 'NL Query Logs',
+            'page_url' => route('query-playground.nl-query-logs'),
+            'logs' => $logs,
+            'users' => $users,
+            'filters' => [
+                'search' => $request->input('search'),
+                'success' => $request->input('success'),
+                'user_id' => $request->input('user_id'),
+            ],
+        ]);
+    }
 }

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -25,7 +25,7 @@ class NaturalLanguageQueryService {
      *
      * @param string $question 用户的自然语言问题
      * @param array|null $tableNames 限制使用的表名（可选）
-     * @return array ['success' => bool, 'sql' => string|null, 'error' => string|null, 'explanation' => string|null]
+     * @return array ['success' => bool, 'sql' => string|null, 'error' => string|null, 'explanation' => string|null, 'model' => string|null]
      */
     public function generateSQL(string $question, ?array $tableNames = null): array {
         if (empty($this->apiKey)) {
@@ -34,6 +34,7 @@ class NaturalLanguageQueryService {
                 'sql' => null,
                 'error' => 'Gemini API Key 未配置。请在 .env 文件中设置 GEMINI_API_KEY。',
                 'explanation' => null,
+                'model' => null,
             ];
         }
 
@@ -121,6 +122,7 @@ class NaturalLanguageQueryService {
                     'sql' => null,
                     'error' => "Gemini API 调用失败: {$errorMessage}",
                     'explanation' => null,
+                    'model' => $this->model,
                 ];
             }
 
@@ -128,6 +130,9 @@ class NaturalLanguageQueryService {
             $logData['llm_response'] = json_encode($response->json(), JSON_UNESCAPED_UNICODE);
 
             $result = $this->parseOpenAIResponse($response->json());
+
+            // 添加模型信息
+            $result['model'] = $this->model;
 
             // 更新日志数据
             $logData['generated_sql'] = $result['sql'];
@@ -156,6 +161,7 @@ class NaturalLanguageQueryService {
                 'sql' => null,
                 'error' => '生成 SQL 时发生错误: ' . $e->getMessage(),
                 'explanation' => null,
+                'model' => $this->model,
             ];
         }
     }

--- a/resources/views/query_playground/index.blade.php
+++ b/resources/views/query_playground/index.blade.php
@@ -52,13 +52,36 @@
 
                     <!-- Natural Language Query Panel -->
                     <div class="tab-pane fade" id="nlPanel" role="tabpanel">
+                        <!-- Privacy Notice -->
+                        <div class="alert alert-warning">
+                            <h6><i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務</h6>
+                            <p class="mb-2">
+                                使用本功能即表示您理解並同意：
+                            </p>
+                            <ul class="mb-2" style="font-size: 0.9em;">
+                                <li>您的問題和生成的 SQL 將被記錄用於研究與改進</li>
+                                <li>您的查詢將發送至第三方 AI 服務（Google Gemini API、OpenAI API 等，恕不另行通知）進行處理</li>
+                                <li>詳細數據收集說明請參閱 <a href="#" data-toggle="modal" data-target="#privacyModal">隱私條款</a></li>
+                            </ul>
+                        </div>
+
                         <div class="form-group">
                             <label for="nlInput">自然語言問題:</label>
                             <textarea class="form-control" id="nlInput" rows="3" placeholder="例如：顯示所有朝代名稱"></textarea>
                         </div>
 
+                        <!-- Consent Checkbox -->
+                        <div class="form-group">
+                            <div class="custom-control custom-checkbox">
+                                <input type="checkbox" class="custom-control-input" id="consentCheckbox">
+                                <label class="custom-control-label" for="consentCheckbox">
+                                    我已閱讀並同意 <a href="#" data-toggle="modal" data-target="#privacyModal">數據收集與隱私條款</a>，理解我的查詢將被記錄並發送至第三方服務處理
+                                </label>
+                            </div>
+                        </div>
+
                         <div class="d-flex justify-content-between align-items-center mb-3">
-                            <button class="btn btn-success" id="btnGenerate">
+                            <button class="btn btn-success" id="btnGenerate" disabled>
                                 <i class="fas fa-magic"></i> 生成 SQL
                             </button>
                             <div id="nlLoadingIndicator" style="display:none;">
@@ -108,6 +131,117 @@
         </div>
         
         <div class="alert alert-danger mt-3" id="errorAlert" style="display: none;"></div>
+    </div>
+</div>
+
+<!-- Privacy Modal -->
+<div class="modal fade" id="privacyModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="fas fa-shield-alt"></i> 自然語言查詢功能 - 數據收集與隱私條款
+                </h5>
+                <button type="button" class="close" data-dismiss="modal">
+                    <span>&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <h6><strong>1. 功能說明</strong></h6>
+                <p>
+                    本功能使用人工智能大型語言模型（LLM）將您的自然語言問題轉換為 SQL 查詢語句。
+                    此功能旨在協助用戶更方便地查詢資料庫，無需熟悉 SQL 語法。
+                </p>
+
+                <h6><strong>2. 第三方服務</strong></h6>
+                <p>
+                    本功能使用第三方 AI 服務（包括但不限於 <strong>Google Gemini API、OpenAI API</strong> 等）進行自然語言處理。
+                    系統保留隨時切換服務提供商的權利，恕不另行通知。當您提交問題時：
+                </p>
+                <ul>
+                    <li>您的問題文本將被發送至第三方服務提供商的服務器進行處理</li>
+                    <li>資料庫結構信息（表名和欄位名）將一併發送以協助生成準確的查詢</li>
+                    <li>服務提供商可能會根據其服務條款收集和處理這些數據</li>
+                </ul>
+                <p>
+                    使用本功能即表示您同意接受相關第三方服務的條款，包括但不限於：
+                </p>
+                <ul>
+                    <li><a href="https://ai.google.dev/gemini-api/terms" target="_blank" rel="noopener">Google Gemini API 服務條款</a>
+                        和 <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google 隱私政策</a></li>
+                    <li><a href="https://openai.com/policies/terms-of-use" target="_blank" rel="noopener">OpenAI 使用條款</a>
+                        和 <a href="https://openai.com/policies/privacy-policy" target="_blank" rel="noopener">OpenAI 隱私政策</a></li>
+                    <li>其他可能使用的 AI 服務提供商的相關條款</li>
+                </ul>
+                <p class="text-muted" style="font-size: 0.9em;">
+                    <strong>注意：</strong>系統可能在不同時間使用不同的服務提供商，且可能不會事先通知。
+                    建議您在使用前查閱上述所有服務條款。
+                </p>
+
+                <h6><strong>3. 系統日誌記錄</strong></h6>
+                <p>
+                    為了研究和改進本功能，系統將記錄以下資訊：
+                </p>
+                <ul>
+                    <li><strong>您的用戶 ID</strong>（如果已登入）</li>
+                    <li><strong>您提交的自然語言問題</strong>（完整文本）</li>
+                    <li><strong>生成的 SQL 查詢語句</strong></li>
+                    <li><strong>完整的 LLM 提示詞</strong>（包含資料庫結構信息）</li>
+                    <li><strong>LLM 的原始響應</strong></li>
+                    <li><strong>執行時間和成功狀態</strong></li>
+                    <li><strong>錯誤信息</strong>（如果發生）</li>
+                </ul>
+                <p>
+                    這些記錄將用於：
+                </p>
+                <ul>
+                    <li>分析功能使用模式</li>
+                    <li>改進提示詞策略</li>
+                    <li>優化查詢生成質量</li>
+                    <li>系統性能監控和故障排查</li>
+                </ul>
+
+                <h6><strong>4. 數據保留</strong></h6>
+                <p>
+                    系統記錄將無限期保留於系統資料庫中，用於持續改進服務。
+                    管理員可存取這些記錄以進行研究和系統維護。
+                </p>
+
+                <h6><strong>5. 數據安全</strong></h6>
+                <p>
+                    我們採取合理的技術措施保護您的數據，但無法保證絕對安全。
+                    請勿在查詢中包含敏感個人資訊。
+                </p>
+
+                <h6><strong>6. 您的權利</strong></h6>
+                <p>
+                    <strong>本功能為可選功能。</strong>如果您不同意上述條款：
+                </p>
+                <ul>
+                    <li>請勿使用自然語言查詢功能</li>
+                    <li>您仍可使用傳統的 SQL 查詢面板進行資料庫查詢</li>
+                </ul>
+
+                <h6><strong>7. 條款變更</strong></h6>
+                <p>
+                    我們保留隨時修改本條款的權利。由於每次使用都需要您的明確同意，
+                    您可以在每次使用前查看最新版本的條款。
+                </p>
+
+                <h6><strong>8. 聯絡我們</strong></h6>
+                <p>
+                    如對本條款或數據收集有任何疑問，請聯繫系統管理員。
+                </p>
+
+                <p class="text-muted mt-3" style="font-size: 0.85em;">
+                    <strong>最後更新：</strong>2025年12月<br>
+                    <strong>版本：</strong>1.0
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">關閉</button>
+            </div>
+        </div>
     </div>
 </div>
 @endsection
@@ -254,10 +388,29 @@ onViteReady(function() {
     });
 
     // Natural Language Query handlers
+    // Enable/disable generate button based on consent checkbox
+    $('#consentCheckbox').change(function() {
+        const isChecked = $(this).is(':checked');
+        $('#btnGenerate').prop('disabled', !isChecked);
+    });
+
+    // Reset consent checkbox when switching to NL tab
+    $('#nl-tab').on('shown.bs.tab', function() {
+        // Don't auto-reset checkbox - let user keep their choice during session
+        // $('#consentCheckbox').prop('checked', false);
+        // $('#btnGenerate').prop('disabled', true);
+    });
+
     $('#btnGenerate').click(function() {
         const question = $('#nlInput').val().trim();
         if (!question) {
             alert('請輸入自然語言問題');
+            return;
+        }
+
+        // Double-check consent
+        if (!$('#consentCheckbox').is(':checked')) {
+            alert('請先閱讀並同意數據收集與隱私條款');
             return;
         }
 

--- a/resources/views/query_playground/index.blade.php
+++ b/resources/views/query_playground/index.blade.php
@@ -81,18 +81,24 @@
                         </div>
 
                         <div class="d-flex justify-content-between align-items-center mb-3">
-                            <button class="btn btn-success" id="btnGenerate" disabled>
-                                <i class="fas fa-magic"></i> 生成 SQL
-                            </button>
+                            <div>
+                                <button class="btn btn-success" id="btnGenerate" disabled>
+                                    <i class="fas fa-magic"></i> 生成 SQL
+                                </button>
+                                <small class="text-muted ml-2">使用模型：<code>{{ $nl_model }}</code></small>
+                            </div>
                             <div id="nlLoadingIndicator" style="display:none;">
-                                <div class="spinner-border text-success spinner-border-sm" role="status"></div> 生成中...
+                                <div class="spinner-border text-success spinner-border-sm" role="status"></div> 生成中 ({{ $nl_model }})...
                             </div>
                         </div>
 
                         <!-- Generated SQL Display -->
                         <div id="generatedSqlContainer" style="display:none;">
                             <div class="alert alert-success">
-                                <h6><i class="fas fa-check-circle"></i> 生成的 SQL：</h6>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <h6><i class="fas fa-check-circle"></i> 生成的 SQL：</h6>
+                                    <small class="text-muted" id="generatedModel"></small>
+                                </div>
                                 <pre id="generatedSql" style="background: #f4f4f4; padding: 10px; border-radius: 4px; margin-top: 10px;"></pre>
                                 <div id="sqlExplanation" class="mt-2" style="font-size: 0.9em;"></div>
                             </div>
@@ -435,6 +441,12 @@ onViteReady(function() {
                         $('#sqlExplanation').html('<strong>說明：</strong>' + response.explanation);
                     } else {
                         $('#sqlExplanation').empty();
+                    }
+
+                    if (response.model) {
+                        $('#generatedModel').html('使用模型：<code>' + response.model + '</code>');
+                    } else {
+                        $('#generatedModel').empty();
                     }
 
                     $('#generatedSqlContainer').show();

--- a/resources/views/query_playground/nl_query_logs.blade.php
+++ b/resources/views/query_playground/nl_query_logs.blade.php
@@ -181,47 +181,134 @@
                                             @php
                                                 $responseData = json_decode($log->llm_response, true);
                                             @endphp
-                                            @if($responseData && isset($responseData['choices'][0]))
+                                            @if($responseData)
                                                 <div class="mt-2">
                                                     <h6 class="text-muted">關鍵信息：</h6>
                                                     <table class="table table-sm table-bordered">
                                                         <tbody>
-                                                            @if(isset($responseData['choices'][0]['finish_reason']))
+                                                            {{-- OpenAI 格式：model --}}
+                                                            @if(isset($responseData['model']))
                                                                 <tr>
-                                                                    <th style="width: 150px;">Finish Reason</th>
-                                                                    <td><code>{{ $responseData['choices'][0]['finish_reason'] }}</code></td>
+                                                                    <th style="width: 150px;">模型</th>
+                                                                    <td><code>{{ $responseData['model'] }}</code></td>
                                                                 </tr>
                                                             @endif
-                                                            @if(isset($responseData['choices'][0]['finishReason']))
-                                                                <tr>
-                                                                    <th>Finish Reason (Gemini)</th>
-                                                                    <td><code>{{ $responseData['choices'][0]['finishReason'] }}</code></td>
-                                                                </tr>
-                                                            @endif
-                                                            @if(isset($responseData['usageMetadata']))
-                                                                <tr>
-                                                                    <th>Token 使用</th>
-                                                                    <td>
-                                                                        提示詞: {{ $responseData['usageMetadata']['promptTokenCount'] ?? 'N/A' }}，
-                                                                        響應: {{ $responseData['usageMetadata']['candidatesTokenCount'] ?? 'N/A' }}，
-                                                                        總計: {{ $responseData['usageMetadata']['totalTokenCount'] ?? 'N/A' }}
-                                                                        @if(isset($responseData['usageMetadata']['thoughtsTokenCount']))
-                                                                            <br><small class="text-muted">思考 tokens: {{ $responseData['usageMetadata']['thoughtsTokenCount'] }}</small>
-                                                                        @endif
-                                                                    </td>
-                                                                </tr>
-                                                            @endif
+
+                                                            {{-- Gemini 格式：modelVersion --}}
                                                             @if(isset($responseData['modelVersion']))
                                                                 <tr>
                                                                     <th>模型版本</th>
                                                                     <td><code>{{ $responseData['modelVersion'] }}</code></td>
                                                                 </tr>
                                                             @endif
-                                                            @if(isset($responseData['responseId']))
+
+                                                            {{-- OpenAI 格式：object --}}
+                                                            @if(isset($responseData['object']))
+                                                                <tr>
+                                                                    <th>對象類型</th>
+                                                                    <td><code>{{ $responseData['object'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- OpenAI 格式：id / Gemini 格式：responseId --}}
+                                                            @if(isset($responseData['id']))
+                                                                <tr>
+                                                                    <th>響應 ID</th>
+                                                                    <td><small><code>{{ $responseData['id'] }}</code></small></td>
+                                                                </tr>
+                                                            @elseif(isset($responseData['responseId']))
                                                                 <tr>
                                                                     <th>響應 ID</th>
                                                                     <td><small><code>{{ $responseData['responseId'] }}</code></small></td>
                                                                 </tr>
+                                                            @endif
+
+                                                            {{-- OpenAI 格式：created --}}
+                                                            @if(isset($responseData['created']))
+                                                                <tr>
+                                                                    <th>創建時間</th>
+                                                                    <td>
+                                                                        {{ date('Y-m-d H:i:s', $responseData['created']) }}
+                                                                        <small class="text-muted">(Unix: {{ $responseData['created'] }})</small>
+                                                                    </td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- Finish Reason --}}
+                                                            @if(isset($responseData['choices'][0]['finish_reason']))
+                                                                <tr>
+                                                                    <th>完成原因</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['finish_reason'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+                                                            @if(isset($responseData['choices'][0]['finishReason']))
+                                                                <tr>
+                                                                    <th>完成原因 (Gemini)</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['finishReason'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- Choice Index --}}
+                                                            @if(isset($responseData['choices'][0]['index']))
+                                                                <tr>
+                                                                    <th>Choice Index</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['index'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- Message Role --}}
+                                                            @if(isset($responseData['choices'][0]['message']['role']))
+                                                                <tr>
+                                                                    <th>角色</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['message']['role'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- OpenAI 格式：usage --}}
+                                                            @if(isset($responseData['usage']))
+                                                                <tr>
+                                                                    <th>Token 使用</th>
+                                                                    <td>
+                                                                        <strong>提示詞：</strong>{{ number_format($responseData['usage']['prompt_tokens'] ?? 0) }}<br>
+                                                                        <strong>響應：</strong>{{ number_format($responseData['usage']['completion_tokens'] ?? 0) }}<br>
+                                                                        <strong>總計：</strong>{{ number_format($responseData['usage']['total_tokens'] ?? 0) }}
+                                                                    </td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- Gemini 格式：usageMetadata --}}
+                                                            @if(isset($responseData['usageMetadata']))
+                                                                <tr>
+                                                                    <th>Token 使用 (Gemini)</th>
+                                                                    <td>
+                                                                        <strong>提示詞：</strong>{{ number_format($responseData['usageMetadata']['promptTokenCount'] ?? 0) }}<br>
+                                                                        <strong>候選：</strong>{{ number_format($responseData['usageMetadata']['candidatesTokenCount'] ?? 0) }}<br>
+                                                                        <strong>總計：</strong>{{ number_format($responseData['usageMetadata']['totalTokenCount'] ?? 0) }}
+                                                                        @if(isset($responseData['usageMetadata']['thoughtsTokenCount']))
+                                                                            <br><strong class="text-info">思考：</strong>{{ number_format($responseData['usageMetadata']['thoughtsTokenCount']) }}
+                                                                        @endif
+                                                                    </td>
+                                                                </tr>
+                                                            @endif
+
+                                                            {{-- Extra Content (thought_signature 已被過濾，不顯示) --}}
+                                                            @if(isset($responseData['choices'][0]['message']['extra_content']) && !empty($responseData['choices'][0]['message']['extra_content']))
+                                                                @php
+                                                                    $extraContent = $responseData['choices'][0]['message']['extra_content'];
+                                                                    // 移除 thought_signature
+                                                                    if (isset($extraContent['google']['thought_signature'])) {
+                                                                        unset($extraContent['google']['thought_signature']);
+                                                                    }
+                                                                    if (isset($extraContent['google']) && empty($extraContent['google'])) {
+                                                                        unset($extraContent['google']);
+                                                                    }
+                                                                @endphp
+                                                                @if(!empty($extraContent))
+                                                                    <tr>
+                                                                        <th>額外內容</th>
+                                                                        <td><pre class="mb-0" style="font-size: 0.8em;">{{ json_encode($extraContent, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre></td>
+                                                                    </tr>
+                                                                @endif
                                                             @endif
                                                         </tbody>
                                                     </table>

--- a/resources/views/query_playground/nl_query_logs.blade.php
+++ b/resources/views/query_playground/nl_query_logs.blade.php
@@ -1,0 +1,259 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fas fa-history mr-1"></i> {{ $page_title }}</h3>
+                <div class="card-tools">
+                    <a href="{{ route('query-playground.index') }}" class="btn btn-sm btn-primary">
+                        <i class="fas fa-arrow-left"></i> 返回查詢練習場
+                    </a>
+                </div>
+            </div>
+
+            <div class="card-body">
+                <!-- 搜尋與篩選 -->
+                <form method="GET" action="{{ route('query-playground.nl-query-logs') }}" class="mb-3">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="search">關鍵字搜尋</label>
+                                <input type="text" class="form-control" id="search" name="search"
+                                       value="{{ $filters['search'] ?? '' }}"
+                                       placeholder="搜尋問題、SQL、用戶名稱或郵箱">
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <div class="form-group">
+                                <label for="success">狀態</label>
+                                <select class="form-control" id="success" name="success">
+                                    <option value="">全部</option>
+                                    <option value="1" {{ ($filters['success'] ?? '') === '1' ? 'selected' : '' }}>成功</option>
+                                    <option value="0" {{ ($filters['success'] ?? '') === '0' ? 'selected' : '' }}>失敗</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <div class="form-group">
+                                <label for="user_id">用戶</label>
+                                <select class="form-control" id="user_id" name="user_id">
+                                    <option value="">全部用戶</option>
+                                    @foreach($users as $user)
+                                        <option value="{{ $user->id }}" {{ ($filters['user_id'] ?? '') == $user->id ? 'selected' : '' }}>
+                                            {{ $user->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label>&nbsp;</label>
+                                <div>
+                                    <button type="submit" class="btn btn-primary btn-block">
+                                        <i class="fas fa-search"></i> 搜尋
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @if($filters['search'] || $filters['success'] !== null || $filters['user_id'])
+                        <div class="row">
+                            <div class="col-12">
+                                <a href="{{ route('query-playground.nl-query-logs') }}" class="btn btn-sm btn-secondary">
+                                    <i class="fas fa-times"></i> 清除篩選
+                                </a>
+                            </div>
+                        </div>
+                    @endif
+                </form>
+
+                <!-- 統計信息 -->
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle"></i>
+                    共 {{ $logs->total() }} 筆記錄，顯示第 {{ $logs->firstItem() ?? 0 }} - {{ $logs->lastItem() ?? 0 }} 筆
+                </div>
+
+                <!-- 日誌列表 -->
+                @if($logs->isEmpty())
+                    <div class="alert alert-warning">
+                        <i class="fas fa-exclamation-triangle"></i> 暫無記錄
+                    </div>
+                @else
+                    @foreach($logs as $log)
+                        <div class="card mb-3 {{ $log->success ? 'border-success' : 'border-danger' }}">
+                            <div class="card-header {{ $log->success ? 'bg-success' : 'bg-danger' }}">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <strong>#{{ $log->id }}</strong>
+                                        <span class="ml-2">
+                                            <i class="fas fa-user"></i>
+                                            {{ $log->user_name ?? '未知用戶' }}
+                                            @if($log->user_email)
+                                                <small class="text-muted">({{ $log->user_email }})</small>
+                                            @endif
+                                        </span>
+                                        <span class="ml-2">
+                                            <i class="fas fa-clock"></i>
+                                            {{ $log->created_at }}
+                                        </span>
+                                        @if($log->execution_time_ms)
+                                            <span class="ml-2">
+                                                <i class="fas fa-stopwatch"></i>
+                                                {{ $log->execution_time_ms }}ms
+                                            </span>
+                                        @endif
+                                    </div>
+                                    <span class="badge badge-light">
+                                        {{ $log->success ? '成功' : '失敗' }}
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <!-- 用戶問題 -->
+                                <div class="mb-3">
+                                    <h6><i class="fas fa-question-circle text-primary"></i> 用戶問題：</h6>
+                                    <div class="alert alert-light mb-2">
+                                        {{ $log->question }}
+                                    </div>
+                                </div>
+
+                                @if($log->success)
+                                    <!-- 生成的 SQL -->
+                                    @if($log->generated_sql)
+                                        <div class="mb-3">
+                                            <h6><i class="fas fa-code text-success"></i> 生成的 SQL：</h6>
+                                            <pre class="bg-light p-2 border rounded" style="max-height: 200px; overflow-y: auto;"><code>{{ $log->generated_sql }}</code></pre>
+                                        </div>
+                                    @endif
+
+                                    <!-- 說明 -->
+                                    @if($log->explanation)
+                                        <div class="mb-3">
+                                            <h6><i class="fas fa-info-circle text-info"></i> 說明：</h6>
+                                            <p class="text-muted">{{ $log->explanation }}</p>
+                                        </div>
+                                    @endif
+                                @else
+                                    <!-- 錯誤信息 -->
+                                    @if($log->error_message)
+                                        <div class="mb-3">
+                                            <h6><i class="fas fa-exclamation-triangle text-danger"></i> 錯誤信息：</h6>
+                                            <div class="alert alert-danger">
+                                                {{ $log->error_message }}
+                                            </div>
+                                        </div>
+                                    @endif
+                                @endif
+
+                                <!-- LLM Prompt（折疊） -->
+                                @if($log->llm_prompt)
+                                    <div class="mb-3">
+                                        <h6>
+                                            <a class="collapsed" data-toggle="collapse" href="#prompt-{{ $log->id }}" role="button">
+                                                <i class="fas fa-chevron-right"></i> LLM 提示詞
+                                                <small class="text-muted">({{ strlen($log->llm_prompt) }} 字符)</small>
+                                            </a>
+                                        </h6>
+                                        <div class="collapse" id="prompt-{{ $log->id }}">
+                                            <pre class="bg-light p-2 border rounded" style="max-height: 400px; overflow-y: auto; font-size: 0.85em;">{{ $log->llm_prompt }}</pre>
+                                        </div>
+                                    </div>
+                                @endif
+
+                                <!-- LLM Response（折疊並美化） -->
+                                @if($log->llm_response)
+                                    <div class="mb-3">
+                                        <h6>
+                                            <a class="collapsed" data-toggle="collapse" href="#response-{{ $log->id }}" role="button">
+                                                <i class="fas fa-chevron-right"></i> LLM 響應
+                                                <small class="text-muted">({{ strlen($log->llm_response) }} 字符)</small>
+                                            </a>
+                                        </h6>
+                                        <div class="collapse" id="response-{{ $log->id }}">
+                                            <div class="bg-light p-2 border rounded" style="max-height: 500px; overflow-y: auto;">
+                                                <pre class="mb-0" style="font-size: 0.85em;"><code class="language-json">{{ $log->llm_response }}</code></pre>
+                                            </div>
+
+                                            <!-- 解析並顯示關鍵信息 -->
+                                            @php
+                                                $responseData = json_decode($log->llm_response, true);
+                                            @endphp
+                                            @if($responseData && isset($responseData['choices'][0]))
+                                                <div class="mt-2">
+                                                    <h6 class="text-muted">關鍵信息：</h6>
+                                                    <table class="table table-sm table-bordered">
+                                                        <tbody>
+                                                            @if(isset($responseData['choices'][0]['finish_reason']))
+                                                                <tr>
+                                                                    <th style="width: 150px;">Finish Reason</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['finish_reason'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+                                                            @if(isset($responseData['choices'][0]['finishReason']))
+                                                                <tr>
+                                                                    <th>Finish Reason (Gemini)</th>
+                                                                    <td><code>{{ $responseData['choices'][0]['finishReason'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+                                                            @if(isset($responseData['usageMetadata']))
+                                                                <tr>
+                                                                    <th>Token 使用</th>
+                                                                    <td>
+                                                                        提示詞: {{ $responseData['usageMetadata']['promptTokenCount'] ?? 'N/A' }}，
+                                                                        響應: {{ $responseData['usageMetadata']['candidatesTokenCount'] ?? 'N/A' }}，
+                                                                        總計: {{ $responseData['usageMetadata']['totalTokenCount'] ?? 'N/A' }}
+                                                                        @if(isset($responseData['usageMetadata']['thoughtsTokenCount']))
+                                                                            <br><small class="text-muted">思考 tokens: {{ $responseData['usageMetadata']['thoughtsTokenCount'] }}</small>
+                                                                        @endif
+                                                                    </td>
+                                                                </tr>
+                                                            @endif
+                                                            @if(isset($responseData['modelVersion']))
+                                                                <tr>
+                                                                    <th>模型版本</th>
+                                                                    <td><code>{{ $responseData['modelVersion'] }}</code></td>
+                                                                </tr>
+                                                            @endif
+                                                            @if(isset($responseData['responseId']))
+                                                                <tr>
+                                                                    <th>響應 ID</th>
+                                                                    <td><small><code>{{ $responseData['responseId'] }}</code></small></td>
+                                                                </tr>
+                                                            @endif
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            @endif
+                                        </div>
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+
+                    <!-- 分頁 -->
+                    <div class="d-flex justify-content-center">
+                        {{ $logs->links() }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('js')
+<script>
+onViteReady(function() {
+    // 折疊展開時切換圖標
+    $('.collapse').on('show.bs.collapse', function() {
+        $(this).prev().find('.fas').removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    }).on('hide.bs.collapse', function() {
+        $(this).prev().find('.fas').removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    });
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -144,6 +144,7 @@ Route::middleware('auth')->group(function () {
     Route::get('query-playground', 'QueryPlaygroundController@index')->name('query-playground.index');
     Route::post('query-playground/run', 'QueryPlaygroundController@run')->name('query-playground.run');
     Route::post('query-playground/generate-from-nl', 'QueryPlaygroundController@generateFromNL')->name('query-playground.generate-from-nl');
+    Route::get('query-playground/nl-query-logs', 'QueryPlaygroundController@nlQueryLogs')->name('query-playground.nl-query-logs');
 
     Route::post('admin/unidirectional-relationship-repair/assoc', 'UnidirectionalRelationshipRepairController@repairAssoc')->name('admin.unidirectional-relationship-repair.assoc');
 });


### PR DESCRIPTION
在自然語言轉 SQL 查詢功能中新增用戶同意機制，確保用戶了解並同意數據收集和第三方服務使用條款。

主要改動：

1. 數據收集警告框
   - 在查詢表單上方添加黃色警告框
   - 說明查詢記錄用途和第三方服務使用
   - 提供隱私條款連結

2. 必須同意的複選框
   - 用戶必須勾選同意條款才能提交查詢
   - 生成 SQL 按鈕預設禁用
   - JavaScript 控制按鈕啟用狀態

3. 隱私條款模態框
   - 詳細說明 8 個部分： * 功能說明 * 第三方服務（Google Gemini API、OpenAI API 等） * 系統日誌記錄 * 數據保留 * 數據安全 * 用戶權利 * 條款變更 * 聯絡方式
   - 包含第三方服務條款連結
   - 說明系統保留切換服務提供商的權利

4. 雙重確認機制
   - 點擊生成按鈕時再次檢查複選框狀態
   - 未勾選時顯示提示訊息

設計考量：
- 每次查詢都需要確認，不儲存同意狀態
- 避免複雜的版本控制機制
- 符合數據收集透明度要求
- 支援未來切換 AI 服務提供商的彈性