### PR TITLE
修正：將測試文件中的默認頭像從 avatar5.png 更新為 avatar0.png

### DIFF
--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -79,7 +79,7 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
             'name' => 'Batch Admin',
             'email' => uniqid('admin', true).'@example.com',
             'password' => bcrypt('secret'),
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => Str::random(10),
         ]);
 

--- a/tests/Feature/AdminBatchLoadOfficesTest.php
+++ b/tests/Feature/AdminBatchLoadOfficesTest.php
@@ -91,7 +91,7 @@ class AdminBatchLoadOfficesTest extends TestCase {
             'name' => 'Batch Admin',
             'email' => uniqid('admin', true).'@example.com',
             'password' => bcrypt('secret'),
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => Str::random(10),
         ]);
 

--- a/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
+++ b/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
@@ -109,7 +109,7 @@ class AdminBatchLoadSocialInstitutesTest extends TestCase {
             'name' => 'Batch Admin',
             'email' => uniqid('admin', true).'@example.com',
             'password' => bcrypt('secret'),
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => Str::random(10),
         ]);
 

--- a/tests/Feature/AdminExplainSqlTest.php
+++ b/tests/Feature/AdminExplainSqlTest.php
@@ -42,7 +42,7 @@ class AdminExplainSqlTest extends TestCase {
             'name' => 'Tester',
             'email' => uniqid().'@example.com',
             'password' => bcrypt('secret'),
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => Str::random(10),
         ]);
 

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -64,7 +64,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
         $user = new User();
         $user->id = $id;
         $user->name = $name;
-        $user->avatar = 'avatar5.png';
+        $user->avatar = 'avatar0.png';
         $user->is_admin = User::ROLE_SUPER_ADMIN;
         $user->is_active = User::STATUS_ACTIVE;
 

--- a/tests/Feature/UserProfileTest.php
+++ b/tests/Feature/UserProfileTest.php
@@ -79,7 +79,7 @@ class UserProfileTest extends TestCase {
             'name' => 'New Name',
             'email' => 'new@example.com',
             'institution' => 'New Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertRedirect('/profile');
@@ -105,7 +105,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'current_password' => 'oldpassword',
             'new_password' => 'newpassword',
             'new_password_confirmation' => 'newpassword',
@@ -132,7 +132,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'new_password' => 'newpassword',
             'new_password_confirmation' => 'newpassword',
         ]);
@@ -154,7 +154,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'current_password' => 'wrongpassword',
             'new_password' => 'newpassword',
             'new_password_confirmation' => 'newpassword',
@@ -180,7 +180,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'current_password' => 'oldpassword',
             'new_password' => 'newpassword',
             'new_password_confirmation' => 'differentpassword',
@@ -215,7 +215,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'existing@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertSessionHasErrors('email');
@@ -240,7 +240,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Updated Name',
             'email' => 'test@example.com',
             'institution' => 'Updated Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertRedirect('/profile');
@@ -266,7 +266,7 @@ class UserProfileTest extends TestCase {
             'name' => '',
             'email' => 'test@example.com',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertSessionHasErrors('name');
@@ -286,7 +286,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => '',
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertSessionHasErrors('email');
@@ -306,7 +306,7 @@ class UserProfileTest extends TestCase {
             'name' => 'Test User',
             'email' => 'test@example.com',
             'institution' => '',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
         ]);
 
         $response->assertRedirect('/profile');
@@ -322,7 +322,7 @@ class UserProfileTest extends TestCase {
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => 'test-token',
             'is_active' => 1,
         ]);
@@ -347,7 +347,7 @@ class UserProfileTest extends TestCase {
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => 'test-token',
             'is_active' => 1,
         ]);
@@ -368,7 +368,7 @@ class UserProfileTest extends TestCase {
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => 'test-token',
             'is_active' => 1,
         ]);
@@ -383,7 +383,7 @@ class UserProfileTest extends TestCase {
         $response->assertSessionHasErrors('avatar');
 
         $user->refresh();
-        $this->assertEquals('avatar5.png', $user->avatar);
+        $this->assertEquals('avatar0.png', $user->avatar);
     }
 
     public function testAvatarMustBeInValidRange() {
@@ -392,7 +392,7 @@ class UserProfileTest extends TestCase {
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
             'institution' => 'Test Institute',
-            'avatar' => 'avatar5.png',
+            'avatar' => 'avatar0.png',
             'confirmation_token' => 'test-token',
             'is_active' => 1,
         ]);
@@ -408,7 +408,7 @@ class UserProfileTest extends TestCase {
         $response->assertSessionHasErrors('avatar');
 
         $user->refresh();
-        $this->assertEquals('avatar5.png', $user->avatar);
+        $this->assertEquals('avatar0.png', $user->avatar);
     }
 
     public function testAllValidAvatarsAreAccepted() {


### PR DESCRIPTION
## Summary
為保持與 migration 文件中的設定一致，將所有測試文件中的默認頭像統一更新為 `avatar0.png`（CBDB Logo）。

## 變更內容
- 將 6 個測試文件中的 `avatar5.png` 替換為 `avatar0.png`
- 更新相關的測試斷言以匹配新的默認值

## 修改的文件
- `tests/Feature/AdminBatchLoadSocialInstitutesTest.php`
- `tests/Feature/AdminBatchLoadBookTitlesTest.php`
- `tests/Feature/AdminExplainSqlTest.php`
- `tests/Feature/AdminBatchLoadOfficesTest.php`
- `tests/Feature/BasicInformationSourcesControllerTest.php`
- `tests/Feature/UserProfileTest.php`

## Test plan
- [x] 運行所有受影響的測試：37 tests, 254 assertions 全部通過
- [x] 確認項目中無其他 `avatar5` 引用
- [x] 與 migration 文件 `database/migrations/2025_01_01_000000_import_cbdb_schema.php:2362` 中的默認值保持一致

## 相關 PR
- #694 - 新增：將 CBDB Logo 設置為用戶默認頭像

🤖 Generated with [Claude Code](https://claude.com/claude-code)