### PR TITLE
修正 EVENTS_DATA 複合主鍵處理及更新 SCHEMAS 定義

### DIFF
--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -111,13 +111,14 @@ class BasicInformationEventsController extends Controller {
 
             return redirect()->back();
         }
-        $_id = $this->biogMainRepository->eventStoreById($request, $id);
+        $result = $this->biogMainRepository->eventStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
         $newPk = [
             'c_personid' => $id,
-            'c_sequence' => $_id,
+            'c_sequence' => $result['c_sequence'],
+            'c_event_code' => $result['c_event_code'],
         ];
 
         return redirect(CompositePrimaryKey::buildUrl(
@@ -196,13 +197,14 @@ class BasicInformationEventsController extends Controller {
 
             return redirect()->back();
         }
-        $_id = $this->biogMainRepository->eventUpdateById($request, $id, $id_);
+        $result = $this->biogMainRepository->eventUpdateById($request, $id, $id_);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
         $newPk = [
             'c_personid' => $id,
-            'c_sequence' => $_id,
+            'c_sequence' => $result['c_sequence'],
+            'c_event_code' => $result['c_event_code'],
         ];
 
         return redirect(CompositePrimaryKey::buildUrl(
@@ -257,8 +259,8 @@ class BasicInformationEventsController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'EVENTS_DATA');
 
-        // 使用 Repository 查詢（格式：c_personid-c_sequence）
-        $id_ = $pk['c_personid'].'-'.$pk['c_sequence'];
+        // 使用 Repository 查詢（格式：c_personid-c_sequence-c_event_code）
+        $id_ = $pk['c_personid'].'-'.$pk['c_sequence'].'-'.$pk['c_event_code'];
         $res = $this->biogMainRepository->eventById($id_);
 
         // 處理 personLabel
@@ -325,18 +327,19 @@ class BasicInformationEventsController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'EVENTS_DATA');
 
-        // 構建舊格式 ID（格式：c_sequence）
-        $id_ = $pk['c_sequence'];
+        // 構建 ID（格式：c_sequence-c_event_code）
+        $id_ = $pk['c_sequence'] . '-' . $pk['c_event_code'];
 
         // 使用 Repository 更新
-        $_id = $this->biogMainRepository->eventUpdateById($request, $id, $id_);
+        $result = $this->biogMainRepository->eventUpdateById($request, $id, $id_);
 
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 重定向到新的查詢參數格式
         $newPk = [
             'c_personid' => $id,
-            'c_sequence' => $_id,
+            'c_sequence' => $result['c_sequence'],
+            'c_event_code' => $result['c_event_code'],
         ];
 
         return redirect(CompositePrimaryKey::buildUrl(
@@ -372,8 +375,8 @@ class BasicInformationEventsController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'EVENTS_DATA');
 
-        // 構建舊格式 ID（格式：c_sequence）
-        $id_ = $pk['c_sequence'];
+        // 構建 ID（格式：c_sequence-c_event_code）
+        $id_ = $pk['c_sequence'] . '-' . $pk['c_event_code'];
 
         $this->biogMainRepository->eventDeleteById($id_, $id);
 

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -244,7 +244,18 @@ class OperationsController extends Controller {
                         break;
                         //20251208新增事件差異比對紀錄
                     case "EVENTS_DATA":
-                        $arr3 = DB::table('EVENTS_DATA')->where('c_personid', $c_personid)->where('c_sequence', $resource_id)->first();
+                        // 支持新格式 "c_personid-c_sequence-c_event_code" 和舊格式 "c_sequence"
+                        $eventParts = explode('-', $resource_id);
+                        $eventQuery = DB::table('EVENTS_DATA')->where('c_personid', $c_personid);
+                        if (count($eventParts) >= 3) {
+                            // 新格式：resource_id = "c_personid-c_sequence-c_event_code"
+                            $eventQuery->where('c_sequence', $eventParts[1])
+                                       ->where('c_event_code', $eventParts[2]);
+                        } else {
+                            // 舊格式：resource_id = "c_sequence"
+                            $eventQuery->where('c_sequence', $resource_id);
+                        }
+                        $arr3 = $eventQuery->first();
                         $arr3 = json_encode($arr3);
                         $arr3 = json_decode($arr3, true);
 
@@ -840,7 +851,7 @@ class OperationsController extends Controller {
             'KIN_DATA' => ['c_personid','c_kin_id','c_kin_code'],
             'POSSESSION_DATA' => ['c_possession_record_id'],
             'BIOG_INST_DATA' => ['c_personid','c_inst_code','c_inst_name_code','c_bi_role_code'],
-            'EVENTS_DATA' => ['c_personid','c_sequence'],
+            'EVENTS_DATA' => ['c_personid','c_sequence','c_event_code'],
             'ASSOC_DATA' => ['c_personid','c_assoc_code','c_assoc_id','c_kin_code','c_kin_id','c_assoc_kin_code','c_assoc_kin_id','c_text_title','c_assoc_first_year'],
         ];
 

--- a/app/Models/BiogMain.php
+++ b/app/Models/BiogMain.php
@@ -112,7 +112,7 @@ class BiogMain extends Model {
     }
 
     public function events() {
-        return $this->belongsToMany('App\Models\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence')->orderBy('c_sequence');
+        return $this->belongsToMany('App\Models\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence', 'c_event_code')->orderBy('c_sequence');
     }
 
     public function kinship() {

--- a/app/Models/BiogMainPower.php
+++ b/app/Models/BiogMainPower.php
@@ -102,7 +102,7 @@ class BiogMainPower extends Model {
     }
 
     public function events() {
-        return $this->belongsToMany('App\Models\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence')->orderBy('c_sequence');
+        return $this->belongsToMany('App\Models\EventCode', 'EVENTS_DATA', 'c_personid', 'c_event_code')->withPivot('c_sequence', 'c_event_code')->orderBy('c_sequence');
     }
 
     public function kinship_name() {

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -1513,7 +1513,14 @@ class BiogMainRepository {
 
     public function eventById($id) {
         $id_arr = explode("-", $id);
-        $row = DB::table('EVENTS_DATA')->where('c_personid', $id_arr[0])->where('c_sequence', $id_arr[1])->first();
+        $query = DB::table('EVENTS_DATA')
+            ->where('c_personid', $id_arr[0])
+            ->where('c_sequence', $id_arr[1]);
+        // 新格式包含 c_event_code（第 3 個字段），舊格式僅 c_personid-c_sequence
+        if (isset($id_arr[2])) {
+            $query->where('c_event_code', $id_arr[2]);
+        }
+        $row = $query->first();
         $text_str = null;
         if ($row->c_source || $row->c_source === 0) {
             $text_ = TextCode::find($row->c_source);
@@ -1541,11 +1548,22 @@ class BiogMainRepository {
     }
 
     public function eventUpdateById(Request $request, $id, $id_) {
+        // $id = c_personid, $id_ = "c_sequence-c_event_code"（新格式）或 "c_sequence"（舊格式）
+        $parts = explode("-", (string) $id_);
+        $c_sequence = $parts[0];
+        $c_event_code = $parts[1] ?? null;
+
         $data = $request->all();
         $data = $this->formatSelect($data);
 
         // 先獲取原始記錄，用於刪除舊的 EVENTS_ADDR
-        $ori = DB::table('EVENTS_DATA')->where('c_personid', $id)->where('c_sequence', $id_)->first();
+        $oriQuery = DB::table('EVENTS_DATA')
+            ->where('c_personid', $id)
+            ->where('c_sequence', $c_sequence);
+        if ($c_event_code !== null) {
+            $oriQuery->where('c_event_code', $c_event_code);
+        }
+        $ori = $oriQuery->first();
 
         // 使用原始值刪除舊地址，再用新值插入新地址
         // 這樣即使用戶修改了 c_sequence 或 c_event_code，也不會留下孤兒記錄
@@ -1561,10 +1579,19 @@ class BiogMainRepository {
         $data = Arr::except($data, ['_method', '_token', 'c_addr_id']);
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository())->timestamp($data);
-        DB::table('EVENTS_DATA')->where('c_personid', $id)->where('c_sequence', $id_)->update($data);
-        (new OperationRepository())->store(Auth::id(), $id, 3, 'EVENTS_DATA', $id_, $data, $ori);
+        $updateQuery = DB::table('EVENTS_DATA')
+            ->where('c_personid', $id)
+            ->where('c_sequence', $c_sequence);
+        if ($c_event_code !== null) {
+            $updateQuery->where('c_event_code', $c_event_code);
+        }
+        $updateQuery->update($data);
 
-        return $data['c_sequence'];
+        // 新格式 resource_id：c_personid-c_sequence-c_event_code
+        $new_resource_id = $id . '-' . $data['c_sequence'] . '-' . $data['c_event_code'];
+        (new OperationRepository())->store(Auth::id(), $id, 3, 'EVENTS_DATA', $new_resource_id, $data, $ori);
+
+        return ['c_sequence' => $data['c_sequence'], 'c_event_code' => $data['c_event_code']];
     }
 
     public function eventStoreById(Request $request, $id) {
@@ -1576,20 +1603,38 @@ class BiogMainRepository {
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository())->timestamp($data, true);
         DB::table('EVENTS_DATA')->insert($data);
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', $data['c_sequence'], $data);
 
-        return $data['c_sequence'];
+        // 新格式 resource_id：c_personid-c_sequence-c_event_code
+        $resource_id = $id . '-' . $data['c_sequence'] . '-' . $data['c_event_code'];
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', $resource_id, $data);
+
+        return ['c_sequence' => $data['c_sequence'], 'c_event_code' => $data['c_event_code']];
     }
 
     public function eventDeleteById($id, $c_personid) {
-        $row = DB::table('EVENTS_DATA')->where('c_personid', $c_personid)->where('c_sequence', $id)->first();
-        DB::table('EVENTS_DATA')->where('c_personid', $c_personid)->where('c_sequence', $id)->delete();
+        // $id = "c_sequence-c_event_code"（新格式）或 "c_sequence"（舊格式）
+        $parts = explode("-", (string) $id);
+        $c_sequence = $parts[0];
+        $c_event_code = $parts[1] ?? null;
+
+        $query = DB::table('EVENTS_DATA')
+            ->where('c_personid', $c_personid)
+            ->where('c_sequence', $c_sequence);
+        if ($c_event_code !== null) {
+            $query->where('c_event_code', $c_event_code);
+        }
+        $row = (clone $query)->first();
+        $query->delete();
+
         DB::table('EVENTS_ADDR')
             ->where('c_personid', $row->c_personid)
             ->where('c_sequence', $row->c_sequence)
             ->where('c_event_code', $row->c_event_code)
             ->delete();
-        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'EVENTS_DATA', $id, $row);
+
+        // 新格式 resource_id：c_personid-c_sequence-c_event_code
+        $resource_id = $c_personid . '-' . $row->c_sequence . '-' . $row->c_event_code;
+        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'EVENTS_DATA', $resource_id, $row);
     }
 
     public function assocById($id) {

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -50,9 +50,9 @@ class CompositePrimaryKey {
             'c_posting_id',
         ],
         'POSTED_TO_ADDR_DATA' => [
-            'c_personid',
-            'c_posting_id',
+            'c_addr_id',
             'c_office_id',
+            'c_posting_id',
         ],
         'ASSOC_DATA' => [
             'c_personid',
@@ -73,6 +73,7 @@ class CompositePrimaryKey {
         'EVENTS_DATA' => [
             'c_personid',
             'c_sequence',
+            'c_event_code',
         ],
         'STATUS_DATA' => [
             'c_personid',
@@ -92,7 +93,6 @@ class CompositePrimaryKey {
             'c_inst_name_code',
         ],
         'POSSESSION_DATA' => [
-            'c_personid',
             'c_possession_record_id',
         ],
         'BIOG_INST_DATA' => [

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - Events --}}
 @php
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.events.update', ['basicinformation' => $id, 'event' => $row->c_sequence])
-        : route('basicinformation.events.store', ['basicinformation' => $id]);
+    if ($isEdit && isset($pk)) {
+        // 查詢參數模式：使用完整複合主鍵
+        $formAction = \App\Support\CompositePrimaryKey::buildUrl(
+            'basicinformation.events.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        // 舊格式
+        $formAction = route('basicinformation.events.update', ['basicinformation' => $id, 'event' => $row->c_sequence]);
+    } else {
+        $formAction = route('basicinformation.events.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">

--- a/resources/views/biogmains/events/index.blade.php
+++ b/resources/views/biogmains/events/index.blade.php
@@ -43,8 +43,9 @@ use App\Support\CompositePrimaryKey;
                             $eventPk = [
                                 'c_personid' => $basicinformation->c_personid,
                                 'c_sequence' => $value->pivot->c_sequence,
+                                'c_event_code' => $value->pivot->c_event_code,
                             ];
-                            $eventFormId = 'delete-form-' . $value->pivot->c_sequence;
+                            $eventFormId = 'delete-form-' . $value->pivot->c_sequence . '-' . $value->pivot->c_event_code;
                             @endphp
                             <div class="btn-group">
                                 <a type="button" class="btn btn-sm btn-info" href="{{ CompositePrimaryKey::buildUrl('basicinformation.events.edit.query', ['id' => $basicinformation->c_personid], $eventPk) }}">edit</a>


### PR DESCRIPTION
## Summary
- **EVENTS_DATA**：補齊 `c_event_code` 至所有 Repository 方法（`eventById`、`eventUpdateById`、`eventStoreById`、`eventDeleteById`）的查詢條件與 `resource_id` 格式，Controller 及 View 同步使用三欄位複合主鍵 `(c_personid, c_sequence, c_event_code)`
- **CompositePrimaryKey SCHEMAS**：修正 `POSTED_TO_ADDR_DATA`（`c_personid` → `c_addr_id`）和 `POSSESSION_DATA`（移除多餘的 `c_personid`），使其與資料庫 PRIMARY KEY 定義一致
- **OperationsController**：`restore` 支援新舊 `resource_id` 格式；`getCompositeKeyFields` 補齊 `c_event_code`
- **BiogMain / BiogMainPower**：`events()` 關聯的 `withPivot` 加入 `c_event_code`

## 變更檔案

| 檔案 | 變更說明 |
|------|----------|
| `app/Support/CompositePrimaryKey.php` | 修正 EVENTS_DATA、POSTED_TO_ADDR_DATA、POSSESSION_DATA 的 SCHEMAS |
| `app/Repositories/BiogMainRepository.php` | 四個 event 方法支援三欄位複合主鍵，resource_id 格式更新 |
| `app/Http/Controllers/BasicInformationEventsController.php` | store/update/editQuery/updateQuery/destroyQuery 同步使用新格式 |
| `app/Http/Controllers/OperationsController.php` | restore 向後兼容新舊 resource_id；getCompositeKeyFields 更新 |
| `app/Models/BiogMain.php` | events() withPivot 加入 c_event_code |
| `app/Models/BiogMainPower.php` | events() withPivot 加入 c_event_code |
| `resources/views/biogmains/events/index.blade.php` | eventPk 和 delete form ID 包含 c_event_code |
| `resources/views/biogmains/events/_form.blade.php` | 表單 action 支援查詢參數模式（$pk 存在時）與舊格式後備 |

## Test plan
- [x] 執行 `./vendor/bin/phpunit` 全部測試通過（440 tests）
- [x] 驗證事件列表頁的 edit/delete 連結包含完整三欄位複合主鍵
- [x] 驗證新增事件後重定向使用查詢參數模式
- [x] 驗證編輯事件後重定向使用查詢參數模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)