### PR TITLE
修復：移動端分頁欄溢出問題

### DIFF
--- a/resources/css/mobile-responsive.css
+++ b/resources/css/mobile-responsive.css
@@ -22,35 +22,36 @@
         font-size: 0.875rem;
     }
 
-    /* 分页外层容器：确保不会超出视窗 */
-    .float-right {
+    /* 分页外层容器：只针对 .card-body 内包含分页的 .float-right */
+    /* 使用 :has() 精确定位，避免影响侧边栏和页眉的 .float-right */
+    .card-body > .float-right:has(nav),
+    .card-body > .float-right:has(.btn-group) {
         width: 100%;
         float: none !important;
         display: flex;
-        justify-content: center;
+        flex-direction: column;
+        align-items: center;
         margin-top: 1rem;
     }
 
-    /* 针对游标分页的响应式处理 */
-    .float-right > div {
-        width: 100%;
-        flex-direction: column;
-        align-items: stretch !important;
+    /* 针对游标分页（包含 .btn-group）的特殊处理 */
+    .card-body > .float-right:has(.btn-group) {
+        gap: 0.5rem;
     }
 
-    .float-right .btn-group {
+    .card-body > .float-right .btn-group {
+        display: flex;
         flex-direction: column;
         width: 100%;
     }
 
-    .float-right .btn-group .btn {
+    .card-body > .float-right .btn-group .btn {
         border-radius: 0.25rem !important;
         margin-bottom: 0.25rem;
     }
 
-    .float-right .input-group {
+    .card-body > .float-right .input-group {
         width: 100% !important;
-        margin-top: 0.5rem;
     }
 }
 

--- a/resources/css/mobile-responsive.css
+++ b/resources/css/mobile-responsive.css
@@ -1,0 +1,68 @@
+/**
+ * Mobile Responsive Fixes
+ * 移动端响应式修复
+ */
+
+/* 修复移动端分页栏溢出问题 */
+@media (max-width: 768px) {
+    /* Bootstrap 分页容器：允许换行并居中对齐 */
+    .pagination {
+        flex-wrap: wrap !important;
+        justify-content: center !important;
+        gap: 4px;
+    }
+
+    /* 分页项：调整间距和尺寸 */
+    .pagination .page-item {
+        margin: 2px 0;
+    }
+
+    .pagination .page-link {
+        padding: 0.375rem 0.75rem;
+        font-size: 0.875rem;
+    }
+
+    /* 分页外层容器：确保不会超出视窗 */
+    .float-right {
+        width: 100%;
+        float: none !important;
+        display: flex;
+        justify-content: center;
+        margin-top: 1rem;
+    }
+
+    /* 针对游标分页的响应式处理 */
+    .float-right > div {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch !important;
+    }
+
+    .float-right .btn-group {
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .float-right .btn-group .btn {
+        border-radius: 0.25rem !important;
+        margin-bottom: 0.25rem;
+    }
+
+    .float-right .input-group {
+        width: 100% !important;
+        margin-top: 0.5rem;
+    }
+}
+
+/* 针对极小屏幕（如手机竖屏）的额外优化 */
+@media (max-width: 480px) {
+    .pagination .page-link {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.8rem;
+    }
+
+    /* 隐藏省略号文本，只保留核心分页按钮 */
+    .pagination .page-item.disabled .page-link {
+        padding: 0.25rem 0.4rem;
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -25,6 +25,7 @@ select2(window, $);
 
 // Import custom CSS overrides (must come after Select2 CSS to properly override)
 import '../css/select2-overrides.css';
+import '../css/mobile-responsive.css';
 
 import { formatTimestamp, getUserOffsetMinutes, getUserTimeZone } from './utils/datetime';
 


### PR DESCRIPTION
新增移動端響應式 CSS，解決 Bootstrap 分頁欄在移動設備上
條目過多時從左側溢出屏幕的問題。

變更內容：
- 新增 resources/css/mobile-responsive.css
  - 分頁項目支援自動換行（flex-wrap）
  - 針對小於 768px 螢幕調整分頁按鈕間距和尺寸
  - 針對極小螢幕（480px）進一步優化顯示
  - 游標分頁導航在移動端改為垂直排列
- 在 resources/js/app.js 中引入新的 CSS 檔案

影響範圍：
- 所有使用 Laravel 分頁的頁面（operations、codes、view 等）
- 僅影響移動端顯示，桌面端無變化