### PR TITLE
修復：移動端日期選擇器「日(干支)」標籤溢出問題

### DIFF
--- a/resources/views/components/inline-time-fields.blade.php
+++ b/resources/views/components/inline-time-fields.blade.php
@@ -78,7 +78,7 @@
             </div>
         @endif
         @if($showLunar)
-            <div class="d-flex align-items-center flex-wrap" style="min-width: 56ch; flex: 1 1 56ch;">
+            <div class="d-flex align-items-center flex-wrap" style="flex: 1 1 56ch;">
                 <div class="custom-control custom-checkbox mr-4">
                     <input type="hidden" name="{{ $intercalaryName }}" value="0">
                     <input type="checkbox"
@@ -109,9 +109,11 @@
                     <div class="invalid-feedback">請輸入 1-30 或留空</div>
                 </div>
                 <span class="mr-2">日</span>
-                <label class="mb-0 mr-2" for="{{ $dayGzName }}">{{ $dayGzLabel }}</label>
-                <div class="flex-grow-1" style="min-width: 12ch;">
-                    <select-vue element-id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
+                <div class="d-flex align-items-center" style="min-width: 0; flex: 1 1 auto;">
+                    <label class="mb-0 mr-2 text-nowrap" for="{{ $dayGzName }}">{{ $dayGzLabel }}</label>
+                    <div class="flex-grow-1" style="min-width: 12ch;">
+                        <select-vue element-id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
+                    </div>
                 </div>
             </div>
         @elseif($showLunarPlaceholder)


### PR DESCRIPTION
問題描述：
在移動設備上查看 basicinformation edit 頁面時，生年/卒年等日期控件中的「日(干支)」標籤溢出到屏幕外。

根本原因：
inline-time-fields 組件中，農曆字段容器設置了 `min-width: 56ch`，在移動設備上強制占據過寬空間，導致最後的「日(干支)」部分無法正確換行。

修復方案：
1. 移除容器的 `min-width: 56ch` 限制，保留 `flex: 1 1 56ch`
2. 將「日(干支)」標籤和選擇框包裝在獨立的 flex 容器中
3. 為標籤添加 `text-nowrap` 類防止文字斷開

效果：
- 桌面端：保持 flex-basis: 56ch 基礎寬度，顯示效果不變
- 移動端：允許容器收縮和自動換行，「日(干支)」部分正確顯示不溢出