### PR TITLE
為地址重建命令新增 --database 選項

### DIFF
--- a/app/Console/Commands/RegenerateAddresses.php
+++ b/app/Console/Commands/RegenerateAddresses.php
@@ -17,6 +17,7 @@ class RegenerateAddresses extends Command {
      * @var string
      */
     protected $signature = 'cbdb:regenerate-addresses-table
+                            {--database= : 指定数据库连接（如 mysql_migrate）}
                             {--verify : 验证特定示例案例（如 Jiangle 100149）}
                             {--dry-run : 仅模拟运行，不实际修改数据}';
 
@@ -43,6 +44,11 @@ class RegenerateAddresses extends Command {
      * @return int
      */
     public function handle() {
+        if ($database = $this->option('database')) {
+            DB::setDefaultConnection($database);
+            $this->info("使用数据库连接: {$database}");
+        }
+
         $this->info('==========================================================');
         $this->info('开始重建地址层级关系（保留间隙）...');
         $this->info('==========================================================');


### PR DESCRIPTION
## Summary
- 為 `php artisan cbdb:regenerate-addresses-table` 新增 `--database` 選項，允許指定資料庫連接（如 `mysql_migrate`）
- 使用 `DB::setDefaultConnection()` 在運行時切換連接，不受 config cache 影響
- 用法：`php artisan cbdb:regenerate-addresses-table --database=mysql_migrate`

## Test plan
- [x] 在伺服器上以 `--database=mysql_migrate` 執行命令，確認使用正確的資料庫連接
- [x] 不帶 `--database` 選項時，確認行為與原先一致（使用預設連接）

🤖 Generated with [Claude Code](https://claude.com/claude-code)