### PR TITLE
修正新增官名時 c_addr_cleared 欄位未排除導致 SQL 錯誤

### DIFF
--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -819,7 +819,7 @@ class BiogMainRepository {
         return DB::transaction(function () use ($request, $id) {
             $payload = $request->all();
             $c_addr = $payload['c_addr'] ?? [];
-            $data = Arr::except($payload, ['_token', 'c_addr']);
+            $data = Arr::except($payload, ['_token', 'c_addr', 'c_addr_cleared']);
 
             $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
             $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);


### PR DESCRIPTION
## Summary
- 修正 `officeStoreById` 新增官名時，表單隱藏欄位 `c_addr_cleared` 未被排除，導致 `INSERT INTO POSTED_TO_OFFICE_DATA` 出現 `Unknown column` 錯誤
- 將 `c_addr_cleared` 加入 `Arr::except` 排除清單，與 `officeUpdateById` 保持一致

## Test plan
- [x] 已通過全部 23 個 Office 相關測試
- [x] 手動測試：錄入官職，確認不再報 SQL 錯誤

Generated with [Claude Code](https://claude.com/claude-code)
