### PR TITLE
地址下拉框依人物朝代起止年過濾搜尋結果

### DIFF
--- a/app/Repositories/AddrCodeRepository.php
+++ b/app/Repositories/AddrCodeRepository.php
@@ -12,6 +12,7 @@ namespace App\Repositories;
 use App\Models\AddrBelong;
 use App\Models\AddrCode;
 use App\Models\AddressCode;
+use App\Models\Dynasty;
 use Illuminate\Http\Request;
 
 /**
@@ -81,8 +82,39 @@ class AddrCodeRepository {
     // }
 
     public function searchAddr(Request $request) {
-        $data = AddrCode::where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_addr_id', $request->q)->paginate(20);
-        $data->appends(['q' => $request->q])->links();
+        $query = AddrCode::where(function ($q) use ($request) {
+            $q->where('c_name_chn', 'like', '%'.$request->q.'%')
+                ->orWhere('c_name', 'like', '%'.$request->q.'%')
+                ->orWhere('c_addr_id', $request->q);
+        });
+
+        // 根據朝代起止年過濾地址：地址的 c_firstyear~c_lastyear 必須與朝代起止年有交集
+        // 若用戶輸入純數字（以 ID 搜尋），則不加朝代限制
+        $isNumericSearch = ctype_digit((string) $request->q);
+        if ($request->dy && !$isNumericSearch) {
+            $dynasty = Dynasty::find($request->dy);
+            if ($dynasty && $dynasty->c_start !== null && $dynasty->c_end !== null) {
+                $dyStart = $dynasty->c_start;
+                $dyEnd = $dynasty->c_end;
+                $query->where(function ($q) use ($dyStart, $dyEnd) {
+                    $q->where(function ($inner) use ($dyStart, $dyEnd) {
+                        // 時間交集條件：addr.firstyear <= dy.end AND addr.lastyear >= dy.start
+                        $inner->where('c_firstyear', '<=', $dyEnd)
+                            ->where('c_lastyear', '>=', $dyStart);
+                    })
+                    // 年份為 NULL 或 0 的地址不過濾（無法判斷時期）
+                    ->orWhereNull('c_firstyear')
+                    ->orWhereNull('c_lastyear')
+                    ->orWhere('c_firstyear', 0)
+                    ->orWhere('c_lastyear', 0)
+                    // 「未詳」地址始終顯示
+                    ->orWhere('c_addr_id', 0);
+                });
+            }
+        }
+
+        $data = $query->paginate(20);
+        $data->appends(['q' => $request->q, 'dy' => $request->dy])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_addr_id;
             if ($item['id'] === 0) {

--- a/resources/views/biogmains/addresses/_form.blade.php
+++ b/resources/views/biogmains/addresses/_form.blade.php
@@ -159,7 +159,17 @@
         textperson_pair_first_load();
 
         // 使用统一的 AJAX Select2 初始化助手函数
-        window.initAjaxSelect($(".c_addr_id"), 'addr');
+        window.initAjaxSelect($(".c_addr_id"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
         window.initAjaxSelect($(".c_source"), 'text');
 
         if (window.initLunarValidation) {

--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -345,7 +345,17 @@
         window.initAjaxSelect($(".c_kin_code"), 'kincode');
         window.initAjaxSelect($(".c_assoc_kin_code"), 'kincode');
         window.initAjaxSelect($(".c_assoc_code"), 'assoccode');
-        window.initAjaxSelect($(".c_addr_id"), 'addr');
+        window.initAjaxSelect($(".c_addr_id"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
         window.initAjaxSelect($(".c_inst_code"), 'socialinstcode');
         window.initAjaxSelect($(".c_source"), 'text');
 

--- a/resources/views/biogmains/entries/_form.blade.php
+++ b/resources/views/biogmains/entries/_form.blade.php
@@ -232,7 +232,17 @@
 
         // 使用统一的 AJAX Select2 初始化助手函数
         window.initAjaxSelect($(".c_entry_code"), 'entry');
-        window.initAjaxSelect($(".c_entry_addr_id"), 'addr');
+        window.initAjaxSelect($(".c_entry_addr_id"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
         window.initAjaxSelect($(".c_kin_code"), 'kincode');
         window.initAjaxSelect($(".c_assoc_code"), 'assoccode');
         window.initAjaxSelect($(".c_inst_code"), 'socialinstcode');

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -158,7 +158,17 @@
 
         // 使用统一的 AJAX Select2 初始化助手函数
         window.initAjaxSelect($(".c_source"), 'text');
-        window.initAjaxSelect($(".c_addr_id"), 'addr');
+        window.initAjaxSelect($(".c_addr_id"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
         window.initAjaxSelect($(".c_event_code"), 'event');
 
         if (window.initLunarValidation) {

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -302,7 +302,17 @@
         window.initAjaxSelect($(".c_office_id"), 'office');
         window.initAjaxSelect($(".c_source"), 'text');
         window.initAjaxSelect($(".c_inst_code"), 'socialinstcode');
-        window.initAjaxSelect($(".c_addr"), 'addr');
+        window.initAjaxSelect($(".c_addr"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
 
         if (window.initLunarValidation) {
             window.initLunarValidation();

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -146,7 +146,17 @@
 
         // 使用统一的 AJAX Select2 初始化助手函数
         window.initAjaxSelect($(".c_source"), 'text');
-        window.initAjaxSelect($(".c_addr_id"), 'addr');
+        window.initAjaxSelect($(".c_addr_id"), 'addr', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        dy: $('.dynasty_code').val() || '',
+                    };
+                }
+            }
+        });
 
         function textperson_pair_first_load(){
             let person_id = $('.person_id').val();


### PR DESCRIPTION
## Summary
- 地址搜尋下拉框新增朝代時間過濾：根據當前人物的朝代（c_dy），查詢 DYNASTIES 表取得起止年（c_start/c_end），僅顯示時間範圍有交集的地址
- 年份未知（NULL/0）的地址及「未詳」選項不受過濾影響，始終顯示
- 純數字搜尋（以 ID 查詢）不加朝代限制
- 覆蓋全部 6 個使用地址下拉框的表單：任官、地址、入仕、社會關係、財產、事件

## Test plan
- [x] 進入宋朝人物（如 personid=1）的任官新增頁面，搜尋「新城」，確認僅顯示與宋朝（960~1279）有時間交集的地址
- [x] 確認年份為空或 0 的地址仍然顯示
- [x] 輸入純數字 ID 搜尋，確認不受朝代過濾限制
- [x] 在地址、入仕、社會關係、財產、事件頁面分別測試過濾是否生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)
