### PR TITLE
人物基本信息組件朝代欄位顯示起止年

### DIFF
--- a/app/Models/BiogMain.php
+++ b/app/Models/BiogMain.php
@@ -36,7 +36,7 @@ class BiogMain extends Model {
     }
 
     public function simpleDynasty() {
-        return $this->belongsTo('App\Models\Dynasty', 'c_dy', 'c_dy')->select(['c_dy','c_dynasty','c_dynasty_chn']);
+        return $this->belongsTo('App\Models\Dynasty', 'c_dy', 'c_dy')->select(['c_dy','c_dynasty','c_dynasty_chn','c_start','c_end']);
     }
 
     public function birthYearNH() {

--- a/resources/views/components/forms/person-id-display.blade.php
+++ b/resources/views/components/forms/person-id-display.blade.php
@@ -8,13 +8,18 @@
     $person = null;
     $dynastyName = '';
     $dynastyCode = '';
+    $dynastyStart = null;
+    $dynastyEnd = null;
 
     if ($personId) {
         try {
             $person = \App\Models\BiogMain::with('simpleDynasty')->find($personId);
             if ($person && $person->simpleDynasty) {
-                $dynastyName = $person->simpleDynasty->c_dynasty_chn ?? $person->simpleDynasty->c_dynasty ?? '';
-                $dynastyCode = $person->simpleDynasty->c_dy ?? '';
+                $dynasty = $person->simpleDynasty;
+                $dynastyName = $dynasty->c_dynasty_chn ?? $dynasty->c_dynasty ?? '';
+                $dynastyCode = $dynasty->c_dy ?? '';
+                $dynastyStart = $dynasty->c_start;
+                $dynastyEnd = $dynasty->c_end;
             }
         } catch (\Exception $e) {
             // 在測試環境或資料庫連線失敗時，優雅降級
@@ -42,7 +47,7 @@
                         </div>
                         <div class="col-md-4">
                             <strong>朝代：</strong>
-                            <span>{{ $dynastyName ?: '—' }}</span>
+                            <span>{{ $dynastyName ?: '—' }}@if($dynastyStart !== null || $dynastyEnd !== null)（{{ $dynastyStart }}–{{ $dynastyEnd }}）@endif</span>
                         </div>
                     @endif
                 </div>


### PR DESCRIPTION
## Summary
- 在所有頁面的「人物基本信息」組件中，朝代名稱後方新增顯示該朝代的起止年（如「宋（960–1279）」）
- 資料來源為 `DYNASTIES` 表的 `c_start`、`c_end` 欄位
- 使用嚴格 null 判斷，避免將 0 視為 falsy 而隱藏有效年份

## Test plan
- [x] 開啟任一人物編輯頁面（任官、入仕、社會關係、事件、地址、著述），確認「朝代」欄位後方有顯示起止年
- [x] 確認無朝代的人物不會出現多餘的括號

🤖 Generated with [Claude Code](https://claude.com/claude-code)