### PR TITLE
將 resource_id 儲存格式改為查詢參數模式

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadOfficesController.php
+++ b/app/Http/Controllers/AdminBatchLoadOfficesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Pinyin;
 use App\Repositories\OperationRepository;
+use App\Support\CompositePrimaryKey;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -88,7 +89,10 @@ class AdminBatchLoadOfficesController extends Controller {
                     '',
                     1,
                     'OFFICE_CODE_TYPE_REL',
-                    $nextOfficeId . '-' . $row['type_id'],
+                    CompositePrimaryKey::buildStoredResourceId([
+                        'c_office_id' => $nextOfficeId,
+                        'c_office_tree_id' => $row['type_id'],
+                    ]),
                     $relationPayload
                 );
 

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -149,7 +149,12 @@ class BasicInformationAddressesController extends Controller {
         }
         $data = $this->toolsRepository->timestamp($data, true);
         DB::table('BIOG_ADDR_DATA')->insert($data);
-        $this->operationRepository->store(Auth::id(), $id, 1, 'BIOG_ADDR_DATA', $data['c_personid']."-".$data['c_addr_id']."-".$data['c_addr_type']."-".$data['c_sequence'], $data);
+        $this->operationRepository->store(Auth::id(), $id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_addr_id' => $data['c_addr_id'],
+            'c_addr_type' => $data['c_addr_type'],
+            'c_sequence' => $data['c_sequence'],
+        ]), $data);
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -338,8 +343,12 @@ class BasicInformationAddressesController extends Controller {
             ['c_sequence', '=', $addr_l[3]],
         ])->update($data);
         $data['c_personid'] = $addr_l[0];
-        $new_addr = $data['c_personid']."-".$data['c_addr_id']."-".$data['c_addr_type']."-".$data['c_sequence'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', $new_addr, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_addr_id' => $data['c_addr_id'],
+            'c_addr_type' => $data['c_addr_type'],
+            'c_sequence' => $data['c_sequence'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -392,7 +401,12 @@ class BasicInformationAddressesController extends Controller {
             ['c_sequence', '=', $addr_l[3]],
         ])->delete();
 
-        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', $addr, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $addr_l[0],
+            'c_addr_id' => $addr_l[1],
+            'c_addr_type' => $addr_l[2],
+            'c_sequence' => $addr_l[3],
+        ]), $row);
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.addresses.index', ['basicinformation' => $id]);
@@ -581,8 +595,7 @@ class BasicInformationAddressesController extends Controller {
             'c_addr_type' => $data['c_addr_type'] ?? $pk['c_addr_type'],
             'c_sequence' => $data['c_sequence'] ?? $pk['c_sequence'],
         ];
-        $resourceId = $newPk['c_personid'].'-'.$newPk['c_addr_id'].'-'.$newPk['c_addr_type'].'-'.$newPk['c_sequence'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', $resourceId, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $data, $ori);
 
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -637,8 +650,7 @@ class BasicInformationAddressesController extends Controller {
         DB::table('BIOG_ADDR_DATA')->where($conditions)->delete();
 
         // 記錄操作
-        $resourceId = $pk['c_personid'].'-'.$pk['c_addr_id'].'-'.$pk['c_addr_type'].'-'.$pk['c_sequence'];
-        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', $resourceId, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -132,7 +132,12 @@ class BasicInformationAltnamesController extends Controller {
 
         // 使用 Query Builder 插入資料
         DB::table('ALTNAME_DATA')->insert($data);
-        $this->operationRepository->store(Auth::id(), $id, 1, 'ALTNAME_DATA', $data['c_personid']."-".$data['c_sequence']."-".$data['c_alt_name_chn']."-".$data['c_alt_name_type_code'], $data);
+        $this->operationRepository->store(Auth::id(), $id, 1, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_sequence' => $data['c_sequence'],
+            'c_alt_name_chn' => $data['c_alt_name_chn'],
+            'c_alt_name_type_code' => $data['c_alt_name_type_code'],
+        ]), $data);
 
         // 手動調用索引服務
         if (Schema::hasTable('CBDB__NAME_FTS') && !empty($data['c_alt_name_chn'])) {
@@ -306,11 +311,12 @@ class BasicInformationAltnamesController extends Controller {
             ['c_alt_name_type_code', '=', $addr_l[3]],
         ])->update($data);
 
-        if ($data['c_sequence'] == null) {
-            $data['c_sequence'] = 'NULL';
-        }
-        $new_alt = $id.'-'.$data['c_sequence'].'-'.$data['c_alt_name_chn'].'-'.$data['c_alt_name_type_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', $new_alt, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_sequence' => $data['c_sequence'],
+            'c_alt_name_chn' => $data['c_alt_name_chn'],
+            'c_alt_name_type_code' => $data['c_alt_name_type_code'],
+        ]), $data, $ori);
 
         // 手動調用索引服務
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
@@ -665,12 +671,7 @@ class BasicInformationAltnamesController extends Controller {
             'c_alt_name_chn' => $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'],
             'c_alt_name_type_code' => $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'],
         ];
-        // 處理 c_sequence 為 null 的情況
-        if ($newPk['c_sequence'] == null) {
-            $newPk['c_sequence'] = null;
-        }
-        $resourceId = $newPk['c_personid'].'-'.($newPk['c_sequence'] ?? 'NULL').'-'.$newPk['c_alt_name_chn'].'-'.$newPk['c_alt_name_type_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', $resourceId, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $data, $ori);
 
         // 更新索引
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
@@ -760,8 +761,7 @@ class BasicInformationAltnamesController extends Controller {
         }
 
         // 記錄操作
-        $resourceId = $pk['c_personid'].'-'.($pk['c_sequence'] ?? 'NULL').'-'.$pk['c_alt_name_chn'].'-'.$pk['c_alt_name_type_code'];
-        $this->operationRepository->store(Auth::id(), $id, 4, 'ALTNAME_DATA', $resourceId, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
 
         // 刪除資料（需要重新構建 query builder）
         $deleteQuery = DB::table('ALTNAME_DATA')->where($conditions);

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -13,6 +13,7 @@ use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\Repositories\YearRangeRepository;
 use App\Services\NameSearchIndexService;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -384,7 +385,12 @@ class BasicInformationController extends Controller {
             $addr_data = Arr::except($addr_data, ['_token']);
             $addr_data = $this->toolRepository->timestamp($addr_data, true); //建檔資訊
             DB::table('BIOG_ADDR_DATA')->insert($addr_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_ADDR_DATA', $addr_data['c_personid']."-".$addr_data['c_addr_id']."-".$addr_data['c_addr_type']."-".$addr_data['c_sequence'], $addr_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $addr_data['c_personid'],
+                'c_addr_id' => $addr_data['c_addr_id'],
+                'c_addr_type' => $addr_data['c_addr_type'],
+                'c_sequence' => $addr_data['c_sequence'],
+            ]), $addr_data);
         }
 
         //出處
@@ -396,7 +402,11 @@ class BasicInformationController extends Controller {
             $source_data['c_personid'] = $new_id;
             $source_data = Arr::except($source_data, ['_token']);
             DB::table('BIOG_SOURCE_DATA')->insert($source_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_SOURCE_DATA', $source_data['c_personid']."-".$source_data['c_textid']."-".$source_data['c_pages'], $source_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $source_data['c_personid'],
+                'c_textid' => $source_data['c_textid'],
+                'c_pages' => $source_data['c_pages'],
+            ]), $source_data);
         }
 
         //親屬
@@ -408,7 +418,11 @@ class BasicInformationController extends Controller {
             $kin_data['c_personid'] = $new_id;
             $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
             DB::table('KIN_DATA')->insert($kin_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'KIN_DATA', $kin_data['c_personid']."-".$kin_data['c_kin_id']."-".$kin_data['c_kin_code'], $kin_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $kin_data['c_personid'],
+                'c_kin_id' => $kin_data['c_kin_id'],
+                'c_kin_code' => $kin_data['c_kin_code'],
+            ]), $kin_data);
         }
 
         $kin_pair = DB::table('KIN_DATA')->where([
@@ -420,7 +434,11 @@ class BasicInformationController extends Controller {
             $kin_data['c_kin_id'] = $new_id;
             $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
             DB::table('KIN_DATA')->insert($kin_data);
-            $this->operationRepository->store(Auth::id(), $kin_pair_id, 1, 'KIN_DATA', $kin_data['c_personid']."-".$kin_data['c_kin_id']."-".$kin_data['c_kin_code'], $kin_data);
+            $this->operationRepository->store(Auth::id(), $kin_pair_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $kin_data['c_personid'],
+                'c_kin_id' => $kin_data['c_kin_id'],
+                'c_kin_code' => $kin_data['c_kin_code'],
+            ]), $kin_data);
         }
 
         //社會關係
@@ -438,12 +456,17 @@ class BasicInformationController extends Controller {
             $assoc_data['c_tertiary_type_notes'] = null;
             $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
             DB::table('ASSOC_DATA')->insert($assoc_data);
-            // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
-            // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-            $assocFirstYearEncoded = str_replace('-', '(minus)', $assoc_data['c_assoc_first_year'] ?? '-9999');
-            // 注意：c_text_title 可能包含 /（如 [n/a]），需要編碼為 (slash) 避免 URL 解析錯誤
-            $textTitleEncoded = $this->biogMainRepository->unionPKDef($assoc_data['c_text_title']);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'ASSOC_DATA', $assoc_data['c_personid']."-".$assoc_data['c_assoc_code']."-".$assoc_data['c_assoc_id']."-".$assoc_data['c_kin_code']."-".$assoc_data['c_kin_id']."-".$assoc_data['c_assoc_kin_code']."-".$assoc_data['c_assoc_kin_id']."-".$textTitleEncoded."-".$assocFirstYearEncoded, $assoc_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $assoc_data['c_personid'],
+                'c_assoc_code' => $assoc_data['c_assoc_code'],
+                'c_assoc_id' => $assoc_data['c_assoc_id'],
+                'c_kin_code' => $assoc_data['c_kin_code'],
+                'c_kin_id' => $assoc_data['c_kin_id'],
+                'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+            ]), $assoc_data);
         }
 
         $assoc_pair = DB::table('ASSOC_DATA')->where([
@@ -461,12 +484,17 @@ class BasicInformationController extends Controller {
             $assoc_data['c_tertiary_type_notes'] = null;
             $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
             DB::table('ASSOC_DATA')->insert($assoc_data);
-            // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
-            // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-            $assocFirstYearEncoded = str_replace('-', '(minus)', $assoc_data['c_assoc_first_year'] ?? '-9999');
-            // 注意：c_text_title 可能包含 /（如 [n/a]），需要編碼為 (slash) 避免 URL 解析錯誤
-            $textTitleEncoded = $this->biogMainRepository->unionPKDef($assoc_data['c_text_title']);
-            $this->operationRepository->store(Auth::id(), $assoc_pair_id, 1, 'ASSOC_DATA', $assoc_data['c_personid']."-".$assoc_data['c_assoc_code']."-".$assoc_data['c_assoc_id']."-".$assoc_data['c_kin_code']."-".$assoc_data['c_kin_id']."-".$assoc_data['c_assoc_kin_code']."-".$assoc_data['c_assoc_kin_id']."-".$textTitleEncoded."-".$assocFirstYearEncoded, $assoc_data);
+            $this->operationRepository->store(Auth::id(), $assoc_pair_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $assoc_data['c_personid'],
+                'c_assoc_code' => $assoc_data['c_assoc_code'],
+                'c_assoc_id' => $assoc_data['c_assoc_id'],
+                'c_kin_code' => $assoc_data['c_kin_code'],
+                'c_kin_id' => $assoc_data['c_kin_id'],
+                'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+            ]), $assoc_data);
         }
 
         //社交機構
@@ -479,7 +507,12 @@ class BasicInformationController extends Controller {
             $inst_data = Arr::except($inst_data, ['_token']);
             $inst_data = $this->toolRepository->timestamp($inst_data, true); //建檔資訊
             DB::table('BIOG_INST_DATA')->insert($inst_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_INST_DATA', $inst_data['c_personid']."-".$inst_data['c_inst_code']."-".$inst_data['c_inst_name_code']."-".$inst_data['c_bi_role_code'], $inst_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $inst_data['c_personid'],
+                'c_inst_code' => $inst_data['c_inst_code'],
+                'c_inst_name_code' => $inst_data['c_inst_name_code'],
+                'c_bi_role_code' => $inst_data['c_bi_role_code'],
+            ]), $inst_data);
         }
 
         //社會區分
@@ -492,7 +525,11 @@ class BasicInformationController extends Controller {
             $status_data = Arr::except($status_data, ['_token']);
             $status_data = $this->toolRepository->timestamp($status_data, true); //建檔資訊
             DB::table('STATUS_DATA')->insert($status_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'STATUS_DATA', $status_data['c_personid'].'-'.$status_data['c_sequence'].'-'.$status_data['c_status_code'], $status_data);
+            $this->operationRepository->store(Auth::id(), $new_id, 1, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $status_data['c_personid'],
+                'c_sequence' => $status_data['c_sequence'],
+                'c_status_code' => $status_data['c_status_code'],
+            ]), $status_data);
         }
 
         //擴充結束

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -174,8 +174,18 @@ class BasicInformationEntriesController extends Controller {
             return redirect()->back();
         }
         DB::table('ENTRY_DATA')->insert($data);
-        $newKey = $data['c_personid'].'-'.$data['c_entry_code'].'-'.$data['c_sequence'].'-'.$data['c_kin_code'].'-'.$data['c_assoc_code'].'-'.$data['c_kin_id'].'-'.$data['c_year'].'-'.$data['c_assoc_id'].'-'.$data['c_inst_code'].'-'.$data['c_inst_name_code'];
-        $this->operationRepository->store(Auth::id(), $id, 1, 'ENTRY_DATA', $newKey, $data);
+        $this->operationRepository->store(Auth::id(), $id, 1, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_entry_code' => $data['c_entry_code'],
+            'c_sequence' => $data['c_sequence'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_year' => $data['c_year'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+        ]), $data);
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -339,8 +349,18 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_code', '=', $addr_a[8]],
             ['c_inst_name_code', '=', $addr_a[9]],
         ])->update($data);
-        $newid = $id.'-'.$data['c_entry_code'].'-'.$data['c_sequence'].'-'.$data['c_kin_code'].'-'.$data['c_assoc_code'].'-'.$data['c_kin_id'].'-'.$data['c_year'].'-'.$data['c_assoc_id'].'-'.$data['c_inst_code'].'-'.$data['c_inst_name_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', $newid, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_entry_code' => $data['c_entry_code'],
+            'c_sequence' => $data['c_sequence'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_year' => $data['c_year'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -400,7 +420,18 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_name_code', '=', $addr_a[9]],
         ])->first();
 
-        $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', $id_, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $addr_a[0],
+            'c_entry_code' => $addr_a[1],
+            'c_sequence' => $addr_a[2],
+            'c_kin_code' => $addr_a[3],
+            'c_assoc_code' => $addr_a[4],
+            'c_kin_id' => $addr_a[5],
+            'c_year' => $addr_a[6],
+            'c_assoc_id' => $addr_a[7],
+            'c_inst_code' => $addr_a[8],
+            'c_inst_name_code' => $addr_a[9],
+        ]), $row);
         DB::table('ENTRY_DATA')->where([
             ['c_personid', '=', $addr_a[0]],
             ['c_entry_code', '=', $addr_a[1]],
@@ -587,8 +618,18 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_name_code', '=', $originalPk['c_inst_name_code']],
         ])->update($data);
 
-        $newid = $id.'-'.$data['c_entry_code'].'-'.$data['c_sequence'].'-'.$data['c_kin_code'].'-'.$data['c_assoc_code'].'-'.$data['c_kin_id'].'-'.$data['c_year'].'-'.$data['c_assoc_id'].'-'.$data['c_inst_code'].'-'.$data['c_inst_name_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', $newid, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_entry_code' => $data['c_entry_code'],
+            'c_sequence' => $data['c_sequence'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_year' => $data['c_year'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 重定向到新的查詢參數格式
@@ -652,20 +693,7 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_name_code', '=', $pk['c_inst_name_code']],
         ])->first();
 
-        $id_ = implode('-', [
-            $pk['c_personid'],
-            $pk['c_entry_code'],
-            $pk['c_sequence'],
-            $pk['c_kin_code'],
-            $pk['c_assoc_code'],
-            $pk['c_kin_id'],
-            $pk['c_year'],
-            $pk['c_assoc_id'],
-            $pk['c_inst_code'],
-            $pk['c_inst_name_code'],
-        ]);
-
-        $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', $id_, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
 
         DB::table('ENTRY_DATA')->where([
             ['c_personid', '=', $pk['c_personid']],

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -275,8 +275,12 @@ class BasicInformationSocialInstController extends Controller {
             ['c_inst_name_code', '=', $addr_l[2]],
             ['c_bi_role_code', '=', $addr_l[3]],
         ])->update($data);
-        $newid = $id.'-'.$data['c_inst_code'].'-'.$data['c_inst_name_code'].'-'.$data['c_bi_role_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_INST_DATA', $newid, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+            'c_bi_role_code' => $data['c_bi_role_code'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -320,7 +324,12 @@ class BasicInformationSocialInstController extends Controller {
             ['c_bi_role_code', '=', $addr_l[3]],
         ])->first();
 
-        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', $id_, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $addr_l[0],
+            'c_inst_code' => $addr_l[1],
+            'c_inst_name_code' => $addr_l[2],
+            'c_bi_role_code' => $addr_l[3],
+        ]), $row);
         DB::table('BIOG_INST_DATA')->where([
             ['c_personid', '=', $addr_l[0]],
             ['c_inst_code', '=', $addr_l[1]],
@@ -469,8 +478,12 @@ class BasicInformationSocialInstController extends Controller {
             ['c_bi_role_code', '=', $originalPk['c_bi_role_code']],
         ])->update($data);
 
-        $newid = $id.'-'.$data['c_inst_code'].'-'.$data['c_inst_name_code'].'-'.$data['c_bi_role_code'];
-        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_INST_DATA', $newid, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+            'c_bi_role_code' => $data['c_bi_role_code'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 重定向到新的查詢參數格式
@@ -522,9 +535,7 @@ class BasicInformationSocialInstController extends Controller {
             ['c_bi_role_code', '=', $pk['c_bi_role_code']],
         ])->first();
 
-        $id_ = $pk['c_personid'].'-'.$pk['c_inst_code'].'-'.$pk['c_inst_name_code'].'-'.$pk['c_bi_role_code'];
-
-        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', $id_, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
 
         DB::table('BIOG_INST_DATA')->where([
             ['c_personid', '=', $pk['c_personid']],

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -136,7 +136,11 @@ class BasicInformationTextsController extends Controller {
             return redirect()->back();
         }
         DB::table($this->table_name)->insert($data);
-        $this->operationRepository->store(Auth::id(), $id, 1, $this->table_name, $data['c_personid']."-".$data['c_textid']."-".$data['c_role_id'], $data);
+        $this->operationRepository->store(Auth::id(), $id, 1, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_textid' => $data['c_textid'],
+            'c_role_id' => $data['c_role_id'],
+        ]), $data);
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -240,8 +244,11 @@ class BasicInformationTextsController extends Controller {
             ['c_role_id', '=', $temp_l[2]],
         ])->update($data);
         $data['c_personid'] = $temp_l[0];
-        $new_id_ = $data['c_personid']."-".$data['c_textid']."-".$data['c_role_id'];
-        $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, $new_id_, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_textid' => $data['c_textid'],
+            'c_role_id' => $data['c_role_id'],
+        ]), $data, $ori);
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -285,7 +292,11 @@ class BasicInformationTextsController extends Controller {
             ['c_textid', '=', $temp_l[1]],
             ['c_role_id', '=', $temp_l[2]],
         ])->delete();
-        $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, $id_, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $temp_l[0],
+            'c_textid' => $temp_l[1],
+            'c_role_id' => $temp_l[2],
+        ]), $row);
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.texts.index', ['basicinformation' => $id]);
@@ -413,8 +424,7 @@ class BasicInformationTextsController extends Controller {
             'c_textid' => $data['c_textid'] ?? $pk['c_textid'],
             'c_role_id' => $data['c_role_id'] ?? $c_role_id,
         ];
-        $resourceId = $newPk['c_personid'].'-'.$newPk['c_textid'].'-'.$newPk['c_role_id'];
-        $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, $resourceId, $data, $ori);
+        $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, CompositePrimaryKey::buildStoredResourceId($newPk), $data, $ori);
 
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -469,8 +479,11 @@ class BasicInformationTextsController extends Controller {
         DB::table($this->table_name)->where($conditions)->delete();
 
         // 記錄操作
-        $resourceId = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$c_role_id;
-        $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, $resourceId, $row);
+        $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $pk['c_personid'],
+            'c_textid' => $pk['c_textid'],
+            'c_role_id' => $c_role_id,
+        ]), $row);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -10,6 +10,7 @@ use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
@@ -161,7 +162,10 @@ class CrowdsourcingController extends Controller {
 
                     break;
                 case "OFFICE_CODE_TYPE_REL":
-                    $new_id = $data['c_office_id']."-".$data['c_office_tree_id'];
+                    $new_id = CompositePrimaryKey::buildStoredResourceId([
+                        'c_office_id' => $data['c_office_id'],
+                        'c_office_tree_id' => $data['c_office_tree_id'],
+                    ]);
                     $message = OfficeCodeTypeRel::create($data);
                     if ($message == true) {
                         DB::table('operations')->where('id', $id)->update(['crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at]);

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -8,6 +8,7 @@ use App\Models\OfficeCodeTypeRel;
 use App\Models\OfficeTypeTree;
 use App\Models\Operation;
 use App\Repositories\OperationRepository;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -70,128 +71,35 @@ class OperationsController extends Controller {
             if (!empty($c_personid = $dataRows[$x]['c_personid']) && $dataRows[$x]['resource'] == "BIOG_MAIN") {
                 $arr3 = BiogMain::find($c_personid)->toArray();
             } elseif (!empty($resource_id = $dataRows[$x]['resource_id']) && !empty($resource = $dataRows[$x]['resource'])) {
-                switch ($resource) {
-                    case "OFFICE_CODES":
-                        if ($office = OfficeCode::find($resource_id)) {
-                            $arr3 = $office->toArray();
-                        }
-
-                        break;
-                    case "OFFICE_CODE_TYPE_REL":
-                        $temp_l = explode("-", $resource_id);
-                        $relation = OfficeCodeTypeRel::where('c_office_id', $temp_l[0])
-                            ->where('c_office_tree_id', $temp_l[1])
-                            ->first();
-                        if ($relation) {
-                            $arr3 = $relation->toArray();
-                        }
-
-                        break;
-                    case "OFFICE_TYPE_TREE":
-                        if ($tree = OfficeTypeTree::find($resource_id)) {
-                            $arr3 = $tree->toArray();
-                        }
-
-                        break;
-                        //20251213新增差異比對紀錄
-                    case "BIOG_ADDR_DATA":
-                        $addr_l = explode("-", $resource_id);
-                        $arr3 = DB::table('BIOG_ADDR_DATA')->where([
-                            ['c_personid', '=', $addr_l[0]],
-                            ['c_addr_id', '=', $addr_l[1]],
-                            ['c_addr_type', '=', $addr_l[2]],
-                            ['c_sequence', '=', $addr_l[3]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                    case "ALTNAME_DATA":
-                        //20251201先遮除原本存取方式，改使用聯合主鍵解析
-                        //$arr3 = $this->fetchAltnameCurrentRow($listsArr['data'][$x]);
-
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $addr_l = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $addr_l = explode("-", $alt);
-                            foreach ($addr_l as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $addr_l[$key] = str_replace("minus", "-", $value);
+                // 新格式：query-string 格式的 resource_id（由 buildStoredResourceId() 產生）
+                // 若 schema key 驗證失敗（舊格式值恰好含 '='），自動回退到舊格式 switch/case
+                $usedNewFormat = false;
+                if (str_contains($resource_id, '=') && !str_contains($resource_id, '_._')) {
+                    $parsedPk = CompositePrimaryKey::parseStoredResourceId($resource_id, $resource);
+                    if ($parsedPk !== null) {
+                        $usedNewFormat = true;
+                        // BIOG_TEXT_DATA 在 SCHEMAS 中有別名 TEXT_DATA，但資料表名為 BIOG_TEXT_DATA
+                        $tableName = ($resource === 'TEXT_DATA') ? 'BIOG_TEXT_DATA' : $resource;
+                        $query = DB::table($tableName);
+                        foreach ($parsedPk as $col => $val) {
+                            if ($val === 'NULL' || $val === null) {
+                                $query->whereNull($col);
+                            } else {
+                                $query->where($col, '=', $val);
                             }
                         }
 
-                        // 檢查陣列長度是否足夠（ALTNAME_DATA 需要 4 個欄位）
-                        if (count($addr_l) < 4) {
-                            // 記錄錯誤並跳過此筆資料
-                            \Log::warning("ALTNAME_DATA resource_id 格式不正確: {$resource_id}", [
-                                'parsed' => $addr_l,
-                                'expected_count' => 4,
-                                'actual_count' => count($addr_l),
-                                'operation_id' => $listsArr['data'][$x]['id'] ?? null,
-                            ]);
-                            $arr3 = null;
-
-                            break;
-                        }
-
-                        if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
-                            $addr_l[1] = null;
-                        }
-                        $arr3 = DB::table('ALTNAME_DATA')->where([
-                            ['c_personid', '=', $addr_l[0]],
-                            ['c_sequence', '=', $addr_l[1]],
-                            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-                            ['c_alt_name_type_code', '=', $addr_l[3]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251214新增差異比對紀錄
-                    case "BIOG_TEXT_DATA":
-                        $temp_l = explode("-", $resource_id);
-                        $arr3 = DB::table('BIOG_TEXT_DATA')->where([
-                            ['c_personid', '=', $temp_l[0]],
-                            ['c_textid', '=', $temp_l[1]],
-                            ['c_role_id', '=', $temp_l[2]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                    case "POSTED_TO_OFFICE_DATA":
-                        $temp_l = explode("-", $resource_id);
-                        $_officeid = $temp_l[0];
-                        $_postingid = $temp_l[1];
-                        $arr3 = DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                    case "POSTED_TO_ADDR_DATA":
-                        $addrParts = explode('-', $resource_id);
-                        $postingOfficeId = $addrParts[0] ?? null;
-                        $postingId = $addrParts[1] ?? null;
-                        $personId = $dataRows[$x]['c_personid'] ?? null;
-                        if ($personId === null) {
-                            $decoded = json_decode($arr1, true);
-                            if (is_array($decoded) && isset($decoded['rows'][0]['c_personid'])) {
-                                $personId = (int) $decoded['rows'][0]['c_personid'];
+                        if ($resource === 'POSTED_TO_ADDR_DATA') {
+                            // POSTED_TO_ADDR_DATA 使用 rows 格式
+                            $personId = $dataRows[$x]['c_personid'] ?? null;
+                            if ($personId === null) {
+                                $decoded = json_decode($arr1, true);
+                                if (is_array($decoded) && isset($decoded['rows'][0]['c_personid'])) {
+                                    $personId = (int) $decoded['rows'][0]['c_personid'];
+                                }
                             }
-                        }
-                        if ($personId !== null && $postingId !== null) {
-                            $query = DB::table('POSTED_TO_ADDR_DATA')
-                                ->where('c_personid', $personId)
-                                ->where('c_posting_id', $postingId);
-                            if ($postingOfficeId !== null && $postingOfficeId !== '') {
-                                $query->where('c_office_id', $postingOfficeId);
+                            if ($personId !== null) {
+                                $query->where('c_personid', $personId);
                             }
                             $rows = $query->get()->map(function ($row) {
                                 return [
@@ -203,348 +111,487 @@ class OperationsController extends Controller {
                             })->values()->all();
                             $arr3 = ['rows' => $rows];
                         } else {
-                            $arr3 = [];
+                            $arr3 = json_decode(json_encode($query->first()), true);
                         }
-
-                        break;
-                        //20251205新增入仕差異比對紀錄
-                    case "ENTRY_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $entry_1 = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $entry_1 = explode("-", $alt);
-                            foreach ($entry_1 as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $entry_1[$key] = str_replace("minus", "-", $value);
+                    }
+                }
+                if (!$usedNewFormat) {
+                    switch ($resource) {
+                        case "OFFICE_CODES":
+                            if ($office = OfficeCode::find($resource_id)) {
+                                $arr3 = $office->toArray();
                             }
-                        }
-                        $arr3 = DB::table('ENTRY_DATA')->where([
-                                        ['c_personid', '=', $entry_1[0]],
-                                        ['c_entry_code', '=', $entry_1[1]],
-                                        ['c_sequence', '=', $entry_1[2]],
-                                        ['c_kin_code', '=', $entry_1[3]],
-                                        ['c_assoc_code', '=', $entry_1[4]],
-                                        ['c_kin_id', '=', $entry_1[5]],
-                                        ['c_year', '=', $entry_1[6]],
-                                        ['c_assoc_id', '=', $entry_1[7]],
-                                        ['c_inst_code', '=', $entry_1[8]],
-                                        ['c_inst_name_code', '=', $entry_1[9]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        //dd($arr3);
-                        break;
-                        //20251208新增事件差異比對紀錄
-                    case "EVENTS_DATA":
-                        // 支持新格式 "c_personid-c_sequence-c_event_code" 和舊格式 "c_sequence"
-                        $eventParts = explode('-', $resource_id);
-                        $eventQuery = DB::table('EVENTS_DATA')->where('c_personid', $c_personid);
-                        if (count($eventParts) >= 3) {
-                            // 新格式：resource_id = "c_personid-c_sequence-c_event_code"
-                            $eventQuery->where('c_sequence', $eventParts[1])
-                                       ->where('c_event_code', $eventParts[2]);
-                        } else {
-                            // 舊格式：resource_id = "c_sequence"
-                            $eventQuery->where('c_sequence', $resource_id);
-                        }
-                        $arr3 = $eventQuery->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增社會區別差異比對紀錄
-                    case "STATUS_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $status_1 = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $status_1 = explode("-", $alt);
-                            foreach ($status_1 as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $status_1[$key] = str_replace("minus", "-", $value);
-                            }
-                        }
-                        $arr3 = DB::table('STATUS_DATA')->where([
-                            ['c_personid', '=', $status_1[0]],
-                            ['c_sequence', '=', $status_1[1]],
-                            ['c_status_code', '=', $status_1[2]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增親屬差異比對紀錄
-                    case "KIN_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $kin_1 = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $kin_1 = explode("-", $alt);
-                            foreach ($kin_1 as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $kin_1[$key] = str_replace("minus", "-", $value);
-                            }
-                        }
-                        $arr3 = DB::table('KIN_DATA')->where([
-                            ['c_personid', '=', $kin_1[0]],
-                            ['c_kin_id', '=', $kin_1[1]],
-                            ['c_kin_code', '=', $kin_1[2]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增社會關係差異比對紀錄
-                    case "ASSOC_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $assoc_1 = explode('_._', $resource_id);
-                            $arr3 = DB::table('ASSOC_DATA')->where([
-                                ['c_personid', '=', $assoc_1[0]],
-                                ['c_assoc_code', '=', $assoc_1[1]],
-                                ['c_assoc_id', '=', $assoc_1[2]],
-                                ['c_kin_code', '=', $assoc_1[3]],
-                                ['c_kin_id', '=', $assoc_1[4]],
-                                ['c_assoc_kin_code', '=', $assoc_1[5]],
-                                ['c_assoc_kin_id', '=', $assoc_1[6]],
-                                ['c_text_title', '=', $assoc_1[7] ?? ''],
-                                ['c_assoc_first_year', '=', $assoc_1[8] ?? '-9999'],
-                            ])->first();
-                        } else {
-                            // 使用 - 格式
-                            // 策略：先嘗試新格式（不做 -- 替換），如果找不到再嘗試舊格式（做 -- 替換）
-                            // 這樣可以正確處理新格式中空 c_text_title 導致的 -- 情況
-
-                            // 輔助函數：解碼保留字（不包括 -- 和 minus）
-                            $decodeReserved = function ($str) {
-                                $str = str_replace("(slash)", "/", $str);
-                                $str = str_replace("(backslash)", "\\", $str);
-                                $str = str_replace("(brackets)", "{", $str);
-                                $str = str_replace("(brackets_r)", "}", $str);
-                                $str = str_replace("(question)", "?", $str);
-                                $str = str_replace("(hash)", "#", $str);
-                                $str = str_replace("(amp)", "&", $str);
-
-                                return $str;
-                            };
-
-                            // 輔助函數：解析 segments 中的 minus 編碼
-                            $decodeMinusInSegments = function ($segments) {
-                                foreach ($segments as $key => $value) {
-                                    // 注意：必須先處理 (minus) 再處理 minus，否則 (minus) 會變成 (-)
-                                    $value = str_replace("(minus)", "-", $value);  // 新版 (minus) 編碼
-                                    $value = str_replace("minus", "-", $value);  // 舊版 -- 格式的向後兼容
-                                    $segments[$key] = $value;
-                                }
-
-                                return $segments;
-                            };
-
-                            $arr3 = null;
-
-                            // 第一次嘗試：新格式（不做 -- 替換，保留空欄位邊界）
-                            $alt_new = $decodeReserved($resource_id);
-                            $assoc_1_new = explode("-", $alt_new);
-                            $assoc_1_new = $decodeMinusInSegments($assoc_1_new);
-
-                            $totalParts = count($assoc_1_new);
-                            if ($totalParts >= 9) {
-                                $c_assoc_first_year_new = $assoc_1_new[$totalParts - 1];
-                                if ($totalParts > 9) {
-                                    $c_text_title_new = implode('-', array_slice($assoc_1_new, 7, $totalParts - 8));
-                                } else {
-                                    $c_text_title_new = $assoc_1_new[7] ?? '';
-                                }
-
-                                $arr3 = DB::table('ASSOC_DATA')->where([
-                                    ['c_personid', '=', $assoc_1_new[0]],
-                                    ['c_assoc_code', '=', $assoc_1_new[1]],
-                                    ['c_assoc_id', '=', $assoc_1_new[2]],
-                                    ['c_kin_code', '=', $assoc_1_new[3]],
-                                    ['c_kin_id', '=', $assoc_1_new[4]],
-                                    ['c_assoc_kin_code', '=', $assoc_1_new[5]],
-                                    ['c_assoc_kin_id', '=', $assoc_1_new[6]],
-                                    ['c_text_title', '=', $c_text_title_new],
-                                    ['c_assoc_first_year', '=', $c_assoc_first_year_new],
-                                ])->first();
-                            }
-
-                            // 第二次嘗試：舊格式（做 -- 替換，用於向後兼容舊版 ID）
-                            if (!$arr3) {
-                                $alt_old = str_replace("--", "-minus", $resource_id);
-                                $alt_old = $decodeReserved($alt_old);
-                                $assoc_1_old = explode("-", $alt_old);
-                                $assoc_1_old = $decodeMinusInSegments($assoc_1_old);
-
-                                $totalPartsOld = count($assoc_1_old);
-
-                                // 嘗試新 9-field 格式（舊編碼）
-                                if ($totalPartsOld >= 9) {
-                                    $c_assoc_first_year_try = $assoc_1_old[$totalPartsOld - 1];
-                                    if ($totalPartsOld > 9) {
-                                        $c_text_title_try = implode('-', array_slice($assoc_1_old, 7, $totalPartsOld - 8));
-                                    } else {
-                                        $c_text_title_try = $assoc_1_old[7] ?? '';
-                                    }
-
-                                    $arr3 = DB::table('ASSOC_DATA')->where([
-                                        ['c_personid', '=', $assoc_1_old[0]],
-                                        ['c_assoc_code', '=', $assoc_1_old[1]],
-                                        ['c_assoc_id', '=', $assoc_1_old[2]],
-                                        ['c_kin_code', '=', $assoc_1_old[3]],
-                                        ['c_kin_id', '=', $assoc_1_old[4]],
-                                        ['c_assoc_kin_code', '=', $assoc_1_old[5]],
-                                        ['c_assoc_kin_id', '=', $assoc_1_old[6]],
-                                        ['c_text_title', '=', $c_text_title_try],
-                                        ['c_assoc_first_year', '=', $c_assoc_first_year_try],
-                                    ])->first();
-                                }
-
-                                // 嘗試舊 8-field 格式
-                                if (!$arr3 && $totalPartsOld >= 8) {
-                                    $c_text_title_old = implode('-', array_slice($assoc_1_old, 7));
-                                    $c_assoc_first_year_old = '-9999';
-
-                                    $arr3 = DB::table('ASSOC_DATA')->where([
-                                        ['c_personid', '=', $assoc_1_old[0]],
-                                        ['c_assoc_code', '=', $assoc_1_old[1]],
-                                        ['c_assoc_id', '=', $assoc_1_old[2]],
-                                        ['c_kin_code', '=', $assoc_1_old[3]],
-                                        ['c_kin_id', '=', $assoc_1_old[4]],
-                                        ['c_assoc_kin_code', '=', $assoc_1_old[5]],
-                                        ['c_assoc_kin_id', '=', $assoc_1_old[6]],
-                                        ['c_text_title', '=', $c_text_title_old],
-                                        ['c_assoc_first_year', '=', $c_assoc_first_year_old],
-                                    ])->first();
-                                }
-                            }
-                        }
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增財產差異比對紀錄
-                    case "POSSESSION_DATA":
-                        $arr3 = DB::table('POSSESSION_DATA')->where('c_possession_record_id', $resource_id)->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增社交機構差異比對紀錄
-                    case "BIOG_INST_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $inst_1 = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $inst_1 = explode("-", $alt);
-                            foreach ($inst_1 as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $inst_1[$key] = str_replace("minus", "-", $value);
-                            }
-                            if ($inst_1[1] == '') {
-                                $inst_1[1] = null;
-                            }
-                            if ($inst_1[2] == '') {
-                                $inst_1[2] = null;
-                            }
-                        }
-                        $arr3 = DB::table('BIOG_INST_DATA')->where([
-                            ['c_personid', '=', $inst_1[0]],
-                            ['c_inst_code', '=', $inst_1[1]],
-                            ['c_inst_name_code', '=', $inst_1[2]],
-                            ['c_bi_role_code', '=', $inst_1[3]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
-
-                        break;
-                        //20251208新增出處差異比對紀錄
-                    case "BIOG_SOURCE_DATA":
-                        // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                        if (strpos($resource_id, '_._') !== false) {
-                            // 使用 _._格式
-                            $source_1 = explode('_._', $resource_id);
-                        } else {
-                            // 使用 - 格式
-                            $alt = str_replace("--", "-minus", $resource_id);
-                            //聯合主鍵保留字弱點防禦函式，解析保留字。
-                            $alt = $this->unionPKDef_decode($alt);
-                            $source_1 = explode("-", $alt);
-                            foreach ($source_1 as $key => $value) {
-                                // 注意：必須先處理 (minus) 再處理 minus
-                                $value = str_replace("(minus)", "-", $value);
-                                $source_1[$key] = str_replace("minus", "-", $value);
-                            }
-                            //防止c_pages欄位內含負號所做的字串重組
-                            $new_c_pages = '';
-                            if (!empty($source_1[3])) {
-                                for ($i = 2; $i < count($source_1); $i++) {
-                                    if (empty($new_c_pages)) {
-                                        $new_c_pages .= $source_1[$i];
-                                    } else {
-                                        $new_c_pages .= "-".$source_1[$i];
-                                    }
-                                }
-                                $source_1[2] = $new_c_pages;
-                            }
-
-                        }
-
-                        // 檢查陣列長度是否足夠（BIOG_SOURCE_DATA 需要 3 個欄位）
-                        if (count($source_1) < 3) {
-                            // 記錄錯誤並跳過此筆資料
-                            \Log::warning("BIOG_SOURCE_DATA resource_id 格式不正確: {$resource_id}", [
-                                'parsed' => $source_1,
-                                'expected_count' => 3,
-                                'actual_count' => count($source_1),
-                                'operation_id' => $listsArr['data'][$x]['id'] ?? null,
-                            ]);
-                            $arr3 = null;
 
                             break;
-                        }
+                        case "OFFICE_CODE_TYPE_REL":
+                            $temp_l = explode("-", $resource_id);
+                            $relation = OfficeCodeTypeRel::where('c_office_id', $temp_l[0])
+                                ->where('c_office_tree_id', $temp_l[1])
+                                ->first();
+                            if ($relation) {
+                                $arr3 = $relation->toArray();
+                            }
 
-                        $arr3 = DB::table('BIOG_SOURCE_DATA')->where([
-                            ['c_personid', '=', $source_1[0]],
-                            ['c_textid', '=', $source_1[1]],
-                            ['c_pages', '=', $source_1[2]],
-                        ])->first();
-                        $arr3 = json_encode($arr3);
-                        $arr3 = json_decode($arr3, true);
+                            break;
+                        case "OFFICE_TYPE_TREE":
+                            if ($tree = OfficeTypeTree::find($resource_id)) {
+                                $arr3 = $tree->toArray();
+                            }
 
-                        break;
-                    default:
-                        $arr3 = [];
+                            break;
+                            //20251213新增差異比對紀錄
+                        case "BIOG_ADDR_DATA":
+                            $addr_l = explode("-", $resource_id);
+                            $arr3 = DB::table('BIOG_ADDR_DATA')->where([
+                                ['c_personid', '=', $addr_l[0]],
+                                ['c_addr_id', '=', $addr_l[1]],
+                                ['c_addr_type', '=', $addr_l[2]],
+                                ['c_sequence', '=', $addr_l[3]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
 
-                        break;
-                }
+                            break;
+                        case "ALTNAME_DATA":
+                            //20251201先遮除原本存取方式，改使用聯合主鍵解析
+                            //$arr3 = $this->fetchAltnameCurrentRow($listsArr['data'][$x]);
+
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $addr_l = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $addr_l = explode("-", $alt);
+                                foreach ($addr_l as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $addr_l[$key] = str_replace("minus", "-", $value);
+                                }
+                            }
+
+                            // 檢查陣列長度是否足夠（ALTNAME_DATA 需要 4 個欄位）
+                            if (count($addr_l) < 4) {
+                                // 記錄錯誤並跳過此筆資料
+                                \Log::warning("ALTNAME_DATA resource_id 格式不正確: {$resource_id}", [
+                                    'parsed' => $addr_l,
+                                    'expected_count' => 4,
+                                    'actual_count' => count($addr_l),
+                                    'operation_id' => $listsArr['data'][$x]['id'] ?? null,
+                                ]);
+                                $arr3 = null;
+
+                                break;
+                            }
+
+                            if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
+                                $addr_l[1] = null;
+                            }
+                            $arr3 = DB::table('ALTNAME_DATA')->where([
+                                ['c_personid', '=', $addr_l[0]],
+                                ['c_sequence', '=', $addr_l[1]],
+                                ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
+                                ['c_alt_name_type_code', '=', $addr_l[3]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251214新增差異比對紀錄
+                        case "BIOG_TEXT_DATA":
+                            $temp_l = explode("-", $resource_id);
+                            $arr3 = DB::table('BIOG_TEXT_DATA')->where([
+                                ['c_personid', '=', $temp_l[0]],
+                                ['c_textid', '=', $temp_l[1]],
+                                ['c_role_id', '=', $temp_l[2]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                        case "POSTED_TO_OFFICE_DATA":
+                            $temp_l = explode("-", $resource_id);
+                            $_officeid = $temp_l[0];
+                            $_postingid = $temp_l[1];
+                            $arr3 = DB::table('POSTED_TO_OFFICE_DATA')->where([['c_office_id' , '=', $_officeid], ['c_posting_id' , '=', $_postingid]])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                        case "POSTED_TO_ADDR_DATA":
+                            $addrParts = explode('-', $resource_id);
+                            $postingOfficeId = $addrParts[0] ?? null;
+                            $postingId = $addrParts[1] ?? null;
+                            $personId = $dataRows[$x]['c_personid'] ?? null;
+                            if ($personId === null) {
+                                $decoded = json_decode($arr1, true);
+                                if (is_array($decoded) && isset($decoded['rows'][0]['c_personid'])) {
+                                    $personId = (int) $decoded['rows'][0]['c_personid'];
+                                }
+                            }
+                            if ($personId !== null && $postingId !== null) {
+                                $query = DB::table('POSTED_TO_ADDR_DATA')
+                                    ->where('c_personid', $personId)
+                                    ->where('c_posting_id', $postingId);
+                                if ($postingOfficeId !== null && $postingOfficeId !== '') {
+                                    $query->where('c_office_id', $postingOfficeId);
+                                }
+                                $rows = $query->get()->map(function ($row) {
+                                    return [
+                                        'c_personid' => (int) $row->c_personid,
+                                        'c_posting_id' => (int) $row->c_posting_id,
+                                        'c_office_id' => (int) $row->c_office_id,
+                                        'c_addr_id' => (int) $row->c_addr_id,
+                                    ];
+                                })->values()->all();
+                                $arr3 = ['rows' => $rows];
+                            } else {
+                                $arr3 = [];
+                            }
+
+                            break;
+                            //20251205新增入仕差異比對紀錄
+                        case "ENTRY_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $entry_1 = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $entry_1 = explode("-", $alt);
+                                foreach ($entry_1 as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $entry_1[$key] = str_replace("minus", "-", $value);
+                                }
+                            }
+                            $arr3 = DB::table('ENTRY_DATA')->where([
+                                            ['c_personid', '=', $entry_1[0]],
+                                            ['c_entry_code', '=', $entry_1[1]],
+                                            ['c_sequence', '=', $entry_1[2]],
+                                            ['c_kin_code', '=', $entry_1[3]],
+                                            ['c_assoc_code', '=', $entry_1[4]],
+                                            ['c_kin_id', '=', $entry_1[5]],
+                                            ['c_year', '=', $entry_1[6]],
+                                            ['c_assoc_id', '=', $entry_1[7]],
+                                            ['c_inst_code', '=', $entry_1[8]],
+                                            ['c_inst_name_code', '=', $entry_1[9]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            //dd($arr3);
+                            break;
+                            //20251208新增事件差異比對紀錄
+                        case "EVENTS_DATA":
+                            // 支持新格式 "c_personid-c_sequence-c_event_code" 和舊格式 "c_sequence"
+                            $eventParts = explode('-', $resource_id);
+                            $eventQuery = DB::table('EVENTS_DATA')->where('c_personid', $c_personid);
+                            if (count($eventParts) >= 3) {
+                                // 新格式：resource_id = "c_personid-c_sequence-c_event_code"
+                                $eventQuery->where('c_sequence', $eventParts[1])
+                                           ->where('c_event_code', $eventParts[2]);
+                            } else {
+                                // 舊格式：resource_id = "c_sequence"
+                                $eventQuery->where('c_sequence', $resource_id);
+                            }
+                            $arr3 = $eventQuery->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增社會區別差異比對紀錄
+                        case "STATUS_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $status_1 = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $status_1 = explode("-", $alt);
+                                foreach ($status_1 as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $status_1[$key] = str_replace("minus", "-", $value);
+                                }
+                            }
+                            $arr3 = DB::table('STATUS_DATA')->where([
+                                ['c_personid', '=', $status_1[0]],
+                                ['c_sequence', '=', $status_1[1]],
+                                ['c_status_code', '=', $status_1[2]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增親屬差異比對紀錄
+                        case "KIN_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $kin_1 = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $kin_1 = explode("-", $alt);
+                                foreach ($kin_1 as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $kin_1[$key] = str_replace("minus", "-", $value);
+                                }
+                            }
+                            $arr3 = DB::table('KIN_DATA')->where([
+                                ['c_personid', '=', $kin_1[0]],
+                                ['c_kin_id', '=', $kin_1[1]],
+                                ['c_kin_code', '=', $kin_1[2]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增社會關係差異比對紀錄
+                        case "ASSOC_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $assoc_1 = explode('_._', $resource_id);
+                                $arr3 = DB::table('ASSOC_DATA')->where([
+                                    ['c_personid', '=', $assoc_1[0]],
+                                    ['c_assoc_code', '=', $assoc_1[1]],
+                                    ['c_assoc_id', '=', $assoc_1[2]],
+                                    ['c_kin_code', '=', $assoc_1[3]],
+                                    ['c_kin_id', '=', $assoc_1[4]],
+                                    ['c_assoc_kin_code', '=', $assoc_1[5]],
+                                    ['c_assoc_kin_id', '=', $assoc_1[6]],
+                                    ['c_text_title', '=', $assoc_1[7] ?? ''],
+                                    ['c_assoc_first_year', '=', $assoc_1[8] ?? '-9999'],
+                                ])->first();
+                            } else {
+                                // 使用 - 格式
+                                // 策略：先嘗試新格式（不做 -- 替換），如果找不到再嘗試舊格式（做 -- 替換）
+                                // 這樣可以正確處理新格式中空 c_text_title 導致的 -- 情況
+
+                                // 輔助函數：解碼保留字（不包括 -- 和 minus）
+                                $decodeReserved = function ($str) {
+                                    $str = str_replace("(slash)", "/", $str);
+                                    $str = str_replace("(backslash)", "\\", $str);
+                                    $str = str_replace("(brackets)", "{", $str);
+                                    $str = str_replace("(brackets_r)", "}", $str);
+                                    $str = str_replace("(question)", "?", $str);
+                                    $str = str_replace("(hash)", "#", $str);
+                                    $str = str_replace("(amp)", "&", $str);
+
+                                    return $str;
+                                };
+
+                                // 輔助函數：解析 segments 中的 minus 編碼
+                                $decodeMinusInSegments = function ($segments) {
+                                    foreach ($segments as $key => $value) {
+                                        // 注意：必須先處理 (minus) 再處理 minus，否則 (minus) 會變成 (-)
+                                        $value = str_replace("(minus)", "-", $value);  // 新版 (minus) 編碼
+                                        $value = str_replace("minus", "-", $value);  // 舊版 -- 格式的向後兼容
+                                        $segments[$key] = $value;
+                                    }
+
+                                    return $segments;
+                                };
+
+                                $arr3 = null;
+
+                                // 第一次嘗試：新格式（不做 -- 替換，保留空欄位邊界）
+                                $alt_new = $decodeReserved($resource_id);
+                                $assoc_1_new = explode("-", $alt_new);
+                                $assoc_1_new = $decodeMinusInSegments($assoc_1_new);
+
+                                $totalParts = count($assoc_1_new);
+                                if ($totalParts >= 9) {
+                                    $c_assoc_first_year_new = $assoc_1_new[$totalParts - 1];
+                                    if ($totalParts > 9) {
+                                        $c_text_title_new = implode('-', array_slice($assoc_1_new, 7, $totalParts - 8));
+                                    } else {
+                                        $c_text_title_new = $assoc_1_new[7] ?? '';
+                                    }
+
+                                    $arr3 = DB::table('ASSOC_DATA')->where([
+                                        ['c_personid', '=', $assoc_1_new[0]],
+                                        ['c_assoc_code', '=', $assoc_1_new[1]],
+                                        ['c_assoc_id', '=', $assoc_1_new[2]],
+                                        ['c_kin_code', '=', $assoc_1_new[3]],
+                                        ['c_kin_id', '=', $assoc_1_new[4]],
+                                        ['c_assoc_kin_code', '=', $assoc_1_new[5]],
+                                        ['c_assoc_kin_id', '=', $assoc_1_new[6]],
+                                        ['c_text_title', '=', $c_text_title_new],
+                                        ['c_assoc_first_year', '=', $c_assoc_first_year_new],
+                                    ])->first();
+                                }
+
+                                // 第二次嘗試：舊格式（做 -- 替換，用於向後兼容舊版 ID）
+                                if (!$arr3) {
+                                    $alt_old = str_replace("--", "-minus", $resource_id);
+                                    $alt_old = $decodeReserved($alt_old);
+                                    $assoc_1_old = explode("-", $alt_old);
+                                    $assoc_1_old = $decodeMinusInSegments($assoc_1_old);
+
+                                    $totalPartsOld = count($assoc_1_old);
+
+                                    // 嘗試新 9-field 格式（舊編碼）
+                                    if ($totalPartsOld >= 9) {
+                                        $c_assoc_first_year_try = $assoc_1_old[$totalPartsOld - 1];
+                                        if ($totalPartsOld > 9) {
+                                            $c_text_title_try = implode('-', array_slice($assoc_1_old, 7, $totalPartsOld - 8));
+                                        } else {
+                                            $c_text_title_try = $assoc_1_old[7] ?? '';
+                                        }
+
+                                        $arr3 = DB::table('ASSOC_DATA')->where([
+                                            ['c_personid', '=', $assoc_1_old[0]],
+                                            ['c_assoc_code', '=', $assoc_1_old[1]],
+                                            ['c_assoc_id', '=', $assoc_1_old[2]],
+                                            ['c_kin_code', '=', $assoc_1_old[3]],
+                                            ['c_kin_id', '=', $assoc_1_old[4]],
+                                            ['c_assoc_kin_code', '=', $assoc_1_old[5]],
+                                            ['c_assoc_kin_id', '=', $assoc_1_old[6]],
+                                            ['c_text_title', '=', $c_text_title_try],
+                                            ['c_assoc_first_year', '=', $c_assoc_first_year_try],
+                                        ])->first();
+                                    }
+
+                                    // 嘗試舊 8-field 格式
+                                    if (!$arr3 && $totalPartsOld >= 8) {
+                                        $c_text_title_old = implode('-', array_slice($assoc_1_old, 7));
+                                        $c_assoc_first_year_old = '-9999';
+
+                                        $arr3 = DB::table('ASSOC_DATA')->where([
+                                            ['c_personid', '=', $assoc_1_old[0]],
+                                            ['c_assoc_code', '=', $assoc_1_old[1]],
+                                            ['c_assoc_id', '=', $assoc_1_old[2]],
+                                            ['c_kin_code', '=', $assoc_1_old[3]],
+                                            ['c_kin_id', '=', $assoc_1_old[4]],
+                                            ['c_assoc_kin_code', '=', $assoc_1_old[5]],
+                                            ['c_assoc_kin_id', '=', $assoc_1_old[6]],
+                                            ['c_text_title', '=', $c_text_title_old],
+                                            ['c_assoc_first_year', '=', $c_assoc_first_year_old],
+                                        ])->first();
+                                    }
+                                }
+                            }
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增財產差異比對紀錄
+                        case "POSSESSION_DATA":
+                            $arr3 = DB::table('POSSESSION_DATA')->where('c_possession_record_id', $resource_id)->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增社交機構差異比對紀錄
+                        case "BIOG_INST_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $inst_1 = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $inst_1 = explode("-", $alt);
+                                foreach ($inst_1 as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $inst_1[$key] = str_replace("minus", "-", $value);
+                                }
+                                if ($inst_1[1] == '') {
+                                    $inst_1[1] = null;
+                                }
+                                if ($inst_1[2] == '') {
+                                    $inst_1[2] = null;
+                                }
+                            }
+                            $arr3 = DB::table('BIOG_INST_DATA')->where([
+                                ['c_personid', '=', $inst_1[0]],
+                                ['c_inst_code', '=', $inst_1[1]],
+                                ['c_inst_name_code', '=', $inst_1[2]],
+                                ['c_bi_role_code', '=', $inst_1[3]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                            //20251208新增出處差異比對紀錄
+                        case "BIOG_SOURCE_DATA":
+                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
+                            if (strpos($resource_id, '_._') !== false) {
+                                // 使用 _._格式
+                                $source_1 = explode('_._', $resource_id);
+                            } else {
+                                // 使用 - 格式
+                                $alt = str_replace("--", "-minus", $resource_id);
+                                //聯合主鍵保留字弱點防禦函式，解析保留字。
+                                $alt = $this->unionPKDef_decode($alt);
+                                $source_1 = explode("-", $alt);
+                                foreach ($source_1 as $key => $value) {
+                                    // 注意：必須先處理 (minus) 再處理 minus
+                                    $value = str_replace("(minus)", "-", $value);
+                                    $source_1[$key] = str_replace("minus", "-", $value);
+                                }
+                                //防止c_pages欄位內含負號所做的字串重組
+                                $new_c_pages = '';
+                                if (!empty($source_1[3])) {
+                                    for ($i = 2; $i < count($source_1); $i++) {
+                                        if (empty($new_c_pages)) {
+                                            $new_c_pages .= $source_1[$i];
+                                        } else {
+                                            $new_c_pages .= "-".$source_1[$i];
+                                        }
+                                    }
+                                    $source_1[2] = $new_c_pages;
+                                }
+
+                            }
+
+                            // 檢查陣列長度是否足夠（BIOG_SOURCE_DATA 需要 3 個欄位）
+                            if (count($source_1) < 3) {
+                                // 記錄錯誤並跳過此筆資料
+                                \Log::warning("BIOG_SOURCE_DATA resource_id 格式不正確: {$resource_id}", [
+                                    'parsed' => $source_1,
+                                    'expected_count' => 3,
+                                    'actual_count' => count($source_1),
+                                    'operation_id' => $listsArr['data'][$x]['id'] ?? null,
+                                ]);
+                                $arr3 = null;
+
+                                break;
+                            }
+
+                            $arr3 = DB::table('BIOG_SOURCE_DATA')->where([
+                                ['c_personid', '=', $source_1[0]],
+                                ['c_textid', '=', $source_1[1]],
+                                ['c_pages', '=', $source_1[2]],
+                            ])->first();
+                            $arr3 = json_encode($arr3);
+                            $arr3 = json_decode($arr3, true);
+
+                            break;
+                        default:
+                            $arr3 = [];
+
+                            break;
+                    }
+                } // end if (!$usedNewFormat)
             } else {
                 $arr3 = [];
             }
@@ -774,11 +821,27 @@ class OperationsController extends Controller {
         }
 
         if (count($conditions) !== count($keys)) {
-            $parsed = $this->parseCompoundKey($operation->resource_id);
-            if (count($parsed) === count($keys)) {
-                foreach ($keys as $index => $column) {
-                    if (!array_key_exists($column, $conditions) || $conditions[$column] === null || $conditions[$column] === '') {
-                        $conditions[$column] = $parsed[$index];
+            // 優先嘗試 query-string 格式（新格式）
+            $namedParsed = CompositePrimaryKey::parseStoredResourceId(
+                $operation->resource_id ?? '',
+                $resource
+            );
+            if ($namedParsed !== null) {
+                foreach ($keys as $column) {
+                    if ((!array_key_exists($column, $conditions) || $conditions[$column] === null || $conditions[$column] === '')
+                        && array_key_exists($column, $namedParsed)) {
+                        $val = $namedParsed[$column];
+                        $conditions[$column] = ($val === 'NULL') ? null : $val;
+                    }
+                }
+            } else {
+                // 回退到舊格式位置解析
+                $parsed = $this->parseCompoundKey($operation->resource_id);
+                if (count($parsed) === count($keys)) {
+                    foreach ($keys as $index => $column) {
+                        if (!array_key_exists($column, $conditions) || $conditions[$column] === null || $conditions[$column] === '') {
+                            $conditions[$column] = $parsed[$index];
+                        }
                     }
                 }
             }
@@ -812,15 +875,36 @@ class OperationsController extends Controller {
         $typeCode = $decoded['c_alt_name_type_code'] ?? null;
 
         if ($personId === null || $sequence === null || $typeCode === null) {
-            $parts = $this->parseCompoundKey($operation['resource_id'] ?? null);
-            if ($personId === null && isset($parts[0]) && is_numeric($parts[0])) {
-                $personId = (int) $parts[0];
-            }
-            if ($sequence === null && isset($parts[1]) && is_numeric($parts[1])) {
-                $sequence = (int) $parts[1];
-            }
-            if ($typeCode === null && isset($parts[3]) && is_numeric($parts[3])) {
-                $typeCode = (int) $parts[3];
+            // 優先嘗試 query-string 格式（新格式）
+            $namedParts = CompositePrimaryKey::parseStoredResourceId(
+                $operation['resource_id'] ?? '',
+                'ALTNAME_DATA'
+            );
+            if ($namedParts !== null) {
+                if ($personId === null && isset($namedParts['c_personid'])) {
+                    $val = $namedParts['c_personid'];
+                    $personId = ($val === 'NULL') ? null : (int) $val;
+                }
+                if ($sequence === null && isset($namedParts['c_sequence'])) {
+                    $val = $namedParts['c_sequence'];
+                    $sequence = ($val === 'NULL') ? null : (int) $val;
+                }
+                if ($typeCode === null && isset($namedParts['c_alt_name_type_code'])) {
+                    $val = $namedParts['c_alt_name_type_code'];
+                    $typeCode = ($val === 'NULL') ? null : (int) $val;
+                }
+            } else {
+                // 回退到舊格式位置解析
+                $parts = $this->parseCompoundKey($operation['resource_id'] ?? null);
+                if ($personId === null && isset($parts[0]) && is_numeric($parts[0])) {
+                    $personId = (int) $parts[0];
+                }
+                if ($sequence === null && isset($parts[1]) && is_numeric($parts[1])) {
+                    $sequence = (int) $parts[1];
+                }
+                if ($typeCode === null && isset($parts[3]) && is_numeric($parts[3])) {
+                    $typeCode = (int) $parts[3];
+                }
             }
         }
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -32,6 +32,7 @@ use App\Repositories\Concerns\DetectsModelChanges;
 
 //20210625建安修改
 use App\Services\VariantCharNormalizer;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -639,7 +640,10 @@ class BiogMainRepository {
                     $c_personid,
                     3,
                     'POSTED_TO_OFFICE_DATA',
-                    $currentOfficeId.'-'.$_postingid,
+                    CompositePrimaryKey::buildStoredResourceId([
+                        'c_office_id' => $currentOfficeId,
+                        'c_posting_id' => $_postingid,
+                    ]),
                     $timestamped,
                     $ori
                 );
@@ -797,19 +801,29 @@ class BiogMainRepository {
                     })
                     ->all();
 
+                $addrResourceId = CompositePrimaryKey::buildStoredResourceId([
+                    'c_office_id' => $currentOfficeId,
+                    'c_posting_id' => $_postingid,
+                ]);
+
                 (new OperationRepository())->store(
                     Auth::id(),
                     $c_personid,
                     3,
                     'POSTED_TO_ADDR_DATA',
-                    $currentOfficeId.'-'.$_postingid,
+                    $addrResourceId,
                     ['rows' => $afterRows],
                     ['rows' => $beforeRows]
                 );
             }
 
+            $updateResourceId = CompositePrimaryKey::buildStoredResourceId([
+                'c_office_id' => $currentOfficeId,
+                'c_posting_id' => $_postingid,
+            ]);
+
             return [
-                'id' => $currentOfficeId.'-'.$_postingid,
+                'id' => $updateResourceId,
                 'no_changes' => false,
             ];
         });
@@ -849,7 +863,10 @@ class BiogMainRepository {
             $data = (new ToolsRepository())->timestamp($data, true);
             DB::table('POSTED_TO_OFFICE_DATA')->insert($data);
 
-            (new OperationRepository())->store(Auth::id(), $id, 1, 'POSTED_TO_OFFICE_DATA', $data['c_office_id'] . '-' . $data['c_posting_id'], $data);
+            (new OperationRepository())->store(Auth::id(), $id, 1, 'POSTED_TO_OFFICE_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_office_id' => $data['c_office_id'],
+                'c_posting_id' => $data['c_posting_id'],
+            ]), $data);
 
             $addressRows = DB::table('POSTED_TO_ADDR_DATA')
                 ->where('c_personid', $id)
@@ -867,18 +884,23 @@ class BiogMainRepository {
                 ->values()
                 ->all();
 
+            $officeResourceId = CompositePrimaryKey::buildStoredResourceId([
+                'c_office_id' => $data['c_office_id'],
+                'c_posting_id' => $data['c_posting_id'],
+            ]);
+
             if (!empty($addressRows)) {
                 (new OperationRepository())->store(
                     Auth::id(),
                     $id,
                     1,
                     'POSTED_TO_ADDR_DATA',
-                    $data['c_office_id'] . '-' . $data['c_posting_id'],
+                    $officeResourceId,
                     ['rows' => $addressRows]
                 );
             }
 
-            return $data['c_office_id'] . '-' . $data['c_posting_id'];
+            return $officeResourceId;
         });
     }
 
@@ -895,7 +917,10 @@ class BiogMainRepository {
             DB::table('POSTED_TO_ADDR_DATA')->where('c_posting_id', $row->c_posting_id)->delete();
             DB::table('POSTING_DATA')->where('c_posting_id', $row->c_posting_id)->delete();
 
-            (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSTED_TO_OFFICE_DATA', $id, $row);
+            (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSTED_TO_OFFICE_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_office_id' => $addr_l[0],
+                'c_posting_id' => $addr_l[1],
+            ]), $row);
         });
     }
 
@@ -1048,8 +1073,11 @@ class BiogMainRepository {
             ['c_sequence', '=', $temp_l[1]],
             ['c_status_code', '=', $temp_l[2]],
         ])->update($data);
-        $new_id = $c_personid."-".$data['c_sequence']."-".$data['c_status_code'];
-        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'STATUS_DATA', $new_id, $data, $row);
+        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $c_personid,
+            'c_sequence' => $data['c_sequence'],
+            'c_status_code' => $data['c_status_code'],
+        ]), $data, $row);
 
         return $data;
     }
@@ -1062,7 +1090,11 @@ class BiogMainRepository {
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
         DB::table('STATUS_DATA')->insert($data);
-        (new OperationRepository())->store(Auth::id(), $data['c_personid'], 1, 'STATUS_DATA', $data['c_personid'].'-'.$data['c_sequence'].'-'.$data['c_status_code'], $data);
+        (new OperationRepository())->store(Auth::id(), $data['c_personid'], 1, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_sequence' => $data['c_sequence'],
+            'c_status_code' => $data['c_status_code'],
+        ]), $data);
 
         return $data;
     }
@@ -1083,7 +1115,11 @@ class BiogMainRepository {
             ['c_sequence', '=', $temp_l[1]],
             ['c_status_code', '=', $temp_l[2]],
         ])->delete();
-        (new OperationRepository())->store(Auth::id(), $id, 4, 'STATUS_DATA', $id, $row);
+        (new OperationRepository())->store(Auth::id(), $id, 4, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $temp_l[0],
+            'c_sequence' => $temp_l[1],
+            'c_status_code' => $temp_l[2],
+        ]), $row);
     }
 
     public function kinshipById($id) {
@@ -1157,8 +1193,11 @@ class BiogMainRepository {
             ['c_kin_code', '=', $temp_l[2]],
         ])->update($data);
         $ori_data = $data;
-        $new_id_ = $id."-".$data['c_kin_id']."-".$data['c_kin_code'];
-        (new OperationRepository())->store(Auth::id(), $id, 3, 'KIN_DATA', $new_id_, $data, $row);
+        (new OperationRepository())->store(Auth::id(), $id, 3, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_kin_id' => $data['c_kin_id'],
+            'c_kin_code' => $data['c_kin_code'],
+        ]), $data, $row);
         $data['c_kin_code'] = $kin_pair;
         $data['c_personid'] = $kin_id;
         $data = Arr::except($data, ['c_kin_id']);
@@ -1221,7 +1260,11 @@ class BiogMainRepository {
         $data = (new ToolsRepository())->timestamp($data, true);
         DB::table('KIN_DATA')->insert($data);
         $ori_Data = $data;
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'KIN_DATA', $data['c_personid']."-".$data['c_kin_id']."-".$data['c_kin_code'], $data);
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_kin_code' => $data['c_kin_code'],
+        ]), $data);
         $data['c_kin_code'] = $kin_pair;
         $data['c_personid'] = $data['c_kin_id'];
         $data['c_kin_id'] = $id;
@@ -1249,7 +1292,11 @@ class BiogMainRepository {
         $old_kin_code = $row->c_kin_code;
         $kin_code_pair = KinshipCode::find($old_kin_code);
 
-        (new OperationRepository())->store(Auth::id(), $id, 4, 'KIN_DATA', $id, $row);
+        (new OperationRepository())->store(Auth::id(), $id, 4, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $temp_l[0],
+            'c_kin_id' => $temp_l[1],
+            'c_kin_code' => $temp_l[2],
+        ]), $row);
 
         $row2Query = DB::table('KIN_DATA')->where(function ($query) use ($row, $kin_code_pair) {
             $query->where('c_kin_id', $row->c_personid)
@@ -1453,7 +1500,12 @@ class BiogMainRepository {
         $data = (new ToolsRepository())->timestamp($data, true);
         $tts = DB::table('BIOG_INST_DATA')->insertGetId($data);
         //新增的聯合主鍵 //20211022修改增加c_inst_code與c_inst_name_code
-        $newid = $data['c_personid']."-".$data['c_inst_code']."-".$data['c_inst_name_code']."-".$data['c_bi_role_code'];
+        $newid = CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_inst_code' => $data['c_inst_code'],
+            'c_inst_name_code' => $data['c_inst_name_code'],
+            'c_bi_role_code' => $data['c_bi_role_code'],
+        ]);
         (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_INST_DATA', $newid, $data);
 
         return $newid;
@@ -1508,7 +1560,15 @@ class BiogMainRepository {
         }
 
         // 記錄操作（即使 $row 為 null 也記錄，以便追蹤失敗的刪除嘗試）
-        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_INST_DATA', $id, $row);
+        $instResourceId = $row
+            ? CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $row->c_personid,
+                'c_inst_code' => $row->c_inst_code,
+                'c_inst_name_code' => $row->c_inst_name_code,
+                'c_bi_role_code' => $row->c_bi_role_code,
+            ])
+            : $id;
+        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_INST_DATA', $instResourceId, $row);
     }
 
     public function eventById($id) {
@@ -1587,9 +1647,11 @@ class BiogMainRepository {
         }
         $updateQuery->update($data);
 
-        // 新格式 resource_id：c_personid-c_sequence-c_event_code
-        $new_resource_id = $id . '-' . $data['c_sequence'] . '-' . $data['c_event_code'];
-        (new OperationRepository())->store(Auth::id(), $id, 3, 'EVENTS_DATA', $new_resource_id, $data, $ori);
+        (new OperationRepository())->store(Auth::id(), $id, 3, 'EVENTS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_sequence' => $data['c_sequence'],
+            'c_event_code' => $data['c_event_code'],
+        ]), $data, $ori);
 
         return ['c_sequence' => $data['c_sequence'], 'c_event_code' => $data['c_event_code']];
     }
@@ -1604,9 +1666,11 @@ class BiogMainRepository {
         $data = (new ToolsRepository())->timestamp($data, true);
         DB::table('EVENTS_DATA')->insert($data);
 
-        // 新格式 resource_id：c_personid-c_sequence-c_event_code
-        $resource_id = $id . '-' . $data['c_sequence'] . '-' . $data['c_event_code'];
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', $resource_id, $data);
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'EVENTS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $id,
+            'c_sequence' => $data['c_sequence'],
+            'c_event_code' => $data['c_event_code'],
+        ]), $data);
 
         return ['c_sequence' => $data['c_sequence'], 'c_event_code' => $data['c_event_code']];
     }
@@ -1632,9 +1696,11 @@ class BiogMainRepository {
             ->where('c_event_code', $row->c_event_code)
             ->delete();
 
-        // 新格式 resource_id：c_personid-c_sequence-c_event_code
-        $resource_id = $c_personid . '-' . $row->c_sequence . '-' . $row->c_event_code;
-        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'EVENTS_DATA', $resource_id, $row);
+        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'EVENTS_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $c_personid,
+            'c_sequence' => $row->c_sequence,
+            'c_event_code' => $row->c_event_code,
+        ]), $row);
     }
 
     public function assocById($id) {
@@ -1969,10 +2035,17 @@ class BiogMainRepository {
         $data['c_personid'] = $c_personid;
         // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
         // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $assocFirstYearEncoded = str_replace('-', '(minus)', $data['c_assoc_first_year'] ?? '-9999');
-        // 注意：c_text_title 可能包含 /（如 [n/a]），需要編碼為 (slash) 避免 URL 解析錯誤
-        $textTitleEncoded = $this->unionPKDef($data['c_text_title']);
-        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$textTitleEncoded."-".$assocFirstYearEncoded, $data, $row);
+        (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_assoc_kin_code' => $data['c_assoc_kin_code'],
+            'c_assoc_kin_id' => $data['c_assoc_kin_id'],
+            'c_text_title' => $data['c_text_title'] ?? '',
+            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
+        ]), $data, $row);
         //20210702取得成對資料原本的c_kin_code
         $data['c_kin_code'] = $kin_pair;
         $data['c_assoc_kin_code'] = $assoc_kin_pair;
@@ -2028,10 +2101,17 @@ class BiogMainRepository {
         $ori_Data = $data;
         // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
         // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $assocFirstYearEncoded = str_replace('-', '(minus)', $data['c_assoc_first_year'] ?? '-9999');
-        // 注意：c_text_title 可能包含 /（如 [n/a]），需要編碼為 (slash) 避免 URL 解析錯誤
-        $textTitleEncoded = $this->unionPKDef($data['c_text_title']);
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', $data['c_personid']."-".$data['c_assoc_code']."-".$data['c_assoc_id']."-".$data['c_kin_code']."-".$data['c_kin_id']."-".$data['c_assoc_kin_code']."-".$data['c_assoc_kin_id']."-".$textTitleEncoded."-".$assocFirstYearEncoded, $data);
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_assoc_kin_code' => $data['c_assoc_kin_code'],
+            'c_assoc_kin_id' => $data['c_assoc_kin_id'],
+            'c_text_title' => $data['c_text_title'] ?? '',
+            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
+        ]), $data);
         $data['c_assoc_code'] = $assoc_pair;
         $data['c_personid'] = $data['c_assoc_id'];
         $data['c_assoc_id'] = $id;
@@ -2191,7 +2271,20 @@ class BiogMainRepository {
             ['c_text_title', '=', $c_text_title],
             ['c_assoc_first_year', '=', $c_assoc_first_year],
         ])->delete();
-        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ASSOC_DATA', $id, $row);
+        $assocResourceId = $row
+            ? CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $row->c_personid,
+                'c_assoc_code' => $row->c_assoc_code,
+                'c_assoc_id' => $row->c_assoc_id,
+                'c_kin_code' => $row->c_kin_code,
+                'c_kin_id' => $row->c_kin_id,
+                'c_assoc_kin_code' => $row->c_assoc_kin_code,
+                'c_assoc_kin_id' => $row->c_assoc_kin_id,
+                'c_text_title' => $row->c_text_title ?? '',
+                'c_assoc_first_year' => $row->c_assoc_first_year ?? '-9999',
+            ])
+            : $id;
+        (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ASSOC_DATA', $assocResourceId, $row);
 
         // 檢查$row2是否存在後再刪除反向關係
         // 修正：使用完整主鍵欄位進行刪除，避免誤刪其他記錄
@@ -2274,7 +2367,11 @@ class BiogMainRepository {
             ['c_textid', '=', $temp_l[1]],
             ['c_pages', '=', $temp_l[2]],
         ])->update($data);
-        (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_SOURCE_DATA', $data['c_personid']."-".$data['c_textid']."-".$data['c_pages'], $data, $row);
+        (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_textid' => $data['c_textid'],
+            'c_pages' => $data['c_pages'],
+        ]), $data, $row);
 
         return $data;
     }
@@ -2292,7 +2389,11 @@ class BiogMainRepository {
         $data['c_created_by'] = $c_created_by;
         $data['c_created_date'] = $c_created_date;
         DB::table('BIOG_SOURCE_DATA')->insert($data);
-        (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_SOURCE_DATA', $data['c_personid']."-".$data['c_textid']."-".$data['c_pages'], $data);
+        (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $data['c_personid'],
+            'c_textid' => $data['c_textid'],
+            'c_pages' => $data['c_pages'],
+        ]), $data);
 
         return $data;
     }
@@ -2316,7 +2417,11 @@ class BiogMainRepository {
             ['c_textid', '=', $temp_l[1]],
             ['c_pages', '=', $temp_l[2]],
         ])->delete();
-        (new OperationRepository())->store(Auth::id(), $id, 4, 'BIOG_SOURCE_DATA', $id, $row);
+        (new OperationRepository())->store(Auth::id(), $id, 4, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => $temp_l[0],
+            'c_textid' => $temp_l[1],
+            'c_pages' => $temp_l[2],
+        ]), $row);
     }
 
     protected function addr_str($id) {

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -113,6 +113,32 @@ class CompositePrimaryKey {
     ];
 
     /**
+     * resource_id 的 schema 別名對應
+     *
+     * 某些資料表的 resource_id 刻意沿用其他表的格式（共用編輯頁面），
+     * 因此解析 resource_id 時需使用目標表的 schema 而非自身的。
+     *
+     * 例如：POSTED_TO_ADDR_DATA 的 resource_id 沿用 POSTED_TO_OFFICE_DATA
+     * 的 c_office_id + c_posting_id 格式，地址資料存放在 resource_data['rows'] 中。
+     */
+    private const RESOURCE_ID_SCHEMA_ALIAS = [
+        'POSTED_TO_ADDR_DATA' => 'POSTED_TO_OFFICE_DATA',
+    ];
+
+    /**
+     * 取得 resource_id 解析用的 schema 表名
+     *
+     * 若該表有別名對應（如 POSTED_TO_ADDR_DATA → POSTED_TO_OFFICE_DATA），
+     * 返回別名表名；否則返回原始表名。
+     *
+     * @param string $table 資料表名稱
+     * @return string 用於解析 resource_id 的 schema 表名
+     */
+    public static function getResourceIdSchemaTable(string $table): string {
+        return self::RESOURCE_ID_SCHEMA_ALIAS[strtoupper($table)] ?? $table;
+    }
+
+    /**
      * 從請求中提取複合主鍵欄位
      *
      * @param Request $request HTTP 請求
@@ -279,6 +305,32 @@ class CompositePrimaryKey {
     ];
 
     /**
+     * 將複合主鍵陣列編碼為可儲存在 resource_id 欄位的字串
+     *
+     * 使用 PHP 標準的 http_build_query() 產生查詢參數格式，
+     * 所有特殊字符（中文、負號、斜線等）自動 URL 編碼，
+     * 完全消除舊格式 `-` 分隔符的解析歧義。
+     *
+     * null 值會被轉為字串 'NULL'，因為 http_build_query() 會省略 null 欄位，
+     * 導致解析時缺少欄位。解析端已有 'NULL' → whereNull 的對應處理。
+     *
+     * 範例：
+     *   buildStoredResourceId(['c_personid' => 12345, 'c_sequence' => 1, 'c_alt_name_chn' => '張三'])
+     *   => 'c_personid=12345&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89'
+     *
+     *   buildStoredResourceId(['c_personid' => 12345, 'c_sequence' => null, ...])
+     *   => 'c_personid=12345&c_sequence=NULL&...'
+     *
+     * @param array $pk 複合主鍵的具名欄位陣列
+     * @return string http_build_query 格式的字串
+     */
+    public static function buildStoredResourceId(array $pk): string {
+        $encoded = array_map(fn ($v) => $v === null ? 'NULL' : $v, $pk);
+
+        return http_build_query($encoded);
+    }
+
+    /**
      * 解析舊格式的複合主鍵字串（用於向後相容）
      *
      * @deprecated 僅用於過渡期向後相容，新代碼請使用 fromRequest()
@@ -336,9 +388,23 @@ class CompositePrimaryKey {
      * @return array|null 解析後的具名欄位陣列，解析失敗則返回 null
      */
     public static function parseStoredResourceId(string $resourceId, string $table): ?array {
-        $schema = self::getSchema($table);
+        // resource_id 可能使用別名表的 schema（如 POSTED_TO_ADDR_DATA → POSTED_TO_OFFICE_DATA）
+        $effectiveTable = self::getResourceIdSchemaTable($table);
+        $schema = self::getSchema($effectiveTable);
         if (!$schema) {
             return null;
+        }
+
+        // 格式 0：query-string 格式（新格式，由 buildStoredResourceId() 產生）
+        // 以 '=' 存在且不含 '_._' 作為判斷條件
+        // 額外驗證：解析後的 key 必須完整覆蓋所有 schema key，避免：
+        // 1. 舊格式欄位值含 '=' 被誤判為新格式
+        // 2. 部分 key 匹配導致 WHERE 條件不完整而查到錯誤資料列
+        if (str_contains($resourceId, '=') && !str_contains($resourceId, '_._')) {
+            parse_str($resourceId, $parsed);
+            if (!empty($parsed) && count(array_intersect($schema, array_keys($parsed))) === count($schema)) {
+                return array_intersect_key($parsed, array_flip($schema));
+            }
         }
 
         $expectedCount = count($schema);
@@ -451,13 +517,9 @@ class CompositePrimaryKey {
             return null;
         }
 
-        // 查詢用的 schema 名稱：POSTED_TO_ADDR_DATA 共用 POSTED_TO_OFFICE_DATA 的路由和 schema
-        $schemaTable = $upperResource;
-        if ($upperResource === 'POSTED_TO_ADDR_DATA') {
-            $schemaTable = 'POSTED_TO_OFFICE_DATA';
-        }
-
-        $pk = self::parseStoredResourceId($resourceId, $schemaTable);
+        // parseStoredResourceId() 內部已透過 getResourceIdSchemaTable() 處理別名對應
+        // （如 POSTED_TO_ADDR_DATA → POSTED_TO_OFFICE_DATA），直接傳入原始表名即可
+        $pk = self::parseStoredResourceId($resourceId, $upperResource);
         if ($pk === null) {
             return null;
         }

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -34,8 +34,13 @@ class CompositePrimaryKey {
             'c_addr_type',
             'c_sequence',
         ],
-        // 注意：實際表名是 BIOG_TEXT_DATA
+        // 注意：實際表名是 BIOG_TEXT_DATA，此處同時提供兩個鍵名以便查詢
         'TEXT_DATA' => [
+            'c_personid',
+            'c_textid',
+            'c_role_id',
+        ],
+        'BIOG_TEXT_DATA' => [
             'c_personid',
             'c_textid',
             'c_role_id',
@@ -252,6 +257,28 @@ class CompositePrimaryKey {
     }
 
     /**
+     * 資源表名對應的查詢參數模式編輯路由名稱
+     *
+     * 用於 Operations 模組等需要根據資源表名生成編輯連結的場景。
+     */
+    public const EDIT_ROUTE_MAP = [
+        'ALTNAME_DATA' => 'basicinformation.altnames.edit.query',
+        'BIOG_ADDR_DATA' => 'basicinformation.addresses.edit.query',
+        'TEXT_DATA' => 'basicinformation.texts.edit.query',
+        'BIOG_TEXT_DATA' => 'basicinformation.texts.edit.query',
+        'BIOG_SOURCE_DATA' => 'basicinformation.sources.edit.query',
+        'POSTED_TO_OFFICE_DATA' => 'basicinformation.offices.edit.query',
+        'POSTED_TO_ADDR_DATA' => 'basicinformation.offices.edit.query',
+        'ASSOC_DATA' => 'basicinformation.assoc.edit.query',
+        'KIN_DATA' => 'basicinformation.kinship.edit.query',
+        'EVENTS_DATA' => 'basicinformation.events.edit.query',
+        'STATUS_DATA' => 'basicinformation.statuses.edit.query',
+        'ENTRY_DATA' => 'basicinformation.entries.edit.query',
+        'POSSESSION_DATA' => 'basicinformation.possession.edit.query',
+        'BIOG_INST_DATA' => 'basicinformation.socialinst.edit.query',
+    ];
+
+    /**
      * 解析舊格式的複合主鍵字串（用於向後相容）
      *
      * @deprecated 僅用於過渡期向後相容，新代碼請使用 fromRequest()
@@ -295,5 +322,146 @@ class CompositePrimaryKey {
         }
 
         return array_combine($schema, $parts);
+    }
+
+    /**
+     * 解析資料庫中儲存的 resource_id 字串為具名欄位陣列
+     *
+     * 支援兩種分隔符格式：
+     * - '_._' 分隔符（CodesController 使用）
+     * - '-' 分隔符（BasicInformation 系列 Controller 使用，欄位值中的特殊字符以 (minus)/(slash) 等編碼）
+     *
+     * @param string $resourceId 資料庫中儲存的 resource_id
+     * @param string $table 資料表名稱
+     * @return array|null 解析後的具名欄位陣列，解析失敗則返回 null
+     */
+    public static function parseStoredResourceId(string $resourceId, string $table): ?array {
+        $schema = self::getSchema($table);
+        if (!$schema) {
+            return null;
+        }
+
+        $expectedCount = count($schema);
+
+        // 格式 1：_._  分隔符（CodesController）
+        if (strpos($resourceId, '_._') !== false) {
+            $parts = explode('_._', $resourceId);
+            if (count($parts) >= $expectedCount) {
+                return array_combine($schema, array_slice($parts, 0, $expectedCount));
+            }
+
+            return null;
+        }
+
+        // 格式 2：- 分隔符，欄位值中的特殊字符以佔位符編碼
+        // 先解碼除 (minus) 以外的保留字
+        $decoded = str_replace(
+            ['(slash)', '(backslash)', '(brackets)', '(brackets_r)', '(question)', '(hash)', '(amp)'],
+            ['/', '\\', '{', '}', '?', '#', '&'],
+            $resourceId
+        );
+
+        // 以 - 分割，然後在每個欄位中還原 (minus)
+        $parts = explode('-', $decoded);
+        $parts = array_map(fn ($p) => str_replace('(minus)', '-', $p), $parts);
+
+        $result = self::combinePartsWithSchema($parts, $schema, $table);
+        if ($result !== null) {
+            return $result;
+        }
+
+        // 回退策略：嘗試舊格式（-- 代表欄位值中的負號）
+        $decoded2 = str_replace(
+            ['(slash)', '(backslash)', '(brackets)', '(brackets_r)', '(question)', '(hash)', '(amp)'],
+            ['/', '\\', '{', '}', '?', '#', '&'],
+            $resourceId
+        );
+        $decoded2 = str_replace('--', "\x00MINUS\x00", $decoded2);
+        $parts2 = explode('-', $decoded2);
+        $parts2 = array_map(function ($p) {
+            $p = str_replace("\x00MINUS\x00", '-', $p);
+            $p = str_replace('(minus)', '-', $p);
+
+            return $p;
+        }, $parts2);
+
+        return self::combinePartsWithSchema($parts2, $schema, $table);
+    }
+
+    /**
+     * 將分割後的欄位值陣列與 schema 定義合併為具名陣列
+     *
+     * @param array $parts 分割後的欄位值
+     * @param array $schema schema 欄位名稱
+     * @param string $table 資料表名稱（用於特殊處理）
+     * @return array|null 成功時返回具名陣列，失敗返回 null
+     */
+    private static function combinePartsWithSchema(array $parts, array $schema, string $table): ?array {
+        $expectedCount = count($schema);
+        $actualCount = count($parts);
+
+        if ($actualCount === $expectedCount) {
+            return array_combine($schema, $parts);
+        }
+
+        if ($actualCount > $expectedCount) {
+            $upperTable = strtoupper($table);
+
+            // ASSOC_DATA：c_text_title（倒數第 2 個欄位）可能含 -，c_assoc_first_year 固定在最後
+            if ($upperTable === 'ASSOC_DATA' && $expectedCount === 9) {
+                $lastPart = $parts[$actualCount - 1];
+                $firstSeven = array_slice($parts, 0, 7);
+                $textTitle = implode('-', array_slice($parts, 7, $actualCount - 8));
+                $combined = array_merge($firstSeven, [$textTitle, $lastPart]);
+                if (count($combined) === $expectedCount) {
+                    return array_combine($schema, $combined);
+                }
+            }
+
+            // BIOG_SOURCE_DATA：c_pages（最後一個欄位）可能含 -
+            if ($upperTable === 'BIOG_SOURCE_DATA' && $expectedCount === 3) {
+                $firstTwo = array_slice($parts, 0, 2);
+                $cPages = implode('-', array_slice($parts, 2));
+                $combined = array_merge($firstTwo, [$cPages]);
+
+                return array_combine($schema, $combined);
+            }
+
+            // 其他表不應有多餘的 parts，視為解析失敗
+            return null;
+        }
+
+        // actualCount < expectedCount：欄位不足，解析失敗
+        return null;
+    }
+
+    /**
+     * 根據資源表名和 resource_id 生成查詢參數模式的編輯頁面 URL
+     *
+     * @param string $resource 資源表名（如 'ALTNAME_DATA'）
+     * @param string $resourceId 資料庫中儲存的 resource_id
+     * @param int|string $personId 人物 ID（用於路由的 {id} 參數）
+     * @return string|null 成功時返回新格式 URL，無法解析時返回 null
+     */
+    public static function buildResourceEditUrl(string $resource, string $resourceId, $personId): ?string {
+        $upperResource = strtoupper($resource);
+
+        $routeName = self::EDIT_ROUTE_MAP[$upperResource] ?? null;
+        if (!$routeName) {
+            return null;
+        }
+
+        // 查詢用的 schema 名稱：POSTED_TO_ADDR_DATA 共用 POSTED_TO_OFFICE_DATA 的路由和 schema
+        $schemaTable = $upperResource;
+        if ($upperResource === 'POSTED_TO_ADDR_DATA') {
+            $schemaTable = 'POSTED_TO_OFFICE_DATA';
+        }
+
+        $pk = self::parseStoredResourceId($resourceId, $schemaTable);
+        if ($pk === null) {
+            return null;
+        }
+
+        return self::buildUrl($routeName, ['id' => $personId], $pk);
     }
 }

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -60,8 +60,15 @@ use App\Support\CompositePrimaryKey;
                     @foreach($lists as $item)
 @php
 $rawResourceId = $item->resource_id;
-// 用於顯示：對整個字串編碼然後解碼（處理 Blade 模板衝突）
-$item->resource_id = unionPKDef($item->resource_id);
+// 用於顯示：偵測格式後轉換（處理 Blade 模板衝突）
+if (str_contains($rawResourceId ?? '', '=') && !str_contains($rawResourceId ?? '', '_._')) {
+    // 新格式（query-string）：解碼後以 - 分隔顯示值
+    parse_str($rawResourceId, $parsedQs);
+    $displayValues = implode('-', array_values($parsedQs));
+    $item->resource_id = str_replace(['{{', '}}'], ['{ {', '} }'], $displayValues);
+} else {
+    $item->resource_id = unionPKDef($item->resource_id);
+}
 $item->resource_data = unionPKDef($item->resource_data);
 @endphp
                         <tr>

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -1,3 +1,6 @@
+@php
+use App\Support\CompositePrimaryKey;
+@endphp
 @extends('layouts.dashboard-v3')
 
 @section('content')
@@ -60,8 +63,6 @@ $rawResourceId = $item->resource_id;
 // 用於顯示：對整個字串編碼然後解碼（處理 Blade 模板衝突）
 $item->resource_id = unionPKDef($item->resource_id);
 $item->resource_data = unionPKDef($item->resource_data);
-// 用於構建 URL：對每個欄位值分別編碼，保留分隔符 -
-$encodedResourceIdForUrl = unionPKDef_for_url($rawResourceId);
 @endphp
                         <tr>
                             <td>
@@ -71,57 +72,13 @@ $encodedResourceIdForUrl = unionPKDef_for_url($rawResourceId);
                                 $resourceSpecificLink = null;
                                 $a = $item->resource;
                                 $id = $item->c_personid;
-                                $res_id = $encodedResourceIdForUrl;
                                 if ((int) $id !== 0) {
                                     // 人物链接统一指向编辑页面
                                     $personLink = "/basicinformation/{$id}/edit";
 
-                                    // 根据资源类型生成特定的资源链接
+                                    // 根据资源类型生成查詢參數模式的編輯連結
                                     if ($item->op_type != 4) {
-                                        switch ($a) {
-                                            case "BIOG_ADDR_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/addresses/{$res_id}/edit";
-                                                break;
-                                            case "ALTNAME_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/altnames/{$res_id}/edit";
-                                                break;
-                                            case "TEXT_DATA":
-                                            case "BIOG_TEXT_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/texts/{$res_id}/edit";
-                                                break;
-                                            case "POSTED_TO_OFFICE_DATA":
-                                            case "POSTED_TO_ADDR_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/offices/{$res_id}/edit";
-                                                break;
-                                            case "ENTRY_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/entries/{$res_id}/edit";
-                                                break;
-                                            case "EVENTS_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/events/{$res_id}/edit";
-                                                break;
-                                            case "STATUS_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/statuses/{$res_id}/edit";
-                                                break;
-                                            case "KIN_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/kinship/{$res_id}/edit";
-                                                break;
-                                            case "ASSOC_DATA":
-                                                // $res_id 已經通過 unionPKDef_for_url() 對每個欄位值編碼，
-                                                // 包括斜線 / 已被編碼為 (slash)，不需要再額外處理
-                                                $resourceSpecificLink = "/basicinformation/{$id}/assoc/{$res_id}/edit";
-                                                break;
-                                            case "POSSESSION_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/possession/{$res_id}/edit";
-                                                break;
-                                            case "BIOG_INST_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/socialinst/{$res_id}/edit";
-                                                break;
-                                            case "BIOG_SOURCE_DATA":
-                                                $resourceSpecificLink = "/basicinformation/{$id}/sources/{$res_id}/edit";
-                                                break;
-                                            default:
-                                                $resourceSpecificLink = null;
-                                        }
+                                        $resourceSpecificLink = CompositePrimaryKey::buildResourceEditUrl($a, $rawResourceId, $id);
                                     }
                                 }
                                 $item->resource_id = unionPKDef_decode_for_convert($item->resource_id);

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -96,7 +96,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
 
         $operation = DB::table('operations')->first();
         $this->assertSame('BIOG_SOURCE_DATA', $operation->resource);
-        $this->assertSame('321-500-p10', $operation->resource_id);
+        $this->assertSame('c_personid=321&c_textid=500&c_pages=p10', $operation->resource_id);
         $this->assertEquals(1, $operation->op_type);
         $this->assertNull($operation->resource_original);
 
@@ -139,7 +139,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
 
         $operation = DB::table('operations')->orderByDesc('id')->first();
         $this->assertSame('BIOG_SOURCE_DATA', $operation->resource);
-        $this->assertSame('654-501-p20', $operation->resource_id);
+        $this->assertSame('c_personid=654&c_textid=501&c_pages=p20', $operation->resource_id);
         $this->assertEquals(3, $operation->op_type);
         $this->assertNotNull($operation->resource_original);
 
@@ -207,7 +207,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
         $operation = DB::table('operations')->orderByDesc('id')->first();
         $this->assertSame('BIOG_SOURCE_DATA', $operation->resource);
         $this->assertSame(4, $operation->op_type);
-        $this->assertSame('654', $operation->resource_id);
+        $this->assertSame('c_personid=654&c_textid=501&c_pages=p20', $operation->resource_id);
         $this->assertNull($operation->resource_original);
 
         $payload = json_decode($operation->resource_data, true);

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -114,7 +114,7 @@ class OfficeAddressOperationLoggingTest extends TestCase {
         $operation = DB::table('operations')->orderByDesc('id')->first();
         $this->assertNotNull($operation);
         $this->assertEquals('POSTED_TO_ADDR_DATA', $operation->resource);
-        $this->assertEquals('71313-312754', $operation->resource_id);
+        $this->assertEquals('c_office_id=71313&c_posting_id=312754', $operation->resource_id);
         $this->assertNotNull($operation->resource_original);
 
         $after = json_decode($operation->resource_data, true);

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -99,7 +99,7 @@ class OfficePostingStoreTest extends TestCase {
 
         $response = $repository->officeStoreById($request, 123);
 
-        $this->assertSame('10-1', $response);
+        $this->assertSame('c_office_id=10&c_posting_id=1', $response);
 
         $this->assertDatabaseHas('POSTING_DATA', [
             'c_posting_id' => 1,
@@ -121,13 +121,13 @@ class OfficePostingStoreTest extends TestCase {
 
         $this->assertDatabaseHas('operations', [
             'resource' => 'POSTED_TO_OFFICE_DATA',
-            'resource_id' => '10-1',
+            'resource_id' => 'c_office_id=10&c_posting_id=1',
             'op_type' => 1,
         ]);
 
         $this->assertDatabaseHas('operations', [
             'resource' => 'POSTED_TO_ADDR_DATA',
-            'resource_id' => '10-1',
+            'resource_id' => 'c_office_id=10&c_posting_id=1',
             'op_type' => 1,
         ]);
     }
@@ -186,7 +186,7 @@ class OfficePostingStoreTest extends TestCase {
 
         $this->assertDatabaseHas('operations', [
             'resource' => 'POSTED_TO_OFFICE_DATA',
-            'resource_id' => '20-1',
+            'resource_id' => 'c_office_id=20&c_posting_id=1',
             'op_type' => 3,
         ]);
     }
@@ -207,7 +207,7 @@ class OfficePostingStoreTest extends TestCase {
 
         $this->assertDatabaseHas('operations', [
             'resource' => 'POSTED_TO_OFFICE_DATA',
-            'resource_id' => '30-1',
+            'resource_id' => 'c_office_id=30&c_posting_id=1',
             'op_type' => 4,
         ]);
     }

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -442,6 +442,310 @@ class CompositePrimaryKeyTest extends TestCase {
         $this->assertEquals('張-三', $result['c_alt_name_chn']);
     }
 
+    // === buildStoredResourceId 測試 ===
+
+    /** @test */
+    public function it_builds_stored_resource_id_basic(): void {
+        $pk = [
+            'c_personid' => 12345,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '張三',
+            'c_alt_name_type_code' => 10,
+        ];
+
+        $result = CompositePrimaryKey::buildStoredResourceId($pk);
+
+        // 應該是 query-string 格式
+        $this->assertStringContainsString('c_personid=12345', $result);
+        $this->assertStringContainsString('c_sequence=1', $result);
+        $this->assertStringContainsString('c_alt_name_chn=', $result);
+        $this->assertStringContainsString('c_alt_name_type_code=10', $result);
+        // 不能包含 - 分隔符（作為欄位分隔）
+        $this->assertStringContainsString('&', $result);
+    }
+
+    /** @test */
+    public function it_builds_stored_resource_id_preserves_null_as_string(): void {
+        // null 值應被轉為字串 'NULL'，避免 http_build_query() 省略該欄位
+        $pk = [
+            'c_personid' => 12345,
+            'c_sequence' => null,
+            'c_alt_name_chn' => '張三',
+            'c_alt_name_type_code' => 10,
+        ];
+
+        $result = CompositePrimaryKey::buildStoredResourceId($pk);
+
+        // c_sequence 應存在且值為 'NULL'
+        $this->assertStringContainsString('c_sequence=NULL', $result);
+        $this->assertStringContainsString('c_personid=12345', $result);
+
+        // 來回測試：build → parse → 應還原 'NULL' 字串
+        $parsed = CompositePrimaryKey::parseStoredResourceId($result, 'ALTNAME_DATA');
+        $this->assertNotNull($parsed);
+        $this->assertArrayHasKey('c_sequence', $parsed);
+        $this->assertSame('NULL', $parsed['c_sequence']);
+        $this->assertEquals('12345', $parsed['c_personid']);
+        $this->assertEquals('張三', $parsed['c_alt_name_chn']);
+        $this->assertEquals('10', $parsed['c_alt_name_type_code']);
+    }
+
+    /** @test */
+    public function it_builds_stored_resource_id_preserves_multiple_nulls(): void {
+        // BIOG_INST_DATA 的 c_inst_code 和 c_inst_name_code 可為 null
+        $pk = [
+            'c_personid' => 12345,
+            'c_inst_code' => null,
+            'c_inst_name_code' => null,
+            'c_bi_role_code' => 5,
+        ];
+
+        $result = CompositePrimaryKey::buildStoredResourceId($pk);
+
+        $this->assertStringContainsString('c_inst_code=NULL', $result);
+        $this->assertStringContainsString('c_inst_name_code=NULL', $result);
+        $this->assertStringContainsString('c_personid=12345', $result);
+        $this->assertStringContainsString('c_bi_role_code=5', $result);
+
+        $parsed = CompositePrimaryKey::parseStoredResourceId($result, 'BIOG_INST_DATA');
+        $this->assertNotNull($parsed);
+        $this->assertCount(4, $parsed);
+        $this->assertSame('NULL', $parsed['c_inst_code']);
+        $this->assertSame('NULL', $parsed['c_inst_name_code']);
+    }
+
+    /** @test */
+    public function it_builds_stored_resource_id_with_special_chars(): void {
+        $pk = [
+            'c_personid' => 12345,
+            'c_assoc_code' => 1,
+            'c_assoc_id' => 67890,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => '論語-註釋/卷一',
+            'c_assoc_first_year' => -9999,
+        ];
+
+        $result = CompositePrimaryKey::buildStoredResourceId($pk);
+
+        // 應包含 = 分隔符
+        $this->assertStringContainsString('=', $result);
+        // 特殊字符應被 URL 編碼，而非裸露
+        $this->assertStringNotContainsString('論語-註釋/卷一', $result);
+    }
+
+    /** @test */
+    public function it_roundtrips_build_and_parse_for_altname(): void {
+        $pk = [
+            'c_personid' => '12345',
+            'c_sequence' => '1',
+            'c_alt_name_chn' => '張-三',
+            'c_alt_name_type_code' => '10',
+        ];
+
+        $stored = CompositePrimaryKey::buildStoredResourceId($pk);
+        $parsed = CompositePrimaryKey::parseStoredResourceId($stored, 'ALTNAME_DATA');
+
+        $this->assertEquals($pk, $parsed);
+    }
+
+    /** @test */
+    public function it_roundtrips_build_and_parse_for_assoc_data(): void {
+        $pk = [
+            'c_personid' => '12345',
+            'c_assoc_code' => '1',
+            'c_assoc_id' => '67890',
+            'c_kin_code' => '0',
+            'c_kin_id' => '0',
+            'c_assoc_kin_code' => '0',
+            'c_assoc_kin_id' => '0',
+            'c_text_title' => '論語-註釋/卷一',
+            'c_assoc_first_year' => '-9999',
+        ];
+
+        $stored = CompositePrimaryKey::buildStoredResourceId($pk);
+        $parsed = CompositePrimaryKey::parseStoredResourceId($stored, 'ASSOC_DATA');
+
+        $this->assertEquals($pk, $parsed);
+    }
+
+    /** @test */
+    public function it_roundtrips_build_and_parse_for_entry_data(): void {
+        $pk = [
+            'c_personid' => '12345',
+            'c_entry_code' => '36',
+            'c_sequence' => '1',
+            'c_kin_code' => '0',
+            'c_assoc_code' => '0',
+            'c_kin_id' => '0',
+            'c_year' => '1000',
+            'c_assoc_id' => '0',
+            'c_inst_code' => '0',
+            'c_inst_name_code' => '0',
+        ];
+
+        $stored = CompositePrimaryKey::buildStoredResourceId($pk);
+        $parsed = CompositePrimaryKey::parseStoredResourceId($stored, 'ENTRY_DATA');
+
+        $this->assertEquals($pk, $parsed);
+    }
+
+    /** @test */
+    public function it_roundtrips_build_and_parse_with_chinese_chars(): void {
+        $pk = [
+            'c_personid' => '12345',
+            'c_sequence' => '1',
+            'c_alt_name_chn' => '張三',
+            'c_alt_name_type_code' => '10',
+        ];
+
+        $stored = CompositePrimaryKey::buildStoredResourceId($pk);
+        $parsed = CompositePrimaryKey::parseStoredResourceId($stored, 'ALTNAME_DATA');
+
+        $this->assertEquals('張三', $parsed['c_alt_name_chn']);
+    }
+
+    /** @test */
+    public function it_roundtrips_build_and_parse_with_brackets(): void {
+        $pk = [
+            'c_personid' => '12345',
+            'c_sequence' => '1',
+            'c_alt_name_chn' => '{張三}',
+            'c_alt_name_type_code' => '10',
+        ];
+
+        $stored = CompositePrimaryKey::buildStoredResourceId($pk);
+        $parsed = CompositePrimaryKey::parseStoredResourceId($stored, 'ALTNAME_DATA');
+
+        $this->assertEquals('{張三}', $parsed['c_alt_name_chn']);
+    }
+
+    /** @test */
+    public function it_parses_query_string_format_resource_id(): void {
+        // 直接測試 parseStoredResourceId 對 query-string 格式的偵測
+        $resourceId = 'c_personid=12345&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
+
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('1', $result['c_sequence']);
+        $this->assertEquals('張三', $result['c_alt_name_chn']);
+        $this->assertEquals('10', $result['c_alt_name_type_code']);
+    }
+
+    /** @test */
+    public function it_still_parses_old_dash_format_after_adding_query_string(): void {
+        // 確保加入 query-string 偵測後，舊格式仍可正常解析
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-張三-10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('張三', $result['c_alt_name_chn']);
+    }
+
+    /** @test */
+    public function it_still_parses_underscore_dot_format_with_equals(): void {
+        // 確保含 = 但也含 _._ 的格式不會被誤判為 query-string
+        // （雖然現實中不太可能，但邊界情況要處理）
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345_._1_._a=b_._10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('a=b', $result['c_alt_name_chn']);
+    }
+
+    /** @test */
+    public function it_rejects_legacy_id_with_equals_via_schema_validation(): void {
+        // 舊格式 resource_id 的欄位值恰好含有 '='（極端邊界情況）
+        // parse_str('12345-1-a=b-10') 會產生 ['12345-1-a' => 'b-10']
+        // 因為 key 不在 ALTNAME_DATA schema 中，應回退到 dash 分隔符解析
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-a=b-10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertNotNull($result);
+        // 應走 dash 分隔符路徑，正確解析出 4 個欄位
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('1', $result['c_sequence']);
+        $this->assertEquals('a=b', $result['c_alt_name_chn']);
+        $this->assertEquals('10', $result['c_alt_name_type_code']);
+    }
+
+    /** @test */
+    public function it_accepts_query_string_with_valid_schema_keys(): void {
+        // 新格式 resource_id 的 key 與 schema 匹配，應被正確識別
+        $resourceId = 'c_personid=12345&c_addr_id=100&c_addr_type=2&c_sequence=1';
+
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'BIOG_ADDR_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('100', $result['c_addr_id']);
+        $this->assertEquals('2', $result['c_addr_type']);
+        $this->assertEquals('1', $result['c_sequence']);
+    }
+
+    /** @test */
+    public function it_filters_parsed_query_string_to_schema_keys_only(): void {
+        // 如果 query-string 包含額外的非 schema key，應該被過濾掉
+        $resourceId = 'c_personid=12345&c_addr_id=100&c_addr_type=2&c_sequence=1&extra_field=bogus';
+
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'BIOG_ADDR_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(4, $result);
+        $this->assertArrayHasKey('c_personid', $result);
+        $this->assertArrayHasKey('c_addr_id', $result);
+        $this->assertArrayHasKey('c_addr_type', $result);
+        $this->assertArrayHasKey('c_sequence', $result);
+        $this->assertArrayNotHasKey('extra_field', $result);
+    }
+
+    /** @test */
+    public function it_rejects_partial_query_string_missing_schema_keys(): void {
+        // query-string 只包含部分 schema key（缺少 c_sequence），
+        // 應回退到舊格式解析，避免部分 key 匹配導致查到錯誤資料列
+        $resourceId = 'c_personid=12345&c_addr_id=100&c_addr_type=2';
+
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'BIOG_ADDR_DATA');
+
+        // BIOG_ADDR_DATA schema 有 4 個 key，但只提供了 3 個，
+        // 新格式驗證應失敗，回退到 dash 分隔符解析也會失敗（格式不符），返回 null
+        $this->assertNull($result);
+    }
+
+    // === buildResourceEditUrl 與新格式整合測試 ===
+
+    /** @test */
+    public function it_builds_edit_url_from_query_string_resource_id(): void {
+        // 新格式的 resource_id 也能生成正確的編輯 URL
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => '448',
+            'c_posting_id' => '130',
+        ]);
+
+        $url = CompositePrimaryKey::buildResourceEditUrl(
+            'POSTED_TO_OFFICE_DATA',
+            $resourceId,
+            12345
+        );
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('/basicinformation/12345/offices/edit', $url);
+        $this->assertStringContainsString('c_office_id=448', $url);
+        $this->assertStringContainsString('c_posting_id=130', $url);
+    }
+
     // === EDIT_ROUTE_MAP 測試 ===
 
     /** @test */
@@ -501,6 +805,59 @@ class CompositePrimaryKeyTest extends TestCase {
         $url = CompositePrimaryKey::buildResourceEditUrl(
             'POSTED_TO_ADDR_DATA',
             '448-130',
+            12345
+        );
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('/basicinformation/12345/offices/edit', $url);
+        $this->assertStringContainsString('c_office_id=448', $url);
+        $this->assertStringContainsString('c_posting_id=130', $url);
+    }
+
+    // === RESOURCE_ID_SCHEMA_ALIAS 與 getResourceIdSchemaTable 測試 ===
+
+    /** @test */
+    public function it_returns_alias_table_for_posted_to_addr_data(): void {
+        $result = CompositePrimaryKey::getResourceIdSchemaTable('POSTED_TO_ADDR_DATA');
+
+        $this->assertSame('POSTED_TO_OFFICE_DATA', $result);
+    }
+
+    /** @test */
+    public function it_returns_original_table_when_no_alias_exists(): void {
+        $result = CompositePrimaryKey::getResourceIdSchemaTable('ALTNAME_DATA');
+
+        $this->assertSame('ALTNAME_DATA', $result);
+    }
+
+    /** @test */
+    public function it_parses_posted_to_addr_data_query_string_using_office_schema(): void {
+        // POSTED_TO_ADDR_DATA 的 resource_id 沿用 POSTED_TO_OFFICE_DATA 格式
+        // 只有 c_office_id + c_posting_id（2 個 key），不含完整的 3 key schema
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => 10,
+            'c_posting_id' => 1,
+        ]);
+
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'POSTED_TO_ADDR_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals('10', $result['c_office_id']);
+        $this->assertEquals('1', $result['c_posting_id']);
+    }
+
+    /** @test */
+    public function it_builds_edit_url_for_addr_data_query_string_format(): void {
+        // POSTED_TO_ADDR_DATA 使用新格式 resource_id 也能正確生成編輯 URL
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => 448,
+            'c_posting_id' => 130,
+        ]);
+
+        $url = CompositePrimaryKey::buildResourceEditUrl(
+            'POSTED_TO_ADDR_DATA',
+            $resourceId,
             12345
         );
 

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -270,4 +270,243 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertNull($decoded);
     }
+
+    // === parseStoredResourceId 測試 ===
+
+    /** @test */
+    public function it_parses_simple_numeric_resource_id(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-100-2-1',
+            'BIOG_ADDR_DATA'
+        );
+
+        $this->assertEquals([
+            'c_personid' => '12345',
+            'c_addr_id' => '100',
+            'c_addr_type' => '2',
+            'c_sequence' => '1',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_parses_resource_id_with_encoded_slash(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-張(slash)三-10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertEquals([
+            'c_personid' => '12345',
+            'c_sequence' => '1',
+            'c_alt_name_chn' => '張/三',
+            'c_alt_name_type_code' => '10',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_parses_resource_id_with_minus_encoding(): void {
+        // 新格式：(minus) 編碼
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-67890-0-0-0-0-論語(slash)卷一-(minus)9999',
+            'ASSOC_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('論語/卷一', $result['c_text_title']);
+        $this->assertEquals('-9999', $result['c_assoc_first_year']);
+    }
+
+    /** @test */
+    public function it_parses_assoc_resource_id_with_dash_in_text_title(): void {
+        // c_text_title 包含 -，以 (minus) 編碼
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-67890-0-0-0-0-論語(minus)註釋-(minus)9999',
+            'ASSOC_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('論語-註釋', $result['c_text_title']);
+        $this->assertEquals('-9999', $result['c_assoc_first_year']);
+    }
+
+    /** @test */
+    public function it_parses_source_data_with_dash_in_pages(): void {
+        // c_pages 包含 -，以 (minus) 編碼
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-448-12(minus)15',
+            'BIOG_SOURCE_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('448', $result['c_textid']);
+        $this->assertEquals('12-15', $result['c_pages']);
+    }
+
+    /** @test */
+    public function it_parses_underscore_dot_separator_format(): void {
+        // CodesController 使用的 _._ 分隔符格式
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345_._1_._張三_._10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertEquals([
+            'c_personid' => '12345',
+            'c_sequence' => '1',
+            'c_alt_name_chn' => '張三',
+            'c_alt_name_type_code' => '10',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_returns_null_for_unknown_table_in_parse(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId('12345', 'UNKNOWN_TABLE');
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_returns_null_for_insufficient_parts(): void {
+        // ALTNAME_DATA 需要 4 個欄位，只提供 2 個
+        $result = CompositePrimaryKey::parseStoredResourceId('12345-1', 'ALTNAME_DATA');
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_parses_posted_to_office_data(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '448-130',
+            'POSTED_TO_OFFICE_DATA'
+        );
+
+        $this->assertEquals([
+            'c_office_id' => '448',
+            'c_posting_id' => '130',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_parses_events_data_three_fields(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-0-50',
+            'EVENTS_DATA'
+        );
+
+        $this->assertEquals([
+            'c_personid' => '12345',
+            'c_sequence' => '0',
+            'c_event_code' => '50',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_parses_entry_data_ten_fields(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-36-1-0-0-0-1000-0-0-0',
+            'ENTRY_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertCount(10, $result);
+        $this->assertEquals('12345', $result['c_personid']);
+        $this->assertEquals('36', $result['c_entry_code']);
+        $this->assertEquals('1000', $result['c_year']);
+    }
+
+    /** @test */
+    public function it_parses_biog_text_data_alias(): void {
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-448-1',
+            'BIOG_TEXT_DATA'
+        );
+
+        $this->assertEquals([
+            'c_personid' => '12345',
+            'c_textid' => '448',
+            'c_role_id' => '1',
+        ], $result);
+    }
+
+    /** @test */
+    public function it_parses_old_format_with_double_dash(): void {
+        // 舊格式：-- 代表欄位值中的 -
+        $result = CompositePrimaryKey::parseStoredResourceId(
+            '12345-1-張--三-10',
+            'ALTNAME_DATA'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('張-三', $result['c_alt_name_chn']);
+    }
+
+    // === EDIT_ROUTE_MAP 測試 ===
+
+    /** @test */
+    public function edit_route_map_covers_all_resource_tables(): void {
+        $requiredTables = [
+            'ALTNAME_DATA',
+            'BIOG_ADDR_DATA',
+            'TEXT_DATA',
+            'BIOG_TEXT_DATA',
+            'BIOG_SOURCE_DATA',
+            'POSTED_TO_OFFICE_DATA',
+            'POSTED_TO_ADDR_DATA',
+            'ASSOC_DATA',
+            'KIN_DATA',
+            'EVENTS_DATA',
+            'STATUS_DATA',
+            'ENTRY_DATA',
+            'POSSESSION_DATA',
+            'BIOG_INST_DATA',
+        ];
+
+        foreach ($requiredTables as $table) {
+            $this->assertArrayHasKey(
+                $table,
+                CompositePrimaryKey::EDIT_ROUTE_MAP,
+                "EDIT_ROUTE_MAP should contain '{$table}'"
+            );
+        }
+    }
+
+    // === buildResourceEditUrl 測試 ===
+
+    /** @test */
+    public function it_returns_null_for_unknown_resource_type(): void {
+        $result = CompositePrimaryKey::buildResourceEditUrl('UNKNOWN_TABLE', '12345', 1);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_builds_edit_url_for_simple_resource(): void {
+        $url = CompositePrimaryKey::buildResourceEditUrl(
+            'POSTED_TO_OFFICE_DATA',
+            '448-130',
+            12345
+        );
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('/basicinformation/12345/offices/edit', $url);
+        $this->assertStringContainsString('c_office_id=448', $url);
+        $this->assertStringContainsString('c_posting_id=130', $url);
+    }
+
+    /** @test */
+    public function it_builds_edit_url_for_addr_data_using_office_route(): void {
+        // POSTED_TO_ADDR_DATA 共用 offices 路由
+        $url = CompositePrimaryKey::buildResourceEditUrl(
+            'POSTED_TO_ADDR_DATA',
+            '448-130',
+            12345
+        );
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('/basicinformation/12345/offices/edit', $url);
+        $this->assertStringContainsString('c_office_id=448', $url);
+        $this->assertStringContainsString('c_posting_id=130', $url);
+    }
 }

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Http\Controllers\OperationsController;
+use App\Models\Operation;
 use App\Repositories\OperationRepository;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -61,5 +62,78 @@ class OperationsAltnameResolverTest extends TestCase {
         $this->assertNotNull($row);
         $this->assertSame('張-一', $row->c_alt_name_chn);
         $this->assertSame('Zi Jing', $row->c_alt_name);
+    }
+
+    #[Test]
+    public function test_fetch_altname_handles_null_sentinel_in_query_string_resource_id(): void {
+        // 當 resource_data 缺少欄位，且 resource_id 用新格式包含 NULL sentinel 時，
+        // fetchAltnameCurrentRow 不應將 'NULL' 強轉為 (int)0
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 200,
+            'c_sequence' => 0,
+            'c_alt_name_type_code' => 5,
+            'c_alt_name' => 'Test',
+            'c_alt_name_chn' => '測試',
+        ]);
+
+        $controller = new class (new OperationRepository()) extends OperationsController {
+            public function resolveAltname(array $payload) {
+                return $this->fetchAltnameCurrentRow($payload);
+            }
+        };
+
+        // resource_data 只有 c_personid，其餘需從 resource_id 補齊
+        // c_sequence=NULL 表示該值為 null
+        $operationPayload = [
+            'resource_id' => 'c_personid=200&c_sequence=NULL&c_alt_name_chn=%E6%B8%AC%E8%A9%A6&c_alt_name_type_code=5',
+            'resource_data' => json_encode([
+                'c_personid' => 200,
+            ]),
+        ];
+
+        $row = $controller->resolveAltname($operationPayload);
+
+        // c_sequence=NULL 應解析為 null，WHERE c_sequence IS NULL 不會匹配到 c_sequence=0
+        // 因此 row 應為 null（因為資料庫中 c_sequence=0，不是 NULL）
+        $this->assertNull($row);
+    }
+
+    #[Test]
+    public function test_build_key_conditions_normalizes_null_sentinel(): void {
+        // buildKeyConditions() 從 resource_id 的 query-string 中讀取 'NULL' 時，
+        // 應轉換為 PHP null（以便後續產生 WHERE IS NULL）
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->timestamps();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->tinyInteger('rate')->default(0);
+        });
+
+        $controller = new class (new OperationRepository()) extends OperationsController {
+            public function publicBuildKeyConditions(Operation $op, array $current, array $fallback) {
+                return $this->buildKeyConditions($op, $current, $fallback);
+            }
+        };
+
+        $op = new Operation();
+        $op->resource = 'ALTNAME_DATA';
+        $op->resource_id = 'c_personid=123&c_sequence=NULL&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
+
+        // $current 和 $fallback 都不含完整 key，迫使 buildKeyConditions 解析 resource_id
+        $conditions = $controller->publicBuildKeyConditions($op, [], []);
+
+        $this->assertCount(3, $conditions); // ALTNAME_DATA schema 有 3 個 key columns
+        $this->assertSame('123', $conditions['c_personid']);
+        $this->assertNull($conditions['c_sequence']); // 'NULL' 應轉為 PHP null
+        $this->assertSame('10', $conditions['c_alt_name_type_code']);
+
+        Schema::dropIfExists('operations');
     }
 }


### PR DESCRIPTION
## Summary

- 將 operations 表的 `resource_id` 從 `-` 分隔格式改為 PHP query-string 格式（`c_personid=12345&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89`），徹底消除欄位值含 `-` 時的解析歧義
- 所有複合主鍵資料表的寫入端統一使用 `CompositePrimaryKey::buildStoredResourceId()`，讀取端新增通用 query-string 處理器並自動回退舊格式
- 新增 `RESOURCE_ID_SCHEMA_ALIAS` 機制處理 `POSTED_TO_ADDR_DATA` 共用 `POSTED_TO_OFFICE_DATA` 格式的特殊情況

## 影響範圍

### 寫入端（13 個資料表）
| 資料表 | Controller / Repository |
|--------|------------------------|
| ALTNAME_DATA | BasicInformationAltnamesController |
| BIOG_ADDR_DATA | BasicInformationAddressesController |
| TEXT_DATA / BIOG_TEXT_DATA | BasicInformationTextsController |
| BIOG_SOURCE_DATA | BiogMainRepository |
| POSTED_TO_OFFICE_DATA | BiogMainRepository |
| POSTED_TO_ADDR_DATA | BiogMainRepository |
| ENTRY_DATA | BasicInformationEntriesController |
| BIOG_INST_DATA | BasicInformationSocialInstController |
| ASSOC_DATA | BiogMainRepository |
| KIN_DATA | BiogMainRepository |
| EVENTS_DATA | BiogMainRepository |
| STATUS_DATA | BiogMainRepository |
| OFFICE_CODE_TYPE_REL | AdminBatchLoadOfficesController, CrowdsourcingController |

另包含 BasicInformationController（複製人物功能）的相關寫入。

### 讀取端
- `OperationsController::index()`：新增通用 query-string 處理器，`$usedNewFormat` flag 控制回退
- `buildKeyConditions()`、`fetchAltnameCurrentRow()`：支援 `'NULL'` sentinel → `whereNull()`

### 核心類
- `CompositePrimaryKey`：新增 `buildStoredResourceId()`、`RESOURCE_ID_SCHEMA_ALIAS`、`getResourceIdSchemaTable()`；更新 `parseStoredResourceId()` 和 `buildResourceEditUrl()`

## 向後相容

- 舊格式紀錄保持原樣，讀取端自動偵測格式（`=` 字符不存在於舊格式中）
- 新格式驗證失敗時自動回退到舊格式 switch/case
- Operations 頁面同時正確顯示新舊格式

## Test plan

- [x] `./vendor/bin/phpunit` 全部 480 個測試通過
- [x] `php-cs-fixer` 格式檢查通過（0 files to fix）
- [x] Operations 頁面手動驗證：舊紀錄和新紀錄共存顯示正常
- [x] 新建/修改/刪除操作後，Operations 頁面的 diff 比對正確
- [x] 編輯連結正確指向查詢參數模式 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)