### PR TITLE
修正 weekly-sqlite-sync.sh 的 snap gh CLI 沙箱問題

### DIFF
--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -143,11 +143,20 @@ FILE_SIZE=$(ls -lh "${WORK_DIR}/latest.7z" | awk '{print $5}')
 echo "壓縮完成，檔案大小: $FILE_SIZE"
 
 # Step 4: 克隆倉庫並更新
+# 注意：使用 git clone 而非 gh repo clone，因為 snap 版的 gh 在沙箱中無法正常調用系統 git
 echo ""
 echo "[4/5] 克隆 $GITHUB_REPO 並更新..."
 cd "$TEMP_DIR"
-gh repo clone "$GITHUB_REPO" -- --depth=1
+git clone --depth=1 "https://github.com/${GITHUB_REPO}.git"
 cd cbdb_sqlite
+
+# 設置推送認證（使用 gh auth token）
+GH_TOKEN=$(gh auth token 2>/dev/null)
+if [ -n "$GH_TOKEN" ]; then
+    git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPO}.git"
+else
+    echo "警告: 無法取得 GitHub token，推送可能會失敗"
+fi
 
 # 確保 LFS 已初始化
 git lfs install


### PR DESCRIPTION
## Summary
- 改用 `git clone` 取代 `gh repo clone`，因為 snap 版的 gh CLI 在沙箱環境中無法正常調用系統 git
- 透過 `gh auth token` 獲取認證 token，設置 git remote URL 以支援推送

## 問題背景
Snap 安裝的 gh CLI 運行在隔離沙箱中，導致：
- 無法正確存取 `/etc/gitconfig`
- 無法找到 `git-remote-https` 等 git 組件
- Clone 操作失敗並報錯 `failed to run git: exit status 128`

## Test plan
- [x] 在伺服器上手動測試 `git clone` 成功
- [x] 驗證推送認證正常運作
- [x] 確認 GitHub 倉庫成功更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)