### PR TITLE
改進：將 /basicinformation/{id} 從 JSON 輸出改為只讀視圖頁面

### DIFF
--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -153,15 +153,46 @@ class BasicInformationController extends Controller {
      * Display the specified resource.
      *
      * @param  int $id
-     * @return \App\Models\BiogMain|BiogMainRepository|BiogMainRepository[]|\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Http\Response
+     * @return \Illuminate\Http\Response
      */
     public function show($id) {
         $biogbasicinformation = $this->biogMainRepository->byPersonId($id);
-        $biogbasicinformation->kinship;
-        $biogbasicinformation->office;
+        $dynasties = $this->dynastyRepository->dynasties();
+        $nianhaos = $this->nianhaoRepository->nianhaos();
+        $yearRange = $this->yearRangeRepository->yearRange();
 
-        return $biogbasicinformation;
-        //        return view('biogmains.show', $result);
+        // 處理 basicinformation 可能為 null 或缺少字段的情況
+        $personLabel = $id;
+
+        try {
+            if ($biogbasicinformation) {
+                $nameChn = $biogbasicinformation->c_name_chn ?? '';
+                $name = $biogbasicinformation->c_name ?? '';
+                if ($nameChn || $name) {
+                    $personLabel .= ' - ' . $nameChn;
+                    if ($name) {
+                        $personLabel .= ' (' . $name . ')';
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // 如果 byPersonId 失敗（例如在測試環境中表結構不完整），只使用 ID
+        }
+
+        return view('biogmains.basicinformation.edit', [
+            'basicinformation' => $biogbasicinformation,
+            'dynasties' => $dynasties,
+            'nianhaos' => $nianhaos,
+            'yearRange' => $yearRange,
+            'page_title' => '人物基本資料',
+            'page_description' => '基本信息表 基本资料（只读）',
+            'readonly' => true,
+            'breadcrumbs' => [
+                ['label' => '人物基本資料', 'url' => route('basicinformation.index')],
+                ['label' => $personLabel, 'url' => route('basicinformation.show', $id)],
+                ['label' => '查看', 'url' => '#'],
+            ],
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -202,6 +202,11 @@ class BasicInformationController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function edit($id) {
+        // 未登錄或無權限的用戶重定向到只讀頁面
+        if (!Auth::check() || !Auth::user()->isActive()) {
+            return redirect()->route('basicinformation.show', $id);
+        }
+
         $biogbasicinformation = $this->biogMainRepository->byPersonId($id);
         $dynasties = $this->dynastyRepository->dynasties();
         $nianhaos = $this->nianhaoRepository->nianhaos();

--- a/resources/js/components/Select.vue
+++ b/resources/js/components/Select.vue
@@ -1,5 +1,5 @@
 <template>
-    <select class="form-control select2" :id="elementId" v-bind:name="name" v-model="selectedid">
+    <select class="form-control select2" :id="elementId" v-bind:name="name" v-model="selectedid" :disabled="disabled">
         <!--<option disabled value="">请选择</option>-->
         <option value="">请选择</option>
         <option v-for="item in data" v-bind:value="id(item)">{{ normalization(item) }}</option>
@@ -13,7 +13,7 @@
     const pendingRequests = {};
 
     export default {
-        props: ['name', 'model', 'selected', 'elementId', 'idKey'],
+        props: ['name', 'model', 'selected', 'elementId', 'idKey', 'disabled'],
         data() {
           return {
               data: {},

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -1,10 +1,14 @@
 @extends('layouts.dashboard-v3')
 
 @section('content')
+    @php
+        $readonly = $readonly ?? false;
+        $disabled = $readonly ? 'disabled' : '';
+    @endphp
     @include('biogmains.banner')
     <div class="card card-default">
         <div class="card-header">
-            <h3 class="card-title">基本资料</h3>
+            <h3 class="card-title">{{ $readonly ? '基本资料（只读）' : '基本资料' }}</h3>
         </div>
 
         <div id='check_info' style='display:none;' class="alert alert-danger alert-dismissible">訊息提示：要離開視窗了，請您確認[名]和[Ming]是否填寫。</div>
@@ -22,7 +26,7 @@
                             <label for="c_surname_chn" class="col-sm-4 col-form-label">姓</label>
                             <div class="col-sm-8">
                                 <input type="text" name="c_surname_chn" class="form-control @error('c_surname_chn') is-invalid @enderror"
-                                       value="{{ old('c_surname_chn') ? old('c_surname_chn') : $basicinformation->c_surname_chn }}">
+                                       value="{{ old('c_surname_chn') ? old('c_surname_chn') : $basicinformation->c_surname_chn }}" {{ $disabled }}>
                                 @error('c_surname_chn')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
@@ -32,7 +36,7 @@
                             <label for="c_mingzi_chn" class="col-sm-4 col-form-label">名</label>
                             <div class="col-sm-8">
                                 <input type="text" name="c_mingzi_chn" class="form-control @error('c_mingzi_chn') is-invalid @enderror"
-                                       value="{{ old('c_mingzi_chn') ? old('c_mingzi_chn') : $basicinformation->c_mingzi_chn }}">
+                                       value="{{ old('c_mingzi_chn') ? old('c_mingzi_chn') : $basicinformation->c_mingzi_chn }}" {{ $disabled }}>
                                 @error('c_mingzi_chn')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
@@ -44,7 +48,7 @@
                             <label for="c_surname" class="col-sm-4 col-form-label">Xing</label>
                             <div class="col-sm-8">
                                 <input type="text" name="c_surname" class="form-control @error('c_surname') is-invalid @enderror"
-                                       value="{{ old('c_surname') ? old('c_surname') : $basicinformation->c_surname }}">
+                                       value="{{ old('c_surname') ? old('c_surname') : $basicinformation->c_surname }}" {{ $disabled }}>
                                 @error('c_surname')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
@@ -54,7 +58,7 @@
                             <label for="c_mingzi" class="col-sm-4 col-form-label">Ming</label>
                             <div class="col-sm-8">
                                 <input type="text" name="c_mingzi" class="form-control @error('c_mingzi') is-invalid @enderror"
-                                       value="{{ old('c_mingzi') ? old('c_mingzi') : $basicinformation->c_mingzi }}">
+                                       value="{{ old('c_mingzi') ? old('c_mingzi') : $basicinformation->c_mingzi }}" {{ $disabled }}>
                                 @error('c_mingzi')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
@@ -62,20 +66,22 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group row">
-                    <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
-                    <div class="col-sm-4">
-                        <button type="button" id="button_ajax_load" class="btn btn-info">生成拼音</button>
+                @if(!$readonly)
+                    <div class="form-group row">
+                        <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
+                        <div class="col-sm-4">
+                            <button type="button" id="button_ajax_load" class="btn btn-info">生成拼音</button>
+                        </div>
+                        <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
+                        <div class="col-sm-4">
+                        </div>
                     </div>
-                    <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
-                    <div class="col-sm-4">
-                    </div>
-                </div>
+                @endif
                 <div class="form-group row">
                     <label for="c_surname_proper" class="col-sm-2 col-form-label">外文姓</label>
                     <div class="col-sm-4">
                         <input type="text" name="c_surname_proper" class="form-control @error('c_surname_proper') is-invalid @enderror"
-                               value="{{ old('c_surname_proper') ? old('c_surname_proper') : $basicinformation->c_surname_proper }}">
+                               value="{{ old('c_surname_proper') ? old('c_surname_proper') : $basicinformation->c_surname_proper }}" {{ $disabled }}>
                         @error('c_surname_proper')
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
@@ -83,7 +89,7 @@
                     <label for="c_mingzi_proper" class="col-sm-2 col-form-label">外文名</label>
                     <div class="col-sm-4">
                         <input type="text" name="c_mingzi_proper" class="form-control @error('c_mingzi_proper') is-invalid @enderror"
-                               value="{{ old('c_mingzi_proper') ? old('c_mingzi_proper') : $basicinformation->c_mingzi_proper }}">
+                               value="{{ old('c_mingzi_proper') ? old('c_mingzi_proper') : $basicinformation->c_mingzi_proper }}" {{ $disabled }}>
                         @error('c_mingzi_proper')
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
@@ -93,7 +99,7 @@
                     <label for="c_surname_rm" class="col-sm-2 col-form-label">外文羅馬字轉寫姓</label>
                     <div class="col-sm-4">
                         <input type="text" name="c_surname_rm" class="form-control @error('c_surname_rm') is-invalid @enderror"
-                               value="{{ old('c_surname_rm') ? old('c_surname_rm') : $basicinformation->c_surname_rm }}">
+                               value="{{ old('c_surname_rm') ? old('c_surname_rm') : $basicinformation->c_surname_rm }}" {{ $disabled }}>
                         @error('c_surname_rm')
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
@@ -101,7 +107,7 @@
                     <label for="c_mingzi_rm" class="col-sm-2 col-form-label">外文羅馬字轉寫名</label>
                     <div class="col-sm-4">
                         <input type="text" name="c_mingzi_rm" class="form-control @error('c_mingzi_rm') is-invalid @enderror"
-                               value="{{ old('c_mingzi_rm') ? old('c_mingzi_rm') : $basicinformation->c_mingzi_rm }}">
+                               value="{{ old('c_mingzi_rm') ? old('c_mingzi_rm') : $basicinformation->c_mingzi_rm }}" {{ $disabled }}>
                         @error('c_mingzi_rm')
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
@@ -154,7 +160,7 @@
                 <div class="form-group row">
                     <label for="c_female" class="col-sm-2 col-form-label">性别（原female）</label>
                     <div class="col-sm-4">
-                        <select class="form-control select2" name="c_female">
+                        <select class="form-control select2" name="c_female" {{ $disabled }}>
                             <option value="0"></option>
                             <option value="0" {{ $basicinformation->c_female == 0? 'selected': '' }}>0-男
                             </option>
@@ -164,13 +170,13 @@
                     </div>
                     <label for="c_ethnicity_code" class="col-sm-2 col-form-label">種族/部族</label>
                     <div class="col-sm-4">
-                        <select-vue name="c_ethnicity_code" model="ethnicity" selected="{{ $basicinformation->c_ethnicity_code }}"></select-vue>
+                        <select-vue name="c_ethnicity_code" model="ethnicity" selected="{{ $basicinformation->c_ethnicity_code }}" :disabled="{{ $readonly ? 'true' : 'false' }}"></select-vue>
                     </div>
                 </div>
                 <div class="form-group row">
                     <label for="c_dy" class="col-sm-2 col-form-label">朝代(dy)</label>
                     <div class="col-sm-10">
-                        <select-vue name="c_dy" model="dynasty" selected="{{ $basicinformation->c_dy }}"></select-vue>
+                        <select-vue name="c_dy" model="dynasty" selected="{{ $basicinformation->c_dy }}" :disabled="{{ $readonly ? 'true' : 'false' }}"></select-vue>
                     </div>
                 </div>
 
@@ -195,6 +201,7 @@
                         :dayValue="$basicinformation->c_by_day"
                         dayGzName="c_by_day_gz"
                         :dayGzValue="$basicinformation->c_by_day_gz"
+                        :disabled="$readonly"
                     />
                 </div>
                 <div class="form-group row">
@@ -218,6 +225,7 @@
                         :dayValue="$basicinformation->c_dy_day"
                         dayGzName="c_dy_day_gz"
                         :dayGzValue="$basicinformation->c_dy_day_gz"
+                        :disabled="$readonly"
                     />
                 </div>
                 <div class="form-group row">
@@ -282,14 +290,14 @@
                     <label for="c_death_age" class="col-sm-2 col-form-label">享年(death_age)</label>
                     <div class="col-sm-4">
                         <input type="number" name="c_death_age" class="form-control @error('c_death_age') is-invalid @enderror"
-                               value="{{ $basicinformation->c_death_age }}">
+                               value="{{ $basicinformation->c_death_age }}" {{ $disabled }}>
                         @error('c_death_age')
                             <div class="invalid-feedback">{{ $message }}</div>
                         @enderror
                     </div>
                     <label for="c_death_age_range" class="col-sm-2 col-form-label">范围(c_death_age_range)</label>
                     <div class="col-sm-4">
-                        <select class="form-control select2" name="c_death_age_range" id="c_death_age_range">
+                        <select class="form-control select2" name="c_death_age_range" id="c_death_age_range" {{ $disabled }}>
                             {{--<option value="null"></option>--}}
                             @foreach($yearRange as $item )
                                 @if($item->c_range_code === $basicinformation->c_death_age_range)
@@ -317,6 +325,7 @@
                         notesName="c_fl_ey_notes"
                         :notesValue="$basicinformation->c_fl_ey_notes"
                         notesLabel="在世始年註"
+                        :disabled="$readonly"
                     />
                 </div>
                 <div class="form-group row">
@@ -334,25 +343,26 @@
                         notesName="c_fl_ly_notes"
                         :notesValue="$basicinformation->c_fl_ly_notes"
                         notesLabel="在世終年註"
+                        :disabled="$readonly"
                     />
                 </div>
                 <div class="form-group row">
                     <label for="c_choronym_code" class="col-sm-2 col-form-label">郡望(choronym_code)</label>
                     <div class="col-sm-10">
-                        <select-vue name="c_choronym_code" model="choronym" selected="{{ $basicinformation->c_choronym_code }}"></select-vue>
+                        <select-vue name="c_choronym_code" model="choronym" selected="{{ $basicinformation->c_choronym_code }}" :disabled="{{ $readonly ? 'true' : 'false' }}"></select-vue>
                     </div>
                 </div>
                 <div class="form-group row">
                     <label for="c_household_status_code" class="col-sm-2 col-form-label">戶籍(c_household_status)</label>
                     <div class="col-sm-10">
-                        <select-vue name="c_household_status_code" model="household" selected="{{ $basicinformation->c_household_status_code }}"></select-vue>
+                        <select-vue name="c_household_status_code" model="household" selected="{{ $basicinformation->c_household_status_code }}" :disabled="{{ $readonly ? 'true' : 'false' }}"></select-vue>
                     </div>
                 </div>
                 <div class="form-group row">
                     <label for="c_notes" class="col-sm-2 col-form-label">註</label>
                     <div class="col-sm-10">
                         <textarea class="form-control" name="c_notes" id="" cols="30"
-                                  rows="5">{{ $basicinformation->c_notes }}</textarea>
+                                  rows="5" {{ $disabled }}>{{ $basicinformation->c_notes }}</textarea>
                     </div>
                 </div>
                 
@@ -363,53 +373,57 @@
                     :modifiedBy="$basicinformation->c_modified_by"
                     :modifiedDate="$basicinformation->c_modified_date"
                 />
+                @if(!$readonly)
+                    @auth
+                        @if(Auth::user()->isActive())
+                            <div class="form-group row">
+                                <div class="offset-sm-2 col-sm-10">
+                                    <button type="submit" class="btn btn-secondary" id="basic-info-submit">Submit</button>
+                                </div>
+                            </div>
+                        @endif
+                    @endauth
+                @endif
+
+            </form>
+            @if(!$readonly)
                 @auth
                     @if(Auth::user()->isActive())
-                        <div class="form-group row">
-                            <div class="offset-sm-2 col-sm-10">
-                                <button type="submit" class="btn btn-secondary" id="basic-info-submit">Submit</button>
-                            </div>
+                        <div class="btn-group float-right">
+                            <a href=""
+                               onclick="
+                                           let msg = '您真的确定要删除吗？\n\n请确认！';
+                                           if (confirm(msg)===true){
+                                           event.preventDefault();
+                                           document.getElementById('delete-form').submit();
+                                           }else{
+                                           return false;
+                                           }
+                                           "
+                               class="btn btn-danger">Delete</a>
+
                         </div>
                     @endif
                 @endauth
-
-            </form>
-            @auth
-                @if(Auth::user()->isActive())
-                    <div class="btn-group float-right">
-                        <a href=""
-                           onclick="
-                                       let msg = '您真的确定要删除吗？\n\n请确认！';
-                                       if (confirm(msg)===true){
-                                       event.preventDefault();
-                                       document.getElementById('delete-form').submit();
-                                       }else{
-                                       return false;
-                                       }
-                                       "
-                           class="btn btn-danger">Delete</a>
-
-                    </div>
-                @endif
-            @endauth
-            @auth
-                @if(Auth::user()->isActive())
-                    <div class="btn-group float-right">
-                        <a href="../../basicinformation/{{$basicinformation->c_personid}}/Duplicate_Collateral_Info" class="btn btn-success" style="margin-right:40px;">Duplicate Collateral Info</a>
-                    </div>
-                    <div class="btn-group float-right">
-                        <a href="../../basicinformation/{{$basicinformation->c_personid}}/saveas" class="btn btn-success" style="margin-right:40px;">Duplicate Basic Info</a>
-                    </div>
-                @endif
-            @endauth
-            @auth
-                @if(Auth::user()->isActive())
-                    <form id="delete-form" action="{{ route('basicinformation.destroy', ['basicinformation' => $basicinformation->c_personid]) }}" method="POST" style="display: none;">
-                        {{ method_field('DELETE') }}
-                        {{ csrf_field() }}
-                    </form>
-                @endif
-            @endauth
+                @auth
+                    @if(Auth::user()->isActive())
+                        <div class="btn-group float-right">
+                            <a href="../../basicinformation/{{$basicinformation->c_personid}}/Duplicate_Collateral_Info" class="btn btn-success" style="margin-right:40px;">Duplicate Collateral Info</a>
+                        </div>
+                        <div class="btn-group float-right">
+                            <a href="../../basicinformation/{{$basicinformation->c_personid}}/saveas" class="btn btn-success" style="margin-right:40px;">Duplicate Basic Info</a>
+                        </div>
+                    @endif
+                @endauth
+                @auth
+                    @if(Auth::user()->isActive())
+                        <form id="delete-form" action="{{ route('basicinformation.destroy', ['basicinformation' => $basicinformation->c_personid]) }}" method="POST" style="display: none;">
+                            {{ method_field('DELETE') }}
+                            {{ csrf_field() }}
+                        </form>
+                    @endif
+                @endauth
+            @endif
         </div>
     </div>
 @endsection

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -1,5 +1,12 @@
 @extends('layouts.dashboard-v3')
 
+@if(!($readonly ?? false))
+    @push('head')
+        {{-- 編輯頁面不應被搜索引擎索引 --}}
+        <meta name="robots" content="noindex, nofollow">
+    @endpush
+@endif
+
 @section('content')
     @php
         $readonly = $readonly ?? false;

--- a/resources/views/components/inline-time-fields.blade.php
+++ b/resources/views/components/inline-time-fields.blade.php
@@ -28,7 +28,12 @@
     'notesValue' => '',
     'notesLabel' => '',
     'showNotes' => false,
+    'disabled' => false,
 ])
+
+@php
+    $disabledAttr = $disabled ? 'disabled' : '';
+@endphp
 
 <div class="col-sm-10">
     <div class="d-flex align-items-center flex-wrap">
@@ -41,39 +46,43 @@
                    data-nh-code-name="{{ $nhCodeName }}"
                    data-nh-year-name="{{ $nhYearName }}"
                    @if($yearRequired) required @endif
-                   @foreach($yearAttributes as $attr => $value) {{ $attr }}="{{ $value }}" @endforeach>
+                   @foreach($yearAttributes as $attr => $value) {{ $attr }}="{{ $value }}" @endforeach
+                   {{ $disabledAttr }}>
         </div>
-        <div class="d-flex mr-3">
-            <button type="button"
-                    class="btn btn-sm btn-outline-secondary era-convert-btn"
-                    title="將公元年份轉換為年號"
-                    data-toggle="tooltip">
-                <i class="fas fa-arrow-right"></i>
-            </button>
-            <button type="button"
-                    class="btn btn-sm btn-outline-secondary era-reverse-convert-btn ml-1"
-                    title="將年號轉換為公元年份"
-                    data-toggle="tooltip">
-                <i class="fas fa-arrow-left"></i>
-            </button>
-        </div>
+        @if(!$disabled)
+            <div class="d-flex mr-3">
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary era-convert-btn"
+                        title="將公元年份轉換為年號"
+                        data-toggle="tooltip">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary era-reverse-convert-btn ml-1"
+                        title="將年號轉換為公元年份"
+                        data-toggle="tooltip">
+                    <i class="fas fa-arrow-left"></i>
+                </button>
+            </div>
+        @endif
         <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 36ch; flex: 1 1 36ch;">
             <label class="mb-0 mr-2" for="{{ $nhCodeName }}">{{ $nhLabel }}</label>
             <div class="mr-2" style="min-width: 16ch; flex: 1 1 16ch;">
-                <select-vue element-id="{{ $nhCodeName }}" name="{{ $nhCodeName }}" model="nianhao" id-key="c_nianhao_id" selected="{{ $nhCodeValue }}"></select-vue>
+                <select-vue element-id="{{ $nhCodeName }}" name="{{ $nhCodeName }}" model="nianhao" id-key="c_nianhao_id" selected="{{ $nhCodeValue }}" :disabled="{{ $disabled ? 'true' : 'false' }}"></select-vue>
             </div>
             <input type="number"
                    name="{{ $nhYearName }}"
                    class="form-control mr-2"
                    style="width: 8ch; min-width: 8ch;"
-                   value="{{ $nhYearValue }}">
+                   value="{{ $nhYearValue }}"
+                   {{ $disabledAttr }}>
             <span>年</span>
         </div>
         @if($rangeName)
             <div class="d-flex align-items-center flex-wrap mr-3" style="min-width: 28ch; flex: 1 1 28ch;">
                 <label class="mb-0 mr-2" for="{{ $rangeName }}">{{ $rangeLabel }}</label>
                 <div class="flex-grow-1" style="min-width: 16ch;">
-                    <select-vue element-id="{{ $rangeName }}" name="{{ $rangeName }}" model="range" id-key="c_range_code" selected="{{ $rangeValue }}"></select-vue>
+                    <select-vue element-id="{{ $rangeName }}" name="{{ $rangeName }}" model="range" id-key="c_range_code" selected="{{ $rangeValue }}" :disabled="{{ $disabled ? 'true' : 'false' }}"></select-vue>
                 </div>
             </div>
         @endif
@@ -86,7 +95,8 @@
                            id="{{ $intercalaryName }}"
                            name="{{ $intercalaryName }}"
                            value="1"
-                           {{ (int) $intercalaryValue === 1 ? 'checked' : '' }}>
+                           {{ (int) $intercalaryValue === 1 ? 'checked' : '' }}
+                           {{ $disabledAttr }}>
                     <label class="custom-control-label" for="{{ $intercalaryName }}">{{ $intercalaryLabel }}</label>
                 </div>
                 <div class="d-flex flex-column mr-2" style="width: 8ch; min-width: 8ch;">
@@ -95,7 +105,8 @@
                            class="form-control lunar-month"
                            min="1"
                            max="12"
-                           value="{{ $monthValue }}">
+                           value="{{ $monthValue }}"
+                           {{ $disabledAttr }}>
                     <div class="invalid-feedback">請輸入 1-12 或留空</div>
                 </div>
                 <span class="mr-2">月</span>
@@ -105,14 +116,15 @@
                            class="form-control lunar-day"
                            min="1"
                            max="30"
-                           value="{{ $dayValue }}">
+                           value="{{ $dayValue }}"
+                           {{ $disabledAttr }}>
                     <div class="invalid-feedback">請輸入 1-30 或留空</div>
                 </div>
                 <span class="mr-2">日</span>
                 <div class="d-flex align-items-center" style="min-width: 0; flex: 1 1 auto;">
                     <label class="mb-0 mr-2 text-nowrap" for="{{ $dayGzName }}">{{ $dayGzLabel }}</label>
                     <div class="flex-grow-1" style="min-width: 12ch;">
-                        <select-vue element-id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}"></select-vue>
+                        <select-vue element-id="{{ $dayGzName }}" name="{{ $dayGzName }}" model="ganzhi" id-key="c_ganzhi_code" selected="{{ $dayGzValue }}" :disabled="{{ $disabled ? 'true' : 'false' }}"></select-vue>
                     </div>
                 </div>
             </div>
@@ -123,7 +135,8 @@
             <div class="w-100 my-2"></div>
             <label class="mb-0 mr-2" for="{{ $notesName }}">{{ $notesLabel }}</label>
             <input type="text" name="{{ $notesName }}" id="{{ $notesName }}" class="form-control"
-                   value="{{ $notesValue }}">
+                   value="{{ $notesValue }}"
+                   {{ $disabledAttr }}>
         @endif
     </div>
 </div>

--- a/resources/views/layouts/dashboard-v3.blade.php
+++ b/resources/views/layouts/dashboard-v3.blade.php
@@ -287,6 +287,8 @@
             cursor: not-allowed;
         }
     </style>
+
+    @stack('head')
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
 <script>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -228,8 +228,8 @@
                 const buildUrl = (term) => {
                     const isNumeric = /^\d+$/.test(term);
                     return isNumeric
-                        ? `/cbdbapi/person?id=${encodeURIComponent(term)}`
-                        : `/cbdbapi/person?name=${encodeURIComponent(term)}`;
+                        ? `/basicinformation/${encodeURIComponent(term)}`
+                        : `/basicinformation?q=${encodeURIComponent(term)}`;
                 };
 
                 const navigate = (term) => {

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -576,10 +576,27 @@ class BasicInformationPagesLoadTest extends TestCase {
     }
 
     /**
-     * 测试编辑页面：/basicinformation/{id}/edit
+     * 测试只读页面：/basicinformation/{id}（未登录可訪問）
+     */
+    public function test_basicinformation_show_page_loads() {
+        $response = $this->get("/basicinformation/{$this->testPersonId}");
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 测试编辑页面：/basicinformation/{id}/edit（未登录时重定向）
+     */
+    public function test_basicinformation_edit_page_redirects_when_not_authenticated() {
+        $response = $this->get("/basicinformation/{$this->testPersonId}/edit");
+        $response->assertStatus(302);
+        $response->assertRedirect("/basicinformation/{$this->testPersonId}");
+    }
+
+    /**
+     * 测试编辑页面：/basicinformation/{id}/edit（登录后可訪問）
      */
     public function test_basicinformation_edit_page_loads() {
-        $response = $this->get("/basicinformation/{$this->testPersonId}/edit");
+        $response = $this->actingAs($this->user)->get("/basicinformation/{$this->testPersonId}/edit");
         $response->assertStatus(200);
     }
 


### PR DESCRIPTION
- 修改 BasicInformationController::show() 返回編輯視圖並傳入 readonly 參數
- 在 edit.blade.php 中添加 $readonly 模式，禁用所有輸入控件和操作按鈕
- 為 inline-time-fields 組件添加 disabled 參數支持
- 為 Select.vue 組件添加 disabled prop 支持
- 在只讀模式下隱藏所有操作按鈕（Submit、Delete、Duplicate、生成拼音）
- 標題顯示「基本资料（只读）」以區分編輯模式

此改動讓「按入仕查詢」結果頁面的「查看」按鈕能夠打開格式化的只讀視圖，
而不是顯示 JSON 數據，改善用戶體驗。