### PR TITLE
將未匹配路由的 metrics path 標籤記錄為 /__unknown__

### DIFF
--- a/app/Http/Middleware/PrometheusMetrics.php
+++ b/app/Http/Middleware/PrometheusMetrics.php
@@ -210,17 +210,29 @@ class PrometheusMetrics {
 
     /**
      * 获取路径（可选择包含路由参数）
+     *
+     * 注意：为避免 label cardinality 爆量（例如机器人扫描随机 URL），
+     * 当请求不匹配任何已定义路由时，统一归类为 __unknown__。
      */
     protected function getPath(Request $request): string {
+        $route = $request->route();
+
         if (config('prometheus.http_metrics.include_route_params', false)) {
             // 使用路由模式（如 /user/{id}）
-            $route = $request->route();
             if ($route) {
                 return '/' . ltrim($route->uri(), '/');
             }
+
+            // 未匹配任何路由，归类为 /__unknown__ 避免 cardinality 过高
+            return '/__unknown__';
         }
 
-        // 使用实际路径
-        return '/' . ltrim($request->path(), '/');
+        // 使用实际路径（但仍需处理未匹配路由的情况）
+        if ($route) {
+            return '/' . ltrim($request->path(), '/');
+        }
+
+        // 未匹配任何路由，归类为 /__unknown__
+        return '/__unknown__';
     }
 }

--- a/tests/Feature/PrometheusMetricsTest.php
+++ b/tests/Feature/PrometheusMetricsTest.php
@@ -378,4 +378,29 @@ class PrometheusMetricsTest extends TestCase {
             }
         }
     }
+
+    #[Test]
+    public function unmatched_routes_are_recorded_as_unknown_to_prevent_cardinality_explosion(): void {
+        Config::set('prometheus.enabled', true);
+        Config::set('prometheus.http_metrics.enabled', true);
+        Config::set('prometheus.http_metrics.include_route_params', true);
+        Config::set('prometheus.namespace', 'cbdb');
+
+        // 访问一个不存在的随机路径（模拟机器人扫描）
+        $this->get('/random-bot-scan-path-12345');
+        $this->get('/wp-admin/login.php');
+        $this->get('/.env');
+
+        // 获取 metrics
+        $response = $this->get('/metrics');
+        $content = $response->getContent();
+
+        // 验证未匹配路由的请求被记录为 /__unknown__
+        $this->assertStringContainsString('path="/__unknown__"', $content, '未匹配路由的請求應該被記錄為 /__unknown__ 以避免 cardinality 過高');
+
+        // 验证不应该有实际的随机路径出现在 metrics 中
+        $this->assertStringNotContainsString('random-bot-scan-path', $content, '不應記錄隨機路徑');
+        $this->assertStringNotContainsString('wp-admin', $content, '不應記錄機器人掃描路徑');
+        $this->assertStringNotContainsString('.env', $content, '不應記錄敏感文件探測路徑');
+    }
 }


### PR DESCRIPTION
## Summary
- 修改 `PrometheusMetrics` middleware，將不匹配任何已定義路由的請求（如機器人掃描）統一記錄為 `/__unknown__`
- 避免隨機 URL 掃描導致 Prometheus metrics 的 label cardinality 過高
- 保持 path 標籤格式一致（皆以 `/` 開頭），不破壞現有 PromQL 查詢

## Test plan
- [x] 新增測試案例驗證未匹配路由記錄為 `/__unknown__`
- [x] 驗證隨機路徑不會出現在 metrics 中
- [x] 所有 19 個 Prometheus 相關測試通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)