### PR TITLE
改用 HuggingFace 同步 SQLite 匯出檔

### DIFF
--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 #
-# 每週 SQLite 匯出並同步到 GitHub
+# 每週 SQLite 匯出並同步到 HuggingFace
 #
 # 功能：
 #   1. 執行 export-daily-sqlite.sh 匯出資料庫
 #   2. 重新命名為 latest.db 並壓縮為 latest.zip
-#   3. 推送到 cbdb-project/cbdb_sqlite 倉庫
+#   3. 上傳到 HuggingFace datasets/cbdb/cbdb-sqlite
 #
 # 前置要求：
 #   - zip (zip 命令)
-#   - git-lfs
-#   - gh CLI 已登入
+#   - hf CLI (pipx install huggingface-hub)
+#   - HF_TOKEN 環境變數已設定（HuggingFace Access Token）
 #
 # 使用方式：
-#   ./scripts/weekly-sqlite-sync.sh
+#   HF_TOKEN=hf_xxx ./scripts/weekly-sqlite-sync.sh
 #
 # Cron 設定範例（每週日凌晨 3 點）：
-#   0 3 * * 0 /path/to/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
+#   0 3 * * 0 HF_TOKEN=hf_xxx /path/to/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
 #
 
 set -e
@@ -31,12 +31,6 @@ if [ -z "$HOME" ]; then
     fi
 fi
 
-# 僅在無法讀取系統級 git 配置時才跳過（避免影響 LFS 等系統配置）
-if [ -f /etc/gitconfig ] && [ ! -r /etc/gitconfig ]; then
-    export GIT_CONFIG_NOSYSTEM=1
-    echo "注意: /etc/gitconfig 無法讀取，已設置 GIT_CONFIG_NOSYSTEM=1"
-fi
-
 # 前置檢查：確認必要工具已安裝
 check_requirements() {
     local missing=()
@@ -45,12 +39,8 @@ check_requirements() {
         missing+=("zip (請安裝: sudo apt-get install zip)")
     fi
 
-    if ! command -v gh &> /dev/null; then
-        missing+=("gh (請安裝 GitHub CLI: https://cli.github.com/)")
-    fi
-
-    if ! command -v git-lfs &> /dev/null; then
-        missing+=("git-lfs (請安裝: sudo apt-get install git-lfs)")
+    if ! command -v hf &> /dev/null; then
+        missing+=("hf (請安裝: pipx install huggingface-hub)")
     fi
 
     if [ ${#missing[@]} -gt 0 ]; then
@@ -61,10 +51,14 @@ check_requirements() {
         exit 1
     fi
 
-    # 檢查 gh CLI 是否已登入
-    if ! gh auth status &> /dev/null; then
-        echo "錯誤: gh CLI 尚未登入，請先執行 'gh auth login'"
-        echo "提示: 若在 cron 環境執行，請確保 GH_TOKEN 環境變量已設置"
+    # 檢查 HF_TOKEN 是否已設定
+    if [ -z "$HF_TOKEN" ]; then
+        echo "錯誤: HF_TOKEN 環境變數未設定"
+        echo "請先設定 HuggingFace Access Token："
+        echo "  export HF_TOKEN=hf_你的token"
+        echo ""
+        echo "Token 可在此建立: https://huggingface.co/settings/tokens"
+        echo "需要的權限: Repositories → Write"
         exit 1
     fi
 }
@@ -74,9 +68,7 @@ show_environment() {
     echo "環境資訊:"
     echo "  - USER: $(whoami)"
     echo "  - HOME: $HOME"
-    if [ -n "$GIT_CONFIG_NOSYSTEM" ]; then
-        echo "  - GIT_CONFIG_NOSYSTEM: $GIT_CONFIG_NOSYSTEM"
-    fi
+    echo "  - HF_TOKEN: (已設定)"
     echo ""
 }
 
@@ -86,15 +78,14 @@ check_requirements
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="${PROJECT_ROOT}/db-data"
-GITHUB_REPO="cbdb-project/cbdb_sqlite"
-TEMP_DIR=$(mktemp -d)
+HF_DATASET_REPO="cbdb/cbdb-sqlite"
 
 # 清理函數
 cleanup() {
     echo "清理暫存檔案..."
-    rm -rf "$TEMP_DIR"
     rm -f "${WORK_DIR}/latest.db"
     rm -f "${WORK_DIR}/latest.zip"
+    rm -f "${WORK_DIR}/latest.json"
     # 刪除當天產生的原始 sqlite 匯出檔
     if [ -n "$SQLITE_FILE" ] && [ -f "$SQLITE_FILE" ]; then
         echo "刪除原始匯出檔: $SQLITE_FILE"
@@ -110,7 +101,7 @@ trap cleanup EXIT
 cd "$PROJECT_ROOT"
 
 echo "================================================"
-echo "CBDB SQLite 每週同步"
+echo "CBDB SQLite 每週同步（HuggingFace）"
 echo "================================================"
 echo "時間: $(date '+%Y-%m-%d %H:%M:%S')"
 echo ""
@@ -118,7 +109,7 @@ echo ""
 show_environment
 
 # Step 1: 執行匯出腳本
-echo "[1/5] 執行 SQLite 匯出腳本..."
+echo "[1/4] 執行 SQLite 匯出腳本..."
 bash scripts/export-daily-sqlite.sh
 
 # 找到今天產生的檔案
@@ -134,80 +125,126 @@ echo "匯出檔案: $SQLITE_FILE"
 
 # Step 2: 複製並重新命名
 echo ""
-echo "[2/5] 複製並重新命名為 latest.db..."
+echo "[2/4] 複製並重新命名為 latest.db..."
 cp "$SQLITE_FILE" "${WORK_DIR}/latest.db"
 
 # Step 3: 壓縮為 zip
 echo ""
-echo "[3/5] 壓縮為 latest.zip..."
+echo "[3/4] 壓縮為 latest.zip..."
 rm -f "${WORK_DIR}/latest.zip"
 zip -9 "${WORK_DIR}/latest.zip" "${WORK_DIR}/latest.db" > /dev/null
 
 FILE_SIZE=$(ls -lh "${WORK_DIR}/latest.zip" | awk '{print $5}')
 echo "壓縮完成，檔案大小: $FILE_SIZE"
 
-# Step 4: 克隆倉庫並更新
-# 注意：使用 git clone 而非 gh repo clone，因為 snap 版的 gh 在沙箱中無法正常調用系統 git
+# Step 4: 上傳到 HuggingFace
 echo ""
-echo "[4/5] 克隆 $GITHUB_REPO 並更新..."
-cd "$TEMP_DIR"
-git clone --depth=1 "https://github.com/${GITHUB_REPO}.git"
-cd cbdb_sqlite
+echo "[4/4] 上傳到 HuggingFace ${HF_DATASET_REPO}..."
 
-# 設置推送認證（使用 gh auth token）
-GH_TOKEN=$(gh auth token 2>/dev/null)
-if [ -n "$GH_TOKEN" ]; then
-    git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPO}.git"
-else
-    echo "警告: 無法取得 GitHub token，推送可能會失敗"
-fi
-
-# 確保 LFS 已初始化
-git lfs install
-
-# 設置 git 用戶資訊（僅在未配置或為空時設置，避免覆蓋手動執行者的配置）
-if [ -z "$(git config --get user.name)" ]; then
-    git config user.name "sudoghut"
-fi
-if [ -z "$(git config --get user.email)" ]; then
-    git config user.email "sudospace@gmail.com"
-fi
-
-# 複製新檔案
+# 上傳 latest.zip
 META_FILE="${WORK_DIR}/cbdb_daily_${DATE_SUFFIX}.json"
-if [ ! -f "$META_FILE" ]; then
-    echo "錯誤: 找不到 metadata 檔案 $META_FILE"
-    exit 1
-fi
-
 META_DATE="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}-${DATE_SUFFIX:6:2}"
 META_MONTH="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}"
-cp "${WORK_DIR}/latest.zip" ./latest.zip
-mkdir -p "metadata/${META_MONTH}"
 META_PATH="metadata/${META_MONTH}/${META_DATE}.json"
-cp "$META_FILE" "${META_PATH}"
-ln -sfn "${META_PATH}" latest.json
 
-# Step 5: 提交並推送
-echo ""
-echo "[5/5] 提交並推送..."
-git add latest.zip latest.json "${META_PATH}"
+# hf CLI 會自動讀取 HF_TOKEN 環境變數，不需要 --token 參數
+# 避免 token 出現在 process list 中
 
-# 檢查是否有變更需要提交
-if git diff --cached --quiet; then
-    echo "檔案內容無變更，跳過推送"
-    SYNC_STATUS="無變更"
+# 準備上傳檔案清單（latest.zip 必須，metadata 可選）
+UPLOAD_ARGS=("${WORK_DIR}/latest.zip" "latest.zip")
+
+if [ -f "$META_FILE" ]; then
+    # 複製一份作為 latest.json（HuggingFace 不支援 symlink）
+    cp "$META_FILE" "${WORK_DIR}/latest.json"
+    UPLOAD_ARGS+=("$META_FILE" "$META_PATH")
+    UPLOAD_ARGS+=("${WORK_DIR}/latest.json" "latest.json")
+    echo "上傳 latest.zip、${META_PATH}、latest.json..."
 else
-    git commit -m "Update latest.zip ($(date '+%Y-%m-%d'))"
-    git push origin master
-    SYNC_STATUS="已推送"
+    echo "警告: 找不到 metadata 檔案 $META_FILE，僅上傳 latest.zip"
 fi
+
+# 單次上傳所有檔案（同一個 commit）
+hf upload "$HF_DATASET_REPO" \
+    "${UPLOAD_ARGS[@]}" \
+    --repo-type dataset \
+    --commit-message "Update CBDB SQLite (${META_DATE})"
+
+SYNC_STATUS="已上傳"
 
 echo ""
 echo "================================================"
 echo "同步完成!"
 echo "================================================"
+echo "目標: https://huggingface.co/datasets/${HF_DATASET_REPO}"
 echo "狀態: $SYNC_STATUS"
 echo "檔案大小: $FILE_SIZE"
 echo "時間: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "================================================"
+
+# ==============================================================================
+# [暫時停用] GitHub 同步
+# 未來可能用於同步其他內容，保留以下代碼供參考
+# ==============================================================================
+#
+# # --- GitHub 前置要求 ---
+# # - git-lfs
+# # - gh CLI 已登入
+#
+# # 僅在無法讀取系統級 git 配置時才跳過（避免影響 LFS 等系統配置）
+# # if [ -f /etc/gitconfig ] && [ ! -r /etc/gitconfig ]; then
+# #     export GIT_CONFIG_NOSYSTEM=1
+# #     echo "注意: /etc/gitconfig 無法讀取，已設置 GIT_CONFIG_NOSYSTEM=1"
+# # fi
+#
+# # --- GitHub 工具檢查 ---
+# # if ! command -v gh &> /dev/null; then
+# #     missing+=("gh (請安裝 GitHub CLI: https://cli.github.com/)")
+# # fi
+# # if ! command -v git-lfs &> /dev/null; then
+# #     missing+=("git-lfs (請安裝: sudo apt-get install git-lfs)")
+# # fi
+# # if ! gh auth status &> /dev/null; then
+# #     echo "錯誤: gh CLI 尚未登入，請先執行 'gh auth login'"
+# #     echo "提示: 若在 cron 環境執行，請確保 GH_TOKEN 環境變量已設置"
+# #     exit 1
+# # fi
+#
+# # --- GitHub 同步邏輯 ---
+# # GITHUB_REPO="cbdb-project/cbdb_sqlite"
+# # TEMP_DIR=$(mktemp -d)
+# #
+# # cd "$TEMP_DIR"
+# # git clone --depth=1 "https://github.com/${GITHUB_REPO}.git"
+# # cd cbdb_sqlite
+# #
+# # GH_TOKEN=$(gh auth token 2>/dev/null)
+# # if [ -n "$GH_TOKEN" ]; then
+# #     git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPO}.git"
+# # else
+# #     echo "警告: 無法取得 GitHub token，推送可能會失敗"
+# # fi
+# #
+# # git lfs install
+# #
+# # if [ -z "$(git config --get user.name)" ]; then
+# #     git config user.name "sudoghut"
+# # fi
+# # if [ -z "$(git config --get user.email)" ]; then
+# #     git config user.email "sudospace@gmail.com"
+# # fi
+# #
+# # cp "${WORK_DIR}/latest.zip" ./latest.zip
+# # mkdir -p "metadata/${META_MONTH}"
+# # cp "$META_FILE" "${META_PATH}"
+# # ln -sfn "${META_PATH}" latest.json
+# #
+# # git add latest.zip latest.json "${META_PATH}"
+# #
+# # if git diff --cached --quiet; then
+# #     echo "檔案內容無變更，跳過推送"
+# # else
+# #     git commit -m "Update latest.zip ($(date '+%Y-%m-%d'))"
+# #     git push origin master
+# # fi
+# #
+# # rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary

- 將每週 SQLite 匯出的同步目標從 GitHub (`cbdb-project/cbdb_sqlite`) 改為 HuggingFace (`datasets/cbdb/cbdb-sqlite`)
- 使用 `hf` CLI 透過 HTTP API 直接上傳，取代原本的 git clone + LFS 流程
- 認證改用 `HF_TOKEN` 環境變數，避免在命令列參數暴露 token
- 所有檔案（`latest.zip`、`metadata/YYYY-MM/YYYY-MM-DD.json`、`latest.json`）合併為單一 HuggingFace commit
- GitHub 同步代碼已註釋保留在腳本底部，供未來恢復使用

## 前置要求

1. 伺服器安裝 `hf` CLI：`pipx install huggingface-hub`
2. 設定 `HF_TOKEN` 環境變數（在 `/etc/environment` 或 crontab 中）
3. Token 需要 Repositories → Write 權限

## Test plan

- [x] 在伺服器確認 `hf version` 可正常執行
- [x] 設定 `HF_TOKEN` 後手動執行 `./scripts/weekly-sqlite-sync.sh` 驗證上傳
- [x] 確認 https://huggingface.co/datasets/cbdb/cbdb-sqlite 出現 `latest.zip`、`latest.json` 及 metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)