### PR TITLE
移除已廢棄的 officeaddr API，統一使用 addr API

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -111,13 +111,6 @@ class ApiController extends Controller {
         return $data;
     }
 
-    public function searchOfficeAddr(Request $request) {
-        $addrcodeRepository = new AddrCodeRepository();
-        $data = $addrcodeRepository->searchOfficeAddr($request);
-
-        return $data;
-    }
-
     public function range() {
         $yearrangeRepository = new YearRangeRepository();
 

--- a/app/Repositories/AddrCodeRepository.php
+++ b/app/Repositories/AddrCodeRepository.php
@@ -122,16 +122,4 @@ class AddrCodeRepository {
 
         return $data;
     }
-
-    public function searchOfficeAddr(Request $request) {
-        $data = AddressCode::where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_addr_id', $request->q)->paginate(20);
-        $data->appends(['q' => $request->q])->links();
-        foreach ($data as $item) {
-            $item['id'] = $item->c_addr_id == 0 ? -999 : $item->c_addr_id;
-            $belongs = $item->belongs1_ID." ".$item->belongs1_Name." ".$item->belongs2_ID." ".$item->belongs2_Name." ".$item->belongs3_ID." ".$item->belongs3_Name." ".$item->belongs4_ID." ".$item->belongs4_Name." ".$item->belongs5_ID." ".$item->belongs5_Name;
-            $item['text'] = $item->c_addr_id." ".$item->c_name." ".$item->c_name_chn." ".trim($belongs);
-        }
-
-        return $data;
-    }
 }

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -144,7 +144,7 @@
 
         // 使用统一的 AJAX Select2 初始化助手函数
         window.initAjaxSelect($(".c_source"), 'text');
-        window.initAjaxSelect($(".c_addr_id"), 'officeaddr');
+        window.initAjaxSelect($(".c_addr_id"), 'addr');
 
         function textperson_pair_first_load(){
             let person_id = $('.person_id').val();

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,7 +47,6 @@ Route::group([
 
     // Search endpoints
     Route::get('search/addr', 'ApiController@searchAddr');
-    Route::get('search/officeaddr', 'ApiController@searchOfficeAddr');
     Route::get('search/text', 'ApiController@searchText');
     Route::get('search/textperson', 'ApiController@searchTextPerson');
     Route::get('search/textauthor', 'ApiController@searchTextAuthor');


### PR DESCRIPTION
## Summary
- 將 possession/_form.blade.php 中的地址搜索從 `officeaddr` 改為使用 `addr` API
- 刪除 `ApiController::searchOfficeAddr` 方法
- 刪除 `AddrCodeRepository::searchOfficeAddr` 方法
- 刪除 `routes/api.php` 中的 `search/officeaddr` 路由

## Background
`officeaddr` API 在 2025年10月17日 `AddressCode` 模型改為指向 `ADDR_CODES` 表後已損壞，因為它引用的 `belongs*` 層級字段在 `ADDR_CODES` 表中不存在（這些字段只存在於舊的 `ADDRESSES` 表）。

`addr` API 通過 `ADDR_BELONGS_DATA` 表查詢上層行政單位，提供相同的功能。

## Test plan
- [x] PHPUnit 測試全部通過（431 個測試）
- [x] 手動測試財產表單的地址選擇功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)