### PR TITLE
移除 CBDB API 對 ADDRESSES 派生表的依賴

### DIFF
--- a/CBDB_PUBLIC_API_V1.md
+++ b/CBDB_PUBLIC_API_V1.md
@@ -65,7 +65,17 @@ GET /cbdbapi/person.php?id=1488                 # HTML 模式（無 o 參數）
 
 ### 別名與地址
 - `PersonAliases.Alias`：別名列表，每筆含 `AliasType`、`AliasTypeId`、`AliasName`。
-- `PersonAddresses.Address`：地址資訊，欄位含 `AddrTypeId`、`AddrType`、`AddrId`、`AddrName`、`belongs1_name`/`belongs1_id` 等。
+- `PersonAddresses.Address`：地址資訊（來源：BIOG_ADDR_DATA + ADDR_CODES 表），欄位含：
+  - `AddrTypeId`：地址類型代碼
+  - `AddrType`：地址類型名稱（中文）
+  - `AddrId`：地址 ID
+  - `AddrName`：地址名稱（中文，來源：ADDR_CODES 表）
+  - `MoveCount`：遷移順序
+  - `FirstYear`：起始年份
+  - `LastYear`：終止年份
+  - `Source`：來源文獻標題
+  - `Pages`：頁碼
+  - `Notes`：註記
 
 ### 科舉與任官
 - `PersonEntryInfo.Entry`：科舉資訊。若無資料為空字串。
@@ -132,6 +142,13 @@ GET /cbdbapi/person.php?id=1488                 # HTML 模式（無 o 參數）
 - `name` 查詢會優先以 BIOG_MAIN 的中文、英文與拼音欄位做全字比對，再依序比對 ALTNAME，若仍找不到才改用模糊查詢；命中後回傳第一筆結果。
 
 ## 版本更新記錄
+
+### 2026-01-28：地址欄位簡化
+- **移除地址層級欄位**：`PersonAddresses.Address` 不再包含 `belongs1_name`/`belongs1_id` 至 `belongs5_name`/`belongs5_id` 等層級欄位
+- **資料來源變更**：地址名稱（`AddrName`）現從 `ADDR_CODES` 表獲取，不再使用 `ADDRESSES` 派生表
+- **效能優化**：移除複雜的時間範圍匹配邏輯，大幅降低系統資源消耗
+- **HTML 界面改進**：地址 ID 現為可點擊鏈接，跳轉至 `/codes/ADDR_CODES?search={id}` 查看詳細資訊
+- **向後兼容說明**：若有依賴 `belongs*` 欄位的外部應用，需改為透過 `AddrId` 查詢 `ADDR_BELONGS_DATA` 表獲取層級關係
 
 ### 2025-11-08：Wikidata 格式支持
 - **ID 格式擴展**：支持 1-7 位數字，包含前置 0（如 `0001367`）

--- a/app/Http/Controllers/CbdbApiController.php
+++ b/app/Http/Controllers/CbdbApiController.php
@@ -554,16 +554,6 @@ SELECT BIOG_ADDR_DATA.c_addr_type AS AddrTypeId,
        (SELECT c_addr_desc_chn FROM BIOG_ADDR_CODES WHERE c_addr_type = BIOG_ADDR_DATA.c_addr_type) AS AddrType,
        BIOG_ADDR_DATA.c_addr_id AS AddrId,
        (SELECT c_name_chn FROM ADDR_CODES WHERE c_addr_id = BIOG_ADDR_DATA.c_addr_id) AS AddrName,
-       ADDR.belongs1_Name AS belongs1_name,
-       ADDR.belongs1_Id AS belongs1_id,
-       ADDR.belongs2_Name AS belongs2_name,
-       ADDR.belongs2_Id AS belongs2_id,
-       ADDR.belongs3_Name AS belongs3_name,
-       ADDR.belongs3_Id AS belongs3_id,
-       ADDR.belongs4_Name AS belongs4_name,
-       ADDR.belongs4_Id AS belongs4_id,
-       ADDR.belongs5_Name AS belongs5_name,
-       ADDR.belongs5_Id AS belongs5_id,
        BIOG_ADDR_DATA.c_sequence AS MoveCount,
        BIOG_ADDR_DATA.c_firstyear AS FirstYear,
        BIOG_ADDR_DATA.c_lastyear AS LastYear,
@@ -571,36 +561,6 @@ SELECT BIOG_ADDR_DATA.c_addr_type AS AddrTypeId,
        BIOG_ADDR_DATA.c_pages AS Pages,
        BIOG_ADDR_DATA.c_notes AS Notes
 FROM BIOG_ADDR_DATA
-LEFT JOIN ADDRESSES AS ADDR
-     ON ADDR.c_addr_id = BIOG_ADDR_DATA.c_addr_id
-     AND (
-         BIOG_ADDR_DATA.c_firstyear IS NULL
-         OR ADDR.c_lastyear IS NULL
-         OR BIOG_ADDR_DATA.c_firstyear <= ADDR.c_lastyear
-     )
-     AND (
-         BIOG_ADDR_DATA.c_lastyear IS NULL
-         OR ADDR.c_firstyear IS NULL
-         OR BIOG_ADDR_DATA.c_lastyear >= ADDR.c_firstyear
-     )
-     AND NOT EXISTS (
-         SELECT 1 FROM ADDRESSES ADDR2
-         WHERE ADDR2.c_addr_id = ADDR.c_addr_id
-         AND (
-             BIOG_ADDR_DATA.c_firstyear IS NULL
-             OR ADDR2.c_lastyear IS NULL
-             OR BIOG_ADDR_DATA.c_firstyear <= ADDR2.c_lastyear
-         )
-         AND (
-             BIOG_ADDR_DATA.c_lastyear IS NULL
-             OR ADDR2.c_firstyear IS NULL
-             OR BIOG_ADDR_DATA.c_lastyear >= ADDR2.c_firstyear
-         )
-         AND (
-             ADDR2.c_firstyear < ADDR.c_firstyear
-             OR (ADDR2.c_firstyear = ADDR.c_firstyear AND ADDR2.c_lastyear < ADDR.c_lastyear)
-         )
-     )
 WHERE BIOG_ADDR_DATA.c_personid = ?
 SQL;
     }
@@ -635,7 +595,7 @@ SELECT POSTED_TO_OFFICE_DATA.c_office_id AS OfficeId,
               AND c_personid = POSTED_TO_OFFICE_DATA.c_personid
               AND c_office_id = POSTED_TO_OFFICE_DATA.c_office_id
             LIMIT 1) AS AddrId,
-       (SELECT c_name_chn FROM ADDRESSES
+       (SELECT c_name_chn FROM ADDR_CODES
             WHERE c_addr_id = (SELECT c_addr_id FROM POSTED_TO_ADDR_DATA
                                 WHERE c_posting_id = POSTED_TO_OFFICE_DATA.c_posting_id
                                   AND c_personid = POSTED_TO_OFFICE_DATA.c_personid

--- a/resources/views/cbdbapi/person.blade.php
+++ b/resources/views/cbdbapi/person.blade.php
@@ -417,11 +417,15 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         var names = escapeHtml(info.ChName || '') + ' / ' + escapeHtml(info.EngName || '');
         html += line('中文名 / 英文名', names);
         html += line('指數年', isValidValue(info.IndexYear) ? escapeHtml(info.IndexYear) : '未詳');
-        var indexAddrParts = [];
+        var indexAddrHtml = '';
         if (info.IndexAddr) {
-            indexAddrParts.push(formatIdLabel(info.IndexAddr, info.IndexAddrId));
+            indexAddrHtml = escapeHtml(info.IndexAddr);
         }
-        html += line('指數地址', indexAddrParts.join(' '));
+        if (info.IndexAddrId) {
+            indexAddrHtml += ' <a href="/codes/ADDR_CODES?search=' + encodeURIComponent(info.IndexAddrId) + '" target="_blank" rel="noopener noreferrer">';
+            indexAddrHtml += '<span class="badge">ID: ' + escapeHtml(info.IndexAddrId) + '</span></a>';
+        }
+        html += line('指數地址', indexAddrHtml.trim() || '<span class="empty">（空）</span>');
 
         var birthParts = [];
         birthParts.push(formatIdLabel(info.DynastyBirth, info.DynastyBirthId));
@@ -520,32 +524,19 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
     }
 
     function buildAddressPath(item) {
-        var path = [];
-        // 先添加具体地点
+        if (!item.AddrName && !item.AddrId) {
+            return '';
+        }
+        var addr = '';
         if (item.AddrName) {
-            var addr = escapeHtml(item.AddrName);
-            if (item.AddrId) {
-                addr += ' <span class="badge">' + escapeHtml(item.AddrId) + '</span>';
-            }
-            path.push(addr);
+            addr = escapeHtml(item.AddrName);
         }
-        // 再添加上级地址，从 belongs1 到 belongs5（从小到大）
-        for (var i = 1; i <= 5; i++) {
-            var nameKey = 'belongs' + i + '_name';
-            var idKey = 'belongs' + i + '_id';
-            if (item[nameKey]) {
-                // 如果遇到 [未詳] 或 ID 为 0，停止渲染
-                if (item[nameKey] === '[未詳]' || item[idKey] === '0' || item[idKey] === 0) {
-                    break;
-                }
-                var label = escapeHtml(item[nameKey]);
-                if (item[idKey]) {
-                    label += ' <span class="badge">ID: ' + escapeHtml(item[idKey]) + '</span>';
-                }
-                path.push(label);
-            }
+        if (item.AddrId) {
+            var addrLink = '<a href="/codes/ADDR_CODES?search=' + encodeURIComponent(item.AddrId) + '" target="_blank" rel="noopener noreferrer">';
+            addrLink += '<span class="badge">' + escapeHtml(item.AddrId) + '</span></a>';
+            addr += ' ' + addrLink;
         }
-        return path.join(' → ');
+        return addr;
     }
 
     function renderAddresses(title, items) {
@@ -699,8 +690,13 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             details.push('終止年：' + endYearText);
 
             // 地點
-            if (item.AddrName) {
-                details.push('地點：<strong>' + escapeHtml(item.AddrName) + '</strong>');
+            if (item.AddrName || item.AddrId) {
+                var addrHtml = '地點：<strong>' + escapeHtml(item.AddrName || '') + '</strong>';
+                if (item.AddrId) {
+                    addrHtml += ' <a href="/codes/ADDR_CODES?search=' + encodeURIComponent(item.AddrId) + '" target="_blank" rel="noopener noreferrer">';
+                    addrHtml += '<span class="badge">' + escapeHtml(item.AddrId) + '</span></a>';
+                }
+                details.push(addrHtml);
             }
 
             // 出處


### PR DESCRIPTION
## Summary
- 移除 `sqlAddresses()` 中的 `LEFT JOIN ADDRESSES` 及 `belongs1-5` 層級欄位，大幅簡化查詢
- 修改 `sqlPostings()` 從 `ADDR_CODES` 表獲取地址名稱
- HTML 界面地址 ID 添加可點擊鏈接至 `/codes/ADDR_CODES?search={id}`
- 更新 `CBDB_PUBLIC_API_V1.md` 文檔反映欄位變更

## 變更原因
- `ADDRESSES` 是由 `ADDR_CODES` + `ADDR_BELONGS_DATA` 生成的派生表
- 原有的 `belongs1-5` 層級查詢在大量請求時對系統資源有巨大消耗
- 用戶如需層級信息，可透過地址 ID 鏈接或直接查詢 API

## Test plan
- [x] 運行 `phpunit --filter CbdbApi` 測試通過（14 tests, 44 assertions）
- [x] 手動測試 `/cbdbapi/person.php?id=xxx` HTML 界面地址鏈接
- [x] 手動測試 `/cbdbapi/person.php?id=xxx&o=json` JSON 輸出格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)