### PR TITLE
文檔：完善 Migration 數據庫兼容性指南和規範

### DIFF
--- a/.claude/skills/migration-guide.md
+++ b/.claude/skills/migration-guide.md
@@ -16,12 +16,302 @@ description: 創建和修改數據庫結構的完整指南，涵蓋複合主鍵�
 - 使用標準 SQL 語法
 - 使用 B-Tree 索引（默認）
 - 保持數據庫無關性
+- **使用 `is_mysql()` 和 `is_sqlite()` 處理兼容性**
 
 ### ❌ 避免的事情
 - 數據庫專屬功能（ngram parser、專屬插件）
 - 供應商特定語法（REGEXP、優化器提示）
 - 直接執行原始 SQL（除非必要）
 - 修改基線 migration 文件
+- **直接使用 `DB::getDriverName()` 判斷數據庫類型**
+
+## MySQL 與 SQLite 兼容性處理
+
+### 為什麼需要兼容性？
+
+本專案在不同環境使用不同數據庫：
+- **生產環境**：MariaDB 10.3.39
+- **測試環境**：SQLite（PHPUnit 測試）
+- **CI/CD**：SQLite in-memory 數據庫
+
+所有 Migration 必須同時兼容 MySQL/MariaDB 和 SQLite，確保測試可靠性和開發一致性。
+
+### 使用 Helper Functions
+
+專案提供了標準的 helper functions（位於 `database/migrations/helpers.php`）：
+
+```php
+// ✅ 正確：使用 helper functions
+if (is_mysql()) {
+    // MySQL/MariaDB 特定操作
+}
+
+if (is_sqlite()) {
+    // SQLite 特定操作
+}
+
+// ✅ 正確：禁用/啟用外鍵檢查
+disable_foreign_keys();
+try {
+    // 你的操作
+} finally {
+    enable_foreign_keys();
+}
+
+// ✅ 正確：獲取當前時間戳 SQL
+$timestamp = get_current_timestamp_sql();
+
+// ❌ 錯誤：不要直接使用 DB::getDriverName()
+if (DB::getDriverName() === 'sqlite') {  // 不要這樣做！
+    // ...
+}
+```
+
+### 常見兼容性問題和解決方案
+
+#### 問題 1：COMMENT 注釋（SQLite 不支持）
+
+```php
+// ❌ 錯誤：直接使用 COMMENT
+DB::statement("
+    CREATE TABLE users (
+        id INT PRIMARY KEY COMMENT 'User ID'
+    )
+");
+
+// ✅ 正確：條件性移除 COMMENT
+public function up(): void {
+    $sql = "
+        CREATE TABLE users (
+            id INT PRIMARY KEY COMMENT 'User ID',
+            name VARCHAR(255) COMMENT 'User name'
+        )
+    ";
+
+    if (is_sqlite()) {
+        // 移除所有 COMMENT 子句
+        $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+    }
+
+    DB::statement($sql);
+}
+```
+
+#### 問題 2：ENGINE 和 ROW_FORMAT（SQLite 不支持）
+
+```php
+// ✅ 方式 1：條件性執行
+public function up(): void {
+    Schema::create('users', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+    });
+
+    // 僅在 MySQL 執行
+    if (is_mysql()) {
+        DB::statement("ALTER TABLE users ENGINE=InnoDB ROW_FORMAT=DYNAMIC");
+    }
+}
+
+// ✅ 方式 2：從 SQL 中移除
+public function up(): void {
+    $sql = "CREATE TABLE users (id INT) ENGINE=InnoDB ROW_FORMAT=DYNAMIC";
+
+    if (is_sqlite()) {
+        $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+        $sql = preg_replace('/ROW_FORMAT\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+    }
+
+    DB::statement($sql);
+}
+```
+
+#### 問題 3：索引類型提示（USING BTREE）
+
+```php
+// ✅ 正確：移除 SQLite 不支持的索引提示
+public function up(): void {
+    $sql = "
+        CREATE TABLE users (
+            id INT,
+            name VARCHAR(255),
+            KEY idx_name (name) USING BTREE
+        )
+    ";
+
+    if (is_sqlite()) {
+        // 移除 USING BTREE
+        $sql = preg_replace('/USING\s+BTREE/i', '', $sql);
+    }
+
+    DB::statement($sql);
+}
+
+// ✅ 更好：使用 Schema Builder（自動兼容）
+Schema::create('users', function (Blueprint $table) {
+    $table->id();
+    $table->string('name');
+    $table->index('name');  // Laravel 自動處理兼容性
+});
+```
+
+#### 問題 4：外鍵約束檢查
+
+```php
+// ✅ 正確：使用 helper functions
+public function up(): void {
+    disable_foreign_keys();
+
+    try {
+        // 修改有外鍵約束的表
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->unsignedBigInteger('user_id')->change();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    } finally {
+        enable_foreign_keys();
+    }
+}
+```
+
+#### 問題 5：VARBINARY 和特殊字符（處理 4 字節 UTF-8）
+
+```php
+// ✅ 正確：使用 VARBINARY 繞過 MySQL 8.0 的 utf8mb4 非 BMP 字符主鍵索引 bug
+public function up(): void {
+    $sql = "
+        CREATE TABLE CBDB__TRAD_SIMP_MAP (
+            trad_char VARBINARY(4) NOT NULL COMMENT '繁體字（UTF-8二進制）',
+            simp_char VARBINARY(4) NOT NULL COMMENT '簡體字（UTF-8二進制）',
+            PRIMARY KEY (trad_char)
+        ) ENGINE=InnoDB
+    ";
+
+    if (is_sqlite()) {
+        // 移除 COMMENT 和 ENGINE
+        $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+        $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+    }
+
+    DB::statement($sql);
+}
+```
+
+### 完整的兼容性 Migration 模板
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        // ========================================
+        // 方式 1：使用 Schema Builder（推薦）
+        // ========================================
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 255);
+            $table->string('email', 255)->unique();
+            $table->timestamps();
+
+            // Laravel 自動處理索引兼容性
+            $table->index('name');
+        });
+
+        // MySQL 特定的優化（可選）
+        if (is_mysql()) {
+            DB::statement("ALTER TABLE users ENGINE=InnoDB ROW_FORMAT=DYNAMIC");
+        }
+
+        // ========================================
+        // 方式 2：需要原始 SQL 時的兼容性處理
+        // ========================================
+        $sql = "
+            CREATE TABLE logs (
+                id INT AUTO_INCREMENT PRIMARY KEY COMMENT '日志ID',
+                message TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                KEY idx_created (created_at) USING BTREE
+            ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+        ";
+
+        if (is_sqlite()) {
+            // 移除 SQLite 不支持的語法
+            $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+            $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+            $sql = preg_replace('/ROW_FORMAT\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+            $sql = preg_replace('/USING\s+BTREE/i', '', $sql);
+        }
+
+        DB::statement($sql);
+
+        // ========================================
+        // 方式 3：處理外鍵約束
+        // ========================================
+        disable_foreign_keys();
+
+        try {
+            Schema::create('posts', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('user_id');
+                $table->foreign('user_id')
+                      ->references('id')
+                      ->on('users')
+                      ->onDelete('cascade');
+            });
+        } finally {
+            enable_foreign_keys();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('posts');
+        Schema::dropIfExists('logs');
+        Schema::dropIfExists('users');
+    }
+};
+```
+
+### 測試兼容性
+
+```bash
+# 1. 在 SQLite 環境測試
+vendor/bin/phpunit
+
+# 2. 手動測試 migration（SQLite）
+php artisan migrate:fresh --database=sqlite
+
+# 3. 回滾測試
+php artisan migrate:rollback --database=sqlite
+```
+
+### 常見錯誤檢查清單
+
+在提交 Migration 之前，請確認：
+
+- [ ] 是否使用了 `is_mysql()` 和 `is_sqlite()` 而非 `DB::getDriverName()`？
+- [ ] 是否處理了 `COMMENT` 子句（SQLite 不支持）？
+- [ ] 是否處理了 `ENGINE` 和 `ROW_FORMAT`（SQLite 不支持）？
+- [ ] 是否處理了 `USING BTREE` 等索引提示（SQLite 不支持）？
+- [ ] 是否在測試環境（SQLite）運行過 `php artisan migrate`？
+- [ ] 是否所有測試通過（`vendor/bin/phpunit`）？
+
+### 參考資料
+
+- `database/migrations/helpers.php` - Helper functions 詳細文檔和使用示例
+- `database/migrations/2025_01_01_000000_import_cbdb_schema.php` - 複雜兼容性處理的實際範例
+- `database/migrations/2025_11_13_000000_create_internal_name_search_tables.php` - VARBINARY 處理範例
 
 ## 創建新 Migration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 本文件彙整 AI 代理在此專案工作時必備的背景知識、流程與測試指引，請在開始作業前閱讀並依循。
 
 ## 專案速覽
-- **技術棧**：Laravel 10.0（PHP 8.2+，建議 8.4）、MariaDB 10.3.39、Blade、Vue 3。前端已完成 **AdminLTE 3** (Bootstrap 4) 升級，使用 **Vite** 構建系統。所有頁面均透過 `layouts/dashboard-v3.blade.php` 佈局，使用 Vite 載入前端資源（`resources/js/jquery-global.js` 將 jQuery 暴露到全局，Bootstrap 4、AdminLTE 3、Select2 等在 `app.js` 中實現）。
+- **技術棧**：Laravel 12.0（PHP 8.2+，建議 8.4）、MariaDB 10.3.39、Blade、Vue 3。前端已完成 **AdminLTE 3** (Bootstrap 4) 升級，使用 **Vite** 構建系統。所有頁面均透過 `layouts/dashboard-v3.blade.php` 佈局，使用 Vite 載入前端資源（`resources/js/jquery-global.js` 將 jQuery 暴露到全局，Bootstrap 4、AdminLTE 3、Select2 等在 `app.js` 中實現）。
 - **數據庫環境**：
   - **生產環境**：MariaDB 10.3.39 (Debian)
   - **測試環境**：SQLite（PHPUnit 測試、CI/CD）
@@ -235,7 +235,7 @@
      - ✅ 使用 `is_mysql()` 和 `is_sqlite()` 而非 `DB::getDriverName()`
      - ✅ 優先使用 Laravel Schema Builder（自動兼容）
      - ✅ 需要原始 SQL 時，使用 `is_sqlite()` 移除不支持的語法（COMMENT、ENGINE、USING BTREE 等）
-     - ✅ 執行 `php artisan migrate:fresh` 測試（確保 SQLite 兼容）
+     - ✅ 使用 SQLite 連線執行 Migration 測試：`php artisan migrate:fresh --database=sqlite`（或先在 `.env` 設定 `DB_CONNECTION=sqlite` 後再執行 `php artisan migrate:fresh`），確保 SQLite 兼容
      - ✅ 參考 `.claude/skills/migration-guide.md` 的兼容性章節
 5. **文檔更新建議**：
    - 有任何 UI／流程重大調整時，請同步更新 `README.md` 與 `CHANGELOG.md`。
@@ -249,7 +249,7 @@
 - Vue/JS 變更未重新編譯會導致前端顯示舊版本，部署前請確認產物最新。
 - dashboard-v3 佈局改用 Vite 打包（`@vite` 載入），共用 `resources/js/jquery-global.js` 並內建 Bootstrap 4 bundle；不要再引用外部 CDN 的 jQuery/Bootstrap/Datatables 以免載入順序衝突。modal 關閉的焦點修復也在 Vite 入口內，全站共用。
 - **測試數據庫依賴陷阱**：避免依賴完整 MySQL schema 或複雜遷移文件，這會導致 CI 失敗和測試不穩定。
-- **PHPUnit 版本兼容性**：專案使用 PHPUnit 10.1，注意使用相容的斷言方法（如 `assertStringContainsString` 替代舊版 `assertContains`）。
+- **PHPUnit 版本兼容性**：本專案依 `composer.lock` 使用 PHPUnit 11.x，撰寫測試時請依 11.x 的 API 與配置撰寫，並使用相容的斷言方法（如以 `assertStringContainsString` 取代舊版以字串為目標的 `assertContains`）。
 - **用戶模型測試**：記得為 `users` 表的 `confirmation_token` 字段提供值，避免 NOT NULL 約束錯誤。
 - **Migration 數據庫兼容性陷阱**：
   - ❌ 錯誤：使用 `DB::getDriverName() === 'sqlite'` 判斷數據庫類型

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,16 @@
 - **技術棧**：Laravel 10.0（PHP 8.2+，建議 8.4）、MariaDB 10.3.39、Blade、Vue 3。前端已完成 **AdminLTE 3** (Bootstrap 4) 升級，使用 **Vite** 構建系統。所有頁面均透過 `layouts/dashboard-v3.blade.php` 佈局，使用 Vite 載入前端資源（`resources/js/jquery-global.js` 將 jQuery 暴露到全局，Bootstrap 4、AdminLTE 3、Select2 等在 `app.js` 中實現）。
 - **數據庫環境**：
   - **生產環境**：MariaDB 10.3.39 (Debian)
+  - **測試環境**：SQLite（PHPUnit 測試、CI/CD）
+  - **⭐ Migration 兼容性要求（核心規範）**：
+    - **所有 Migration 必須同時兼容 MySQL/MariaDB 和 SQLite**
+    - **使用 `is_mysql()` 和 `is_sqlite()` helper functions**（位於 `database/migrations/helpers.php`）
+    - **禁止直接使用 `DB::getDriverName()` 判斷數據庫類型**
+    - 優先使用 Laravel Schema Builder（自動兼容）
+    - 需要原始 SQL 時，使用 `is_sqlite()` 移除不支持的語法（COMMENT、ENGINE、USING BTREE 等）
+    - 詳細指南：`.claude/skills/migration-guide.md` 的「MySQL 與 SQLite 兼容性處理」章節
   - **重要原則**：避免使用特定數據庫專屬功能（如 MySQL 的 ngram parser、MariaDB 專屬插件），以保持未來遷移至其他數據庫實現的可能性
-  - **兼容性目標**：代碼應能在標準 SQL 和通用的 MySQL/MariaDB/PostgreSQL 功能上運行
+  - **兼容性目標**：代碼應能在標準 SQL 和通用的 MySQL/MariaDB/SQLite 功能上運行
 - **內部輔助表**（`CBDB__` 前綴表示內部使用，不直接對終端用戶曝光）：
   - `CBDB__NAME_FTS`：姓名搜尋倒排索引，支援高效能後綴匹配查詢
   - `CBDB__TRAD_SIMP_MAP`：繁簡字符映射及異體字標準化，基於 OpenCC 標準，使用 VARBINARY(4) 支援非BMP字符
@@ -222,7 +230,13 @@
    - 嚴禁在未授權情況下直接修改資料庫結構或大量資料。
    - 避免在 Controller 中直接寫 SQL；如需操作資料庫，優先利用 Repository。對於**單一主鍵**的表可以使用 Eloquent 模型，但對於**複合主鍵**的表（如 `ALTNAME_DATA`、`POSTED_TO_ADDR_DATA` 等）必須使用 Query Builder（`DB::table()`）而非 Eloquent 模型。
    - 所有新路由需通過授權檢查，避免只靠前端限制。
-  - 全站已完成 AdminLTE 3 升級，所有頁面使用 `layouts/dashboard-v3.blade.php` 佈局，透過 Vite 載入前端資源（入口位於 `resources/js/`）。請勿引入外部 CDN 的 jQuery/Bootstrap，以免與 Vite bundle 產生版本衝突。Laravel Mix 時期的 `resources/assets/` 目錄及相關檔案已完全移除。
+   - 全站已完成 AdminLTE 3 升級，所有頁面使用 `layouts/dashboard-v3.blade.php` 佈局，透過 Vite 載入前端資源（入口位於 `resources/js/`）。請勿引入外部 CDN 的 jQuery/Bootstrap，以免與 Vite bundle 產生版本衝突。Laravel Mix 時期的 `resources/assets/` 目錄及相關檔案已完全移除。
+   - **編寫 Migration 時的必要檢查**：
+     - ✅ 使用 `is_mysql()` 和 `is_sqlite()` 而非 `DB::getDriverName()`
+     - ✅ 優先使用 Laravel Schema Builder（自動兼容）
+     - ✅ 需要原始 SQL 時，使用 `is_sqlite()` 移除不支持的語法（COMMENT、ENGINE、USING BTREE 等）
+     - ✅ 執行 `php artisan migrate:fresh` 測試（確保 SQLite 兼容）
+     - ✅ 參考 `.claude/skills/migration-guide.md` 的兼容性章節
 5. **文檔更新建議**：
    - 有任何 UI／流程重大調整時，請同步更新 `README.md` 與 `CHANGELOG.md`。
    - 若整理出新的知識或踩坑，務必補充至 `AGENTS.md`，讓後續代理能快速掌握背景。
@@ -237,6 +251,12 @@
 - **測試數據庫依賴陷阱**：避免依賴完整 MySQL schema 或複雜遷移文件，這會導致 CI 失敗和測試不穩定。
 - **PHPUnit 版本兼容性**：專案使用 PHPUnit 10.1，注意使用相容的斷言方法（如 `assertStringContainsString` 替代舊版 `assertContains`）。
 - **用戶模型測試**：記得為 `users` 表的 `confirmation_token` 字段提供值，避免 NOT NULL 約束錯誤。
+- **Migration 數據庫兼容性陷阱**：
+  - ❌ 錯誤：使用 `DB::getDriverName() === 'sqlite'` 判斷數據庫類型
+  - ✅ 正確：使用 `is_sqlite()` 和 `is_mysql()` helper functions
+  - ❌ 錯誤：在原始 SQL 中直接使用 COMMENT、ENGINE、USING BTREE 等 MySQL 專屬語法
+  - ✅ 正確：使用 `is_sqlite()` 條件移除不支持的語法，或使用 Schema Builder
+  - 詳細說明：`database/migrations/helpers.php` 和 `.claude/skills/migration-guide.md`
 - **Eloquent 與複合主鍵的限制**：Laravel Eloquent ORM **官方不支持**複合主鍵（composite primary key）。雖然社群有第三方套件（如 `laravel-composite-primary-keys`）提供支援，但引入第三方包會增加維護上的不確定性（套件的長期維護狀態難以保證）。因此，本專案決定對於擁有複合主鍵的表（如 `ALTNAME_DATA` 使用 `c_personid + c_sequence + c_alt_name_chn + c_alt_name_type_code`），直接使用 Query Builder（`DB::table()`）而非建立 Eloquent 模型。若需要類似 Observer 的副作用（如自動索引），應在 Repository 或 Service 層手動調用對應服務（如 `NameSearchIndexService`）。
 
   使用 Query Builder 的優勢：

--- a/database/migrations/2025_11_13_000000_create_internal_name_search_tables.php
+++ b/database/migrations/2025_11_13_000000_create_internal_name_search_tables.php
@@ -43,7 +43,7 @@ class CreateInternalNameSearchTables extends Migration {
             ) ENGINE=InnoDB
         ";
 
-        if (DB::getDriverName() === 'sqlite') {
+        if (is_sqlite()) {
             // Remove COMMENT clauses
             $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
             // Remove ENGINE clause

--- a/database/migrations/2025_11_18_034300_convert_indexyear_type_codes_to_innodb.php
+++ b/database/migrations/2025_11_18_034300_convert_indexyear_type_codes_to_innodb.php
@@ -17,7 +17,7 @@ class ConvertIndexyearTypeCodesToInnodb extends Migration {
      */
     public function up() {
         // 將 INDEXYEAR_TYPE_CODES 表轉換為 InnoDB 引擎
-        if (DB::getDriverName() === 'mysql') {
+        if (is_mysql()) {
             DB::statement('ALTER TABLE INDEXYEAR_TYPE_CODES ENGINE=InnoDB');
         }
     }
@@ -29,7 +29,7 @@ class ConvertIndexyearTypeCodesToInnodb extends Migration {
      */
     public function down() {
         // 還原為 MyISAM 引擎
-        if (DB::getDriverName() === 'mysql') {
+        if (is_mysql()) {
             DB::statement('ALTER TABLE INDEXYEAR_TYPE_CODES ENGINE=MyISAM');
         }
     }

--- a/database/migrations/2025_11_20_094916_add_admin_cat_code_to_addr_codes_table.php
+++ b/database/migrations/2025_11_20_094916_add_admin_cat_code_to_addr_codes_table.php
@@ -43,7 +43,7 @@ class AddAdminCatCodeToAddrCodesTable extends Migration {
     public function down() {
         if ($this->foreignKeyExists('ADDR_CODES', 'fk_addr_codes_admin_cat_code')) {
             Schema::table('ADDR_CODES', function (Blueprint $table) {
-                if (DB::getDriverName() !== 'sqlite') {
+                if (!is_sqlite()) {
                     $table->dropForeign('fk_addr_codes_admin_cat_code');
                 }
             });
@@ -60,7 +60,7 @@ class AddAdminCatCodeToAddrCodesTable extends Migration {
      * Determine if a foreign key already exists on the table.
      */
     protected function foreignKeyExists(string $table, string $keyName): bool {
-        if (DB::getDriverName() === 'sqlite') {
+        if (is_sqlite()) {
             // SQLite doesn't store named constraints in a systemic table like information_schema.
             // We check for the existence of a foreign key targeting the specific table and column.
             $foreignKeys = DB::select("PRAGMA foreign_key_list(`{$table}`)");

--- a/database/migrations/2025_11_20_100000_alter_admin_cat_tables_collation.php
+++ b/database/migrations/2025_11_20_100000_alter_admin_cat_tables_collation.php
@@ -12,7 +12,7 @@ class AlterAdminCatTablesCollation extends Migration {
      * @return void
      */
     public function up() {
-        if (DB::getDriverName() === 'sqlite') {
+        if (is_sqlite()) {
             return;
         }
 

--- a/database/migrations/2025_12_09_000000_add_timestamp_temporary_columns.php
+++ b/database/migrations/2025_12_09_000000_add_timestamp_temporary_columns.php
@@ -108,7 +108,7 @@ class AddTimestampTemporaryColumns extends Migration {
      * @return void
      */
     protected function convertDates(string $table): void {
-        $isSqlite = DB::getDriverName() === 'sqlite';
+        $isSqlite = is_sqlite();
 
         // Update c_created_date_timestamp_temporary
         if (Schema::hasColumn($table, 'c_created_date')) {

--- a/database/migrations/helpers.php
+++ b/database/migrations/helpers.php
@@ -3,7 +3,124 @@
 /**
  * 数据库兼容性辅助函数
  *
- * 这些函数用于编写兼容 MySQL 和 SQLite 的迁移文件
+ * 本文件提供了一组辅助函数，用于编写同时兼容 MySQL/MariaDB 和 SQLite 的 Migration 文件。
+ * 这是项目的核心规范，所有 Migration 必须遵循。
+ *
+ * ## 为什么需要兼容性处理？
+ *
+ * - **生产环境**：使用 MySQL/MariaDB
+ * - **测试环境**：使用 SQLite（速度快、无需额外服务）
+ * - **CI/CD**：使用 SQLite in-memory 数据库
+ *
+ * ## 核心原则
+ *
+ * 1. ✅ **优先使用 Laravel Schema Builder**：大多数情况下自动兼容
+ * 2. ✅ **需要原始 SQL 时使用本文件提供的 helper functions**
+ * 3. ✅ **使用 `is_mysql()` 和 `is_sqlite()` 进行条件判断**
+ * 4. ❌ **避免直接使用 `DB::getDriverName()`**：使用 helper 保持一致性
+ *
+ * ## 快速示例
+ *
+ * ```php
+ * // ✅ 正确：使用 helper functions
+ * public function up(): void {
+ *     if (is_mysql()) {
+ *         DB::statement("ALTER TABLE users ENGINE=InnoDB");
+ *     }
+ *     // SQLite 不支持 ENGINE，跳过
+ * }
+ *
+ * // ✅ 正确：移除 SQLite 不支持的语法
+ * public function up(): void {
+ *     $sql = "CREATE TABLE users (id INT COMMENT 'User ID')";
+ *
+ *     if (is_sqlite()) {
+ *         // SQLite 不支持 COMMENT
+ *         $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+ *     }
+ *
+ *     DB::statement($sql);
+ * }
+ *
+ * // ✅ 正确：处理外键约束检查
+ * public function up(): void {
+ *     disable_foreign_keys();
+ *
+ *     try {
+ *         // ... 你的 schema 修改
+ *     } finally {
+ *         enable_foreign_keys();
+ *     }
+ * }
+ *
+ * // ❌ 错误：直接使用 DB::getDriverName()
+ * if (DB::getDriverName() === 'sqlite') { // 不要这样做！
+ *     // ...
+ * }
+ * ```
+ *
+ * ## 常见兼容性问题
+ *
+ * | MySQL 特性 | SQLite 行为 | 解决方案 |
+ * |-----------|------------|---------|
+ * | `COMMENT 'text'` | 不支持 | 使用 preg_replace 移除 |
+ * | `ENGINE=InnoDB` | 不支持 | 使用 `if (is_mysql())` 条件执行 |
+ * | `USING BTREE` | 不支持 | 使用 preg_replace 移除 |
+ * | `AUTO_INCREMENT` | 使用 `AUTOINCREMENT` | Laravel Schema Builder 自动处理 |
+ * | `UNSIGNED` | 不支持 | Laravel Schema Builder 自动处理 |
+ * | 外键约束检查 | `PRAGMA foreign_keys` | 使用 `disable/enable_foreign_keys()` |
+ *
+ * ## 完整的 Migration 示例
+ *
+ * ```php
+ * <?php
+ *
+ * use Illuminate\Database\Migrations\Migration;
+ * use Illuminate\Database\Schema\Blueprint;
+ * use Illuminate\Support\Facades\Schema;
+ * use Illuminate\Support\Facades\DB;
+ *
+ * return new class extends Migration {
+ *     public function up(): void {
+ *         // 方式 1：使用 Schema Builder（推荐，自动兼容）
+ *         Schema::create('users', function (Blueprint $table) {
+ *             $table->id();
+ *             $table->string('name');
+ *             $table->timestamps();
+ *         });
+ *
+ *         // 方式 2：需要原始 SQL 时的兼容性处理
+ *         $sql = "
+ *             CREATE TABLE logs (
+ *                 id INT AUTO_INCREMENT PRIMARY KEY COMMENT '日志ID',
+ *                 message TEXT
+ *             ) ENGINE=InnoDB
+ *         ";
+ *
+ *         if (is_sqlite()) {
+ *             // 移除 SQLite 不支持的语法
+ *             $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+ *             $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+ *         }
+ *
+ *         DB::statement($sql);
+ *
+ *         // 方式 3：数据库特定的优化（可选）
+ *         if (is_mysql()) {
+ *             // 仅在 MySQL 执行的优化
+ *             DB::statement("ALTER TABLE users ROW_FORMAT=DYNAMIC");
+ *         }
+ *     }
+ *
+ *     public function down(): void {
+ *         Schema::dropIfExists('logs');
+ *         Schema::dropIfExists('users');
+ *     }
+ * };
+ * ```
+ *
+ * @see .claude/skills/migration-guide.md 完整的 Migration 编写指南
+ * @see AGENTS.md 项目开发规范
  */
 
 use Illuminate\Support\Facades\DB;
@@ -11,6 +128,30 @@ use Illuminate\Support\Facades\DB;
 if (!function_exists('disable_foreign_keys')) {
     /**
      * 禁用外键约束检查（兼容 MySQL 和 SQLite）
+     *
+     * 在需要修改有外键约束的表时使用。务必在操作完成后调用 enable_foreign_keys()。
+     *
+     * 使用场景：
+     * - 修改外键引用的列
+     * - 导入大量数据时提升性能
+     * - 临时删除或截断有外键约束的表
+     *
+     * @example
+     * ```php
+     * public function up(): void {
+     *     disable_foreign_keys();
+     *
+     *     try {
+     *         // 修改有外键约束的表
+     *         Schema::table('posts', function (Blueprint $table) {
+     *             $table->unsignedBigInteger('user_id')->change();
+     *         });
+     *     } finally {
+     *         // 确保即使出错也能重新启用
+     *         enable_foreign_keys();
+     *     }
+     * }
+     * ```
      *
      * @return void
      */
@@ -29,7 +170,20 @@ if (!function_exists('enable_foreign_keys')) {
     /**
      * 启用外键约束检查（兼容 MySQL 和 SQLite）
      *
+     * 必须与 disable_foreign_keys() 配对使用。建议使用 try-finally 确保执行。
+     *
+     * @example
+     * ```php
+     * disable_foreign_keys();
+     * try {
+     *     // 你的操作
+     * } finally {
+     *     enable_foreign_keys();
+     * }
+     * ```
+     *
      * @return void
+     * @see disable_foreign_keys()
      */
     function enable_foreign_keys() {
         $driver = DB::getDriverName();
@@ -46,7 +200,26 @@ if (!function_exists('get_current_timestamp_sql')) {
     /**
      * 获取当前时间戳的 SQL 表达式（兼容 MySQL 和 SQLite）
      *
-     * @return string
+     * 用于需要在原始 SQL 中插入当前时间戳时。
+     * 注意：大多数情况下应使用 Laravel 的 now() 或 Carbon。
+     *
+     * @example
+     * ```php
+     * // 在原始 SQL 中使用
+     * $timestamp = get_current_timestamp_sql();
+     * DB::statement("
+     *     UPDATE users
+     *     SET last_login = $timestamp
+     *     WHERE id = ?
+     * ", [$userId]);
+     *
+     * // 建议：优先使用 Laravel 的方式
+     * DB::table('users')
+     *     ->where('id', $userId)
+     *     ->update(['last_login' => now()]);
+     * ```
+     *
+     * @return string SQL 时间戳函数名称
      */
     function get_current_timestamp_sql() {
         $driver = DB::getDriverName();
@@ -63,9 +236,45 @@ if (!function_exists('get_current_timestamp_sql')) {
 
 if (!function_exists('is_mysql')) {
     /**
-     * 检查当前数据库是否为 MySQL
+     * 检查当前数据库是否为 MySQL/MariaDB
      *
-     * @return bool
+     * 用于执行 MySQL 特定的优化或语法。
+     * 注意：Laravel 的 'mysql' driver 同时支持 MySQL 和 MariaDB。
+     *
+     * 使用场景：
+     * - MySQL 特定的表引擎设置（ENGINE=InnoDB）
+     * - MySQL 特定的索引类型（USING BTREE）
+     * - MySQL 特定的优化（ROW_FORMAT=DYNAMIC）
+     *
+     * @example
+     * ```php
+     * public function up(): void {
+     *     Schema::create('users', function (Blueprint $table) {
+     *         $table->id();
+     *         $table->string('name');
+     *     });
+     *
+     *     // MySQL 特定的表优化
+     *     if (is_mysql()) {
+     *         DB::statement("ALTER TABLE users ENGINE=InnoDB ROW_FORMAT=DYNAMIC");
+     *     }
+     * }
+     *
+     * // 处理 MySQL 特定的 SQL 语法
+     * public function up(): void {
+     *     $sql = "CREATE TABLE logs (id INT COMMENT 'Log ID') ENGINE=InnoDB";
+     *
+     *     if (!is_mysql()) {
+     *         // 非 MySQL 数据库：移除专属语法
+     *         $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+     *         $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+     *     }
+     *
+     *     DB::statement($sql);
+     * }
+     * ```
+     *
+     * @return bool 当前数据库是否为 MySQL/MariaDB
      */
     function is_mysql() {
         return DB::getDriverName() === 'mysql';
@@ -76,7 +285,64 @@ if (!function_exists('is_sqlite')) {
     /**
      * 检查当前数据库是否为 SQLite
      *
-     * @return bool
+     * 用于移除 SQLite 不支持的 MySQL 语法，确保测试环境正常运行。
+     *
+     * 使用场景：
+     * - 移除 COMMENT 注释（SQLite 不支持）
+     * - 移除 ENGINE 设置（SQLite 不支持）
+     * - 移除 USING BTREE 等索引提示
+     * - 处理 SQLite 特定的数据类型或约束
+     *
+     * @example
+     * ```php
+     * // 示例 1：移除 SQLite 不支持的语法
+     * public function up(): void {
+     *     $sql = "
+     *         CREATE TABLE users (
+     *             id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'User ID',
+     *             name VARCHAR(255)
+     *         ) ENGINE=InnoDB
+     *     ";
+     *
+     *     if (is_sqlite()) {
+     *         // 移除 COMMENT 和 ENGINE
+     *         $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+     *         $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+     *     }
+     *
+     *     DB::statement($sql);
+     * }
+     *
+     * // 示例 2：条件性跳过 MySQL 特定操作
+     * public function up(): void {
+     *     Schema::create('users', function (Blueprint $table) {
+     *         $table->id();
+     *         $table->string('name');
+     *     });
+     *
+     *     // 仅在 MySQL 执行的优化
+     *     if (!is_sqlite()) {
+     *         DB::statement("ALTER TABLE users ENGINE=InnoDB");
+     *     }
+     * }
+     *
+     * // 示例 3：处理复杂的原始 SQL
+     * public function up(): void {
+     *     $sql = file_get_contents(__DIR__ . '/schema.sql');
+     *
+     *     if (is_sqlite()) {
+     *         // 批量移除 SQLite 不支持的语法
+     *         $sql = preg_replace('/COMMENT\s+\'[^\']*\'/i', '', $sql);
+     *         $sql = preg_replace('/ENGINE\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+     *         $sql = preg_replace('/USING\s+BTREE/i', '', $sql);
+     *         $sql = preg_replace('/ROW_FORMAT\s*=\s*[a-zA-Z0-9_]+/i', '', $sql);
+     *     }
+     *
+     *     DB::statement($sql);
+     * }
+     * ```
+     *
+     * @return bool 当前数据库是否为 SQLite
      */
     function is_sqlite() {
         return DB::getDriverName() === 'sqlite';


### PR DESCRIPTION
## 主要改進

### 1. 增強 helpers.php 文檔
- 添加詳細的文件級文檔說明，包含核心原則和快速示例
- 為每個 helper function 添加完整的使用場景和代碼示例
- 新增常見兼容性問題對照表
- 提供完整的 Migration 示例代碼

### 2. 擴展 migration-guide.md
- 新增「MySQL 與 SQLite 兼容性處理」專門章節
- 詳細說明為什麼需要兼容性處理
- 提供 5 個常見兼容性問題的解決方案：
  * COMMENT 注釋處理
  * ENGINE 和 ROW_FORMAT 處理
  * 索引類型提示（USING BTREE）
  * 外鍵約束檢查
  * VARBINARY 與 4 字節 UTF-8 字符處理
- 新增完整的兼容性 Migration 模板
- 添加兼容性檢查清單

### 3. 更新 AGENTS.md 核心規範
- 在「數據庫環境」部分突出標註 Migration 兼容性要求
- 在「開發注意事項」中添加 Migration 必要檢查清單
- 在「常見坑位」中新增數據庫兼容性陷阱說明
- 明確禁止直接使用 DB::getDriverName()

### 4. 統一現有代碼
將所有 migration 文件中的 DB::getDriverName() 替換為 helper functions：
- 2025_11_13_000000_create_internal_name_search_tables.php
- 2025_11_18_034300_convert_indexyear_type_codes_to_innodb.php
- 2025_11_20_094916_add_admin_cat_code_to_addr_codes_table.php
- 2025_11_20_100000_alter_admin_cat_tables_collation.php
- 2025_12_09_000000_add_timestamp_temporary_columns.php

## 影響

- AI Agent 現在可以通過多層次文檔（AGENTS.md → migration-guide.md → helpers.php） 快速了解 Migration 兼容性要求
- 所有 migration 文件使用統一的 helper functions，提高代碼一致性
- 新的 migration 可以直接參考 helpers.php 和 migration-guide.md 中的詳細示例
- 減少 AI Agent 在生成 migration 時的返工次數

## 測試

- ✅ 運行 PHPUnit 測試套件（無新增失敗）
- ✅ 代碼格式化檢查通過
- ✅ 功能等價性驗證（helper functions 與 DB::getDriverName() 等價）