### PR TITLE
新增 db:export-to-sqlite 的 --append 選項及每日導出腳本

### DIFF
--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -127,7 +127,8 @@ class ExportMysqlToSqlite extends Command {
         // 显示统计信息
         $this->displayStats();
 
-        return 0;
+        // 如果有错误，返回非零退出码
+        return $this->stats['errors'] > 0 ? 1 : 0;
     }
 
     /**

--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -22,7 +22,8 @@ class ExportMysqlToSqlite extends Command {
                             {--limit-records= : 限制每张表导出的最大记录数}
                             {--chunk-size=5000 : 分块查询的大小（减少内存使用）}
                             {--min-free-space=1 : 最小可用磁盘空间（GB）}
-                            {--skip-space-check : 跳过磁盘空间检查}';
+                            {--skip-space-check : 跳过磁盘空间检查}
+                            {--append : 追加模式，将表添加到现有 SQLite 文件中（不删除现有文件）}';
 
     /**
      * The console command description.
@@ -221,6 +222,7 @@ class ExportMysqlToSqlite extends Command {
     protected function prepareSqliteDatabase() {
         $absolutePath = base_path($this->outputPath);
         $directory = dirname($absolutePath);
+        $isAppendMode = $this->option('append');
 
         // 确保目录存在
         if (!is_dir($directory)) {
@@ -231,19 +233,27 @@ class ExportMysqlToSqlite extends Command {
             }
         }
 
-        // 如果文件已存在，询问是否覆盖
+        // 如果文件已存在
         if (file_exists($absolutePath)) {
-            if (!$this->confirm(sprintf('文件 %s 已存在，是否覆盖？', $this->outputPath), false)) {
-                $this->info('操作已取消');
+            if ($isAppendMode) {
+                // 追加模式：保留现有文件
+                $this->info(sprintf('✓ 追加模式：使用现有 SQLite 文件: %s', $this->outputPath));
+            } else {
+                // 覆盖模式：询问是否覆盖
+                if (!$this->confirm(sprintf('文件 %s 已存在，是否覆盖？', $this->outputPath), false)) {
+                    $this->info('操作已取消');
 
-                return false;
+                    return false;
+                }
+
+                unlink($absolutePath);
+                // 创建空的 SQLite 数据库文件
+                touch($absolutePath);
             }
-
-            unlink($absolutePath);
+        } else {
+            // 文件不存在，创建新文件
+            touch($absolutePath);
         }
-
-        // 创建空的 SQLite 数据库文件
-        touch($absolutePath);
 
         // 配置临时的 SQLite 连接
         config([
@@ -257,7 +267,12 @@ class ExportMysqlToSqlite extends Command {
 
         try {
             DB::connection('sqlite_export')->getPdo();
-            $this->info(sprintf('✓ SQLite 数据库已创建: %s', $this->outputPath));
+
+            if ($isAppendMode && file_exists($absolutePath)) {
+                $this->info(sprintf('✓ SQLite 数据库已连接: %s', $this->outputPath));
+            } else {
+                $this->info(sprintf('✓ SQLite 数据库已创建: %s', $this->outputPath));
+            }
 
             return true;
         } catch (\Exception $e) {

--- a/scripts/export-daily-sqlite.sh
+++ b/scripts/export-daily-sqlite.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# 將指定的數據庫表格逐個導出到 SQLite 文件
+# 輸出文件名：db-data/cbdb_daily_YYYYMMDD.sqlite3
+#
+# 使用方式：
+#   ./scripts/export-daily-sqlite.sh
+#
+# 可選環境變數：
+#   OUTPUT_DIR  - 輸出目錄（默認：db-data）
+#   SOURCE_DB   - 源數據庫連接名稱（默認：mysql）
+#
+
+set -e
+
+# 切換到項目根目錄
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# 配置
+OUTPUT_DIR="${OUTPUT_DIR:-db-data}"
+SOURCE_DB="${SOURCE_DB:-mysql}"
+DATE_SUFFIX=$(date +%Y%m%d)
+OUTPUT_FILE="${OUTPUT_DIR}/cbdb_daily_${DATE_SUFFIX}.sqlite3"
+
+# 要導出的表格列表
+TABLES=(
+    "ADDR_BELONGS_DATA"
+    "ADDR_CODES"
+    "ADMIN_CAT_CODES"
+    "ADMIN_CAT_CODE_TYPE_REL"
+    "ADMIN_CAT_TYPES"
+    "ALTNAME_CODES"
+    "ALTNAME_DATA"
+    "APPOINTMENT_CODES"
+    "APPOINTMENT_CODE_TYPE_REL"
+    "APPOINTMENT_TYPES"
+    "ASSOC_CODES"
+    "ASSOC_CODE_TYPE_REL"
+    "ASSOC_DATA"
+    "ASSOC_TYPES"
+    "ASSUME_OFFICE_CODES"
+    "BIOG_ADDR_CODES"
+    "BIOG_ADDR_DATA"
+    "BIOG_INST_CODES"
+    "BIOG_INST_DATA"
+    "BIOG_MAIN"
+    "BIOG_SOURCE_DATA"
+    "BIOG_TEXT_DATA"
+    "CHORONYM_CODES"
+    "COUNTRY_CODES"
+    "DYNASTIES"
+    "ENTRY_CODES"
+    "ENTRY_CODE_TYPE_REL"
+    "ENTRY_DATA"
+    "ENTRY_TYPES"
+    "ETHNICITY_TRIBE_CODES"
+    "EVENTS_ADDR"
+    "EVENTS_DATA"
+    "EVENT_CODES"
+    "EXTANT_CODES"
+    "GANZHI_CODES"
+    "HOUSEHOLD_STATUS_CODES"
+    "INDEXYEAR_TYPE_CODES"
+    "KINSHIP_CODES"
+    "KIN_DATA"
+    "KIN_MOURNING"
+    "KIN_MOURNING_STEPS"
+    "LITERARYGENRE_CODES"
+    "MEASURE_CODES"
+    "MERGED_PERSON_DATA"
+    "NIAN_HAO"
+    "OCCASION_CODES"
+    "OFFICE_CATEGORIES"
+    "OFFICE_CODES"
+    "OFFICE_CODE_TYPE_REL"
+    "OFFICE_TYPE_TREE"
+    "PARENTAL_STATUS_CODES"
+    "POSSESSION_ACT_CODES"
+    "POSSESSION_ADDR"
+    "POSSESSION_DATA"
+    "POSTED_TO_ADDR_DATA"
+    "POSTED_TO_OFFICE_DATA"
+    "POSTING_DATA"
+    "SCHOLARLYTOPIC_CODES"
+    "SOCIAL_INSTITUTION_ADDR"
+    "SOCIAL_INSTITUTION_ADDR_TYPES"
+    "SOCIAL_INSTITUTION_ALTNAME_CODES"
+    "SOCIAL_INSTITUTION_ALTNAME_DATA"
+    "SOCIAL_INSTITUTION_CODES"
+    "SOCIAL_INSTITUTION_NAME_CODES"
+    "SOCIAL_INSTITUTION_TYPES"
+    "STATUS_CODES"
+    "STATUS_CODE_TYPE_REL"
+    "STATUS_DATA"
+    "STATUS_TYPES"
+    "TEXT_BIBLCAT_CODES"
+    "TEXT_BIBLCAT_CODE_TYPE_REL"
+    "TEXT_BIBLCAT_TYPES"
+    "TEXT_CODES"
+    "TEXT_INSTANCE_DATA"
+    "TEXT_ROLE_CODES"
+    "TEXT_TYPE"
+    "YEAR_RANGE_CODES"
+)
+
+# 確保輸出目錄存在
+mkdir -p "$OUTPUT_DIR"
+
+# 如果輸出文件已存在，先刪除
+if [ -f "$OUTPUT_FILE" ]; then
+    echo "移除現有文件: $OUTPUT_FILE"
+    rm -f "$OUTPUT_FILE"
+fi
+
+echo "================================================"
+echo "CBDB 每日 SQLite 導出"
+echo "================================================"
+echo "輸出文件: $OUTPUT_FILE"
+echo "源數據庫: $SOURCE_DB"
+echo "表格數量: ${#TABLES[@]}"
+echo "================================================"
+echo ""
+
+# 計數器
+TOTAL=${#TABLES[@]}
+CURRENT=0
+FAILED=0
+FAILED_TABLES=()
+
+# 逐個導出表格
+for TABLE in "${TABLES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    echo "[$CURRENT/$TOTAL] 導出表格: $TABLE"
+
+    if [ $CURRENT -eq 1 ]; then
+        # 第一個表格：創建新文件
+        if php artisan db:export-to-sqlite \
+            --output="$OUTPUT_FILE" \
+            --tables="$TABLE" \
+            --source="$SOURCE_DB" \
+            --skip-space-check \
+            --no-interaction; then
+            echo "  ✓ 成功"
+        else
+            echo "  ✗ 失敗"
+            FAILED=$((FAILED + 1))
+            FAILED_TABLES+=("$TABLE")
+        fi
+    else
+        # 後續表格：追加模式
+        if php artisan db:export-to-sqlite \
+            --output="$OUTPUT_FILE" \
+            --tables="$TABLE" \
+            --source="$SOURCE_DB" \
+            --skip-space-check \
+            --append \
+            --no-interaction; then
+            echo "  ✓ 成功"
+        else
+            echo "  ✗ 失敗"
+            FAILED=$((FAILED + 1))
+            FAILED_TABLES+=("$TABLE")
+        fi
+    fi
+
+    echo ""
+done
+
+echo "================================================"
+echo "導出完成"
+echo "================================================"
+echo "成功: $((TOTAL - FAILED))/$TOTAL"
+if [ $FAILED -gt 0 ]; then
+    echo "失敗: $FAILED"
+    echo "失敗的表格:"
+    for T in "${FAILED_TABLES[@]}"; do
+        echo "  - $T"
+    done
+fi
+echo ""
+
+if [ -f "$OUTPUT_FILE" ]; then
+    FILE_SIZE=$(ls -lh "$OUTPUT_FILE" | awk '{print $5}')
+    echo "輸出文件: $OUTPUT_FILE"
+    echo "文件大小: $FILE_SIZE"
+fi
+
+echo "================================================"
+
+# 如果有失敗，返回非零退出碼
+if [ $FAILED -gt 0 ]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
- 在 ExportMysqlToSqlite 命令中新增 --append 選項，支援將表格追加至現有 SQLite 文件
- 新增 scripts/export-daily-sqlite.sh 腳本，可逐個導出指定的 78 個表格
- 輸出文件命名為 db-data/cbdb_daily_YYYYMMDD.sqlite3

https://claude.ai/code/session_01C9WqinRLdWRZkNfM4eRDbf