### PR TITLE
修正 migration 的 SQLite 兼容性

### DIFF
--- a/database/migrations/2026_01_22_192118_rename_entry_data_columns.php
+++ b/database/migrations/2026_01_22_192118_rename_entry_data_columns.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -13,19 +14,23 @@ return new class () extends Migration {
      * Run the migrations.
      */
     public function up(): void {
-        // 1. 移除舊的外鍵約束
-        Schema::table('ENTRY_DATA', function ($table) {
-            // 移除 c_nianhao_id 的外鍵 (ENTRY_DATA_ibfk_9)
-            $table->dropForeign('ENTRY_DATA_ibfk_9');
-            // 移除 c_parental_status 的外鍵 (ENTRY_DATA_ibfk_10)
-            $table->dropForeign('ENTRY_DATA_ibfk_10');
-        });
+        $isMysql = DB::getDriverName() === 'mysql';
 
-        // 2. 移除舊的索引
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->dropIndex('c_nianhao_id_ENTRY_DATA_index');
-            $table->dropIndex('c_parental_status');
-        });
+        // 1. 移除舊的外鍵約束（僅 MySQL）
+        if ($isMysql) {
+            Schema::table('ENTRY_DATA', function ($table) {
+                // 移除 c_nianhao_id 的外鍵 (ENTRY_DATA_ibfk_9)
+                $table->dropForeign('ENTRY_DATA_ibfk_9');
+                // 移除 c_parental_status 的外鍵 (ENTRY_DATA_ibfk_10)
+                $table->dropForeign('ENTRY_DATA_ibfk_10');
+            });
+
+            // 2. 移除舊的索引
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->dropIndex('c_nianhao_id_ENTRY_DATA_index');
+                $table->dropIndex('c_parental_status');
+            });
+        }
 
         // 3. 重新命名欄位
         Schema::table('ENTRY_DATA', function ($table) {
@@ -33,43 +38,49 @@ return new class () extends Migration {
             $table->renameColumn('c_parental_status', 'c_parental_status_code');
         });
 
-        // 4. 建立新的索引
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->index('c_entry_nh_id', 'c_entry_nh_id_ENTRY_DATA_index');
-            $table->index('c_parental_status_code', 'c_parental_status_code_ENTRY_DATA_index');
-        });
+        // 4. 建立新的索引（僅 MySQL）
+        if ($isMysql) {
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->index('c_entry_nh_id', 'c_entry_nh_id_ENTRY_DATA_index');
+                $table->index('c_parental_status_code', 'c_parental_status_code_ENTRY_DATA_index');
+            });
 
-        // 5. 重新建立外鍵約束
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->foreign('c_entry_nh_id', 'ENTRY_DATA_ibfk_9')
-                ->references('c_nianhao_id')
-                ->on('NIAN_HAO')
-                ->onDelete('cascade')
-                ->onUpdate('cascade');
+            // 5. 重新建立外鍵約束
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->foreign('c_entry_nh_id', 'ENTRY_DATA_ibfk_9')
+                    ->references('c_nianhao_id')
+                    ->on('NIAN_HAO')
+                    ->onDelete('cascade')
+                    ->onUpdate('cascade');
 
-            $table->foreign('c_parental_status_code', 'ENTRY_DATA_ibfk_10')
-                ->references('c_parental_status_code')
-                ->on('PARENTAL_STATUS_CODES')
-                ->onDelete('cascade')
-                ->onUpdate('cascade');
-        });
+                $table->foreign('c_parental_status_code', 'ENTRY_DATA_ibfk_10')
+                    ->references('c_parental_status_code')
+                    ->on('PARENTAL_STATUS_CODES')
+                    ->onDelete('cascade')
+                    ->onUpdate('cascade');
+            });
+        }
     }
 
     /**
      * Reverse the migrations.
      */
     public function down(): void {
-        // 1. 移除新的外鍵約束
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->dropForeign('ENTRY_DATA_ibfk_9');
-            $table->dropForeign('ENTRY_DATA_ibfk_10');
-        });
+        $isMysql = DB::getDriverName() === 'mysql';
 
-        // 2. 移除新的索引
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->dropIndex('c_entry_nh_id_ENTRY_DATA_index');
-            $table->dropIndex('c_parental_status_code_ENTRY_DATA_index');
-        });
+        // 1. 移除新的外鍵約束（僅 MySQL）
+        if ($isMysql) {
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->dropForeign('ENTRY_DATA_ibfk_9');
+                $table->dropForeign('ENTRY_DATA_ibfk_10');
+            });
+
+            // 2. 移除新的索引
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->dropIndex('c_entry_nh_id_ENTRY_DATA_index');
+                $table->dropIndex('c_parental_status_code_ENTRY_DATA_index');
+            });
+        }
 
         // 3. 還原欄位名稱
         Schema::table('ENTRY_DATA', function ($table) {
@@ -77,25 +88,27 @@ return new class () extends Migration {
             $table->renameColumn('c_parental_status_code', 'c_parental_status');
         });
 
-        // 4. 還原舊的索引
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->index('c_nianhao_id', 'c_nianhao_id_ENTRY_DATA_index');
-            $table->index('c_parental_status', 'c_parental_status');
-        });
+        // 4. 還原舊的索引（僅 MySQL）
+        if ($isMysql) {
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->index('c_nianhao_id', 'c_nianhao_id_ENTRY_DATA_index');
+                $table->index('c_parental_status', 'c_parental_status');
+            });
 
-        // 5. 還原舊的外鍵約束
-        Schema::table('ENTRY_DATA', function ($table) {
-            $table->foreign('c_nianhao_id', 'ENTRY_DATA_ibfk_9')
-                ->references('c_nianhao_id')
-                ->on('NIAN_HAO')
-                ->onDelete('cascade')
-                ->onUpdate('cascade');
+            // 5. 還原舊的外鍵約束
+            Schema::table('ENTRY_DATA', function ($table) {
+                $table->foreign('c_nianhao_id', 'ENTRY_DATA_ibfk_9')
+                    ->references('c_nianhao_id')
+                    ->on('NIAN_HAO')
+                    ->onDelete('cascade')
+                    ->onUpdate('cascade');
 
-            $table->foreign('c_parental_status', 'ENTRY_DATA_ibfk_10')
-                ->references('c_parental_status_code')
-                ->on('PARENTAL_STATUS_CODES')
-                ->onDelete('cascade')
-                ->onUpdate('cascade');
-        });
+                $table->foreign('c_parental_status', 'ENTRY_DATA_ibfk_10')
+                    ->references('c_parental_status_code')
+                    ->on('PARENTAL_STATUS_CODES')
+                    ->onDelete('cascade')
+                    ->onUpdate('cascade');
+            });
+        }
     }
 };


### PR DESCRIPTION
## Summary
- 修正 `2026_01_22_192118_rename_entry_data_columns.php` migration 的 SQLite 兼容性問題
- 在 SQLite 測試環境中跳過外鍵約束和索引操作，僅在 MySQL 環境執行

## 問題描述
PR #746 合併後，`MigrationTest` 測試失敗，因為 migration 嘗試在 SQLite in-memory 測試資料庫上執行 `dropForeign()` 和 `dropIndex()` 操作，但 SQLite 不支援這些操作。

## 解決方案
使用 `DB::getDriverName() === 'mysql'` 檢查，僅在 MySQL 環境執行外鍵和索引相關操作。這與專案中其他 migration 的處理方式一致（如 `2025_11_18_034300_convert_indexyear_type_codes_to_innodb.php`）。

## Test plan
- [x] 運行 `vendor/bin/phpunit`，確認所有 426 個測試通過

🤖 Generated with [Claude Code](https://claude.ai/code)