### PR TITLE
新增 SQLite 每週同步腳本

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 * [檢視表總覽](./VIEWS.md)
 * [Wiki 导入任务管理](./WIKI_TASK_MANAGEMENT.md)
 * [姓名搜索索引管理](./NAME_SEARCH_COMMANDS.md)
+* [SQLite 每週同步](#sqlite-每週同步) - 自動匯出並同步到公開倉庫
 
 ## 技術環境
 
@@ -330,3 +331,80 @@ Please make sure that your web server user is the owner of this file
 ```
 sudo chown caddy laravel.log
 ```
+
+## SQLite 每週同步
+
+本專案提供自動化腳本，將生產環境的數據庫匯出為 SQLite 格式，並同步到公開倉庫 [cbdb-project/cbdb_sqlite](https://github.com/cbdb-project/cbdb_sqlite) 供研究者下載使用。
+
+### 腳本位置
+
+- **匯出腳本**：`scripts/export-daily-sqlite.sh` - 將 MySQL/MariaDB 表格匯出為 SQLite
+- **同步腳本**：`scripts/weekly-sqlite-sync.sh` - 匯出、壓縮並推送到 GitHub
+
+### 前置安裝（Ubuntu）
+
+```bash
+# 安裝 7z 壓縮工具
+sudo apt-get install p7zip-full
+
+# 安裝 Git LFS（目標倉庫使用 LFS 存儲大檔案）
+sudo apt-get install git-lfs
+git lfs install
+
+# 安裝 GitHub CLI
+# 參考：https://cli.github.com/manual/installation
+```
+
+### GitHub 認證設定
+
+腳本使用 `gh` CLI 進行 GitHub 操作，需要先完成認證：
+
+```bash
+# 方式一：互動式登入（適合本地測試）
+gh auth login
+
+# 方式二：使用 Personal Access Token（推薦用於服務器）
+echo "ghp_xxxxxxxxxxxx" | gh auth login --with-token
+
+# 驗證登入狀態
+gh auth status
+```
+
+**Personal Access Token 設定**：
+1. GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Generate new token
+3. 勾選 `repo` 權限（需要推送到倉庫）
+4. 設定有效期（可選 "No expiration" 用於自動化任務）
+5. 複製 token 並在服務器上執行認證
+
+### Cron 定時任務
+
+```bash
+# 編輯 crontab
+crontab -e
+
+# 每週日凌晨 3 點執行（GMT+8）
+0 3 * * 0 /path/to/cbdb-online-main-server/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
+```
+
+### 手動執行
+
+```bash
+# 執行完整同步流程
+bash scripts/weekly-sqlite-sync.sh
+
+# 僅匯出 SQLite（不推送）
+bash scripts/export-daily-sqlite.sh
+```
+
+### 腳本流程說明
+
+`weekly-sqlite-sync.sh` 執行以下步驟：
+
+1. **前置檢查**：確認 `7z`、`gh`、`git-lfs` 已安裝且 `gh` 已登入
+2. **匯出數據庫**：呼叫 `export-daily-sqlite.sh` 產生 `cbdb_daily_YYYYMMDD.sqlite3`
+3. **壓縮檔案**：複製為 `latest.db` 並壓縮為 `latest.7z`（最大壓縮率）
+4. **推送到 GitHub**：克隆目標倉庫、替換檔案、提交並推送
+5. **清理**：刪除所有臨時檔案（包括原始 SQLite 匯出檔）
+
+**智能跳過**：如果壓縮檔內容與遠端相同，腳本會跳過推送，避免產生無意義的 commit。

--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# 每週 SQLite 匯出並同步到 GitHub
+#
+# 功能：
+#   1. 執行 export-daily-sqlite.sh 匯出資料庫
+#   2. 重新命名為 latest.db 並壓縮為 latest.7z
+#   3. 推送到 cbdb-project/cbdb_sqlite 倉庫
+#
+# 前置要求：
+#   - p7zip-full (7z 命令)
+#   - git-lfs
+#   - gh CLI 已登入
+#
+# 使用方式：
+#   ./scripts/weekly-sqlite-sync.sh
+#
+# Cron 設定範例（每週日凌晨 3 點）：
+#   0 3 * * 0 /path/to/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
+#
+
+set -e
+
+# 前置檢查：確認必要工具已安裝
+check_requirements() {
+    local missing=()
+
+    if ! command -v 7z &> /dev/null; then
+        missing+=("7z (請安裝 p7zip-full: sudo apt-get install p7zip-full)")
+    fi
+
+    if ! command -v gh &> /dev/null; then
+        missing+=("gh (請安裝 GitHub CLI: https://cli.github.com/)")
+    fi
+
+    if ! command -v git-lfs &> /dev/null; then
+        missing+=("git-lfs (請安裝: sudo apt-get install git-lfs)")
+    fi
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "錯誤: 缺少必要工具："
+        for tool in "${missing[@]}"; do
+            echo "  - $tool"
+        done
+        exit 1
+    fi
+
+    # 檢查 gh CLI 是否已登入
+    if ! gh auth status &> /dev/null; then
+        echo "錯誤: gh CLI 尚未登入，請先執行 'gh auth login'"
+        exit 1
+    fi
+}
+
+check_requirements
+
+# 設定
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+WORK_DIR="${PROJECT_ROOT}/db-data"
+GITHUB_REPO="cbdb-project/cbdb_sqlite"
+TEMP_DIR=$(mktemp -d)
+
+# 清理函數
+cleanup() {
+    echo "清理暫存檔案..."
+    rm -rf "$TEMP_DIR"
+    rm -f "${WORK_DIR}/latest.db"
+    rm -f "${WORK_DIR}/latest.7z"
+    # 刪除當天產生的原始 sqlite 匯出檔
+    if [ -n "$SQLITE_FILE" ] && [ -f "$SQLITE_FILE" ]; then
+        echo "刪除原始匯出檔: $SQLITE_FILE"
+        rm -f "$SQLITE_FILE"
+    fi
+}
+trap cleanup EXIT
+
+cd "$PROJECT_ROOT"
+
+echo "================================================"
+echo "CBDB SQLite 每週同步"
+echo "================================================"
+echo "時間: $(date '+%Y-%m-%d %H:%M:%S')"
+echo ""
+
+# Step 1: 執行匯出腳本
+echo "[1/5] 執行 SQLite 匯出腳本..."
+bash scripts/export-daily-sqlite.sh
+
+# 找到今天產生的檔案
+DATE_SUFFIX=$(date +%Y%m%d)
+SQLITE_FILE="${WORK_DIR}/cbdb_daily_${DATE_SUFFIX}.sqlite3"
+
+if [ ! -f "$SQLITE_FILE" ]; then
+    echo "錯誤: 找不到匯出檔案 $SQLITE_FILE"
+    exit 1
+fi
+
+echo "匯出檔案: $SQLITE_FILE"
+
+# Step 2: 複製並重新命名
+echo ""
+echo "[2/5] 複製並重新命名為 latest.db..."
+cp "$SQLITE_FILE" "${WORK_DIR}/latest.db"
+
+# Step 3: 壓縮為 7z
+echo ""
+echo "[3/5] 壓縮為 latest.7z..."
+rm -f "${WORK_DIR}/latest.7z"
+7z a -mx=9 "${WORK_DIR}/latest.7z" "${WORK_DIR}/latest.db"
+
+FILE_SIZE=$(ls -lh "${WORK_DIR}/latest.7z" | awk '{print $5}')
+echo "壓縮完成，檔案大小: $FILE_SIZE"
+
+# Step 4: 克隆倉庫並更新
+echo ""
+echo "[4/5] 克隆 $GITHUB_REPO 並更新..."
+cd "$TEMP_DIR"
+gh repo clone "$GITHUB_REPO" -- --depth=1
+cd cbdb_sqlite
+
+# 確保 LFS 已初始化
+git lfs install
+
+# 複製新檔案
+cp "${WORK_DIR}/latest.7z" ./latest.7z
+
+# Step 5: 提交並推送
+echo ""
+echo "[5/5] 提交並推送..."
+git add latest.7z
+
+# 檢查是否有變更需要提交
+if git diff --cached --quiet; then
+    echo "檔案內容無變更，跳過推送"
+    SYNC_STATUS="無變更"
+else
+    git commit -m "Update latest.7z ($(date '+%Y-%m-%d'))"
+    git push origin master
+    SYNC_STATUS="已推送"
+fi
+
+echo ""
+echo "================================================"
+echo "同步完成!"
+echo "================================================"
+echo "狀態: $SYNC_STATUS"
+echo "檔案大小: $FILE_SIZE"
+echo "時間: $(date '+%Y-%m-%d %H:%M:%S')"
+echo "================================================"


### PR DESCRIPTION
## Summary
- 新增 `scripts/weekly-sqlite-sync.sh` 腳本，自動將生產環境數據庫匯出為 SQLite 並同步到 [cbdb-project/cbdb_sqlite](https://github.com/cbdb-project/cbdb_sqlite)
- 腳本包含前置工具檢查（7z、gh CLI、git-lfs）、智能跳過無變更推送、自動清理臨時檔案
- 更新 README.md 添加完整的部署說明（前置安裝、GitHub 認證、Cron 配置）

## Test plan
- [x] 在生產服務器安裝前置工具（p7zip-full、git-lfs、gh CLI）
- [x] 執行 `gh auth login` 完成 GitHub 認證
- [x] 手動執行 `bash scripts/weekly-sqlite-sync.sh` 測試完整流程
- [x] 設定 Cron 定時任務

🤖 Generated with [Claude Code](https://claude.com/claude-code)