### PR TITLE
為 Possession 子頁面實作查詢參數模式

### DIFF
--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Repositories\BiogMainRepository;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -113,10 +114,11 @@ class BasicInformationPossessionController extends Controller {
         $_id = $this->biogMainRepository->possessionStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
 
-        return redirect()->route('basicinformation.possession.edit', [
-            'basicinformation' => $id,
-            'possession' => $_id,
-        ]);
+        return redirect(CompositePrimaryKey::buildUrl(
+            'basicinformation.possession.edit.query',
+            ['id' => $id],
+            ['c_possession_record_id' => $_id]
+        ));
 
     }
 
@@ -193,10 +195,11 @@ class BasicInformationPossessionController extends Controller {
         $this->biogMainRepository->possessionUpdateById($request, $id, $id_);
         flash('Update success @ '.Carbon::now(), 'success');
 
-        return redirect()->route('basicinformation.possession.edit', [
-            'basicinformation' => $id,
-            'possession' => $id_,
-        ]);
+        return redirect(CompositePrimaryKey::buildUrl(
+            'basicinformation.possession.edit.query',
+            ['id' => $id],
+            ['c_possession_record_id' => $id_]
+        ));
     }
 
     /**
@@ -216,6 +219,142 @@ class BasicInformationPossessionController extends Controller {
             return redirect()->back();
         }
         $this->biogMainRepository->possessionDeleteById($id_, $id);
+        flash('Delete success @ '.Carbon::now(), 'success');
+
+        return redirect()->route('basicinformation.possession.index', ['basicinformation' => $id]);
+    }
+
+    // ===================================================================
+    // 查詢參數模式方法（推薦使用）
+    // 使用 HTTP 查詢參數傳遞主鍵，避免自定義編碼邏輯
+    // 參考：docs/COMPOSITE_PRIMARY_KEY_URL_DESIGN.md
+    // ===================================================================
+
+    /**
+     * 查詢參數模式：編輯財產記錄
+     *
+     * URL 格式：/basicinformation/{id}/possession/edit?c_possession_record_id=...
+     *
+     * @param Request $request
+     * @param int $id 人物 ID
+     * @return \Illuminate\Http\Response
+     */
+    public function editQuery(Request $request, $id) {
+        // 從查詢參數提取主鍵
+        $schema = CompositePrimaryKey::SCHEMAS['POSSESSION_DATA'];
+        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+
+        // 驗證必填欄位
+        CompositePrimaryKey::validateOrFail($pk, 'POSSESSION_DATA');
+
+        $id_ = $pk['c_possession_record_id'];
+        $res = $this->biogMainRepository->possessionById($id_);
+
+        // 處理 personLabel
+        $personLabel = $id;
+
+        try {
+            $basicinformation = $this->biogMainRepository->byPersonId($id);
+            if ($basicinformation) {
+                $nameChn = $basicinformation->c_name_chn ?? '';
+                $name = $basicinformation->c_name ?? '';
+                if ($nameChn || $name) {
+                    $personLabel .= ' - ' . $nameChn;
+                    if ($name) {
+                        $personLabel .= ' (' . $name . ')';
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // 如果 byPersonId 失敗（例如在測試環境中表結構不完整），只使用 ID
+        }
+
+        return view('biogmains.possession.edit', [
+            'id' => $id,
+            'row' => $res['row'],
+            'res' => $res,
+            'pk' => $pk,
+            'page_title' => '財產',
+            'page_description' => '基本信息表 財產',
+            'page_url' => '/basicinformation/'.$id.'/possession',
+            'archer' => '<li>編輯</li>',
+            'breadcrumb_home' => '人物基本資料',
+            'breadcrumbs' => [
+                ['label' => '人物基本資料', 'url' => route('basicinformation.index')],
+                ['label' => $personLabel, 'url' => route('basicinformation.edit', $id)],
+                ['label' => '財產', 'url' => route('basicinformation.possession.index', $id)],
+                ['label' => '编辑', 'url' => '#'],
+            ],
+        ]);
+    }
+
+    /**
+     * 查詢參數模式：更新財產記錄
+     *
+     * @param Request $request
+     * @param int $id 人物 ID
+     * @return \Illuminate\Http\Response
+     */
+    public function updateQuery(Request $request, $id) {
+        if (!Auth::check()) {
+            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 從查詢參數提取主鍵
+        $schema = CompositePrimaryKey::SCHEMAS['POSSESSION_DATA'];
+        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+
+        // 驗證必填欄位
+        CompositePrimaryKey::validateOrFail($pk, 'POSSESSION_DATA');
+
+        $id_ = $pk['c_possession_record_id'];
+        $this->biogMainRepository->possessionUpdateById($request, $id, $id_);
+
+        flash('Update success @ '.Carbon::now(), 'success');
+
+        return redirect(CompositePrimaryKey::buildUrl(
+            'basicinformation.possession.edit.query',
+            ['id' => $id],
+            ['c_possession_record_id' => $id_]
+        ));
+    }
+
+    /**
+     * 查詢參數模式：刪除財產記錄
+     *
+     * @param Request $request
+     * @param int $id 人物 ID
+     * @return \Illuminate\Http\Response
+     */
+    public function destroyQuery(Request $request, $id) {
+        if (!Auth::check()) {
+            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 從查詢參數提取主鍵
+        $schema = CompositePrimaryKey::SCHEMAS['POSSESSION_DATA'];
+        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+
+        // 驗證必填欄位
+        CompositePrimaryKey::validateOrFail($pk, 'POSSESSION_DATA');
+
+        $id_ = $pk['c_possession_record_id'];
+        $this->biogMainRepository->possessionDeleteById($id_, $id);
+
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.possession.index', ['basicinformation' => $id]);

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -1,8 +1,10 @@
 {{-- 共享表单组件 - Possession --}}
 @php
+    use App\Support\CompositePrimaryKey;
+
     $isEdit = isset($row);
     $formAction = $isEdit
-        ? route('basicinformation.possession.update', ['basicinformation' => $id, 'possession' => $row->c_possession_record_id])
+        ? CompositePrimaryKey::buildUrl('basicinformation.possession.update.query', ['id' => $id], ['c_possession_record_id' => $row->c_possession_record_id])
         : route('basicinformation.possession.store', ['basicinformation' => $id]);
 @endphp
 

--- a/resources/views/biogmains/possession/index.blade.php
+++ b/resources/views/biogmains/possession/index.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.dashboard-v3')
 
+@php
+use App\Support\CompositePrimaryKey;
+@endphp
+
 @section('content')
     @include('biogmains.banner')
     <div class="card card-default">
@@ -39,14 +43,20 @@
                         @auth
                             @if(Auth::user()->isActive())
                                 <td>
+                                    @php
+                                    $possessionPk = [
+                                        'c_possession_record_id' => $value->pivot->c_possession_record_id,
+                                    ];
+                                    $possessionFormId = 'delete-form-' . $value->pivot->c_possession_record_id;
+                                    @endphp
                                     <div class="btn-group">
-                                        <a type="button" class="btn btn-sm btn-info" href="{{ route('basicinformation.possession.edit', ['basicinformation' => $basicinformation->c_personid, 'possession' => $value->pivot->c_possession_record_id]) }}">edit</a>
+                                        <a type="button" class="btn btn-sm btn-info" href="{{ CompositePrimaryKey::buildUrl('basicinformation.possession.edit.query', ['id' => $basicinformation->c_personid], $possessionPk) }}">edit</a>
                                         <a href=""
                                            onclick="
                                                    let msg = '您真的确定要删除吗？\n\n请确认！';
                                                    if (confirm(msg)===true){
                                                        event.preventDefault();
-                                                       document.getElementById('delete-form-{{ $value->pivot->c_possession_record_id }}').submit();
+                                                       document.getElementById('{{ $possessionFormId }}').submit();
                                                    }else{
                                                        return false;
                                                    }
@@ -54,7 +64,7 @@
                                            class="btn btn-sm btn-danger">delete</a>
 
                                     </div>
-                                    <form id="delete-form-{{ $value->pivot->c_possession_record_id }}" action="{{ route('basicinformation.possession.destroy', ['basicinformation' => $basicinformation->c_personid, 'possession' => $value->pivot->c_possession_record_id]) }}" method="POST" style="display: none;">
+                                    <form id="{{ $possessionFormId }}" action="{{ CompositePrimaryKey::buildUrl('basicinformation.possession.destroy.query', ['id' => $basicinformation->c_personid], $possessionPk) }}" method="POST" style="display: none;">
                                         {{ method_field('DELETE') }}
                                         {{ csrf_field() }}
                                     </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,6 +128,14 @@ Route::match(['put', 'patch'], 'basicinformation/{id}/socialinst/update', 'Basic
 Route::delete('basicinformation/{id}/socialinst/delete', 'BasicInformationSocialInstController@destroyQuery')
     ->name('basicinformation.socialinst.destroy.query');
 
+// POSSESSION_DATA
+Route::get('basicinformation/{id}/possession/edit', 'BasicInformationPossessionController@editQuery')
+    ->name('basicinformation.possession.edit.query');
+Route::match(['put', 'patch'], 'basicinformation/{id}/possession/update', 'BasicInformationPossessionController@updateQuery')
+    ->name('basicinformation.possession.update.query');
+Route::delete('basicinformation/{id}/possession/delete', 'BasicInformationPossessionController@destroyQuery')
+    ->name('basicinformation.possession.destroy.query');
+
 // POSTED_TO_OFFICE_DATA（官名）
 Route::get('basicinformation/{id}/offices/edit', 'BasicInformationOfficesController@editQuery')
     ->name('basicinformation.offices.edit.query');


### PR DESCRIPTION
## Summary
- 為 `BasicInformationPossessionController` 添加查詢參數模式（`editQuery`/`updateQuery`/`destroyQuery`），使 12/12 個子頁面 Controller 全部完成查詢參數模式遷移
- 新增 3 條 POSSESSION_DATA 查詢參數路由
- 更新 index / _form Blade 模板使用 `CompositePrimaryKey::buildUrl()` 生成 URL
- `store()` / `update()` 重定向改用查詢參數路由

## Test plan
- [x] `php-cs-fixer fix`：0 個文件需修正
- [x] `phpunit`：440 測試全部通過
- [x] 手動驗證財產頁面的新增、編輯、刪除流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)