### PR TITLE
新增：在側邊欄添加「自然語言查詢日誌」菜單項，並將「SQL 查詢練習場」移入「專家工具」組

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -273,8 +273,8 @@ class QueryPlaygroundController extends Controller {
      * @return \Illuminate\View\View
      */
     public function nlQueryLogs(Request $request) {
-        if (!Auth::user()->isAdmin()) {
-            abort(403, 'Unauthorized. Admin access required.');
+        if (!Auth::user()->isSuperAdmin()) {
+            abort(403, 'Unauthorized. Super admin access required.');
         }
 
         $query = DB::table('nl_query_logs')

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -319,8 +319,35 @@
 
                 @if(Auth::check() and Auth::user()->isAdmin())
                     @php
+                        $expertPages = [
+                            'Query Playground',
+                        ];
+                        $expertMenuOpen = in_array($activePage, $expertPages, true);
+                    @endphp
+                    <li class="nav-item {{ $expertMenuOpen ? 'menu-open' : '' }}">
+                        <a href="{{ route('query-playground.index') }}" class="nav-link {{ $expertMenuOpen ? 'active' : '' }}">
+                            <i class="nav-icon fas fa-flask"></i>
+                            <p>
+                                專家工具
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
+                        </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('query-playground.index') }}" class="nav-link {{ $activePage == 'Query Playground' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-terminal"></i>
+                                    <p>SQL 查詢練習場</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                @endif
+
+                @if(Auth::check() and Auth::user()->isSuperAdmin())
+                    @php
                         $adminPages = [
                             '用戶管理',
+                            'NL Query Logs',
                             'SQL 執行計畫',
                             '批次匯入書稿資料',
                             '批次匯入官職',
@@ -329,7 +356,6 @@
                             'CBDB 內部表維護',
                             '單向關係修復',
                             'MergePreview',
-                            'Query Playground',
                         ];
                         $adminMenuOpen = in_array($activePage, $adminPages, true);
                     @endphp
@@ -349,9 +375,9 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a href="{{ route('query-playground.index') }}" class="nav-link {{ $activePage == 'Query Playground' ? 'active' : '' }}">
-                                    <i class="nav-icon fas fa-terminal"></i>
-                                    <p>SQL 查詢練習場</p>
+                                <a href="{{ route('query-playground.nl-query-logs') }}" class="nav-link {{ $activePage == 'NL Query Logs' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-comments"></i>
+                                    <p>自然語言查詢日誌</p>
                                 </a>
                             </li>
                             <li class="nav-item">


### PR DESCRIPTION
- 新增「專家工具」菜單組，位於「管理員工具」上方
- 專家工具包含「SQL 查詢練習場」，對專家和系統管理員可見（使用 isAdmin() 檢查）
- 管理員工具包含「自然語言查詢日誌」，僅對系統管理員可見（使用 isSuperAdmin() 檢查）
- 更新 QueryPlaygroundController::nlQueryLogs() 權限檢查為 isSuperAdmin()
- 使用 fas fa-flask 圖標代表專家工具