### PR TITLE
新增 AI 填充日誌功能

### DIFF
--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class AiFillLogController extends Controller {
+    /**
+     * AI 填充日誌列表（僅 Super Admin）
+     */
+    public function index(Request $request) {
+        if (!Auth::user()->isSuperAdmin()) {
+            abort(403, '此功能僅限超級管理員使用');
+        }
+
+        $query = DB::table('ai_fill_logs')
+            ->leftJoin('users', 'ai_fill_logs.user_id', '=', 'users.id')
+            ->select(
+                'ai_fill_logs.*',
+                'users.name as user_name',
+                'users.email as user_email'
+            );
+
+        // 關鍵字搜尋
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('ai_fill_logs.source_text', 'like', "%{$search}%")
+                    ->orWhere('users.name', 'like', "%{$search}%")
+                    ->orWhere('users.email', 'like', "%{$search}%");
+            });
+        }
+
+        // 用戶篩選
+        if ($request->filled('user_id')) {
+            $query->where('ai_fill_logs.user_id', $request->input('user_id'));
+        }
+
+        $query->orderBy('ai_fill_logs.created_at', 'desc');
+
+        $logs = $query->paginate(20)->withQueryString();
+
+        // 為每條有 user_submitted 的記錄建構比較數據
+        foreach ($logs as $log) {
+            $log->comparison_rows = null;
+            if ($log->ai_matched && $log->user_submitted) {
+                $aiMatched = json_decode($log->ai_matched, true);
+                $userSubmitted = json_decode($log->user_submitted, true);
+                if (is_array($aiMatched) && is_array($userSubmitted)) {
+                    $log->comparison_rows = $this->buildComparisonRows($aiMatched, $userSubmitted);
+                }
+            }
+        }
+
+        // 獲取有日誌記錄的用戶列表
+        $users = DB::table('users')
+            ->whereIn('id', function ($query) {
+                $query->select('user_id')
+                    ->from('ai_fill_logs')
+                    ->whereNotNull('user_id')
+                    ->distinct();
+            })
+            ->orderBy('name')
+            ->get();
+
+        return view('admin.ai_fill_logs.index', [
+            'page_title' => 'AI 填充日誌',
+            'page_title_key' => 'AI 填充日誌',
+            'page_url' => route('admin.ai-fill-logs'),
+            'logs' => $logs,
+            'users' => $users,
+            'filters' => [
+                'search' => $request->input('search'),
+                'user_id' => $request->input('user_id'),
+            ],
+        ]);
+    }
+
+    /**
+     * 建構 AI 匹配結果與用戶提交數據的比較列表
+     */
+    private function buildComparisonRows(array $aiMatched, array $userSubmitted): array {
+        $fieldLabels = [
+            'c_office_id' => '官名',
+            'c_addr' => '地名',
+            'c_dy' => '朝代',
+            'c_firstyear' => '始年',
+            'c_fy_nh_code' => '始年年號',
+            'c_fy_nh_year' => '年號年數',
+            'c_fy_range' => '始年精確度',
+            'c_fy_intercalary' => '始年閏月',
+            'c_fy_month' => '始年月',
+            'c_fy_day' => '始年日',
+            'c_fy_day_gz' => '始年干支日',
+            'c_lastyear' => '終年',
+            'c_ly_nh_code' => '終年年號',
+            'c_ly_nh_year' => '終年年號年數',
+            'c_ly_range' => '終年精確度',
+            'c_ly_intercalary' => '終年閏月',
+            'c_ly_month' => '終年月',
+            'c_ly_day' => '終年日',
+            'c_ly_day_gz' => '終年干支日',
+            'c_appt_code' => '除授類別',
+            'c_assume_office_code' => '是否赴任',
+            'c_source' => '出處',
+            'c_inst_code' => '社會機構',
+            'c_sequence' => '次序',
+            'c_notes' => '備註',
+        ];
+
+        $matched = $aiMatched['matched_fields'] ?? [];
+        $suggested = $aiMatched['suggested_fields'] ?? [];
+        $allAiFields = array_merge($matched, $suggested);
+
+        // 批次查詢用戶提交代碼欄位的中文名稱
+        $codeLabels = $this->resolveCodeLabels($userSubmitted);
+
+        $rows = [];
+        foreach ($fieldLabels as $field => $label) {
+            // 取得 AI 匹配值
+            $aiEntry = $allAiFields[$field] ?? null;
+            $aiValue = null;
+            $aiText = '';
+            $aiType = 'empty';
+
+            if ($aiEntry !== null) {
+                $aiValue = $aiEntry['value'] ?? null;
+                $aiText = $aiEntry['text'] ?? $aiValue;
+                $aiType = isset($matched[$field]) ? 'matched' : 'suggested';
+            }
+
+            // 取得用戶提交值
+            $userValue = $userSubmitted[$field] ?? null;
+
+            // 格式化顯示值
+            $aiDisplay = $this->formatValue($aiText);
+            $userDisplay = $this->formatValue($userValue);
+
+            // 若用戶提交的是代碼，附上中文名稱
+            if (isset($codeLabels[$field]) && $userDisplay !== '') {
+                $userDisplay = $userDisplay.' ('.$codeLabels[$field].')';
+            }
+
+            // 若兩者都為空，跳過此欄位
+            if ($aiDisplay === '' && $userDisplay === '') {
+                continue;
+            }
+
+            // 判斷是否匹配（用原始值比較）
+            $aiCompare = $this->normalizeForCompare($aiValue);
+            $userCompare = $this->normalizeForCompare($userValue);
+            $matches = ($aiCompare === $userCompare);
+
+            $rows[] = [
+                'field' => $label,
+                'field_key' => $field,
+                'ai_value' => $aiDisplay,
+                'ai_type' => $aiType,
+                'user_value' => $userDisplay,
+                'matches' => $matches,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * 批次查詢用戶提交代碼欄位對應的中文名稱
+     */
+    private function resolveCodeLabels(array $userSubmitted): array {
+        $labels = [];
+
+        // 代碼欄位 → [table, pk_column, text_column]
+        $codeLookups = [
+            'c_office_id' => ['OFFICE_CODES', 'c_office_id', 'c_office_chn'],
+            'c_dy' => ['DYNASTIES', 'c_dy', 'c_dynasty_chn'],
+            'c_fy_nh_code' => ['NIAN_HAO', 'c_nianhao_id', 'c_nianhao_chn'],
+            'c_ly_nh_code' => ['NIAN_HAO', 'c_nianhao_id', 'c_nianhao_chn'],
+            'c_appt_code' => ['APPOINTMENT_CODES', 'c_appt_code', 'c_appt_desc_chn'],
+            'c_assume_office_code' => ['ASSUME_OFFICE_CODES', 'c_assume_office_code', 'c_assume_office_desc_chn'],
+            'c_source' => ['TEXT_CODES', 'c_textid', 'c_title_chn'],
+        ];
+
+        foreach ($codeLookups as $field => [$table, $pk, $textCol]) {
+            $value = $userSubmitted[$field] ?? null;
+            if ($value === null || $value === '' || $value === 0 || $value === '0') {
+                continue;
+            }
+            $text = DB::table($table)->where($pk, $value)->value($textCol);
+            if ($text !== null && $text !== '') {
+                $labels[$field] = $text;
+            }
+        }
+
+        // 地址欄位特殊處理（可能是陣列）
+        $addrValue = $userSubmitted['c_addr'] ?? null;
+        if ($addrValue !== null && $addrValue !== '' && $addrValue !== 0 && $addrValue !== '0') {
+            $addrIds = is_array($addrValue) ? $addrValue : [$addrValue];
+            $addrIds = array_filter($addrIds, fn ($v) => $v !== null && $v !== '' && $v !== 0 && $v !== '0');
+            if (!empty($addrIds)) {
+                $addrNames = DB::table('ADDR_CODES')
+                    ->whereIn('c_addr_id', $addrIds)
+                    ->pluck('c_name_chn', 'c_addr_id');
+                $names = [];
+                foreach ($addrIds as $id) {
+                    $names[] = $addrNames[$id] ?? (string) $id;
+                }
+                $labels['c_addr'] = implode(', ', $names);
+            }
+        }
+
+        // 社會機構特殊處理（需要透過 SOCIAL_INSTITUTION_NAME_CODES 取得名稱）
+        $instCode = $userSubmitted['c_inst_code'] ?? null;
+        if ($instCode !== null && $instCode !== '' && $instCode !== 0 && $instCode !== '0') {
+            $instNameCode = DB::table('SOCIAL_INSTITUTION_CODES')
+                ->where('c_inst_code', $instCode)
+                ->value('c_inst_name_code');
+            if ($instNameCode) {
+                $instName = DB::table('SOCIAL_INSTITUTION_NAME_CODES')
+                    ->where('c_inst_name_code', $instNameCode)
+                    ->value('c_inst_name_hz');
+                if ($instName !== null && $instName !== '') {
+                    $labels['c_inst_code'] = $instName;
+                }
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * 格式化值為顯示字串
+     */
+    private function formatValue(mixed $value): string {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (is_array($value)) {
+            return implode(', ', array_map(fn ($v) => (string) $v, $value));
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * 正規化值以便比較
+     */
+    private function normalizeForCompare(mixed $value): string {
+        if ($value === null || $value === '') {
+            return '';
+        }
+        if (is_array($value)) {
+            $arr = array_map(fn ($v) => trim((string) $v), $value);
+            $arr = array_filter($arr, fn ($v) => $v !== '' && $v !== '0');
+            sort($arr);
+
+            return implode(',', $arr);
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '';
+        }
+
+        $str = trim((string) $value);
+
+        // 統一 "false"/"true" 字串
+        if ($str === 'false') {
+            $str = '0';
+        }
+        if ($str === 'true') {
+            $str = '1';
+        }
+
+        // 0 視為空值（表單預設值，等同於「未設定」）
+        if ($str === '0') {
+            return '';
+        }
+
+        return $str;
+    }
+}

--- a/app/Http/Controllers/AiPostingAutofillController.php
+++ b/app/Http/Controllers/AiPostingAutofillController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\PostingAutofillService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class AiPostingAutofillController extends Controller {
     protected PostingAutofillService $autofillService;
@@ -32,17 +33,61 @@ class AiPostingAutofillController extends Controller {
         $request->validate([
             'source_text' => 'required|string|max:5000',
             'person_id' => 'required|integer',
+            'route_name' => 'nullable|string|max:255',
+            'route_url' => 'nullable|string|max:500',
         ]);
 
         $sourceText = $request->input('source_text');
         $personId = $request->input('person_id');
 
+        $startTime = microtime(true);
         $result = $this->autofillService->extractAndMatch($sourceText, $personId);
+        $executionTimeMs = (int) round((microtime(true) - $startTime) * 1000);
+
+        // 寫入 AI 填充日誌
+        $logId = $this->saveLog($request, $personId, $sourceText, $result, $executionTimeMs);
 
         if (!$result['success']) {
-            return response()->json($result, 400);
+            $response = $result;
+            $response['ai_fill_log_id'] = $logId;
+
+            return response()->json($response, 400);
         }
 
+        $result['ai_fill_log_id'] = $logId;
+
         return response()->json($result);
+    }
+
+    /**
+     * 儲存 AI 填充日誌記錄
+     */
+    private function saveLog(Request $request, int $personId, string $sourceText, array $result, int $executionTimeMs): ?int {
+        try {
+            $logId = DB::table('ai_fill_logs')->insertGetId([
+                'user_id' => Auth::id(),
+                'c_personid' => $personId,
+                'route_name' => $request->input('route_name') ?? '',
+                'route_url' => $request->input('route_url') ?? '',
+                'source_text' => $sourceText,
+                'ai_raw' => isset($result['data']['ai_extracted'])
+                    ? json_encode($result['data']['ai_extracted'], JSON_UNESCAPED_UNICODE)
+                    : null,
+                'ai_matched' => $result['success'] && isset($result['data'])
+                    ? json_encode($result['data'], JSON_UNESCAPED_UNICODE)
+                    : null,
+                'success' => $result['success'],
+                'error_message' => $result['error'] ?? null,
+                'execution_time_ms' => $executionTimeMs,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            return $logId;
+        } catch (\Exception $e) {
+            \Log::warning('[AI Fill Log] 日誌寫入失敗: '.$e->getMessage());
+
+            return null;
+        }
     }
 }

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -145,8 +145,18 @@ class BasicInformationOfficesController extends Controller {
         }
         //return $request;
         //修改結束
+
+        // 提取 AI 填充日誌 ID 並從 request 中移除（避免傳入資料庫操作）
+        $aiFillLogId = $request->input('ai_fill_log_id');
+        $request->request->remove('ai_fill_log_id');
+
         $_id = $this->biogMainRepository->officeStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
+
+        // 更新 AI 填充日誌（如果本次提交使用了 AI 填充）
+        if ($aiFillLogId) {
+            $this->updateAiFillLog($aiFillLogId, $request);
+        }
 
         // 解析主鍵（officeStoreById 返回查詢參數格式，如 c_office_id=87473&c_posting_id=2104406）
         $newPk = CompositePrimaryKey::parseStoredResourceId($_id, 'POSTED_TO_OFFICE_DATA');
@@ -656,5 +666,34 @@ class BasicInformationOfficesController extends Controller {
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.offices.index', ['basicinformation' => $id]);
+    }
+
+    /**
+     * 更新 AI 填充日誌，記錄用戶實際提交的數據
+     */
+    private function updateAiFillLog(int $logId, Request $request): void {
+        try {
+            $relevantFields = [
+                'c_office_id', 'c_addr', 'c_sequence', 'c_source', 'c_pages',
+                'c_firstyear', 'c_fy_nh_code', 'c_fy_nh_year', 'c_fy_range',
+                'c_fy_intercalary', 'c_fy_month', 'c_fy_day', 'c_fy_day_gz',
+                'c_lastyear', 'c_ly_nh_code', 'c_ly_nh_year', 'c_ly_range',
+                'c_ly_intercalary', 'c_ly_month', 'c_ly_day', 'c_ly_day_gz',
+                'c_appt_code', 'c_assume_office_code', 'c_dy',
+                'c_office_category_id', 'c_inst_code', 'c_notes',
+            ];
+            $submittedData = $request->only($relevantFields);
+
+            DB::table('ai_fill_logs')
+                ->where('id', $logId)
+                ->where('user_id', Auth::id())
+                ->update([
+                    'user_submitted' => json_encode($submittedData, JSON_UNESCAPED_UNICODE),
+                    'submitted_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        } catch (\Exception $e) {
+            \Log::warning('[AI Fill Log] 更新用戶提交數據失敗: '.$e->getMessage());
+        }
     }
 }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -607,7 +607,7 @@ class BiogMainRepository {
         $hasAddressChange = $incomingAddr !== null
             && $this->selectionListHasChanges($incomingAddr, $existingAddresses, -999);
 
-        $data = Arr::except($data, ['_method', '_token', 'c_addr', 'c_addr_cleared', '_id', '_postingid', '_officeid']);
+        $data = Arr::except($data, ['_method', '_token', 'c_addr', 'c_addr_cleared', '_id', '_postingid', '_officeid', 'ai_fill_log_id']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
         $data['c_office_id'] = $data['c_office_id'] == -999 ? '0' : $data['c_office_id'];
@@ -836,7 +836,7 @@ class BiogMainRepository {
         return DB::transaction(function () use ($request, $id) {
             $payload = $request->all();
             $c_addr = $payload['c_addr'] ?? [];
-            $data = Arr::except($payload, ['_token', 'c_addr', 'c_addr_cleared']);
+            $data = Arr::except($payload, ['_token', 'c_addr', 'c_addr_cleared', 'ai_fill_log_id']);
 
             $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
             $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -59,11 +59,7 @@ class PostingAutofillService {
                     'matched_fields' => $matchResult['matched'], // 成功匹配的欄位
                     'suggested_fields' => $matchResult['suggested'], // 建議值（未匹配）
                     'empty_fields' => $matchResult['empty'], // 未提取的欄位
-                    'statistics' => [
-                        'matched_count' => count($matchResult['matched']),
-                        'suggested_count' => count($matchResult['suggested']),
-                        'empty_count' => count($matchResult['empty']),
-                    ],
+                    'statistics' => $this->buildStatistics($matchResult),
                 ],
                 'error' => null,
             ];
@@ -80,6 +76,29 @@ class PostingAutofillService {
                 'error' => '處理失敗：' . $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * 建構統計信息，區分有值的建議和無匹配的建議
+     */
+    private function buildStatistics(array $matchResult): array {
+        $suggestedWithValue = 0;
+        $notFoundCount = 0;
+
+        foreach ($matchResult['suggested'] as $fieldData) {
+            if (isset($fieldData['value'])) {
+                $suggestedWithValue++;
+            } else {
+                $notFoundCount++;
+            }
+        }
+
+        return [
+            'matched_count' => count($matchResult['matched']),
+            'suggested_count' => $suggestedWithValue,
+            'not_found_count' => $notFoundCount,
+            'empty_count' => count($matchResult['empty']),
+        ];
     }
 
     /**
@@ -435,9 +454,15 @@ class PostingAutofillService {
                     }
                 }
 
+                // 年號欄位經過名稱→ID 轉換時，text 應保留原始中文名稱
+                $text = $value;
+                if (in_array($fieldName, ['c_fy_nh_code', 'c_ly_nh_code']) && $value !== $aiData[$aiKey]) {
+                    $text = $aiData[$aiKey];
+                }
+
                 $matched[$fieldName] = [
                     'value' => $value,
-                    'text' => $value,
+                    'text' => $text,
                 ];
             } else {
                 $empty[] = $fieldName;
@@ -547,6 +572,48 @@ class PostingAutofillService {
                         'match_type' => 'fuzzy',  // 前綴匹配視為模糊匹配
                     ];
                 }
+            }
+        }
+
+        // ========== Step 5: 後綴匹配 c_office_chn（輸入可能包含地名前綴） ==========
+        // 例如「寧夏將軍」→ 匹配「將軍」（去除地名前綴後的官名）
+        if (mb_strlen($officeName) >= 2) {
+            $isSqlite = is_sqlite();
+
+            // LIKE '%' || col（SQLite）vs LIKE CONCAT('%', col)（MySQL）
+            $likeExpr = $isSqlite
+                ? "? LIKE '%' || c_office_chn"
+                : "? LIKE CONCAT('%', c_office_chn)";
+
+            // LENGTH() 在 SQLite 返回字節長度，CHAR_LENGTH() 在 MySQL 返回字符長度
+            $lenExpr = $isSqlite ? 'LENGTH(c_office_chn)' : 'CHAR_LENGTH(c_office_chn)';
+
+            // SQLite 的 LENGTH() 對 UTF-8 中文返回字節數（每字 3 bytes），需調整閾值
+            $minLen = $isSqlite ? 6 : 2; // 2 個中文字符 = 6 bytes in UTF-8
+            $maxLen = $isSqlite ? mb_strlen($officeName) * 3 : mb_strlen($officeName);
+
+            $query = DB::table('OFFICE_CODES')
+                ->select(
+                    'c_office_id as id',
+                    'c_office_chn as text',
+                    DB::raw("{$lenExpr} as name_len")
+                )
+                ->whereRaw($likeExpr, [$officeName])
+                ->where(DB::raw($lenExpr), '>=', $minLen)
+                ->where(DB::raw($lenExpr), '<', $maxLen);
+
+            if ($dynastyCode !== null) {
+                $query->where('c_dy', '=', $dynastyCode);
+            }
+
+            // 優先取最長的匹配（最具體的官名）
+            $result = $query->orderBy('name_len', 'desc')->first();
+            if ($result) {
+                return [
+                    'id' => $result->id,
+                    'text' => $result->text,
+                    'match_type' => 'fuzzy',
+                ];
             }
         }
 

--- a/database/migrations/2026_02_04_000000_create_ai_fill_logs_table.php
+++ b/database/migrations/2026_02_04_000000_create_ai_fill_logs_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->comment('執行填充的用戶 ID');
+            $table->integer('c_personid')->comment('目標人物 ID');
+
+            // 頁面上下文
+            $table->string('route_name', 255)->comment('路由名稱');
+            $table->string('route_url', 500)->comment('頁面 URL 路徑');
+
+            // 用戶輸入
+            $table->text('source_text')->comment('用戶輸入的原始史料文本');
+
+            // AI 數據（三層結構）
+            $table->longText('ai_raw')->nullable()->comment('AI 原始 JSON 回應（匹配前）');
+            $table->longText('ai_matched')->nullable()->comment('AI 匹配後完整結果 JSON');
+            $table->longText('user_submitted')->nullable()->comment('用戶實際提交的表單數據 JSON');
+
+            // 狀態追蹤
+            $table->boolean('success')->default(false)->comment('AI 提取是否成功');
+            $table->string('error_message', 500)->nullable()->comment('錯誤訊息');
+            $table->integer('execution_time_ms')->nullable()->comment('AI 處理耗時（毫秒）');
+            $table->timestamp('submitted_at')->nullable()->comment('用戶提交表單的時間');
+
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('c_personid');
+            $table->index('success');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('ai_fill_logs');
+    }
+};

--- a/resources/views/admin/ai_fill_logs/index.blade.php
+++ b/resources/views/admin/ai_fill_logs/index.blade.php
@@ -1,0 +1,252 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fas fa-robot mr-1"></i> {{ $page_title }}</h3>
+            </div>
+
+            <div class="card-body">
+                <!-- 搜尋與篩選 -->
+                <form method="GET" action="{{ route('admin.ai-fill-logs') }}" class="mb-3">
+                    <div class="row">
+                        <div class="col-md-5">
+                            <div class="form-group">
+                                <label for="search">關鍵字搜尋</label>
+                                <input type="text" class="form-control" id="search" name="search"
+                                       value="{{ $filters['search'] ?? '' }}"
+                                       placeholder="搜尋原始文本、用戶名稱或郵箱">
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="user_id">用戶</label>
+                                <select class="form-control" id="user_id" name="user_id">
+                                    <option value="">全部用戶</option>
+                                    @foreach($users as $user)
+                                        <option value="{{ $user->id }}" {{ ($filters['user_id'] ?? '') == $user->id ? 'selected' : '' }}>
+                                            {{ $user->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <div class="form-group">
+                                <label>&nbsp;</label>
+                                <div>
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="fas fa-search"></i> 搜尋
+                                    </button>
+                                    @if(($filters['search'] ?? '') || ($filters['user_id'] ?? ''))
+                                        <a href="{{ route('admin.ai-fill-logs') }}" class="btn btn-secondary ml-1">
+                                            <i class="fas fa-times"></i> 清除
+                                        </a>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+
+                <!-- 統計信息 -->
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle"></i>
+                    共 {{ $logs->total() }} 筆記錄，顯示第 {{ $logs->firstItem() ?? 0 }} - {{ $logs->lastItem() ?? 0 }} 筆
+                </div>
+
+                <!-- 日誌列表 -->
+                @if($logs->isEmpty())
+                    <div class="alert alert-warning">
+                        <i class="fas fa-exclamation-triangle"></i> 暫無記錄
+                    </div>
+                @else
+                    @foreach($logs as $log)
+                        @php
+                            $hasComparison = !empty($log->comparison_rows);
+                            $aiMatched = $log->ai_matched ? json_decode($log->ai_matched, true) : null;
+                            $statistics = $aiMatched['statistics'] ?? null;
+                            $cardBorderClass = $log->user_submitted ? 'border-success' : 'border-info';
+                            $cardHeaderClass = $log->user_submitted ? 'bg-success' : 'bg-info';
+                        @endphp
+                        <div class="card mb-3 {{ $cardBorderClass }}">
+                            <div class="card-header {{ $cardHeaderClass }}">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                    <div>
+                                        <strong>#{{ $log->id }}</strong>
+                                        <span class="ml-2">
+                                            <i class="fas fa-user"></i>
+                                            {{ $log->user_name ?? '未知用戶' }}
+                                            @if($log->user_email)
+                                                <small>({{ $log->user_email }})</small>
+                                            @endif
+                                        </span>
+                                        <span class="ml-2">
+                                            <i class="fas fa-id-badge"></i>
+                                            <a href="{{ route('basicinformation.edit', $log->c_personid) }}" class="text-white" target="_blank">
+                                                人物 #{{ $log->c_personid }}
+                                            </a>
+                                        </span>
+                                        <span class="ml-2">
+                                            <i class="fas fa-clock"></i>
+                                            {{ $log->created_at }}
+                                        </span>
+                                        @if($log->execution_time_ms)
+                                            <span class="ml-2">
+                                                <i class="fas fa-stopwatch"></i>
+                                                {{ $log->execution_time_ms }}ms
+                                            </span>
+                                        @endif
+                                    </div>
+                                    <div>
+                                        @if($log->user_submitted)
+                                            <span class="badge badge-light">已提交</span>
+                                        @else
+                                            <span class="badge badge-light">未提交</span>
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <!-- 原始文本 -->
+                                <div class="mb-3">
+                                    <h6><i class="fas fa-file-alt text-primary"></i> 原始史料：</h6>
+                                    <div class="alert alert-light mb-2">
+                                        {{ $log->source_text }}
+                                    </div>
+                                </div>
+
+                                <!-- 匹配統計 -->
+                                @if($statistics)
+                                    <div class="mb-3">
+                                        <span class="badge badge-success">匹配 {{ $statistics['matched_count'] ?? 0 }}</span>
+                                        @if(($statistics['suggested_count'] ?? 0) > 0)
+                                            <span class="badge badge-warning">建議 {{ $statistics['suggested_count'] }}</span>
+                                        @endif
+                                        @if(($statistics['not_found_count'] ?? 0) > 0)
+                                            <span class="badge badge-info">未匹配 {{ $statistics['not_found_count'] }}</span>
+                                        @endif
+                                        <span class="badge badge-secondary">空 {{ $statistics['empty_count'] ?? 0 }}</span>
+                                    </div>
+                                @endif
+
+                                <!-- 路由資訊 -->
+                                @if($log->route_name || $log->route_url)
+                                    <div class="mb-3">
+                                        <small class="text-muted">
+                                            <i class="fas fa-route"></i>
+                                            {{ $log->route_name }}
+                                            @if($log->route_url)
+                                                ({{ $log->route_url }})
+                                            @endif
+                                        </small>
+                                    </div>
+                                @endif
+
+                                <!-- 比較按鈕 -->
+                                @if($hasComparison)
+                                    <button type="button" class="btn btn-info mb-3" data-toggle="modal" data-target="#modal-compare-{{ $log->id }}">
+                                        <i class="fas fa-columns"></i> 比較
+                                    </button>
+                                @endif
+
+                                <!-- AI 原始回應（折疊） -->
+                                @if($log->ai_raw)
+                                    <div class="mb-3">
+                                        <h6>
+                                            <a class="collapsed" data-toggle="collapse" href="#ai-raw-{{ $log->id }}" role="button">
+                                                <i class="fas fa-chevron-right"></i> AI 原始回應
+                                                <small class="text-muted">({{ strlen($log->ai_raw) }} 字符)</small>
+                                            </a>
+                                        </h6>
+                                        <div class="collapse" id="ai-raw-{{ $log->id }}">
+                                            <pre class="bg-light p-2 border rounded" style="max-height: 400px; overflow-y: auto; font-size: 0.85em;">{{ json_encode(json_decode($log->ai_raw, true), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+                                        </div>
+                                    </div>
+                                @endif
+
+                                <!-- AI 匹配結果（折疊） -->
+                                @if($log->ai_matched)
+                                    <div class="mb-3">
+                                        <h6>
+                                            <a class="collapsed" data-toggle="collapse" href="#ai-matched-{{ $log->id }}" role="button">
+                                                <i class="fas fa-chevron-right"></i> AI 匹配結果
+                                                <small class="text-muted">({{ strlen($log->ai_matched) }} 字符)</small>
+                                            </a>
+                                        </h6>
+                                        <div class="collapse" id="ai-matched-{{ $log->id }}">
+                                            <pre class="bg-light p-2 border rounded" style="max-height: 400px; overflow-y: auto; font-size: 0.85em;">{{ json_encode(json_decode($log->ai_matched, true), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+                                        </div>
+                                    </div>
+                                @endif
+
+                                <!-- 用戶提交數據（折疊） -->
+                                @if($log->user_submitted)
+                                    <div class="mb-3">
+                                        <h6>
+                                            <a class="collapsed" data-toggle="collapse" href="#user-submitted-{{ $log->id }}" role="button">
+                                                <i class="fas fa-chevron-right"></i> 用戶提交數據
+                                                <small class="text-muted">({{ strlen($log->user_submitted) }} 字符)</small>
+                                            </a>
+                                        </h6>
+                                        <div class="collapse" id="user-submitted-{{ $log->id }}">
+                                            <pre class="bg-light p-2 border rounded" style="max-height: 400px; overflow-y: auto; font-size: 0.85em;">{{ json_encode(json_decode($log->user_submitted, true), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+                                        </div>
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+
+                        <!-- 比較 Modal -->
+                        @if($hasComparison)
+                            <div id="modal-compare-{{ $log->id }}" class="modal fade" role="dialog">
+                                <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h4 class="modal-title">
+                                                <i class="fas fa-columns"></i>
+                                                #{{ $log->id }} - AI 匹配結果 vs 用戶提交 比較
+                                            </h4>
+                                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                        </div>
+                                        <div class="modal-body" style="word-break: break-all;">
+                                            <div class="alert alert-light mb-3">
+                                                <strong><i class="fas fa-file-alt text-primary"></i> 原始史料：</strong>
+                                                {{ $log->source_text }}
+                                            </div>
+                                            @include('components.ai-fill-diff-table', ['rows' => $log->comparison_rows])
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-default" data-dismiss="modal">關閉</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
+                    @endforeach
+
+                    <!-- 分頁 -->
+                    <div class="d-flex justify-content-center">
+                        {{ $logs->links() }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('js')
+<script>
+onViteReady(function() {
+    // 折疊展開時切換圖標
+    $('.collapse').on('show.bs.collapse', function() {
+        $(this).prev().find('.fas').removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    }).on('hide.bs.collapse', function() {
+        $(this).prev().find('.fas').removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    });
+});
+</script>
+@endsection

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -19,11 +19,26 @@
 
     {{-- AI 智能填充區塊（僅在新增模式且用戶有直接寫入權限時顯示） --}}
     @if(!$isEdit && config('services.gemini.api_key') && auth()->user()->canWriteDirectly())
+        <input type="hidden" name="ai_fill_log_id" id="ai-fill-log-id" value="">
         <div class="card card-info mb-3" id="ai-autofill-section">
-            <div class="card-header">
-                <h3 class="card-title">
+            <div class="card-header d-flex align-items-center">
+                <h3 class="card-title mb-0">
                     <i class="fas fa-magic"></i> AI 智能填充
                 </h3>
+                <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
+                   data-toggle="collapse" href="#ai-privacy-notice" role="button" aria-expanded="false">
+                    <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
+                </a>
+            </div>
+            <div class="collapse" id="ai-privacy-notice">
+                <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
+                    <p class="mb-2">使用智能填充功能即表示您理解並同意：</p>
+                    <ul class="mb-0">
+                        <li>您輸入的原始文本及 AI 填充結果將被記錄用於研究與改進</li>
+                        <li>您的文本將發送至第三方 AI 服務（Google Gemini API、OpenAI API 等，恕不另行通知）進行處理</li>
+                        <li>AI 填充結果僅供參考，請務必核實後再提交</li>
+                    </ul>
+                </div>
             </div>
             <div class="card-body">
                 <div class="form-group">
@@ -47,7 +62,8 @@
             <h5><i class="fas fa-check-circle"></i> AI 填充完成</h5>
             <ul class="mb-2">
                 <li>✅ <strong id="matched-count">0</strong> 個欄位成功匹配</li>
-                <li>⚠️ <strong id="suggested-count">0</strong> 個欄位需要確認（黃色標記，請檢查後直接提交）</li>
+                <li id="suggested-line" style="display:none;">⚠️ <strong id="suggested-count">0</strong> 個欄位需要確認（黃色標記，請檢查後直接提交）</li>
+                <li id="not-found-line" style="display:none;">🔍 <strong id="not-found-count">0</strong> 個欄位需要手動搜尋（AI 已提取關鍵字但未找到匹配）</li>
                 <li>❌ <strong id="empty-count">0</strong> 個欄位無法提取</li>
             </ul>
         </div>
@@ -374,6 +390,8 @@
                     data: {
                         source_text: sourceText,
                         person_id: {{ $id }},
+                        route_name: '{{ Route::currentRouteName() ?? '' }}',
+                        route_url: window.location.pathname,
                         _token: '{{ csrf_token() }}'
                     },
                     success: function(response) {
@@ -399,14 +417,32 @@
                                 }
                             }, 500);
 
-                            // 顯示結果摘要
+                            // 顯示結果摘要（先重置所有計數與可見性，避免前次殘留）
+                            var stats = response.data.statistics;
+                            $('#matched-count').text(stats.matched_count);
+                            $('#empty-count').text(stats.empty_count);
+                            $('#suggested-count').text(stats.suggested_count);
+                            $('#not-found-count').text(stats.not_found_count);
+
+                            if (stats.suggested_count > 0) {
+                                $('#suggested-line').show();
+                            } else {
+                                $('#suggested-line').hide();
+                            }
+                            if (stats.not_found_count > 0) {
+                                $('#not-found-line').show();
+                            } else {
+                                $('#not-found-line').hide();
+                            }
                             $aiResultSummary.show();
-                            $('#matched-count').text(response.data.statistics.matched_count);
-                            $('#suggested-count').text(response.data.statistics.suggested_count);
-                            $('#empty-count').text(response.data.statistics.empty_count);
 
                             $btnClearAi.show();
                             $aiStatus.html('<span class="text-success"><i class="fas fa-check-circle"></i> 填充完成</span>');
+
+                            // 儲存 AI 填充日誌 ID，用於表單提交時關聯
+                            if (response.ai_fill_log_id) {
+                                $('#ai-fill-log-id').val(response.ai_fill_log_id);
+                            }
                         } else {
                             $aiStatus.html('<span class="text-danger"><i class="fas fa-exclamation-circle"></i> ' + response.error + '</span>');
                         }
@@ -750,32 +786,9 @@
                                 }
                             }
                         } else {
-                            // 情況 2: 完全找不到匹配（只有 ai_extracted）→ 顯示提示需要搜索
-                            if (isAjaxSelect) {
-                                // AJAX Select2：可以添加提示選項
-                                $field.empty();
-                                const option = new Option(
-                                    `⚠️ AI 建議：${fieldData.ai_extracted}（請搜索確認）`,
-                                    '',
-                                    true,
-                                    true
-                                );
-                                $field.append(option).trigger('change');
-                                addAiClass($field, 'ai-suggested');
-                            } else if (isVueSelect) {
-                                // Vue select-vue：不修改，只添加樣式
-                                addAiClass($field, 'ai-suggested');
-                            } else {
-                                // 其他：添加提示選項
-                                const option = new Option(
-                                    `⚠️ AI 建議：${fieldData.ai_extracted}（請搜索確認）`,
-                                    '',
-                                    true,
-                                    true
-                                );
-                                $field.append(option).trigger('change');
-                                addAiClass($field, 'ai-suggested');
-                            }
+                            // 情況 2: 完全找不到匹配（只有 ai_extracted）→ 不修改欄位，跳過
+                            debugLog(`[AI Autofill] 欄位 ${fieldName} 未找到匹配，跳過填充`);
+                            continue;
                         }
                     } else {
                         // 普通 input 欄位

--- a/resources/views/components/ai-fill-diff-table.blade.php
+++ b/resources/views/components/ai-fill-diff-table.blade.php
@@ -1,0 +1,65 @@
+@php
+    $rows = $rows ?? [];
+@endphp
+
+@if (!empty($rows))
+    <div class="table-responsive">
+        <table class="table table-bordered table-striped table-condensed">
+            <colgroup>
+                <col style="width:15%;">
+                <col style="width:42.5%;">
+                <col style="width:42.5%;">
+            </colgroup>
+            <thead>
+                <tr>
+                    <th>欄位</th>
+                    <th>AI 匹配結果</th>
+                    <th>用戶提交</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($rows as $row)
+                    @php
+                        $matches = !empty($row['matches']);
+                        $aiType = $row['ai_type'] ?? 'empty';
+                        // AI 欄位背景色：匹配(綠)、建議(黃)、空(無)
+                        $aiTypeClass = match($aiType) {
+                            'matched' => 'ai-diff-matched',
+                            'suggested' => 'ai-diff-suggested',
+                            default => '',
+                        };
+                        // 比較結果：相同→綠色，不同→警告色
+                        $matchClass = $matches ? 'table-success' : 'table-warning';
+                    @endphp
+                    <tr>
+                        <td>
+                            {{ $row['field'] }}
+                            @if($aiType === 'matched')
+                                <span class="badge badge-success badge-sm" title="AI 確認匹配">匹配</span>
+                            @elseif($aiType === 'suggested')
+                                <span class="badge badge-warning badge-sm" title="AI 建議">建議</span>
+                            @endif
+                        </td>
+                        <td class="{{ $aiTypeClass }}">{{ $row['ai_value'] !== '' ? $row['ai_value'] : '-' }}</td>
+                        <td class="{{ $matchClass }}">{{ $row['user_value'] !== '' ? $row['user_value'] : '-' }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+@else
+    <p class="text-muted small">沒有比對紀錄</p>
+@endif
+
+<style>
+    .ai-diff-matched {
+        background-color: #d4edda !important;
+    }
+    .ai-diff-suggested {
+        background-color: #fff3cd !important;
+    }
+    .badge-sm {
+        font-size: 0.7em;
+        padding: 2px 4px;
+    }
+</style>

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -335,6 +335,7 @@
                         $adminPages = [
                             '用戶管理',
                             'NL Query Logs',
+                            'AI 填充日誌',
                             'SQL 執行計畫',
                             '批次匯入書稿資料',
                             '批次匯入官職',
@@ -365,6 +366,12 @@
                                 <a href="{{ route('query-playground.nl-query-logs') }}" class="nav-link {{ $activePage == 'NL Query Logs' ? 'active' : '' }}">
                                     <i class="nav-icon fas fa-comments"></i>
                                     <p>自然語言查詢日誌</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('admin.ai-fill-logs') }}" class="nav-link {{ $activePage == 'AI 填充日誌' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-robot"></i>
+                                    <p>AI 填充日誌</p>
                                 </a>
                             </li>
                             <li class="nav-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -256,5 +256,8 @@ Route::middleware('auth')->group(function () {
     // AI 智能填充任官信息
     Route::post('api/ai/posting/extract', 'AiPostingAutofillController@extract')->name('ai.posting.extract');
 
+    // AI 填充日誌（管理員工具）
+    Route::get('admin/ai-fill-logs', 'AiFillLogController@index')->name('admin.ai-fill-logs');
+
     Route::post('admin/unidirectional-relationship-repair/assoc', 'UnidirectionalRelationshipRepairController@repairAssoc')->name('admin.unidirectional-relationship-repair.assoc');
 });

--- a/tests/Feature/AiFillLogTest.php
+++ b/tests/Feature/AiFillLogTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AiFillLogTest extends TestCase {
+    use RefreshDatabase;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config(['services.gemini.api_key' => 'test-api-key']);
+        config(['services.gemini.api_endpoint' => 'https://example.com/api']);
+        config(['services.gemini.model' => 'test-model']);
+
+        // 測試朝代數據
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 20, 'c_dynasty_chn' => '清', 'c_dynasty' => 'Qing', 'c_start' => 1644, 'c_end' => 1911, 'c_sort' => 20],
+        ]);
+    }
+
+    /**
+     * 測試訪客無法存取 AI 填充日誌頁面
+     */
+    public function test_guest_cannot_access_ai_fill_logs() {
+        $response = $this->get('/admin/ai-fill-logs');
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * 測試一般用戶無法存取 AI 填充日誌頁面
+     */
+    public function test_regular_user_cannot_access_ai_fill_logs() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->get('/admin/ai-fill-logs');
+        $response->assertStatus(403);
+    }
+
+    /**
+     * 測試 Super Admin 可以存取 AI 填充日誌頁面
+     */
+    public function test_super_admin_can_access_ai_fill_logs() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 3, // ROLE_SUPER_ADMIN
+        ]);
+
+        $response = $this->actingAs($user)->get('/admin/ai-fill-logs');
+        $response->assertStatus(200);
+        $response->assertSee('AI 填充日誌');
+    }
+
+    /**
+     * 測試 AI 填充成功時建立日誌記錄
+     */
+    public function test_ai_fill_creates_log_record() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // Mock Gemini API 響應
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => json_encode([
+                                'postings' => [
+                                    [
+                                        'posting_str' => '知縣',
+                                        'addr_str' => null,
+                                        'c_firstyear' => 1723,
+                                        'c_fy_nh_code' => '雍正',
+                                        'c_fy_nh_year' => 1,
+                                        'c_fy_range' => null,
+                                        'c_fy_intercalary' => false,
+                                        'c_fy_month' => 1,
+                                        'c_fy_day' => 3,
+                                        'c_fy_day_gz' => null,
+                                        'c_lastyear' => null,
+                                        'c_ly_nh_code' => null,
+                                        'c_ly_nh_year' => null,
+                                        'c_ly_range' => null,
+                                        'c_ly_intercalary' => null,
+                                        'c_ly_month' => null,
+                                        'c_ly_day' => null,
+                                        'c_ly_day_gz' => null,
+                                        'c_appt_code' => null,
+                                        'c_assume_office_code' => null,
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '雍正元年正月初三知新城縣',
+            'person_id' => 1,
+            'route_name' => 'basicinformation.offices.create',
+            'route_url' => '/basicinformation/1/offices/create',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['ai_fill_log_id']);
+
+        // 驗證日誌記錄已建立
+        $this->assertDatabaseHas('ai_fill_logs', [
+            'user_id' => $user->id,
+            'c_personid' => 1,
+            'source_text' => '雍正元年正月初三知新城縣',
+            'route_name' => 'basicinformation.offices.create',
+            'success' => true,
+        ]);
+
+        // 驗證 ai_raw 和 ai_matched 不為空
+        $log = DB::table('ai_fill_logs')->first();
+        $this->assertNotNull($log->ai_raw);
+        $this->assertNotNull($log->ai_matched);
+        $this->assertNull($log->user_submitted);
+    }
+
+    /**
+     * 測試日誌記錄可以更新 user_submitted
+     * 直接測試 updateAiFillLog 的邏輯（透過 DB 操作驗證）
+     */
+    public function test_log_record_can_be_updated_with_user_submitted() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 建立日誌記錄
+        $logId = DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $user->id,
+            'c_personid' => 1,
+            'route_name' => 'basicinformation.offices.create',
+            'route_url' => '/basicinformation/1/offices/create',
+            'source_text' => '雍正元年正月初三知新城縣',
+            'ai_raw' => json_encode(['posting_str' => '知縣']),
+            'ai_matched' => json_encode([
+                'matched_fields' => ['c_firstyear' => ['value' => 1723, 'text' => '1723']],
+                'suggested_fields' => [],
+                'empty_fields' => [],
+                'statistics' => ['matched_count' => 1, 'suggested_count' => 0, 'not_found_count' => 0, 'empty_count' => 0],
+            ]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // 模擬 user_submitted 更新（與 BasicInformationOfficesController::updateAiFillLog 相同的邏輯）
+        $submittedData = [
+            'c_office_id' => 123,
+            'c_firstyear' => 1723,
+            'c_fy_month' => 1,
+            'c_fy_day' => 3,
+            'c_dy' => 20,
+        ];
+
+        $updated = DB::table('ai_fill_logs')
+            ->where('id', $logId)
+            ->where('user_id', $user->id)
+            ->update([
+                'user_submitted' => json_encode($submittedData, JSON_UNESCAPED_UNICODE),
+                'submitted_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $this->assertEquals(1, $updated);
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted);
+        $this->assertNotNull($log->submitted_at);
+
+        $submitted = json_decode($log->user_submitted, true);
+        $this->assertEquals(123, $submitted['c_office_id']);
+        $this->assertEquals(1723, $submitted['c_firstyear']);
+    }
+
+    /**
+     * 測試安全檢查：不能更新他人的日誌
+     */
+    public function test_cannot_update_others_log_record() {
+        $user1 = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+        $user2 = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // user1 建立日誌
+        $logId = DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $user1->id,
+            'c_personid' => 1,
+            'route_name' => 'test',
+            'route_url' => '/test',
+            'source_text' => '測試文本',
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // user2 嘗試更新（WHERE user_id 不匹配，應影響 0 行）
+        $updated = DB::table('ai_fill_logs')
+            ->where('id', $logId)
+            ->where('user_id', $user2->id)
+            ->update([
+                'user_submitted' => json_encode(['c_office_id' => 999]),
+                'submitted_at' => now(),
+            ]);
+
+        $this->assertEquals(0, $updated);
+
+        // 驗證未被更新
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted);
+    }
+
+    /**
+     * 測試管理頁面篩選功能
+     */
+    public function test_admin_page_filters() {
+        $admin = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 3, // ROLE_SUPER_ADMIN
+        ]);
+
+        // 建立測試日誌
+        DB::table('ai_fill_logs')->insert([
+            'user_id' => $admin->id,
+            'c_personid' => 1,
+            'route_name' => 'test.route',
+            'route_url' => '/test',
+            'source_text' => '唐朝開元年間知縣',
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // 搜尋關鍵字
+        $response = $this->actingAs($admin)->get('/admin/ai-fill-logs?search=開元');
+        $response->assertStatus(200);
+        $response->assertSee('唐朝開元年間知縣');
+
+        // 搜尋不存在的關鍵字
+        $response = $this->actingAs($admin)->get('/admin/ai-fill-logs?search=不存在的文字');
+        $response->assertStatus(200);
+        $response->assertSee('暫無記錄');
+    }
+
+    /**
+     * 測試管理頁面比較功能（有 user_submitted 時顯示比較按鈕）
+     */
+    public function test_admin_page_shows_compare_button_when_submitted() {
+        $admin = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 3, // ROLE_SUPER_ADMIN
+        ]);
+
+        // 建立有 user_submitted 的日誌
+        DB::table('ai_fill_logs')->insert([
+            'user_id' => $admin->id,
+            'c_personid' => 1,
+            'route_name' => 'test.route',
+            'route_url' => '/test',
+            'source_text' => '測試文本',
+            'ai_matched' => json_encode([
+                'matched_fields' => ['c_firstyear' => ['value' => 1723, 'text' => '1723']],
+                'suggested_fields' => [],
+                'empty_fields' => [],
+                'statistics' => ['matched_count' => 1, 'suggested_count' => 0, 'not_found_count' => 0, 'empty_count' => 0],
+            ]),
+            'user_submitted' => json_encode(['c_firstyear' => 1723]),
+            'success' => true,
+            'submitted_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->actingAs($admin)->get('/admin/ai-fill-logs');
+        $response->assertStatus(200);
+        $response->assertSee('比較');
+    }
+}

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -180,6 +180,7 @@ class AiPostingAutofillTest extends TestCase {
                     'statistics' => [
                         'matched_count',
                         'suggested_count',
+                        'not_found_count',
                         'empty_count',
                     ],
                 ],


### PR DESCRIPTION
## Summary
- 新增 `ai_fill_logs` 資料表，記錄每次 AI 智能填充的輸入文本、AI 原始回應、匹配結果及用戶最終提交數據
- 新增 Super Admin 專用的 AI 填充日誌管理頁面（`/admin/ai-fill-logs`），支援搜尋、用戶篩選與 AI 匹配結果 vs 用戶提交的比較功能
- AI 提取完成後自動寫入日誌並回傳 log ID，表單提交時更新對應日誌的 `user_submitted` 欄位
- 優化統計資訊區分有值建議與未匹配項目；新增官名後綴匹配邏輯（如「寧夏將軍」→「將軍」）
- 前端新增數據收集提示與隱私聲明

## Test plan
- [x] 502 個 PHPUnit 測試全部通過
- [x] 驗證訪客與一般用戶無法存取 AI 填充日誌頁面
- [x] 驗證 Super Admin 可正常瀏覽日誌列表、搜尋與篩選
- [x] 驗證 AI 填充後日誌記錄正確建立，表單提交後 `user_submitted` 正確更新
- [x] 驗證比較功能（Modal）正確顯示 AI 匹配結果與用戶提交的差異

🤖 Generated with [Claude Code](https://claude.com/claude-code)