### PR TITLE
修正 hf upload 多檔上傳方式並清理舊代碼

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 * [檢視表總覽](./VIEWS.md)
 * [Wiki 导入任务管理](./WIKI_TASK_MANAGEMENT.md)
 * [姓名搜索索引管理](./NAME_SEARCH_COMMANDS.md)
-* [SQLite 每週同步](#sqlite-每週同步) - 自動匯出並同步到公開倉庫
+* [SQLite 每週同步](#sqlite-每週同步) - 自動匯出並同步到 HuggingFace
 
 ## 技術環境
 
@@ -334,12 +334,12 @@ sudo chown caddy laravel.log
 
 ## SQLite 每週同步
 
-本專案提供自動化腳本，將生產環境的數據庫匯出為 SQLite 格式，並同步到公開倉庫 [cbdb-project/cbdb_sqlite](https://github.com/cbdb-project/cbdb_sqlite) 供研究者下載使用。
+本專案提供自動化腳本，將生產環境的數據庫匯出為 SQLite 格式，並同步到 HuggingFace 公開數據集 [cbdb/cbdb-sqlite](https://huggingface.co/datasets/cbdb/cbdb-sqlite) 供研究者下載使用。
 
 ### 腳本位置
 
 - **匯出腳本**：`scripts/export-daily-sqlite.sh` - 將 MySQL/MariaDB 表格匯出為 SQLite
-- **同步腳本**：`scripts/weekly-sqlite-sync.sh` - 匯出、壓縮並推送到 GitHub
+- **同步腳本**：`scripts/weekly-sqlite-sync.sh` - 匯出、壓縮並上傳到 HuggingFace
 
 ### 前置安裝（Ubuntu）
 
@@ -347,35 +347,32 @@ sudo chown caddy laravel.log
 # 安裝 zip 壓縮工具
 sudo apt-get install zip
 
-# 安裝 Git LFS（目標倉庫使用 LFS 存儲大檔案）
-sudo apt-get install git-lfs
-git lfs install
-
-# 安裝 GitHub CLI
-# 參考：https://cli.github.com/manual/installation
+# 安裝 hf CLI
+sudo apt-get install -y pipx
+pipx install huggingface-hub
+pipx ensurepath
 ```
 
-### GitHub 認證設定
+### HuggingFace 認證設定
 
-腳本使用 `gh` CLI 進行 GitHub 操作，需要先完成認證：
+腳本支持兩種認證方式（二擇一）：
 
 ```bash
-# 方式一：互動式登入（適合本地測試）
-gh auth login
+# 方式一：hf auth login（推薦，token 安全存儲於 ~/.cache/huggingface/）
+hf auth login
 
-# 方式二：使用 Personal Access Token（推薦用於服務器）
-echo "ghp_xxxxxxxxxxxx" | gh auth login --with-token
+# 方式二：HF_TOKEN 環境變數
+export HF_TOKEN=hf_你的token
 
-# 驗證登入狀態
-gh auth status
+# 驗證認證狀態
+hf auth status
 ```
 
-**Personal Access Token 設定**：
-1. GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Generate new token
-3. 勾選 `repo` 權限（需要推送到倉庫）
-4. 設定有效期（可選 "No expiration" 用於自動化任務）
-5. 複製 token 並在服務器上執行認證
+**Access Token 設定**：
+1. 前往 https://huggingface.co/settings/tokens
+2. Create new token → 選擇 Fine-grained
+3. 勾選 Repositories → Write 權限
+4. 複製 token 並在服務器上執行認證
 
 ### Cron 定時任務
 
@@ -393,7 +390,7 @@ crontab -e
 # 執行完整同步流程
 bash scripts/weekly-sqlite-sync.sh
 
-# 僅匯出 SQLite（不推送）
+# 僅匯出 SQLite（不上傳）
 bash scripts/export-daily-sqlite.sh
 ```
 
@@ -401,11 +398,8 @@ bash scripts/export-daily-sqlite.sh
 
 `weekly-sqlite-sync.sh` 執行以下步驟：
 
-1. **前置檢查**：確認 `zip`、`gh`、`git-lfs` 已安裝且 `gh` 已登入
+1. **前置檢查**：確認 `zip`、`hf` 已安裝且 HuggingFace 認證有效
 2. **匯出數據庫**：呼叫 `export-daily-sqlite.sh` 產生 `cbdb_daily_YYYYMMDD.sqlite3` 與 `cbdb_daily_YYYYMMDD.json`
 3. **壓縮檔案**：複製為 `latest.db` 並壓縮為 `latest.zip`（最大壓縮率）
-4. **整理 metadata**：將 `cbdb_daily_YYYYMMDD.json` 存為 `metadata/YYYY-MM/YYYY-MM-DD.json`，並以 `latest.json` 符號連結指向最新檔案
-5. **推送到 GitHub**：克隆目標倉庫、替換檔案、提交並推送
-6. **清理**：刪除所有臨時檔案（包括原始 SQLite 匯出檔與 metadata）
-
-**智能跳過**：如果壓縮檔內容與遠端相同，腳本會跳過推送，避免產生無意義的 commit。
+4. **上傳到 HuggingFace**：將 `latest.zip`、`metadata/YYYY-MM/YYYY-MM-DD.json` 及 `latest.json`（metadata 副本）以單一 commit 上傳至數據集倉庫
+5. **清理**：刪除所有臨時檔案（包括原始 SQLite 匯出檔與 metadata）

--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -10,13 +10,15 @@
 # 前置要求：
 #   - zip (zip 命令)
 #   - hf CLI (pipx install huggingface-hub)
-#   - HF_TOKEN 環境變數已設定（HuggingFace Access Token）
+#   - HuggingFace 認證（二擇一）：
+#     1. hf auth login（推薦，token 存於 ~/.cache/huggingface/）
+#     2. HF_TOKEN 環境變數
 #
 # 使用方式：
-#   HF_TOKEN=hf_xxx ./scripts/weekly-sqlite-sync.sh
+#   ./scripts/weekly-sqlite-sync.sh
 #
 # Cron 設定範例（每週日凌晨 3 點）：
-#   0 3 * * 0 HF_TOKEN=hf_xxx /path/to/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
+#   0 3 * * 0 /path/to/scripts/weekly-sqlite-sync.sh >> /var/log/cbdb-sqlite-sync.log 2>&1
 #
 
 set -e
@@ -51,11 +53,12 @@ check_requirements() {
         exit 1
     fi
 
-    # 檢查 HF_TOKEN 是否已設定
-    if [ -z "$HF_TOKEN" ]; then
-        echo "錯誤: HF_TOKEN 環境變數未設定"
-        echo "請先設定 HuggingFace Access Token："
-        echo "  export HF_TOKEN=hf_你的token"
+    # 檢查 HuggingFace 認證（支持 hf auth login 或 HF_TOKEN 環境變數）
+    if [ -z "$HF_TOKEN" ] && ! hf auth status &> /dev/null; then
+        echo "錯誤: 未找到 HuggingFace 認證"
+        echo "請使用以下任一方式設定："
+        echo "  1. hf auth login（推薦，token 安全存儲於 ~/.cache/huggingface/）"
+        echo "  2. export HF_TOKEN=hf_你的token"
         echo ""
         echo "Token 可在此建立: https://huggingface.co/settings/tokens"
         echo "需要的權限: Repositories → Write"
@@ -68,7 +71,11 @@ show_environment() {
     echo "環境資訊:"
     echo "  - USER: $(whoami)"
     echo "  - HOME: $HOME"
-    echo "  - HF_TOKEN: (已設定)"
+    if [ -n "$HF_TOKEN" ]; then
+        echo "  - HF 認證: HF_TOKEN 環境變數"
+    else
+        echo "  - HF 認證: hf auth login"
+    fi
     echo ""
 }
 
@@ -79,13 +86,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="${PROJECT_ROOT}/db-data"
 HF_DATASET_REPO="cbdb/cbdb-sqlite"
+HF_STAGE_DIR=$(mktemp -d)
 
 # 清理函數
 cleanup() {
     echo "清理暫存檔案..."
+    if [ -n "$HF_STAGE_DIR" ] && [ -d "$HF_STAGE_DIR" ]; then
+        rm -rf "$HF_STAGE_DIR"
+    fi
     rm -f "${WORK_DIR}/latest.db"
     rm -f "${WORK_DIR}/latest.zip"
-    rm -f "${WORK_DIR}/latest.json"
     # 刪除當天產生的原始 sqlite 匯出檔
     if [ -n "$SQLITE_FILE" ] && [ -f "$SQLITE_FILE" ]; then
         echo "刪除原始匯出檔: $SQLITE_FILE"
@@ -147,25 +157,21 @@ META_DATE="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}-${DATE_SUFFIX:6:2}"
 META_MONTH="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}"
 META_PATH="metadata/${META_MONTH}/${META_DATE}.json"
 
-# hf CLI 會自動讀取 HF_TOKEN 環境變數，不需要 --token 參數
-# 避免 token 出現在 process list 中
-
-# 準備上傳檔案清單（latest.zip 必須，metadata 可選）
-UPLOAD_ARGS=("${WORK_DIR}/latest.zip" "latest.zip")
+# 準備暫存目錄，模擬 repo 內的檔案結構
+cp "${WORK_DIR}/latest.zip" "${HF_STAGE_DIR}/latest.zip"
 
 if [ -f "$META_FILE" ]; then
-    # 複製一份作為 latest.json（HuggingFace 不支援 symlink）
-    cp "$META_FILE" "${WORK_DIR}/latest.json"
-    UPLOAD_ARGS+=("$META_FILE" "$META_PATH")
-    UPLOAD_ARGS+=("${WORK_DIR}/latest.json" "latest.json")
+    mkdir -p "${HF_STAGE_DIR}/metadata/${META_MONTH}"
+    cp "$META_FILE" "${HF_STAGE_DIR}/${META_PATH}"
+    cp "$META_FILE" "${HF_STAGE_DIR}/latest.json"
     echo "上傳 latest.zip、${META_PATH}、latest.json..."
 else
     echo "警告: 找不到 metadata 檔案 $META_FILE，僅上傳 latest.zip"
 fi
 
-# 單次上傳所有檔案（同一個 commit）
+# 上傳整個目錄（所有檔案在同一個 commit）
 hf upload "$HF_DATASET_REPO" \
-    "${UPLOAD_ARGS[@]}" \
+    "$HF_STAGE_DIR" . \
     --repo-type dataset \
     --commit-message "Update CBDB SQLite (${META_DATE})"
 
@@ -180,71 +186,3 @@ echo "狀態: $SYNC_STATUS"
 echo "檔案大小: $FILE_SIZE"
 echo "時間: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "================================================"
-
-# ==============================================================================
-# [暫時停用] GitHub 同步
-# 未來可能用於同步其他內容，保留以下代碼供參考
-# ==============================================================================
-#
-# # --- GitHub 前置要求 ---
-# # - git-lfs
-# # - gh CLI 已登入
-#
-# # 僅在無法讀取系統級 git 配置時才跳過（避免影響 LFS 等系統配置）
-# # if [ -f /etc/gitconfig ] && [ ! -r /etc/gitconfig ]; then
-# #     export GIT_CONFIG_NOSYSTEM=1
-# #     echo "注意: /etc/gitconfig 無法讀取，已設置 GIT_CONFIG_NOSYSTEM=1"
-# # fi
-#
-# # --- GitHub 工具檢查 ---
-# # if ! command -v gh &> /dev/null; then
-# #     missing+=("gh (請安裝 GitHub CLI: https://cli.github.com/)")
-# # fi
-# # if ! command -v git-lfs &> /dev/null; then
-# #     missing+=("git-lfs (請安裝: sudo apt-get install git-lfs)")
-# # fi
-# # if ! gh auth status &> /dev/null; then
-# #     echo "錯誤: gh CLI 尚未登入，請先執行 'gh auth login'"
-# #     echo "提示: 若在 cron 環境執行，請確保 GH_TOKEN 環境變量已設置"
-# #     exit 1
-# # fi
-#
-# # --- GitHub 同步邏輯 ---
-# # GITHUB_REPO="cbdb-project/cbdb_sqlite"
-# # TEMP_DIR=$(mktemp -d)
-# #
-# # cd "$TEMP_DIR"
-# # git clone --depth=1 "https://github.com/${GITHUB_REPO}.git"
-# # cd cbdb_sqlite
-# #
-# # GH_TOKEN=$(gh auth token 2>/dev/null)
-# # if [ -n "$GH_TOKEN" ]; then
-# #     git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPO}.git"
-# # else
-# #     echo "警告: 無法取得 GitHub token，推送可能會失敗"
-# # fi
-# #
-# # git lfs install
-# #
-# # if [ -z "$(git config --get user.name)" ]; then
-# #     git config user.name "sudoghut"
-# # fi
-# # if [ -z "$(git config --get user.email)" ]; then
-# #     git config user.email "sudospace@gmail.com"
-# # fi
-# #
-# # cp "${WORK_DIR}/latest.zip" ./latest.zip
-# # mkdir -p "metadata/${META_MONTH}"
-# # cp "$META_FILE" "${META_PATH}"
-# # ln -sfn "${META_PATH}" latest.json
-# #
-# # git add latest.zip latest.json "${META_PATH}"
-# #
-# # if git diff --cached --quiet; then
-# #     echo "檔案內容無變更，跳過推送"
-# # else
-# #     git commit -m "Update latest.zip ($(date '+%Y-%m-%d'))"
-# #     git push origin master
-# # fi
-# #
-# # rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- hf upload 不支援多組檔案對參數，改用暫存目錄模擬 repo 結構後整目錄上傳
- 所有檔案（latest.zip、metadata、latest.json）在同一個 HuggingFace commit
- cleanup 加入暫存目錄保護檢查，避免空值導致異常
- 移除已停用的 GitHub 同步代碼
- 認證改為同時支持 hf auth login 與 HF_TOKEN 環境變數
- 同步更新 README 中的 SQLite 同步章節

## Test plan
- [x] 在伺服器執行 hf auth login 完成認證
- [x] 手動執行腳本驗證 latest.zip、latest.json、metadata 均成功上傳
- [x] 確認 HuggingFace 上為單一 commit