### PR TITLE
修正社會關係編輯頁面 URL 編碼問題

### DIFF
--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -1,15 +1,16 @@
 {{-- 共享表单组件 - Assoc --}}
 @php
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.assoc.update', ['basicinformation' => $id, 'assoc' => $row->c_personid.'-'.$row->c_assoc_code.'-'.$row->c_assoc_id.'-'.$row->c_kin_code.'-'.$row->c_kin_id.'-'.$row->c_assoc_kin_code.'-'.$row->c_assoc_kin_id.'-'.$row->c_text_title])
-        : route('basicinformation.assoc.store', ['basicinformation' => $id]);
 
-    // 处理编辑模式的数据
+    // 处理编辑模式的数据 - 必须在构建 formAction 之前执行
     if ($isEdit) {
         $row->c_text_title = unionPKDef($row->c_text_title);
         $row->c_notes = unionPKDef($row->c_notes);
     }
+
+    $formAction = $isEdit
+        ? route('basicinformation.assoc.update', ['basicinformation' => $id, 'assoc' => $row->c_personid.'-'.$row->c_assoc_code.'-'.$row->c_assoc_id.'-'.$row->c_kin_code.'-'.$row->c_kin_id.'-'.$row->c_assoc_kin_code.'-'.$row->c_assoc_kin_id.'-'.$row->c_text_title])
+        : route('basicinformation.assoc.store', ['basicinformation' => $id]);
 @endphp
 
 <form action="{{ $formAction }}" method="post">


### PR DESCRIPTION
## Summary

修正社會關係（assoc）編輯頁面提交後出現 404 錯誤的問題。當 c_text_title 欄位包含斜線（如 `[n/a]`）時，URL 未正確編碼導致路由匹配失敗。

## Root Cause

在 `_form.blade.php` 中，`formAction` 的計算使用了原始的 `c_text_title` 值，而 `unionPKDef()`（將 `/` 轉換為 `(slash)`）是在計算 `formAction` 之後才執行的。

## Fix

將 `unionPKDef()` 的調用移到 `formAction` 計算之前，確保特殊字符在構建 URL 時已正確編碼。

## Test plan

- [x] PHPUnit 測試通過
- [x] 手動測試：編輯包含 `[n/a]` 的社會關係記錄，確認提交後不再出現 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
