### PR TITLE
新增：整合 Prometheus metrics 監控系統

### DIFF
--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+
+class MetricsController extends Controller {
+    protected CollectorRegistry $registry;
+
+    public function __construct(CollectorRegistry $registry) {
+        $this->registry = $registry;
+    }
+
+    /**
+     * 暴露 Prometheus metrics
+     */
+    public function index(Request $request): Response {
+        // 检查 IP 白名单
+        if (!$this->isAllowedIp($request)) {
+            abort(403, 'Access denied');
+        }
+
+        // 检查基本认证
+        if (!$this->checkBasicAuth($request)) {
+            return response('Unauthorized', 401)
+                ->header('WWW-Authenticate', 'Basic realm="Prometheus Metrics"');
+        }
+
+        // 渲染 metrics
+        $renderer = new RenderTextFormat();
+        $result = $renderer->render($this->registry->getMetricFamilySamples());
+
+        return response($result, 200)
+            ->header('Content-Type', RenderTextFormat::MIME_TYPE);
+    }
+
+    /**
+     * 检查 IP 是否在白名单中
+     */
+    protected function isAllowedIp(Request $request): bool {
+        $allowedIps = config('prometheus.metrics_endpoint.allowed_ips', []);
+
+        // 空数组表示允许所有 IP
+        if (empty($allowedIps)) {
+            return true;
+        }
+
+        $clientIp = $request->ip();
+
+        return in_array($clientIp, $allowedIps);
+    }
+
+    /**
+     * 检查基本认证
+     */
+    protected function checkBasicAuth(Request $request): bool {
+        // 如果未启用认证，直接返回 true
+        if (!config('prometheus.metrics_endpoint.auth_enabled', false)) {
+            return true;
+        }
+
+        $username = config('prometheus.metrics_endpoint.username');
+        $password = config('prometheus.metrics_endpoint.password');
+
+        // 获取 HTTP Basic Auth 凭据
+        $providedUsername = $request->getUser();
+        $providedPassword = $request->getPassword();
+
+        return $providedUsername === $username && $providedPassword === $password;
+    }
+}

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -50,7 +50,113 @@ class MetricsController extends Controller {
 
         $clientIp = $request->ip();
 
-        return in_array($clientIp, $allowedIps);
+        foreach ($allowedIps as $allowedIp) {
+            // 去除空格
+            $allowedIp = trim($allowedIp);
+
+            // 检查是否为 CIDR 格式
+            if (str_contains($allowedIp, '/')) {
+                if ($this->ipMatchesCidr($clientIp, $allowedIp)) {
+                    return true;
+                }
+            } else {
+                // 精确匹配
+                if ($clientIp === $allowedIp) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 检查 IP 是否匹配 CIDR 格式
+     */
+    protected function ipMatchesCidr(string $ip, string $cidr): bool {
+        // 分离 IP 和前缀长度
+        [$subnet, $prefixLength] = explode('/', $cidr);
+
+        // 验证 IP 地址格式
+        if (!filter_var($ip, FILTER_VALIDATE_IP) || !filter_var($subnet, FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        // 确定是 IPv4 还是 IPv6
+        $isIpv4 = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+        $isSubnetIpv4 = filter_var($subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+
+        // IP 版本必须一致
+        if ($isIpv4 !== $isSubnetIpv4) {
+            return false;
+        }
+
+        if ($isIpv4) {
+            return $this->ipv4MatchesCidr($ip, $subnet, (int) $prefixLength);
+        } else {
+            return $this->ipv6MatchesCidr($ip, $subnet, (int) $prefixLength);
+        }
+    }
+
+    /**
+     * 检查 IPv4 是否匹配 CIDR
+     */
+    protected function ipv4MatchesCidr(string $ip, string $subnet, int $prefixLength): bool {
+        // 验证前缀长度
+        if ($prefixLength < 0 || $prefixLength > 32) {
+            return false;
+        }
+
+        $ipLong = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+
+        // 创建子网掩码
+        $mask = -1 << (32 - $prefixLength);
+
+        // 比较网络地址部分
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+
+    /**
+     * 检查 IPv6 是否匹配 CIDR
+     */
+    protected function ipv6MatchesCidr(string $ip, string $subnet, int $prefixLength): bool {
+        // 验证前缀长度
+        if ($prefixLength < 0 || $prefixLength > 128) {
+            return false;
+        }
+
+        // 转换为二进制
+        $ipBinary = inet_pton($ip);
+        $subnetBinary = inet_pton($subnet);
+
+        if ($ipBinary === false || $subnetBinary === false) {
+            return false;
+        }
+
+        // 计算需要比较的完整字节数和部分位数
+        $fullBytes = (int) floor($prefixLength / 8);
+        $remainingBits = $prefixLength % 8;
+
+        // 比较完整字节
+        if ($fullBytes > 0) {
+            if (substr($ipBinary, 0, $fullBytes) !== substr($subnetBinary, 0, $fullBytes)) {
+                return false;
+            }
+        }
+
+        // 比较剩余位
+        if ($remainingBits > 0) {
+            $mask = ~((1 << (8 - $remainingBits)) - 1);
+            $ipByte = ord($ipBinary[$fullBytes]);
+            $subnetByte = ord($subnetBinary[$fullBytes]);
+
+            if (($ipByte & $mask) !== ($subnetByte & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,8 @@ class Kernel extends HttpKernel {
         // \App\Http\Middleware\EnableCrossRequestMiddleware::class,
         // 20200909建安新增
         \App\Http\Middleware\Cors::class,
+        // Prometheus metrics 收集
+        \App\Http\Middleware\PrometheusMetrics::class,
     ];
 
     /**

--- a/app/Http/Middleware/PrometheusMetrics.php
+++ b/app/Http/Middleware/PrometheusMetrics.php
@@ -29,19 +29,33 @@ class PrometheusMetrics {
         // 增加正在处理的请求计数
         $this->incrementInProgressRequests($request);
 
-        // 处理请求
-        $response = $next($request);
+        $response = null;
+        $exception = null;
 
-        // 计算请求耗时
-        $duration = microtime(true) - $startTime;
+        try {
+            // 处理请求
+            $response = $next($request);
 
-        // 减少正在处理的请求计数
-        $this->decrementInProgressRequests($request);
+            return $response;
+        } catch (\Throwable $e) {
+            $exception = $e;
 
-        // 记录 metrics
-        $this->recordMetrics($request, $response, $duration);
+            throw $e;
+        } finally {
+            // 计算请求耗时
+            $duration = microtime(true) - $startTime;
 
-        return $response;
+            // 减少正在处理的请求计数（确保即使发生异常也会执行）
+            $this->decrementInProgressRequests($request);
+
+            // 记录 metrics
+            if ($response !== null) {
+                $this->recordMetrics($request, $response, $duration);
+            } elseif ($exception !== null) {
+                // 对于未被捕获的异常，记录为 500 错误
+                $this->recordExceptionMetrics($request, $exception, $duration);
+            }
+        }
     }
 
     /**
@@ -113,6 +127,45 @@ class PrometheusMetrics {
             $labels = array_merge(
                 $this->getLabels($request),
                 ['status' => $response->getStatusCode()]
+            );
+
+            // 记录请求总数
+            $counter = $this->registry->getOrRegisterCounter(
+                config('prometheus.namespace', 'cbdb'),
+                'http_requests_total',
+                'Total number of HTTP requests',
+                ['method', 'path', 'status']
+            );
+            $counter->inc($labels);
+
+            // 记录请求延迟分布
+            $histogram = $this->registry->getOrRegisterHistogram(
+                config('prometheus.namespace', 'cbdb'),
+                'http_request_duration_seconds',
+                'HTTP request latency in seconds',
+                ['method', 'path', 'status'],
+                config('prometheus.http_metrics.latency_buckets')
+            );
+            $histogram->observe($duration, $labels);
+        } catch (\Exception $e) {
+            report($e);
+        }
+    }
+
+    /**
+     * 记录异常情况的 metrics
+     */
+    protected function recordExceptionMetrics(Request $request, \Throwable $exception, float $duration): void {
+        try {
+            // 确定 HTTP 状态码
+            $statusCode = 500;
+            if (method_exists($exception, 'getStatusCode')) {
+                $statusCode = $exception->getStatusCode();
+            }
+
+            $labels = array_merge(
+                $this->getLabels($request),
+                ['status' => $statusCode]
             );
 
             // 记录请求总数

--- a/app/Http/Middleware/PrometheusMetrics.php
+++ b/app/Http/Middleware/PrometheusMetrics.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Prometheus\CollectorRegistry;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrometheusMetrics {
+    protected CollectorRegistry $registry;
+
+    public function __construct(CollectorRegistry $registry) {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response {
+        // 如果 Prometheus 未启用或路径被排除，则跳过
+        if (!$this->shouldCollectMetrics($request)) {
+            return $next($request);
+        }
+
+        // 记录请求开始时间
+        $startTime = microtime(true);
+
+        // 增加正在处理的请求计数
+        $this->incrementInProgressRequests($request);
+
+        // 处理请求
+        $response = $next($request);
+
+        // 计算请求耗时
+        $duration = microtime(true) - $startTime;
+
+        // 减少正在处理的请求计数
+        $this->decrementInProgressRequests($request);
+
+        // 记录 metrics
+        $this->recordMetrics($request, $response, $duration);
+
+        return $response;
+    }
+
+    /**
+     * 检查是否应该收集 metrics
+     */
+    protected function shouldCollectMetrics(Request $request): bool {
+        if (!config('prometheus.enabled', true)) {
+            return false;
+        }
+
+        if (!config('prometheus.http_metrics.enabled', true)) {
+            return false;
+        }
+
+        $excludedPaths = config('prometheus.http_metrics.excluded_paths', []);
+        $path = $request->path();
+
+        foreach ($excludedPaths as $excludedPath) {
+            if ($path === trim($excludedPath, '/')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 增加正在处理的请求计数
+     */
+    protected function incrementInProgressRequests(Request $request): void {
+        try {
+            $gauge = $this->registry->getOrRegisterGauge(
+                config('prometheus.namespace', 'cbdb'),
+                'http_requests_in_progress',
+                'Number of HTTP requests currently being processed',
+                ['method', 'path']
+            );
+
+            $gauge->inc($this->getLabels($request));
+        } catch (\Exception $e) {
+            // 忽略 metrics 收集错误，不影响正常请求
+            report($e);
+        }
+    }
+
+    /**
+     * 减少正在处理的请求计数
+     */
+    protected function decrementInProgressRequests(Request $request): void {
+        try {
+            $gauge = $this->registry->getOrRegisterGauge(
+                config('prometheus.namespace', 'cbdb'),
+                'http_requests_in_progress',
+                'Number of HTTP requests currently being processed',
+                ['method', 'path']
+            );
+
+            $gauge->dec($this->getLabels($request));
+        } catch (\Exception $e) {
+            report($e);
+        }
+    }
+
+    /**
+     * 记录请求 metrics
+     */
+    protected function recordMetrics(Request $request, Response $response, float $duration): void {
+        try {
+            $labels = array_merge(
+                $this->getLabels($request),
+                ['status' => $response->getStatusCode()]
+            );
+
+            // 记录请求总数
+            $counter = $this->registry->getOrRegisterCounter(
+                config('prometheus.namespace', 'cbdb'),
+                'http_requests_total',
+                'Total number of HTTP requests',
+                ['method', 'path', 'status']
+            );
+            $counter->inc($labels);
+
+            // 记录请求延迟分布
+            $histogram = $this->registry->getOrRegisterHistogram(
+                config('prometheus.namespace', 'cbdb'),
+                'http_request_duration_seconds',
+                'HTTP request latency in seconds',
+                ['method', 'path', 'status'],
+                config('prometheus.http_metrics.latency_buckets')
+            );
+            $histogram->observe($duration, $labels);
+        } catch (\Exception $e) {
+            report($e);
+        }
+    }
+
+    /**
+     * 获取请求的标签
+     */
+    protected function getLabels(Request $request): array {
+        $path = $this->getPath($request);
+
+        return [
+            'method' => $request->method(),
+            'path' => $path,
+        ];
+    }
+
+    /**
+     * 获取路径（可选择包含路由参数）
+     */
+    protected function getPath(Request $request): string {
+        if (config('prometheus.http_metrics.include_route_params', false)) {
+            // 使用路由模式（如 /user/{id}）
+            $route = $request->route();
+            if ($route) {
+                return '/' . ltrim($route->uri(), '/');
+            }
+        }
+
+        // 使用实际路径
+        return '/' . ltrim($request->path(), '/');
+    }
+}

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Prometheus\CollectorRegistry;
+use Prometheus\Storage\APC;
+use Prometheus\Storage\InMemory;
+use Prometheus\Storage\Redis;
+
+class PrometheusServiceProvider extends ServiceProvider {
+    /**
+     * Register services.
+     */
+    public function register(): void {
+        $this->app->singleton(CollectorRegistry::class, function ($app) {
+            return new CollectorRegistry($this->createStorageAdapter());
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void {
+        //
+    }
+
+    /**
+     * 根据配置创建存储适配器
+     */
+    protected function createStorageAdapter() {
+        $adapter = config('prometheus.storage_adapter', 'memory');
+
+        return match ($adapter) {
+            'redis' => $this->createRedisAdapter(),
+            'apc' => new APC(),
+            default => new InMemory(),
+        };
+    }
+
+    /**
+     * 创建 Redis 存储适配器
+     */
+    protected function createRedisAdapter(): Redis {
+        $config = config('prometheus.redis');
+
+        Redis::setDefaultOptions([
+            'host' => $config['host'],
+            'port' => $config['port'],
+            'password' => $config['password'],
+            'database' => $config['database'],
+            'timeout' => $config['timeout'],
+            'read_timeout' => $config['read_timeout'],
+            'persistent_connections' => $config['persistent_connections'],
+        ]);
+
+        return new Redis([
+            'prefix' => $config['prefix'],
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "laravel/tinker": "^2.8",
         "laravel/ui": "^4.5",
         "nesbot/carbon": "^2.67 || ^3.0",
-        "phpmyadmin/sql-parser": "^6.0"
+        "phpmyadmin/sql-parser": "^6.0",
+        "promphp/prometheus_client_php": "^2.14"
     },
     "require-dev": {
         "spatie/laravel-ignition": "^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d08e62fb37f135a25ae679a6653e082",
+    "content-hash": "c6b814c7f777092c6a62bed025b2c206",
     "packages": [
         {
             "name": "brick/math",
@@ -2866,6 +2866,74 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "promphp/prometheus_client_php",
+            "version": "v2.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/a283aea8269287dc35313a0055480d950c59ac1f",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "endclothing/prometheus_client_php": "*",
+                "jimdo/prometheus_client_php": "*",
+                "lkaemmerling/prometheus_client_php": "*"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/polyfill-apcu": "^1.6"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
+                "ext-redis": "Required if using Redis.",
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prometheus\\": "src/Prometheus/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kämmerling",
+                    "email": "kontakt@lukas-kaemmerling.de"
+                }
+            ],
+            "description": "Prometheus instrumentation library for PHP applications.",
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.14.1"
+            },
+            "time": "2025-04-14T07:59:43+00:00"
         },
         {
             "name": "psr/clock",

--- a/config/app.php
+++ b/config/app.php
@@ -178,6 +178,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\PrometheusServiceProvider::class,
 
     ],
 

--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -1,0 +1,122 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Prometheus Metrics 配置
+    |--------------------------------------------------------------------------
+    |
+    | 此配置文件定义 Prometheus metrics 的各項設定，包括存儲適配器、
+    | 命名空間、標籤等。
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | 启用状态
+    |--------------------------------------------------------------------------
+    |
+    | 控制是否启用 Prometheus metrics 收集。生产环境建议启用。
+    |
+    */
+    'enabled' => env('PROMETHEUS_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | 命名空间
+    |--------------------------------------------------------------------------
+    |
+    | Metrics 的命名空间前缀，用于区分不同的应用。
+    |
+    */
+    'namespace' => env('PROMETHEUS_NAMESPACE', 'cbdb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | 存储适配器
+    |--------------------------------------------------------------------------
+    |
+    | 支持的适配器：
+    | - memory: 内存存储（适合单进程、开发环境）
+    | - redis: Redis 存储（推荐用于生产环境，支持多进程）
+    | - apc: APC 存储（适合多进程，但不支持跨机器）
+    |
+    */
+    'storage_adapter' => env('PROMETHEUS_STORAGE_ADAPTER', 'memory'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redis 配置
+    |--------------------------------------------------------------------------
+    |
+    | 当使用 redis 适配器时的连接配置。
+    |
+    */
+    'redis' => [
+        'host' => env('PROMETHEUS_REDIS_HOST', env('REDIS_HOST', '127.0.0.1')),
+        'port' => env('PROMETHEUS_REDIS_PORT', env('REDIS_PORT', 6379)),
+        'password' => env('PROMETHEUS_REDIS_PASSWORD', env('REDIS_PASSWORD', null)),
+        'database' => env('PROMETHEUS_REDIS_DB', 2),
+        'timeout' => 0.1,
+        'read_timeout' => 10,
+        'persistent_connections' => false,
+        'prefix' => env('PROMETHEUS_REDIS_PREFIX', 'PROMETHEUS_'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | 默认标签
+    |--------------------------------------------------------------------------
+    |
+    | 所有 metrics 都会带上这些标签。
+    |
+    */
+    'default_labels' => [
+        'app' => env('APP_NAME', 'cbdb'),
+        'env' => env('APP_ENV', 'production'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Metrics 配置
+    |--------------------------------------------------------------------------
+    |
+    | HTTP 请求相关的 metrics 配置。
+    |
+    */
+    'http_metrics' => [
+        // 是否启用 HTTP metrics 收集
+        'enabled' => env('PROMETHEUS_HTTP_METRICS_ENABLED', true),
+
+        // 请求延迟分布的 bucket（单位：秒）
+        'latency_buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
+
+        // 排除的路径（不收集 metrics）
+        'excluded_paths' => [
+            '/metrics',
+        ],
+
+        // 是否记录路由参数（如 /user/{id}）
+        'include_route_params' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Metrics Endpoint 配置
+    |--------------------------------------------------------------------------
+    |
+    | /metrics 端点的访问控制配置。
+    |
+    */
+    'metrics_endpoint' => [
+        // 是否启用基本认证
+        'auth_enabled' => env('PROMETHEUS_AUTH_ENABLED', false),
+
+        // 认证用户名和密码（仅在 auth_enabled 为 true 时使用）
+        'username' => env('PROMETHEUS_AUTH_USERNAME', 'prometheus'),
+        'password' => env('PROMETHEUS_AUTH_PASSWORD', 'secret'),
+
+        // 允许访问的 IP 白名单（空数组表示允许所有 IP）
+        'allowed_ips' => array_filter(explode(',', env('PROMETHEUS_ALLOWED_IPS', ''))),
+    ],
+];

--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -1,0 +1,241 @@
+# Prometheus Metrics 整合指南
+
+本文件說明如何配置和使用專案中的 Prometheus metrics 功能。
+
+## 功能概述
+
+本專案已整合 Prometheus metrics 收集功能，可以監控以下指標：
+
+- **HTTP 請求總數** (`cbdb_http_requests_total`): 按方法、路徑和狀態碼分類的請求計數
+- **HTTP 請求延遲** (`cbdb_http_request_duration_seconds`): 請求處理時間的直方圖分佈
+- **正在處理的請求數** (`cbdb_http_requests_in_progress`): 當前正在處理的併發請求數量
+
+## 快速開始
+
+### 1. 基本配置
+
+Metrics 功能預設已啟用。訪問以下端點即可查看 metrics：
+
+```
+http://your-domain.com/metrics
+```
+
+### 2. 環境變數配置
+
+在 `.env` 檔案中可以配置以下選項：
+
+```env
+# 啟用/停用 Prometheus metrics
+PROMETHEUS_ENABLED=true
+
+# Metrics 命名空間（用於區分不同應用）
+PROMETHEUS_NAMESPACE=cbdb
+
+# 存儲適配器（memory/redis/apc）
+PROMETHEUS_STORAGE_ADAPTER=memory
+
+# HTTP metrics 啟用/停用
+PROMETHEUS_HTTP_METRICS_ENABLED=true
+
+# /metrics 端點的 IP 白名單（逗號分隔，留空表示允許所有 IP）
+PROMETHEUS_ALLOWED_IPS=
+
+# /metrics 端點的基本認證（可選）
+PROMETHEUS_AUTH_ENABLED=false
+PROMETHEUS_AUTH_USERNAME=prometheus
+PROMETHEUS_AUTH_PASSWORD=secret
+```
+
+## 配置詳解
+
+### 存儲適配器
+
+#### Memory（預設）
+- **適用場景**: 開發環境、單進程應用
+- **優點**: 無需額外依賴
+- **缺點**: 不支援多進程/多伺服器
+
+#### Redis（推薦用於生產環境）
+- **適用場景**: 生產環境、多進程/多伺服器部署
+- **配置**:
+  ```env
+  PROMETHEUS_STORAGE_ADAPTER=redis
+  PROMETHEUS_REDIS_HOST=127.0.0.1
+  PROMETHEUS_REDIS_PORT=6379
+  PROMETHEUS_REDIS_PASSWORD=
+  PROMETHEUS_REDIS_DB=2
+  ```
+- **優點**: 支援多進程和分散式部署
+- **缺點**: 需要 Redis 服務
+
+#### APC
+- **適用場景**: 多進程應用（如 PHP-FPM）
+- **優點**: 快速、無需外部服務
+- **缺點**: 不支援跨機器聚合
+
+### 存取控制
+
+#### IP 白名單
+
+限制只有特定 IP 可以訪問 `/metrics` 端點：
+
+```env
+PROMETHEUS_ALLOWED_IPS=10.0.0.1,10.0.0.2,192.168.1.0/24
+```
+
+#### HTTP 基本認證
+
+為 `/metrics` 端點添加密碼保護：
+
+```env
+PROMETHEUS_AUTH_ENABLED=true
+PROMETHEUS_AUTH_USERNAME=prometheus
+PROMETHEUS_AUTH_PASSWORD=your-secure-password
+```
+
+訪問時需要提供認證信息：
+```bash
+curl -u prometheus:your-secure-password http://your-domain.com/metrics
+```
+
+### 排除特定路徑
+
+預設情況下，`/metrics` 端點本身不會被記錄。如需排除其他路徑，可在 `config/prometheus.php` 中配置：
+
+```php
+'http_metrics' => [
+    'excluded_paths' => [
+        '/metrics',
+        '/health',
+        '/ping',
+    ],
+],
+```
+
+### 延遲分布 Bucket
+
+可以自定義延遲直方圖的 bucket（單位：秒）：
+
+```php
+'http_metrics' => [
+    'latency_buckets' => [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+],
+```
+
+## Prometheus 配置範例
+
+在 Prometheus 伺服器的配置檔案中添加 scrape 配置：
+
+```yaml
+scrape_configs:
+  - job_name: 'cbdb-laravel'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['your-domain.com:80']
+    metrics_path: '/metrics'
+
+    # 如果啟用了基本認證
+    basic_auth:
+      username: 'prometheus'
+      password: 'your-secure-password'
+```
+
+## 常見查詢範例
+
+### Grafana Dashboard 查詢
+
+#### 請求速率（QPS）
+```promql
+rate(cbdb_http_requests_total[5m])
+```
+
+#### 錯誤率
+```promql
+sum(rate(cbdb_http_requests_total{status=~"5.."}[5m])) / sum(rate(cbdb_http_requests_total[5m]))
+```
+
+#### 平均延遲
+```promql
+rate(cbdb_http_request_duration_seconds_sum[5m]) / rate(cbdb_http_request_duration_seconds_count[5m])
+```
+
+#### P95 延遲
+```promql
+histogram_quantile(0.95, rate(cbdb_http_request_duration_seconds_bucket[5m]))
+```
+
+#### 按路徑分組的請求數
+```promql
+sum by (path) (rate(cbdb_http_requests_total[5m]))
+```
+
+## 疑難排解
+
+### Metrics 端點返回空白
+
+1. 確認 `PROMETHEUS_ENABLED=true`
+2. 確認至少有一個請求被處理過（訪問首頁等）
+3. 檢查 IP 白名單配置
+
+### Redis 連線錯誤
+
+1. 確認 Redis 服務正在運行
+2. 檢查 Redis 連線配置（主機、端口、密碼）
+3. 確認 PHP Redis 擴展已安裝
+
+### 性能影響
+
+- Memory 適配器：幾乎無影響
+- Redis 適配器：每個請求約增加 1-2ms 延遲
+- 如需完全停用：設定 `PROMETHEUS_ENABLED=false`
+
+## 擴展自定義 Metrics
+
+如需添加自定義業務 metrics，可以注入 `CollectorRegistry`：
+
+```php
+use Prometheus\CollectorRegistry;
+
+class YourController extends Controller {
+    protected CollectorRegistry $registry;
+
+    public function __construct(CollectorRegistry $registry) {
+        $this->registry = $registry;
+    }
+
+    public function yourMethod() {
+        // 計數器
+        $counter = $this->registry->getOrRegisterCounter(
+            'cbdb',
+            'your_custom_metric',
+            'Description of your metric',
+            ['label1', 'label2']
+        );
+        $counter->inc(['value1', 'value2']);
+
+        // 直方圖
+        $histogram = $this->registry->getOrRegisterHistogram(
+            'cbdb',
+            'your_duration_metric',
+            'Duration of your operation',
+            ['label1'],
+            [0.1, 0.5, 1.0, 5.0]
+        );
+        $histogram->observe($duration, ['value1']);
+    }
+}
+```
+
+## 測試
+
+執行 Prometheus metrics 相關測試：
+
+```bash
+./vendor/bin/phpunit --filter PrometheusMetricsTest
+```
+
+## 相關文件
+
+- [Prometheus PHP Client](https://github.com/promphp/prometheus_client_php)
+- [Prometheus 文檔](https://prometheus.io/docs/)
+- [PromQL 查詢語言](https://prometheus.io/docs/prometheus/latest/querying/basics/)

--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -77,10 +77,24 @@ PROMETHEUS_AUTH_PASSWORD=secret
 
 #### IP 白名單
 
-限制只有特定 IP 可以訪問 `/metrics` 端點：
+限制只有特定 IP 可以訪問 `/metrics` 端點。支援以下格式：
+
+- **精確匹配**: `10.0.0.1`
+- **CIDR IPv4**: `192.168.1.0/24`
+- **CIDR IPv6**: `2001:db8::/32`
+- **混合格式**: 可以同時使用多種格式，用逗號分隔
+
+範例：
 
 ```env
-PROMETHEUS_ALLOWED_IPS=10.0.0.1,10.0.0.2,192.168.1.0/24
+# 單一 IP
+PROMETHEUS_ALLOWED_IPS=10.0.0.1
+
+# CIDR 格式
+PROMETHEUS_ALLOWED_IPS=192.168.1.0/24
+
+# 混合多個格式
+PROMETHEUS_ALLOWED_IPS=10.0.0.1,192.168.1.0/24,2001:db8::/32
 ```
 
 #### HTTP 基本認證
@@ -188,6 +202,29 @@ sum by (path) (rate(cbdb_http_requests_total[5m]))
 - Memory 適配器：幾乎無影響
 - Redis 適配器：每個請求約增加 1-2ms 延遲
 - 如需完全停用：設定 `PROMETHEUS_ENABLED=false`
+
+### 可靠性與異常處理
+
+Metrics 收集系統經過強化設計，確保即使在異常情況下也能正確運作：
+
+#### 異常時的 Metrics 記錄
+
+- 使用 `try/finally` 結構確保即使請求處理過程中發生異常，仍能正確：
+  - 遞減 `http_requests_in_progress` gauge（避免計數器洩漏）
+  - 記錄錯誤請求的 metrics（包含狀態碼和延遲）
+- 未被捕獲的異常會被記錄為 500 錯誤
+- HTTP 異常（如 404、403）會正確記錄其狀態碼
+
+#### 錯誤隔離
+
+- Metrics 收集過程中的錯誤**不會影響**正常的 HTTP 請求處理
+- 所有 metrics 操作都包含異常捕獲，失敗時會通過 `report()` 記錄但不會中斷請求
+
+#### IP 白名單的容錯性
+
+- 支援 CIDR 格式（IPv4 和 IPv6）
+- 自動去除空格，容忍格式錯誤
+- 無效的 CIDR 格式會被安全忽略
 
 ## 擴展自定義 Metrics
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,8 @@
 |
 */
 
+// Prometheus metrics endpoint
+Route::get('metrics', 'MetricsController@index')->name('metrics');
 
 Route::get('/', 'WelcomeController@index');
 

--- a/tests/Feature/PrometheusMetricsTest.php
+++ b/tests/Feature/PrometheusMetricsTest.php
@@ -176,4 +176,82 @@ class PrometheusMetricsTest extends TestCase {
         // HTTP metrics 应该不存在
         $this->assertStringNotContainsString('http_requests_total', $content);
     }
+
+    #[Test]
+    public function metrics_endpoint_supports_cidr_ipv4_whitelist(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', ['192.168.1.0/24']);
+
+        // 从子网内的 IP 访问（应该允许）
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.1.100']);
+        $response->assertStatus(200);
+
+        // 从子网外的 IP 访问（应该拒绝）
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.2.100']);
+        $response->assertStatus(403);
+
+        // 边界测试：子网的第一个地址
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.1.0']);
+        $response->assertStatus(200);
+
+        // 边界测试：子网的最后一个地址
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.1.255']);
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function metrics_endpoint_supports_cidr_ipv6_whitelist(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', ['2001:db8::/32']);
+
+        // 从子网内的 IP 访问（应该允许）
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '2001:db8::1']);
+        $response->assertStatus(200);
+
+        // 从子网外的 IP 访问（应该拒绝）
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '2001:db9::1']);
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function metrics_endpoint_supports_mixed_ip_formats(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', [
+            '10.0.0.1',              // 精确匹配
+            '192.168.1.0/24',        // CIDR IPv4
+            '2001:db8::/32',         // CIDR IPv6
+        ]);
+
+        // 精确匹配
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '10.0.0.1']);
+        $response->assertStatus(200);
+
+        // CIDR IPv4 匹配
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.1.50']);
+        $response->assertStatus(200);
+
+        // CIDR IPv6 匹配
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '2001:db8::100']);
+        $response->assertStatus(200);
+
+        // 不匹配任何规则
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '172.16.0.1']);
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function metrics_endpoint_handles_whitespace_in_ip_list(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', [
+            ' 10.0.0.1 ',            // 带空格
+            '192.168.1.0/24 ',       // 尾部空格
+        ]);
+
+        // 应该正确去除空格并匹配
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '10.0.0.1']);
+        $response->assertStatus(200);
+
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '192.168.1.1']);
+        $response->assertStatus(200);
+    }
 }

--- a/tests/Feature/PrometheusMetricsTest.php
+++ b/tests/Feature/PrometheusMetricsTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PrometheusMetricsTest extends TestCase {
+    #[Test]
+    public function metrics_endpoint_returns_prometheus_format(): void {
+        // 启用 Prometheus metrics
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.http_metrics.enabled', true);
+
+        // 发起一个测试请求来生成一些 metrics
+        $this->get('/');
+
+        // 访问 /metrics 端点
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+
+        // 验证返回的内容包含 Prometheus metrics
+        $content = $response->getContent();
+        $this->assertStringContainsString('# HELP', $content);
+        $this->assertStringContainsString('# TYPE', $content);
+    }
+
+    #[Test]
+    public function metrics_endpoint_includes_http_request_metrics(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.http_metrics.enabled', true);
+        Config::set('prometheus.namespace', 'cbdb');
+
+        // 发起多个测试请求
+        $this->get('/');
+        $this->get('/');
+
+        // 访问 metrics 端点
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(200);
+
+        $content = $response->getContent();
+
+        // 验证包含请求总数指标
+        $this->assertStringContainsString('cbdb_http_requests_total', $content);
+
+        // 验证包含请求延迟指标
+        $this->assertStringContainsString('cbdb_http_request_duration_seconds', $content);
+
+        // 验证包含正在处理的请求数指标
+        $this->assertStringContainsString('cbdb_http_requests_in_progress', $content);
+    }
+
+    #[Test]
+    public function metrics_endpoint_excludes_metrics_path(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.http_metrics.enabled', true);
+        Config::set('prometheus.http_metrics.excluded_paths', ['/metrics']);
+
+        // 访问 metrics 端点（不应该被记录）
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(200);
+
+        $content = $response->getContent();
+
+        // 不应该包含 /metrics 路径的记录
+        $this->assertStringNotContainsString('path="/metrics"', $content);
+    }
+
+    #[Test]
+    public function metrics_endpoint_respects_ip_whitelist(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', ['192.168.1.1']);
+
+        // 从不在白名单中的 IP 访问
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '10.0.0.1']);
+
+        $response->assertStatus(403);
+    }
+
+    #[Test]
+    public function metrics_endpoint_allows_all_ips_when_whitelist_empty(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.allowed_ips', []);
+
+        // 从任意 IP 访问
+        $response = $this->get('/metrics', ['REMOTE_ADDR' => '10.0.0.1']);
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function metrics_endpoint_requires_basic_auth_when_enabled(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.auth_enabled', true);
+        Config::set('prometheus.metrics_endpoint.username', 'prometheus');
+        Config::set('prometheus.metrics_endpoint.password', 'secret');
+
+        // 不提供认证信息
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(401);
+        $response->assertHeader('WWW-Authenticate', 'Basic realm="Prometheus Metrics"');
+    }
+
+    #[Test]
+    public function metrics_endpoint_accepts_valid_basic_auth(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.auth_enabled', true);
+        Config::set('prometheus.metrics_endpoint.username', 'prometheus');
+        Config::set('prometheus.metrics_endpoint.password', 'secret');
+
+        // 提供正确的认证信息
+        $response = $this->get('/metrics', [
+            'PHP_AUTH_USER' => 'prometheus',
+            'PHP_AUTH_PW' => 'secret',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    #[Test]
+    public function metrics_endpoint_rejects_invalid_basic_auth(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.metrics_endpoint.auth_enabled', true);
+        Config::set('prometheus.metrics_endpoint.username', 'prometheus');
+        Config::set('prometheus.metrics_endpoint.password', 'secret');
+
+        // 提供错误的认证信息
+        $response = $this->get('/metrics', [
+            'PHP_AUTH_USER' => 'wrong',
+            'PHP_AUTH_PW' => 'wrong',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    #[Test]
+    public function metrics_are_not_collected_when_disabled(): void {
+        Config::set('prometheus.enabled', false);
+
+        // 发起测试请求
+        $this->get('/');
+
+        // 访问 metrics 端点（metrics 应该为空或最小化）
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(200);
+
+        $content = $response->getContent();
+
+        // 当禁用时，不应该收集 HTTP metrics
+        $this->assertStringNotContainsString('http_requests_total', $content);
+    }
+
+    #[Test]
+    public function http_metrics_collection_can_be_disabled_separately(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.http_metrics.enabled', false);
+
+        // 发起测试请求
+        $this->get('/');
+
+        // 访问 metrics 端点
+        $response = $this->get('/metrics');
+
+        $response->assertStatus(200);
+
+        $content = $response->getContent();
+
+        // HTTP metrics 应该不存在
+        $this->assertStringNotContainsString('http_requests_total', $content);
+    }
+}


### PR DESCRIPTION
本次提交為 Laravel 應用添加完整的 Prometheus metrics 支援，用於監控 HTTP 請求的速率、錯誤率和延遲分佈。

主要變更：

1. 安裝依賴
   - 新增 promphp/prometheus_client_php (v2.14.1)

2. 核心組件
   - PrometheusServiceProvider: 註冊 CollectorRegistry 服務，支援 Memory/Redis/APC 存儲適配器
   - PrometheusMetrics Middleware: 自動收集 HTTP 請求指標
   - MetricsController: 暴露 /metrics 端點供 Prometheus 抓取

3. 配置功能
   - config/prometheus.php: 完整的配置選項
   - 支援 IP 白名單限制
   - 支援 HTTP 基本認證
   - 可排除特定路徑
   - 可自定義延遲 bucket

4. 監控指標
   - cbdb_http_requests_total: HTTP 請求總數（按方法、路徑、狀態碼分類）
   - cbdb_http_request_duration_seconds: HTTP 請求延遲直方圖
   - cbdb_http_requests_in_progress: 當前正在處理的請求數

5. 測試
   - PrometheusMetricsTest: 10 個測試案例，涵蓋所有核心功能
   - 測試 metrics 格式、存取控制、配置開關等

6. 文檔
   - docs/PROMETHEUS_METRICS.md: 完整的使用指南和配置說明

技術特點：
- 預設使用 in-memory 存儲，適合開發環境
- 支援切換至 Redis 存儲，適合生產環境多進程部署
- 錯誤處理完善，metrics 收集失敗不影響正常請求
- 可通過環境變數完全啟用/停用