### PR TITLE
新增：按入仕查詢功能

### DIFF
--- a/app/Http/Controllers/SearchByEntryController.php
+++ b/app/Http/Controllers/SearchByEntryController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class SearchByEntryController extends Controller {
+    /**
+     * 顯示按入仕查詢頁面
+     */
+    public function index() {
+        return view('search-by.entry.index');
+    }
+
+    /**
+     * 獲取入仕類型樹狀結構（AJAX API）
+     */
+    public function getEntryTypes() {
+        $types = DB::table('ENTRY_TYPES')
+            ->select(
+                'c_entry_type',
+                'c_entry_type_desc',
+                'c_entry_type_desc_chn',
+                'c_entry_type_parent_id',
+                'c_entry_type_level',
+                'c_entry_type_sortorder'
+            )
+            ->orderBy('c_entry_type_sortorder')
+            ->orderBy('c_entry_type')
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $types,
+        ]);
+    }
+
+    /**
+     * 根據入仕類型獲取對應的入仕代碼（AJAX API）
+     */
+    public function getEntryCodes(Request $request) {
+        $typeId = $request->input('type_id');
+
+        $query = DB::table('ENTRY_CODES as ec')
+            ->select(
+                'ec.c_entry_code',
+                'ec.c_entry_desc',
+                'ec.c_entry_desc_chn'
+            )
+            ->orderBy('ec.c_entry_code');
+
+        // 如果指定了類型，則通過關聯表過濾
+        if ($typeId) {
+            $query->join('ENTRY_CODE_TYPE_REL as rel', 'ec.c_entry_code', '=', 'rel.c_entry_code')
+                ->where('rel.c_entry_type', $typeId);
+        }
+
+        $codes = $query->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $codes,
+        ]);
+    }
+
+    /**
+     * 執行搜索查詢
+     */
+    public function search(Request $request) {
+        $request->validate([
+            'entry_codes' => 'nullable|array',
+            'entry_codes.*' => 'integer',
+            'year_from' => 'nullable|integer',
+            'year_to' => 'nullable|integer',
+            'addr_id' => 'nullable|integer',
+        ]);
+
+        $entryCodes = $request->input('entry_codes', []);
+        $yearFrom = $request->input('year_from');
+        $yearTo = $request->input('year_to');
+        $addrId = $request->input('addr_id');
+
+        // 構建查詢
+        $query = DB::table('ENTRY_DATA as ed')
+            ->join('BIOG_MAIN as bm', 'ed.c_personid', '=', 'bm.c_personid')
+            ->join('ENTRY_CODES as ec', 'ed.c_entry_code', '=', 'ec.c_entry_code')
+            ->leftJoin('DYNASTIES as dy', 'dy.c_dy', '=', 'bm.c_dy')
+            ->leftJoin('ADDR_CODES as addr', 'addr.c_addr_id', '=', 'bm.c_index_addr_id')
+            ->select(
+                'bm.c_personid',
+                'bm.c_name_chn',
+                'bm.c_name',
+                'bm.c_dy',
+                'dy.c_dynasty',
+                'dy.c_dynasty_chn',
+                'bm.c_index_year',
+                'bm.c_index_addr_id',
+                'addr.c_name as c_index_addr_name',
+                'addr.c_name_chn as c_index_addr_chn',
+                'ec.c_entry_code',
+                'ec.c_entry_desc_chn',
+                'ec.c_entry_desc',
+                'ed.c_year',
+                'ed.c_sequence'
+            );
+
+        // 過濾：入仕代碼
+        if (!empty($entryCodes)) {
+            $query->whereIn('ed.c_entry_code', $entryCodes);
+        }
+
+        // 過濾：年份範圍
+        if ($yearFrom !== null) {
+            $query->where('ed.c_year', '>=', $yearFrom);
+        }
+        if ($yearTo !== null) {
+            $query->where('ed.c_year', '<=', $yearTo);
+        }
+
+        // 過濾：地址
+        if ($addrId !== null) {
+            $query->where('ed.c_entry_addr_id', $addrId);
+        }
+
+        // 執行查詢並分頁
+        $results = $query
+            ->orderBy('bm.c_index_year')
+            ->orderBy('bm.c_personid')
+            ->paginate(50)
+            ->appends($request->all());
+
+        return view('search-by.entry.results', compact('results'));
+    }
+}

--- a/resources/views/search-by/entry/index.blade.php
+++ b/resources/views/search-by/entry/index.blade.php
@@ -1,0 +1,320 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">按入仕查詢</h3>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <!-- 左側：入仕類型 -->
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">入仕類型</h5>
+                        </div>
+                        <div class="card-body p-0">
+                            <div id="entry-types-tree" style="height: 400px; overflow-y: auto; border: 1px solid #dee2e6;">
+                                <div class="text-center p-3">
+                                    <div class="spinner-border spinner-border-sm" role="status">
+                                        <span class="sr-only">載入中...</span>
+                                    </div>
+                                    載入中...
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 中間：入仕代碼 -->
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="card-title mb-0">入仕代碼</h5>
+                            <div>
+                                <button type="button" class="btn btn-sm btn-outline-primary" id="btn-select-all">全選</button>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-deselect-all">取消全選</button>
+                            </div>
+                        </div>
+                        <div class="card-body p-0">
+                            <div id="entry-codes-list" style="height: 400px; overflow-y: auto; border: 1px solid #dee2e6;">
+                                <div class="text-muted p-3">請先選擇入仕類型</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 右側：搜尋條件 -->
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">搜尋條件</h5>
+                        </div>
+                        <div class="card-body">
+                            <form method="GET" action="{{ route('search-by.entry.search', [], false) }}" id="search-form">
+                                <!-- 已選擇的入仕代碼 -->
+                                <div class="form-group">
+                                    <label>已選擇的入仕代碼：</label>
+                                    <div id="selected-codes-display" class="small text-muted">
+                                        尚未選擇
+                                    </div>
+                                    <div id="entry_codes_inputs"></div>
+                                </div>
+
+                                <hr>
+
+                                <!-- 年份範圍 -->
+                                <div class="form-group">
+                                    <label for="year_from">年份範圍</label>
+                                    <div class="row">
+                                        <div class="col-6">
+                                            <input type="number" class="form-control form-control-sm" id="year_from" name="year_from" placeholder="起始年">
+                                        </div>
+                                        <div class="col-6">
+                                            <input type="number" class="form-control form-control-sm" id="year_to" name="year_to" placeholder="結束年">
+                                        </div>
+                                    </div>
+                                    <small class="form-text text-muted">可留空表示不限制</small>
+                                </div>
+
+                                <!-- 地址 ID -->
+                                <div class="form-group">
+                                    <label for="addr_id">入仕地址 ID</label>
+                                    <input type="number" class="form-control form-control-sm" id="addr_id" name="addr_id" placeholder="請輸入地址 ID">
+                                    <small class="form-text text-muted">可留空表示不限制</small>
+                                </div>
+
+                                <hr>
+
+                                <!-- 搜尋按鈕 -->
+                                <div class="form-group mb-0">
+                                    <button type="submit" class="btn btn-primary btn-block">
+                                        <i class="fas fa-search"></i> 執行搜尋
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+onViteReady(function() {
+    $(document).ready(function() {
+        let entryTypes = [];
+        let entryCodes = [];
+        let selectedCodes = new Set();
+        let currentTypeId = null;
+
+        // 載入入仕類型
+        function loadEntryTypes() {
+        $.ajax({
+            url: "{{ route('search-by.entry.types', [], false) }}",
+            method: 'GET',
+            success: function(response) {
+                if (response.success) {
+                    entryTypes = response.data;
+                    renderEntryTypesTree();
+                }
+            },
+            error: function() {
+                $('#entry-types-tree').html('<div class="alert alert-danger m-3">載入失敗</div>');
+            }
+        });
+    }
+
+    // 渲染入仕類型樹狀結構
+    function renderEntryTypesTree() {
+        const $tree = $('#entry-types-tree');
+        $tree.empty();
+
+        // 構建樹狀結構
+        const typeMap = {};
+        const rootTypes = [];
+
+        entryTypes.forEach(type => {
+            typeMap[type.c_entry_type] = {
+                ...type,
+                children: []
+            };
+        });
+
+        entryTypes.forEach(type => {
+            if (type.c_entry_type_parent_id && typeMap[type.c_entry_type_parent_id]) {
+                typeMap[type.c_entry_type_parent_id].children.push(typeMap[type.c_entry_type]);
+            } else {
+                rootTypes.push(typeMap[type.c_entry_type]);
+            }
+        });
+
+        // 渲染樹
+        function renderNode(node, level = 0) {
+            const $node = $('<div>')
+                .addClass('entry-type-node')
+                .css('padding-left', (level * 20 + 10) + 'px')
+                .css('padding-top', '5px')
+                .css('padding-bottom', '5px')
+                .css('cursor', 'pointer')
+                .css('border-bottom', '1px solid #f0f0f0')
+                .attr('data-type-id', node.c_entry_type)
+                .text(node.c_entry_type_desc_chn || node.c_entry_type_desc || node.c_entry_type)
+                .on('click', function() {
+                    $('.entry-type-node').removeClass('bg-primary text-white');
+                    $(this).addClass('bg-primary text-white');
+                    loadEntryCodes(node.c_entry_type);
+                })
+                .on('mouseenter', function() {
+                    if (!$(this).hasClass('bg-primary')) {
+                        $(this).addClass('bg-light');
+                    }
+                })
+                .on('mouseleave', function() {
+                    $(this).removeClass('bg-light');
+                });
+
+            $tree.append($node);
+
+            node.children.forEach(child => {
+                renderNode(child, level + 1);
+            });
+        }
+
+        rootTypes.forEach(root => renderNode(root));
+    }
+
+    // 載入入仕代碼
+    function loadEntryCodes(typeId) {
+        currentTypeId = typeId;
+        const $list = $('#entry-codes-list');
+        $list.html('<div class="text-center p-3"><div class="spinner-border spinner-border-sm"></div> 載入中...</div>');
+
+        $.ajax({
+            url: "{{ route('search-by.entry.codes', [], false) }}",
+            method: 'GET',
+            data: { type_id: typeId },
+            success: function(response) {
+                if (response.success) {
+                    entryCodes = response.data;
+                    renderEntryCodes();
+                }
+            },
+            error: function() {
+                $list.html('<div class="alert alert-danger m-3">載入失敗</div>');
+            }
+        });
+    }
+
+    // 渲染入仕代碼列表
+    function renderEntryCodes() {
+        const $list = $('#entry-codes-list');
+        $list.empty();
+
+        if (entryCodes.length === 0) {
+            $list.html('<div class="text-muted p-3">此類型無入仕代碼</div>');
+            return;
+        }
+
+        entryCodes.forEach(code => {
+            const isChecked = selectedCodes.has(code.c_entry_code);
+            const $item = $('<div>')
+                .addClass('entry-code-item')
+                .css('padding', '8px 10px')
+                .css('border-bottom', '1px solid #f0f0f0')
+                .css('cursor', 'pointer')
+                .on('click', function(e) {
+                    // 如果点击的是复选框本身，让浏览器处理
+                    if (e.target.type === 'checkbox') return;
+
+                    // 否则切换复选框状态
+                    $checkbox.prop('checked', !$checkbox.prop('checked')).trigger('change');
+                })
+                .on('mouseenter', function() {
+                    $(this).css('background-color', '#f8f9fa');
+                })
+                .on('mouseleave', function() {
+                    $(this).css('background-color', '');
+                });
+
+            const $checkbox = $('<input>')
+                .attr('type', 'checkbox')
+                .addClass('mr-2')
+                .prop('checked', isChecked)
+                .on('change', function(e) {
+                    e.stopPropagation();
+                    if (this.checked) {
+                        selectedCodes.add(code.c_entry_code);
+                    } else {
+                        selectedCodes.delete(code.c_entry_code);
+                    }
+                    updateSelectedCodesDisplay();
+                });
+
+            const $label = $('<span>')
+                .text(code.c_entry_desc_chn || code.c_entry_desc || code.c_entry_code);
+
+            $item.append($checkbox).append($label);
+            $list.append($item);
+        });
+    }
+
+    // 更新已選擇代碼顯示
+    function updateSelectedCodesDisplay() {
+        const $display = $('#selected-codes-display');
+        const $inputs = $('#entry_codes_inputs');
+
+        // 清空之前的隐藏字段
+        $inputs.empty();
+
+        if (selectedCodes.size === 0) {
+            $display.html('<span class="text-muted">尚未選擇</span>');
+        } else {
+            const codesArray = Array.from(selectedCodes);
+            $display.html('<span class="badge badge-primary mr-1 mb-1">' + codesArray.join('</span> <span class="badge badge-primary mr-1 mb-1">') + '</span>');
+
+            // 为每个选中的代码创建一个隐藏字段
+            codesArray.forEach(code => {
+                $('<input>')
+                    .attr('type', 'hidden')
+                    .attr('name', 'entry_codes[]')
+                    .val(code)
+                    .appendTo($inputs);
+            });
+        }
+    }
+
+    // 全選/取消全選按鈕
+    $('#btn-select-all').on('click', function() {
+        entryCodes.forEach(code => {
+            selectedCodes.add(code.c_entry_code);
+        });
+        renderEntryCodes();
+        updateSelectedCodesDisplay();
+    });
+
+    $('#btn-deselect-all').on('click', function() {
+        entryCodes.forEach(code => {
+            selectedCodes.delete(code.c_entry_code);
+        });
+        renderEntryCodes();
+        updateSelectedCodesDisplay();
+    });
+
+    // 表單提交驗證
+    $('#search-form').on('submit', function(e) {
+        if (selectedCodes.size === 0) {
+            e.preventDefault();
+            alert('請至少選擇一個入仕代碼');
+            return false;
+        }
+    });
+
+        // 初始化
+        loadEntryTypes();
+    });
+});
+</script>
+@endpush

--- a/resources/views/search-by/entry/results.blade.php
+++ b/resources/views/search-by/entry/results.blade.php
@@ -1,0 +1,102 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+    <div class="card card-default">
+        <div class="card-header">
+            <h3 class="card-title">按入仕查詢結果</h3>
+            <div class="card-tools">
+                <a href="{{ route('search-by.entry.index') }}" class="btn btn-sm btn-secondary">
+                    <i class="fas fa-arrow-left"></i> 返回搜尋
+                </a>
+            </div>
+        </div>
+        <div class="card-body">
+            <!-- 搜尋條件摘要 -->
+            <div class="alert alert-info">
+                <h5 class="mb-2"><i class="icon fas fa-info"></i> 搜尋條件</h5>
+                <ul class="mb-0">
+                    @if(request()->input('entry_codes'))
+                        <li>
+                            入仕代碼：
+                            @foreach(request()->input('entry_codes') as $code)
+                                <span class="badge badge-primary">{{ $code }}</span>
+                            @endforeach
+                        </li>
+                    @endif
+                    @if(request()->input('year_from'))
+                        <li>起始年：{{ request()->input('year_from') }}</li>
+                    @endif
+                    @if(request()->input('year_to'))
+                        <li>結束年：{{ request()->input('year_to') }}</li>
+                    @endif
+                    @if(request()->input('addr_id'))
+                        <li>地址 ID：{{ request()->input('addr_id') }}</li>
+                    @endif
+                </ul>
+            </div>
+
+            <!-- 結果統計 -->
+            <div class="mb-3">
+                <p class="text-muted">
+                    共找到 <strong>{{ $results->total() }}</strong> 筆結果
+                    （顯示第 {{ $results->firstItem() ?? 0 }} - {{ $results->lastItem() ?? 0 }} 筆）
+                </p>
+            </div>
+
+            <!-- 結果表格 -->
+            <div class="table-responsive">
+                <table class="table table-bordered table-striped table-sm">
+                    <thead>
+                        <tr>
+                            <th>人物 ID</th>
+                            <th>中文名</th>
+                            <th>英文名</th>
+                            <th>朝代</th>
+                            <th>索引年</th>
+                            <th>索引地址</th>
+                            <th>入仕代碼</th>
+                            <th>入仕途徑（中文）</th>
+                            <th>入仕途徑（英文）</th>
+                            <th>入仕年份</th>
+                            <th>序號</th>
+                            <th>操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($results as $row)
+                            <tr>
+                                <td>{{ $row->c_personid }}</td>
+                                <td>{{ $row->c_name_chn }}</td>
+                                <td>{{ $row->c_name }}</td>
+                                <td>{{ $row->c_dynasty_chn ?? $row->c_dynasty }}</td>
+                                <td>{{ $row->c_index_year }}</td>
+                                <td>{{ $row->c_index_addr_chn ?? $row->c_index_addr_name }}</td>
+                                <td>{{ $row->c_entry_code }}</td>
+                                <td>{{ $row->c_entry_desc_chn }}</td>
+                                <td>{{ $row->c_entry_desc }}</td>
+                                <td>{{ $row->c_year }}</td>
+                                <td>{{ $row->c_sequence }}</td>
+                                <td>
+                                    <a href="{{ route('basicinformation.show', $row->c_personid) }}" class="btn btn-sm btn-info" target="_blank">
+                                        查看
+                                    </a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="12" class="text-center">無符合條件的結果</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- 分頁 -->
+            @if($results->hasPages())
+                <div class="d-flex justify-content-center">
+                    {{ $results->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,6 +118,12 @@ Route::middleware('auth')->group(function () {
     Route::delete('api-tokens/{tokenId}', 'ApiTokenController@destroy')->name('api-tokens.destroy');
     Route::delete('api-tokens', 'ApiTokenController@destroyAll')->name('api-tokens.destroy-all');
 
+    // 按入仕查詢
+    Route::get('search-by/entry', 'SearchByEntryController@index')->name('search-by.entry.index');
+    Route::get('search-by/entry/types', 'SearchByEntryController@getEntryTypes')->name('search-by.entry.types');
+    Route::get('search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('search-by.entry.codes');
+    Route::get('search-by/entry/search', 'SearchByEntryController@search')->name('search-by.entry.search');
+
     Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
     Route::post('admin/explainsql', 'AdminExplainSqlController@explain');
     Route::get('admin/batch-load-book-titles', 'AdminBatchLoadBookTitlesController@showForm')->name('admin.batch-load-book-titles');

--- a/tests/Feature/SearchByEntryControllerTest.php
+++ b/tests/Feature/SearchByEntryControllerTest.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SearchByEntryControllerTest extends TestCase {
+    use RefreshDatabase;
+
+    protected $user;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        // 創建測試用戶
+        $this->user = User::factory()->create([
+            'is_active' => 1,
+        ]);
+
+        // 創建測試數據表
+        $this->createTestTables();
+        $this->seedTestData();
+    }
+
+    /**
+     * 創建測試所需的數據表
+     */
+    protected function createTestTables(): void {
+        // 禁用外鍵約束檢查
+        DB::statement('PRAGMA foreign_keys = OFF');
+
+        // ENTRY_TYPES 表
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_TYPES (
+                c_entry_type VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_entry_type_desc VARCHAR(255),
+                c_entry_type_desc_chn VARCHAR(255),
+                c_entry_type_parent_id VARCHAR(255),
+                c_entry_type_level DOUBLE,
+                c_entry_type_sortorder DOUBLE
+            )
+        ');
+
+        // ENTRY_CODES 表
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_CODES (
+                c_entry_code SMALLINT NOT NULL PRIMARY KEY,
+                c_entry_desc VARCHAR(255),
+                c_entry_desc_chn VARCHAR(255)
+            )
+        ');
+
+        // ENTRY_CODE_TYPE_REL 表
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_CODE_TYPE_REL (
+                c_entry_code SMALLINT NOT NULL,
+                c_entry_type VARCHAR(255) NOT NULL,
+                PRIMARY KEY (c_entry_code, c_entry_type)
+            )
+        ');
+
+        // ENTRY_DATA 表
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_DATA (
+                c_personid INT NOT NULL,
+                c_entry_code SMALLINT NOT NULL,
+                c_sequence SMALLINT NOT NULL,
+                c_year INT,
+                c_entry_addr_id INT,
+                c_exam_rank VARCHAR(255),
+                c_kin_code SMALLINT NOT NULL DEFAULT 0,
+                c_kin_id INT NOT NULL DEFAULT 0,
+                c_assoc_code SMALLINT NOT NULL DEFAULT 0,
+                c_assoc_id INT NOT NULL DEFAULT 0,
+                c_inst_code INT NOT NULL DEFAULT 0,
+                c_inst_name_code INT NOT NULL DEFAULT 0,
+                c_notes TEXT,
+                PRIMARY KEY (c_personid, c_entry_code, c_sequence, c_kin_code, c_assoc_code, c_kin_id, c_year, c_assoc_id, c_inst_code, c_inst_name_code)
+            )
+        ');
+
+        // BIOG_MAIN 表
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS BIOG_MAIN (
+                c_personid INT NOT NULL PRIMARY KEY,
+                c_name VARCHAR(255),
+                c_name_chn VARCHAR(255),
+                c_index_year INT
+            )
+        ');
+    }
+
+    /**
+     * 填充測試數據
+     */
+    protected function seedTestData(): void {
+        // 插入入仕類型
+        DB::table('ENTRY_TYPES')->insert([
+            [
+                'c_entry_type' => 'TYPE1',
+                'c_entry_type_desc' => 'Type 1',
+                'c_entry_type_desc_chn' => '類型一',
+                'c_entry_type_parent_id' => null,
+                'c_entry_type_level' => 1,
+                'c_entry_type_sortorder' => 1,
+            ],
+            [
+                'c_entry_type' => 'TYPE2',
+                'c_entry_type_desc' => 'Type 2',
+                'c_entry_type_desc_chn' => '類型二',
+                'c_entry_type_parent_id' => 'TYPE1',
+                'c_entry_type_level' => 2,
+                'c_entry_type_sortorder' => 2,
+            ],
+        ]);
+
+        // 插入入仕代碼
+        DB::table('ENTRY_CODES')->insert([
+            [
+                'c_entry_code' => 1,
+                'c_entry_desc' => 'Entry Code 1',
+                'c_entry_desc_chn' => '入仕代碼一',
+            ],
+            [
+                'c_entry_code' => 2,
+                'c_entry_desc' => 'Entry Code 2',
+                'c_entry_desc_chn' => '入仕代碼二',
+            ],
+        ]);
+
+        // 插入代碼類型關聯
+        DB::table('ENTRY_CODE_TYPE_REL')->insert([
+            ['c_entry_code' => 1, 'c_entry_type' => 'TYPE1'],
+            ['c_entry_code' => 2, 'c_entry_type' => 'TYPE2'],
+        ]);
+
+        // 插入人物數據
+        DB::table('BIOG_MAIN')->insert([
+            [
+                'c_personid' => 1,
+                'c_name' => 'Test Person 1',
+                'c_name_chn' => '測試人物一',
+                'c_index_year' => 1000,
+            ],
+            [
+                'c_personid' => 2,
+                'c_name' => 'Test Person 2',
+                'c_name_chn' => '測試人物二',
+                'c_index_year' => 1100,
+            ],
+        ]);
+
+        // 插入入仕數據
+        DB::table('ENTRY_DATA')->insert([
+            [
+                'c_personid' => 1,
+                'c_entry_code' => 1,
+                'c_sequence' => 1,
+                'c_year' => 1020,
+                'c_entry_addr_id' => 100,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_code' => 0,
+                'c_assoc_id' => 0,
+                'c_inst_code' => 0,
+                'c_inst_name_code' => 0,
+            ],
+            [
+                'c_personid' => 2,
+                'c_entry_code' => 2,
+                'c_sequence' => 1,
+                'c_year' => 1120,
+                'c_entry_addr_id' => 200,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_code' => 0,
+                'c_assoc_id' => 0,
+                'c_inst_code' => 0,
+                'c_inst_name_code' => 0,
+            ],
+        ]);
+    }
+
+    /**
+     * 測試主頁面是否正常顯示（需要登入）
+     */
+    public function test_index_requires_authentication(): void {
+        $response = $this->get(route('search-by.entry.index'));
+        $response->assertRedirect(route('login'));
+    }
+
+    /**
+     * 測試登入用戶可以訪問主頁面
+     */
+    public function test_authenticated_user_can_access_index(): void {
+        $response = $this->actingAs($this->user)->get(route('search-by.entry.index'));
+        $response->assertStatus(200);
+        $response->assertViewIs('search-by.entry.index');
+    }
+
+    /**
+     * 測試獲取入仕類型 API
+     */
+    public function test_can_get_entry_types(): void {
+        $response = $this->actingAs($this->user)
+            ->getJson(route('search-by.entry.types'));
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    '*' => [
+                        'c_entry_type',
+                        'c_entry_type_desc',
+                        'c_entry_type_desc_chn',
+                        'c_entry_type_parent_id',
+                        'c_entry_type_level',
+                        'c_entry_type_sortorder',
+                    ],
+                ],
+            ]);
+
+        $this->assertCount(2, $response->json('data'));
+    }
+
+    /**
+     * 測試獲取入仕代碼 API（無類型過濾）
+     */
+    public function test_can_get_all_entry_codes(): void {
+        $response = $this->actingAs($this->user)
+            ->getJson(route('search-by.entry.codes'));
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    '*' => [
+                        'c_entry_code',
+                        'c_entry_desc',
+                        'c_entry_desc_chn',
+                    ],
+                ],
+            ]);
+
+        $this->assertCount(2, $response->json('data'));
+    }
+
+    /**
+     * 測試根據類型獲取入仕代碼 API
+     */
+    public function test_can_get_entry_codes_by_type(): void {
+        $response = $this->actingAs($this->user)
+            ->getJson(route('search-by.entry.codes', ['type_id' => 'TYPE1']));
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ]);
+
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        $this->assertEquals(1, $data[0]['c_entry_code']);
+    }
+
+    /**
+     * 測試搜索功能（基本搜索）
+     */
+    public function test_can_search_by_entry_codes(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('search-by.entry.search', [
+                'entry_codes' => [1],
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('search-by.entry.results');
+        $response->assertViewHas('results');
+
+        $results = $response->viewData('results');
+        $this->assertCount(1, $results);
+        $this->assertEquals(1, $results[0]->c_personid);
+    }
+
+    /**
+     * 測試搜索功能（年份範圍過濾）
+     */
+    public function test_can_search_with_year_range(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('search-by.entry.search', [
+                'entry_codes' => [1, 2],
+                'year_from' => 1100,
+                'year_to' => 1200,
+            ]));
+
+        $response->assertStatus(200);
+        $results = $response->viewData('results');
+        $this->assertCount(1, $results);
+        $this->assertEquals(2, $results[0]->c_personid);
+        $this->assertEquals(1120, $results[0]->c_year);
+    }
+
+    /**
+     * 測試搜索功能（地址過濾）
+     */
+    public function test_can_search_with_address_filter(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('search-by.entry.search', [
+                'entry_codes' => [1, 2],
+                'addr_id' => 100,
+            ]));
+
+        $response->assertStatus(200);
+        $results = $response->viewData('results');
+        $this->assertCount(1, $results);
+        $this->assertEquals(1, $results[0]->c_personid);
+    }
+
+    /**
+     * 測試搜索驗證（entry_codes 必須為陣列）
+     */
+    public function test_search_validation_requires_entry_codes_as_array(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('search-by.entry.search', [
+                'entry_codes' => 'invalid',
+            ]));
+
+        // GET 請求驗證失敗會返回 302 重定向
+        $response->assertStatus(302);
+    }
+
+    /**
+     * 測試搜索驗證（年份必須為整數）
+     */
+    public function test_search_validation_requires_integer_years(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('search-by.entry.search', [
+                'entry_codes' => [1],
+                'year_from' => 'invalid',
+            ]));
+
+        // GET 請求驗證失敗會返回 302 重定向
+        $response->assertStatus(302);
+    }
+}


### PR DESCRIPTION
仿照 CBDB Access 數據庫的「按入仕查詢」功能，提供基於入仕類型和代碼的層級選擇查詢。

## 主要功能

### 查詢界面
- 三欄式布局設計（仿 Access 界面）：
  - 左側：入仕類型樹狀列表（支持層級展示）
  - 中間：入仕代碼多選列表（支持全選/取消全選）
  - 右側：搜索條件表單（年份範圍、地址 ID）
- 整個入仕代碼項可點擊選擇，並有滑鼠懸停效果
- 實時顯示已選擇的入仕代碼

### 搜索功能
- 支持按入仕代碼過濾（可多選）
- 支持年份範圍過濾（起始年、結束年）
- 支持入仕地址 ID 過濾
- 搜索結果分頁顯示（每頁 50 筆）
- 可通過 URL 分享搜索結果

### 結果顯示
- 顯示欄位：人物 ID、中英文名、朝代、索引年、索引地址、 入仕代碼、入仕途徑（中英文）、入仕年份、序號
- 支持分頁導航
- 提供查看人物詳情鏈接

## 技術實現

### 後端
- Controller: SearchByEntryController
  - index(): 顯示搜索頁面
  - getEntryTypes(): API - 獲取入仕類型樹狀結構
  - getEntryCodes(): API - 根據類型獲取入仕代碼
  - search(): 執行搜索查詢
- 使用 Query Builder 查詢複合主鍵表
- JOIN DYNASTIES 和 ADDR_CODES 表獲取朝代和地址信息

### 前端
- 使用 jQuery + AJAX 實現動態加載
- 使用 onViteReady 確保 jQuery 正確加載
- 使用 GET 方法提交表單（支持分頁和 URL 分享）
- 多個隱藏字段提交入仕代碼數組

### 路由
- GET /search-by/entry - 主頁面
- GET /search-by/entry/types - 獲取入仕類型 API
- GET /search-by/entry/codes - 獲取入仕代碼 API
- GET /search-by/entry/search - 執行搜索

### 測試
- 完整的 Feature 測試覆蓋
- 測試認證、API、搜索和驗證功能

## 訪問控制
- 限登錄用戶訪問
- 路由位於 /search-by/entry (測試期間，暫未加入側邊欄)