### PR TITLE
根據 audit_log 提案進度清單實作本功能（BIOG_MAIN 部分）

### DIFF
--- a/app/Http/Controllers/AdminAuditLogController.php
+++ b/app/Http/Controllers/AdminAuditLogController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AdminAuditLogController extends Controller {
+    /**
+     * Audit Log 列表（僅 Super Admin）
+     */
+    public function index(Request $request) {
+        if (!Auth::user()->isSuperAdmin()) {
+            abort(403, '此功能僅限超級管理員使用');
+        }
+
+        if (!Schema::hasTable('audit_log')) {
+            abort(404, 'audit_log 資料表尚未建立');
+        }
+
+        $query = DB::table('audit_log');
+
+        if ($request->filled('table_name')) {
+            $query->where('table_name', $request->input('table_name'));
+        }
+
+        if ($request->filled('operation')) {
+            $query->where('operation', strtoupper($request->input('operation')));
+        }
+
+        if ($request->filled('actor_type')) {
+            $query->where('actor_type', $request->input('actor_type'));
+        }
+
+        if ($request->filled('actor_id')) {
+            $query->where('actor_id', $request->input('actor_id'));
+        }
+
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('operation_id', 'like', "%{$search}%")
+                    ->orWhere('row_pk_text', 'like', "%{$search}%")
+                    ->orWhere('table_name', 'like', "%{$search}%");
+            });
+        }
+
+        $tableNames = DB::table('audit_log')
+            ->select('table_name')
+            ->distinct()
+            ->orderBy('table_name')
+            ->pluck('table_name');
+
+        $actorTypes = DB::table('audit_log')
+            ->select('actor_type')
+            ->distinct()
+            ->orderBy('actor_type')
+            ->pluck('actor_type');
+
+        $query->orderByDesc('occurred_at')->orderByDesc('id');
+
+        $logs = $query->paginate(20)->withQueryString();
+
+        return view('admin.audit_logs.index', [
+            'page_title' => '審計日誌',
+            'page_title_key' => '審計日誌',
+            'page_url' => route('admin.audit-logs'),
+            'logs' => $logs,
+            'table_names' => $tableNames,
+            'actor_types' => $actorTypes,
+            'filters' => [
+                'search' => $request->input('search'),
+                'table_name' => $request->input('table_name'),
+                'operation' => $request->input('operation'),
+                'actor_type' => $request->input('actor_type'),
+                'actor_id' => $request->input('actor_id'),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -202,14 +202,14 @@ class OperationsController extends Controller {
         //20190531這邊要取得table名稱, 規劃建置switch case來處理各種儲存
         $id = $request['id'];
         DB::table('operations')->where('id', $id)->update(['crowdsourcing_status' => 1]);
-        $data = DB::table('operations')->where('id', $id)->get();
-        $data = json_decode($data, true);
-        $data = $data[0]['resource_data'];
-        $data = json_decode($data, true);
+        $operationRow = DB::table('operations')->where('id', $id)->first();
+        $resourceData = $operationRow ? $operationRow->resource_data : null;
+        $data = $resourceData ? json_decode($resourceData, true) : [];
         $new_id = BiogMain::max('c_personid') + 1;
         $data['c_personid'] = $new_id;
+        $actorId = $operationRow ? (string) $operationRow->user_id : '';
         $message = null;
-        DB::transaction(function () use (&$message, $data) {
+        DB::transaction(function () use (&$message, $data, $actorId) {
             $message = BiogMain::create($data);
 
             (new \App\Services\AuditLogService())->write(
@@ -219,7 +219,7 @@ class OperationsController extends Controller {
                 null,
                 $message->toArray(),
                 'api',
-                (string) $data['c_personid']
+                $actorId
             );
         });
         $message = $message ? '200' : '500';

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -208,8 +208,21 @@ class OperationsController extends Controller {
         $data = json_decode($data, true);
         $new_id = BiogMain::max('c_personid') + 1;
         $data['c_personid'] = $new_id;
-        $message = BiogMain::create($data);
-        $message ? $message = '200' : $message = '500';
+        $message = null;
+        DB::transaction(function () use (&$message, $data) {
+            $message = BiogMain::create($data);
+
+            (new \App\Services\AuditLogService())->write(
+                'BIOG_MAIN',
+                'INSERT',
+                ['c_personid' => $data['c_personid']],
+                null,
+                $message->toArray(),
+                'api',
+                (string) $data['c_personid']
+            );
+        });
+        $message = $message ? '200' : '500';
 
         return $message;
     }

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -12,6 +12,7 @@ use App\Repositories\NianHaoRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\Repositories\YearRangeRepository;
+use App\Services\AuditLogService;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
@@ -152,8 +153,22 @@ class BasicInformationController extends Controller {
             //20230628觸發「自動生成」功能
             $data = $this->biogMainRepository->auto_pinyin($data);
             //增加完成
-            $flight = BiogMain::create($data);
-            $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data);
+            $flight = null;
+            DB::transaction(function () use (&$flight, $data) {
+                $flight = BiogMain::create($data);
+                $operation = $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data);
+
+                (new AuditLogService())->write(
+                    'BIOG_MAIN',
+                    'INSERT',
+                    ['c_personid' => $data['c_personid']],
+                    null,
+                    $flight->toArray(),
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            });
 
             if (Schema::hasTable('CBDB__NAME_FTS')) {
                 $this->nameSearchIndexService->reindexPerson($flight);
@@ -339,8 +354,22 @@ class BasicInformationController extends Controller {
         $data['c_personid'] = $new_id;
         $data = $this->toolRepository->timestamp($data, true); //建檔資訊
         $data['c_modified_by'] = $data['c_modified_date'] = '';
-        $flight = BiogMain::create($data);
-        $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
+        $flight = null;
+        DB::transaction(function () use (&$flight, $data, $new_id) {
+            $flight = BiogMain::create($data);
+            $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
+
+            (new AuditLogService())->write(
+                'BIOG_MAIN',
+                'INSERT',
+                ['c_personid' => $new_id],
+                null,
+                $flight->toArray(),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         if (Schema::hasTable('CBDB__NAME_FTS')) {
             $this->nameSearchIndexService->reindexPerson($flight);
@@ -367,8 +396,22 @@ class BasicInformationController extends Controller {
         $data['c_personid'] = $new_id;
         $data = $this->toolRepository->timestamp($data, true); //建檔資訊
         $data['c_modified_by'] = $data['c_modified_date'] = '';
-        $flight = BiogMain::create($data);
-        $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
+        $flight = null;
+        DB::transaction(function () use (&$flight, $data, $new_id) {
+            $flight = BiogMain::create($data);
+            $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
+
+            (new AuditLogService())->write(
+                'BIOG_MAIN',
+                'INSERT',
+                ['c_personid' => $new_id],
+                null,
+                $flight->toArray(),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         if (Schema::hasTable('CBDB__NAME_FTS')) {
             $this->nameSearchIndexService->reindexPerson($flight);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -31,6 +31,7 @@ use App\Repositories\Concerns\DetectsModelChanges;
 //修改結束
 
 //20210625建安修改
+use App\Services\AuditLogService;
 use App\Services\VariantCharNormalizer;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
@@ -250,8 +251,23 @@ class BiogMainRepository {
         if (Auth::user()->isCrowdsourcingUser()) {
             (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori, 2);
         } else {
-            $biogbasicinformation->update($data);
-            (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori);
+            DB::transaction(function () use ($data, $id, $biogbasicinformation, $ori) {
+                $biogbasicinformation->update($data);
+                $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_MAIN', $biogbasicinformation->c_personid, $data, $ori);
+
+                $newData = $biogbasicinformation->fresh()->toArray();
+
+                (new AuditLogService())->write(
+                    'BIOG_MAIN',
+                    'UPDATE',
+                    ['c_personid' => $biogbasicinformation->c_personid],
+                    $ori,
+                    $newData,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            });
         }
         //20190531修改結束
 

--- a/app/Services/AuditLogService.php
+++ b/app/Services/AuditLogService.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Services;
+
+use App\Support\CompositePrimaryKey;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class AuditLogService {
+    public function buildRowPkText(string $tableName, array $rowPk): string {
+        $normalized = $this->normalizeRowPk($tableName, $rowPk);
+
+        return $this->buildRowPkTextFromNormalized($normalized);
+    }
+
+    public function write(
+        string $tableName,
+        string $operation,
+        array $rowPk,
+        ?array $oldData,
+        ?array $newData,
+        string $actorType,
+        string $actorId,
+        ?string $operationId = null,
+        ?Carbon $occurredAt = null,
+        ?Carbon $createdAt = null
+    ): void {
+        $normalizedRowPk = $this->normalizeRowPk($tableName, $rowPk);
+        $rowPkText = $this->buildRowPkTextFromNormalized($normalizedRowPk);
+
+        $occurredAt = $occurredAt ?? Carbon::now();
+        $createdAt = $createdAt ?? $occurredAt;
+        $operationId = $operationId ?: (string) Str::ulid();
+
+        DB::table('audit_log')->insert([
+            'occurred_at' => $occurredAt,
+            'created_at' => $createdAt,
+            'table_name' => $tableName,
+            'operation' => strtoupper($operation),
+            'actor_type' => $actorType,
+            'actor_id' => $actorId,
+            'operation_id' => $operationId,
+            'row_pk' => json_encode($normalizedRowPk, JSON_UNESCAPED_UNICODE),
+            'row_pk_text' => $rowPkText,
+            'old_data' => $oldData === null ? null : json_encode($oldData, JSON_UNESCAPED_UNICODE),
+            'new_data' => $newData === null ? null : json_encode($newData, JSON_UNESCAPED_UNICODE),
+        ]);
+    }
+
+    private function buildRowPkTextFromNormalized(array $rowPk): string {
+        $encoded = array_map(fn ($value) => $value === null ? 'NULL' : $value, $rowPk);
+
+        return http_build_query($encoded, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    private function normalizeRowPk(string $tableName, array $rowPk): array {
+        $schema = CompositePrimaryKey::getSchema($tableName);
+        if (!$schema) {
+            ksort($rowPk);
+
+            return $rowPk;
+        }
+
+        $missing = [];
+        $normalized = [];
+        foreach ($schema as $field) {
+            if (!array_key_exists($field, $rowPk)) {
+                $missing[] = $field;
+            }
+            $normalized[$field] = $rowPk[$field] ?? null;
+        }
+
+        if (!empty($missing)) {
+            throw new InvalidArgumentException(sprintf(
+                'Missing primary key fields for %s: %s',
+                $tableName,
+                implode(', ', $missing)
+            ));
+        }
+
+        return $normalized;
+    }
+}

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -22,6 +22,9 @@ class CompositePrimaryKey {
      * 參考：database/migrations/2025_01_01_* baseline migrations
      */
     public const SCHEMAS = [
+        'BIOG_MAIN' => [
+            'c_personid',
+        ],
         'ALTNAME_DATA' => [
             'c_personid',
             'c_sequence',

--- a/database/migrations/2026_02_08_000000_create_audit_log_table.php
+++ b/database/migrations/2026_02_08_000000_create_audit_log_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void {
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            column_comment($table->dateTime('occurred_at'), 'When the operation actually occurred');
+            column_comment($table->dateTime('created_at'), 'When the audit log was written');
+
+            column_comment($table->string('table_name', 64), 'Target business table');
+            column_comment($table->string('operation', 16), 'INSERT/UPDATE/DELETE');
+
+            column_comment($table->string('actor_type', 32), 'user/system/job/api_key');
+            column_comment($table->string('actor_id', 128), 'Actor identifier in business layer');
+
+            column_comment($table->char('operation_id', 26), 'Unique identifier of the operation');
+
+            column_comment($table->json('row_pk'), 'Primary key (supports composite key)');
+            column_comment($table->string('row_pk_text', 512), 'Stable serialized primary key');
+
+            column_comment($table->json('old_data')->nullable(), 'Full row before change');
+            column_comment($table->json('new_data')->nullable(), 'Full row after change');
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('audit_log');
+    }
+};

--- a/database/migrations/helpers.php
+++ b/database/migrations/helpers.php
@@ -348,3 +348,20 @@ if (!function_exists('is_sqlite')) {
         return DB::getDriverName() === 'sqlite';
     }
 }
+
+if (!function_exists('column_comment')) {
+    /**
+     * Apply column comment only for MySQL/MariaDB (SQLite ignores comments).
+     *
+     * @param \Illuminate\Database\Schema\ColumnDefinition $column
+     * @param string $comment
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    function column_comment($column, string $comment) {
+        if (is_mysql()) {
+            $column->comment($comment);
+        }
+
+        return $column;
+    }
+}

--- a/docs/AUDIT_LOG_PROPOSAL.md
+++ b/docs/AUDIT_LOG_PROPOSAL.md
@@ -51,6 +51,22 @@ This proposal only targets `/basicinformation` and its 12 subpages. No other mod
    - cover basic insert/update/delete flows for at least one composite key table
 6. **(Optional) Capture semantic snapshots** for selected reference fields where historical human-readable meaning is required.
 
+## Progress Tracker
+- [x] Create migration for `audit_log` (`database/migrations/2026_02_08_000000_create_audit_log_table.php`)
+- [x] Add AuditLog service (create + tests)
+- [x] Integrate `BIOG_MAIN` repository writes
+- [ ] Integrate `POSTED_TO_OFFICE_DATA` / `POSTED_TO_ADDR_DATA` writes
+- [ ] Integrate remaining `/basicinformation` tables
+- [ ] Ensure transactional writes for audit + data changes
+- [ ] Add SQLite migration coverage in tests
+
+## Planned Touchpoints
+- `app/Services/AuditLogService.php`
+- `app/Support/CompositePrimaryKey.php` (RFC 3986 encoding for `row_pk_text`)
+- `app/Repositories/*` for `/basicinformation` writes
+- `tests/Feature/*` or `tests/Unit/*` for audit log coverage
+- `docs/AUDIT_LOG_PROPOSAL.md` progress updates
+
 ## Audit Semantics Boundary
 The `audit_log` table records factual row-level changes of business tables at the time they occur (field values before/after).
 
@@ -131,6 +147,9 @@ Escaping example:
 
 ## Write Location (Implementation Guideline)
 Audit logs should be written at the Repository/Service layer within the same database transaction as the data change. This avoids divergence between row data and audit log entries.
+
+Note (current implementation):
+- `BIOG_MAIN` inserts are currently performed in `BasicInformationController` (including `saveas` and `Duplicate_Collateral_Info`) and in `Api\OperationsController@storeProcess`. Audit log writes have been added on these paths and are executed in the same transaction as the data write.
 
 ## Non-Goals (for this initial proposal)
 - No JSON indexes or additional search columns (to avoid premature redundancy).

--- a/resources/views/admin/audit_logs/index.blade.php
+++ b/resources/views/admin/audit_logs/index.blade.php
@@ -1,0 +1,345 @@
+@extends('layouts.dashboard-v3')
+
+@section('content')
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title"><i class="fas fa-clipboard-check mr-1"></i> {{ $page_title }}</h3>
+            </div>
+
+            <div class="card-body">
+                <form method="GET" action="{{ route('admin.audit-logs') }}" class="mb-3">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <div class="form-group">
+                                <label for="search">關鍵字</label>
+                                <input type="text" class="form-control" id="search" name="search"
+                                       value="{{ $filters['search'] ?? '' }}"
+                                       placeholder="operation_id / row_pk_text / table_name">
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label for="table_name">資料表</label>
+                                <select class="form-control" id="table_name" name="table_name">
+                                    <option value="">全部</option>
+                                    @foreach($table_names as $tableName)
+                                        <option value="{{ $tableName }}" {{ ($filters['table_name'] ?? '') == $tableName ? 'selected' : '' }}>
+                                            {{ $tableName }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label for="operation">操作</label>
+                                <select class="form-control" id="operation" name="operation">
+                                    <option value="">全部</option>
+                                    @foreach(['INSERT', 'UPDATE', 'DELETE'] as $op)
+                                        <option value="{{ $op }}" {{ ($filters['operation'] ?? '') == $op ? 'selected' : '' }}>
+                                            {{ $op }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label for="actor_type">角色</label>
+                                <select class="form-control" id="actor_type" name="actor_type">
+                                    <option value="">全部</option>
+                                    @foreach($actor_types as $actorType)
+                                        <option value="{{ $actorType }}" {{ ($filters['actor_type'] ?? '') == $actorType ? 'selected' : '' }}>
+                                            {{ $actorType }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label for="actor_id">操作者 ID</label>
+                                <input type="text" class="form-control" id="actor_id" name="actor_id"
+                                       value="{{ $filters['actor_id'] ?? '' }}"
+                                       placeholder="例如 1">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-search"></i> 搜尋
+                            </button>
+                            @if(($filters['search'] ?? '') || ($filters['table_name'] ?? '') || ($filters['operation'] ?? '') || ($filters['actor_type'] ?? '') || ($filters['actor_id'] ?? ''))
+                                <a href="{{ route('admin.audit-logs') }}" class="btn btn-secondary ml-1">
+                                    <i class="fas fa-times"></i> 清除
+                                </a>
+                            @endif
+                        </div>
+                    </div>
+                </form>
+
+                <div class="alert alert-info">
+                    <i class="fas fa-info-circle"></i>
+                    共 {{ $logs->total() }} 筆記錄，顯示第 {{ $logs->firstItem() ?? 0 }} - {{ $logs->lastItem() ?? 0 }} 筆
+                </div>
+
+                @if($logs->isEmpty())
+                    <div class="alert alert-warning">
+                        <i class="fas fa-exclamation-triangle"></i> 暫無記錄
+                    </div>
+                @else
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="thead-light">
+                                <tr>
+                                    <th>#</th>
+                                    <th>時間</th>
+                                    <th>表名</th>
+                                    <th>操作</th>
+                                    <th>操作者</th>
+                                    <th>PK</th>
+                                    <th>operation_id</th>
+                                    <th>資料</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($logs as $log)
+                                    @php
+                                        $rowPk = $log->row_pk ? json_decode($log->row_pk, true) : null;
+                                        $oldData = $log->old_data ? json_decode($log->old_data, true) : null;
+                                        $newData = $log->new_data ? json_decode($log->new_data, true) : null;
+                                        $formatValue = function ($value) {
+                                            if (is_array($value) || is_object($value)) {
+                                                return json_encode($value, JSON_UNESCAPED_UNICODE);
+                                            }
+                                            if ($value === null) {
+                                                return '(null)';
+                                            }
+                                            if (is_bool($value)) {
+                                                return $value ? 'true' : 'false';
+                                            }
+                                            return (string) $value;
+                                        };
+                                        $normalizeValue = function ($value) {
+                                            if (is_array($value) || is_object($value)) {
+                                                return json_encode($value);
+                                            }
+                                            if ($value === null) {
+                                                return '';
+                                            }
+                                            if (is_bool($value)) {
+                                                return $value ? '1' : '0';
+                                            }
+                                            return trim((string) $value);
+                                        };
+                                        $oldArr = is_array($oldData) ? $oldData : [];
+                                        $newArr = is_array($newData) ? $newData : [];
+                                        $allKeys = array_unique(array_merge(array_keys($oldArr), array_keys($newArr)));
+                                        $diffRows = [];
+                                        foreach ($allKeys as $key) {
+                                            if (in_array($key, ['_method', '_token'], true)) {
+                                                continue;
+                                            }
+                                            $beforeRaw = array_key_exists($key, $oldArr) ? $oldArr[$key] : null;
+                                            $afterRaw = array_key_exists($key, $newArr) ? $newArr[$key] : null;
+                                            if ($normalizeValue($beforeRaw) === $normalizeValue($afterRaw)) {
+                                                continue;
+                                            }
+                                            $diffRows[] = [
+                                                'field' => $key,
+                                                'before' => $formatValue($beforeRaw),
+                                                'after' => $formatValue($afterRaw),
+                                                'current' => '(未取得)',
+                                                'matches_current' => false,
+                                                'matches_before' => false,
+                                            ];
+                                        }
+                                        $diffSource = !empty($diffRows) ? ['rows' => $diffRows] : null;
+                                    @endphp
+                                    <tr>
+                                        <td>{{ $log->id }}</td>
+                                        <td>
+                                            @php
+                                                $appTimezone = config('app.timezone', 'Asia/Shanghai');
+                                                $occurredUtc = '';
+                                                $occurredDisplay = '';
+                                                $occurredRaw = $log->occurred_at;
+                                                if ($occurredRaw instanceof \Carbon\Carbon) {
+                                                    $occurredDisplay = $occurredRaw;
+                                                    $occurredUtc = $occurredRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                                } elseif (is_string($occurredRaw) && trim($occurredRaw) !== '') {
+                                                    $occurredDisplay = trim($occurredRaw);
+                                                    try {
+                                                        $parsed = \Carbon\Carbon::parse($occurredRaw, $appTimezone);
+                                                        $occurredUtc = $parsed->setTimezone('UTC')->toIso8601String();
+                                                    } catch (\Exception $e) {
+                                                        $occurredUtc = $occurredDisplay;
+                                                    }
+                                                }
+
+                                                $createdUtc = '';
+                                                $createdDisplay = '';
+                                                $createdRaw = $log->created_at;
+                                                if ($createdRaw instanceof \Carbon\Carbon) {
+                                                    $createdDisplay = $createdRaw;
+                                                    $createdUtc = $createdRaw->copy()->setTimezone('UTC')->toIso8601String();
+                                                } elseif (is_string($createdRaw) && trim($createdRaw) !== '') {
+                                                    $createdDisplay = trim($createdRaw);
+                                                    try {
+                                                        $parsed = \Carbon\Carbon::parse($createdRaw, $appTimezone);
+                                                        $createdUtc = $parsed->setTimezone('UTC')->toIso8601String();
+                                                    } catch (\Exception $e) {
+                                                        $createdUtc = $createdDisplay;
+                                                    }
+                                                }
+                                            @endphp
+                                            <div class="js-utc-datetime" data-utc="{{ $occurredUtc }}">
+                                                {{ $occurredDisplay }}
+                                            </div>
+                                            @if($log->created_at !== $log->occurred_at)
+                                                <small class="text-muted js-utc-datetime" data-utc="{{ $createdUtc }}">
+                                                    寫入：{{ $createdDisplay }}
+                                                </small>
+                                            @endif
+                                        </td>
+                                        <td>{{ $log->table_name }}</td>
+                                        <td>
+                                            <span class="badge badge-{{ $log->operation === 'DELETE' ? 'danger' : ($log->operation === 'INSERT' ? 'success' : 'warning') }}">
+                                                {{ $log->operation }}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <div>{{ $log->actor_type }}</div>
+                                            <small class="text-muted">{{ $log->actor_id }}</small>
+                                        </td>
+                                        <td>
+                                            <div class="text-monospace">{{ $log->row_pk_text }}</div>
+                                            @if($rowPk)
+                                                <small class="text-muted">{{ json_encode($rowPk, JSON_UNESCAPED_UNICODE) }}</small>
+                                            @endif
+                                        </td>
+                                        <td class="text-monospace">{{ $log->operation_id }}</td>
+                                        <td>
+                                            <div class="btn-group mb-2" role="group">
+                                                <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#audit-diff-{{ $log->id }}"
+                                                    {{ $diffSource ? '' : 'disabled' }}>
+                                                    比較
+                                                </button>
+                                                <button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#audit-old-{{ $log->id }}"
+                                                    {{ $oldData ? '' : 'disabled' }}>
+                                                    old_data
+                                                </button>
+                                                <button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#audit-new-{{ $log->id }}"
+                                                    {{ $newData ? '' : 'disabled' }}>
+                                                    new_data
+                                                </button>
+                                            </div>
+                                            @if(!$oldData && !$newData)
+                                                <div class="text-muted">—</div>
+                                            @endif
+
+                                            <div id="audit-diff-{{ $log->id }}" class="modal fade" role="dialog" tabindex="-1">
+                                                <div class="modal-dialog modal-lg" style="width:80vw;max-width:80vw;">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h4 class="modal-title">比較</h4>
+                                                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                                        </div>
+                                                        <div class="modal-body" style="word-break: break-all;">
+                                                            @include('components.diff-table', ['diff' => $diffSource])
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            <div id="audit-old-{{ $log->id }}" class="modal fade" role="dialog" tabindex="-1">
+                                                <div class="modal-dialog modal-lg">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h4 class="modal-title">old_data</h4>
+                                                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                                        </div>
+                                                        <div class="modal-body" style="word-break: break-all;">
+                                                            @include('components.key-value-table', ['data' => $oldData])
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            <div id="audit-new-{{ $log->id }}" class="modal fade" role="dialog" tabindex="-1">
+                                                <div class="modal-dialog modal-lg">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h4 class="modal-title">new_data</h4>
+                                                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                                                        </div>
+                                                        <div class="modal-body" style="word-break: break-all;">
+                                                            @include('components.key-value-table', ['data' => $newData])
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mt-3">
+                        {{ $logs->links() }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('js')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var getFormatTimestampFn = function() {
+        return typeof window.formatTimestamp === 'function'
+            ? window.formatTimestamp
+            : function(value) { return value; };
+    };
+    var userOffsetMinutes = typeof window.getUserOffsetMinutes === 'function'
+        ? window.getUserOffsetMinutes()
+        : new Date().getTimezoneOffset();
+
+    var nodes = document.querySelectorAll('.js-utc-datetime');
+    Array.prototype.forEach.call(nodes, function (node) {
+        var original = node.getAttribute('data-utc') || (node.textContent || '').trim();
+        if (!original) {
+            return;
+        }
+
+        var displayText = getFormatTimestampFn()(original);
+        node.textContent = displayText;
+        if (userOffsetMinutes !== -480) {
+            var chinaText = getFormatTimestampFn()(original, 'Asia/Shanghai');
+            if (chinaText && chinaText !== original) {
+                node.setAttribute('title', chinaText);
+            } else {
+                node.removeAttribute('title');
+            }
+        } else {
+            node.removeAttribute('title');
+        }
+    });
+});
+</script>
+@endsection

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -336,6 +336,7 @@
                             '用戶管理',
                             'NL Query Logs',
                             'AI 填充日誌',
+                            '審計日誌',
                             'SQL 執行計畫',
                             '批次匯入書稿資料',
                             '批次匯入官職',
@@ -372,6 +373,12 @@
                                 <a href="{{ route('admin.ai-fill-logs') }}" class="nav-link {{ $activePage == 'AI 填充日誌' ? 'active' : '' }}">
                                     <i class="nav-icon fas fa-robot"></i>
                                     <p>AI 填充日誌</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('admin.audit-logs') }}" class="nav-link {{ $activePage == '審計日誌' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-clipboard-check"></i>
+                                    <p>審計日誌</p>
                                 </a>
                             </li>
                             <li class="nav-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -258,6 +258,7 @@ Route::middleware('auth')->group(function () {
 
     // AI 填充日誌（管理員工具）
     Route::get('admin/ai-fill-logs', 'AiFillLogController@index')->name('admin.ai-fill-logs');
+    Route::get('admin/audit-logs', 'AdminAuditLogController@index')->name('admin.audit-logs');
 
     Route::post('admin/unidirectional-relationship-repair/assoc', 'UnidirectionalRelationshipRepairController@repairAssoc')->name('admin.unidirectional-relationship-repair.assoc');
 });

--- a/tests/Feature/BasicInformationUpdateTest.php
+++ b/tests/Feature/BasicInformationUpdateTest.php
@@ -82,11 +82,29 @@ class BasicInformationUpdateTest extends TestCase {
             $table->integer('crowdsourcing_status')->default(0);
             $table->timestamps();
         });
+
+        // 創建 audit_log 表（供審計記錄寫入）
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
     }
 
     protected function tearDown(): void {
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('operations');
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('users');
         parent::tearDown();
     }

--- a/tests/Feature/BiogMainBasicInfoNameMergeTest.php
+++ b/tests/Feature/BiogMainBasicInfoNameMergeTest.php
@@ -48,6 +48,23 @@ class BiogMainBasicInfoNameMergeTest extends TestCase {
             $table->timestamps();
         });
 
+        // 創建 audit_log 表（供審計記錄寫入）
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+
         Schema::dropIfExists('BIOG_MAIN');
         Schema::create('BIOG_MAIN', function (Blueprint $table) {
             $table->integer('c_personid')->primary();
@@ -91,6 +108,7 @@ class BiogMainBasicInfoNameMergeTest extends TestCase {
     protected function tearDown(): void {
         Schema::dropIfExists('operations');
         Schema::dropIfExists('BIOG_MAIN');
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('users');
         parent::tearDown();
     }

--- a/tests/Unit/AuditLogServiceTest.php
+++ b/tests/Unit/AuditLogServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AuditLogService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AuditLogServiceTest extends TestCase {
+    // NOTE: Avoid RefreshDatabase; full migrations on SQLite can fail due to
+    // foreign key mismatch constraints. Create the audit_log table manually.
+
+    protected AuditLogService $service;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->service = new AuditLogService();
+
+        DB::statement('PRAGMA foreign_keys = OFF');
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    /** @test */
+    public function it_builds_row_pk_text_using_schema_order_and_rfc3986(): void {
+        $rowPk = [
+            'c_alt_name_type_code' => 10,
+            'c_alt_name_chn' => 'A & B',
+            'c_sequence' => 1,
+            'c_personid' => 123,
+        ];
+
+        $text = $this->service->buildRowPkText('ALTNAME_DATA', $rowPk);
+
+        $this->assertSame(
+            'c_personid=123&c_sequence=1&c_alt_name_chn=A%20%26%20B&c_alt_name_type_code=10',
+            $text
+        );
+    }
+
+    /** @test */
+    public function it_writes_audit_log_with_generated_operation_id(): void {
+        $this->service->write(
+            'BIOG_MAIN',
+            'insert',
+            ['c_personid' => 100],
+            null,
+            ['c_personid' => 100, 'c_name_chn' => '張三'],
+            'user',
+            '1'
+        );
+
+        $row = DB::table('audit_log')->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('BIOG_MAIN', $row->table_name);
+        $this->assertSame('INSERT', $row->operation);
+        $this->assertSame('c_personid=100', $row->row_pk_text);
+        $this->assertSame(26, strlen($row->operation_id));
+        $this->assertSame(['c_personid' => 100], json_decode($row->row_pk, true));
+        $this->assertSame(
+            ['c_personid' => 100, 'c_name_chn' => '張三'],
+            json_decode($row->new_data, true)
+        );
+    }
+}


### PR DESCRIPTION
整合稽核日誌功能:

- 新增 audit_log migration（含 SQLite 註解兼容）與 AuditLogService，支援 row_pk_text RFC3986 序列化
- 擴充 CompositePrimaryKey（BIOG_MAIN）並補上相關單元測試
- BIOG_MAIN 更新/新增與 API storeProcess 寫入稽核記錄，維持同一交易
- 新增管理員審計日誌頁與側欄入口，提供 diff 檢視與本地/GMT+8 時間顯示
- 測試環境手動建立 audit_log 表，避免 SQLite 測試缺表
- 已執行 ./vendor/bin/phpunit --filter AuditLogServiceTest

<img width="1440" height="805" alt="image" src="https://github.com/user-attachments/assets/4e2f1ec2-b842-4a7f-92f1-8ca93afe4644" />
