### PR TITLE
新增異體字映射：于→於、槀→稿

### DIFF
--- a/app/Services/VariantCharNormalizer.php
+++ b/app/Services/VariantCharNormalizer.php
@@ -34,6 +34,8 @@ class VariantCharNormalizer {
         '嶽' => '岳',  // yue
         '愼' => '慎',  // shen
         '註' => '注',  // zhu
+        '于' => '於',  // yu
+        '槀' => '稿',  // gao
     ];
 
     /**

--- a/tests/Unit/VariantCharNormalizerTest.php
+++ b/tests/Unit/VariantCharNormalizerTest.php
@@ -29,6 +29,8 @@ class VariantCharNormalizerTest extends TestCase {
             ['嶽', '岳'],   // 周君嶽 -> 周君岳
             ['愼', '慎'],   // 四書愼獄 -> 四書慎獄
             ['註', '注'],   // 左氏補註 -> 左氏補注
+            ['于', '於'],   // 于謙 -> 於謙
+            ['槀', '稿'],   // 槀本 -> 稿本
         ];
 
         foreach ($testCases as [$variant, $standard]) {
@@ -47,6 +49,8 @@ class VariantCharNormalizerTest extends TestCase {
             ['周君嶽', '周君岳'],
             ['四書愼獄講義', '四書慎獄講義'],
             ['左氏補註', '左氏補注'],
+            ['于謙', '於謙'],
+            ['槀本', '稿本'],
             ['清輝堂詩: 一卷', '清輝堂詩: 一卷'],  // 沒有異體字，應保持不變
         ];
 


### PR DESCRIPTION
## Summary
- 在 `VariantCharNormalizer` 的 fallback 映射表中新增兩組異體字對應：`于→於`、`槀→稿`
- 同步更新單元測試，覆蓋新映射的單字轉換及文本轉換場景

## Test plan
- [x] `VariantCharNormalizerTest` 全部 5 個測試通過（27 assertions）

🤖 Generated with [Claude Code](https://claude.com/claude-code)