### PR TITLE
修正：提高 API 速率限制以改善效能

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -20,11 +20,11 @@ Route::group([], function () {
 
 // Select APIs with optional authentication
 // Allows both authenticated users and guests to access
-// - Authenticated users: Rate limited per user (120 req/min)
-// - Guest users: Rate limited per IP address (120 req/min)
+// - Authenticated users: Rate limited per user (300 req/min)
+// - Guest users: Rate limited per IP address (300 req/min)
 Route::group([
     'prefix' => 'select',
-    'middleware' => ['auth.optional', 'throttle:120,1'],
+    'middleware' => ['auth.optional', 'throttle:300,1'],
 ], function () {
     Route::get('ethnicity', 'ApiController@ethnicity');
     Route::get('choronym', 'ApiController@choronym');


### PR DESCRIPTION
## 摘要
- 將 `/api/select/*` 端點的速率限制從 120 提高到 300 請求/分鐘
- 作為暫時性措施觀察是否能改善目前的速率限制問題

## 相關 Issue
解決 https://github.com/cbdb-project/cbdb-online-main-server/issues/718#issuecomment-3729732538 中建議的速率限制調整

🤖 使用 [Claude Code](https://claude.com/claude-code) 產生