### PR TITLE
調整 SQLite 釋出流程與文件說明

### DIFF
--- a/docs/SQLITE_DATA_RELEASE.md
+++ b/docs/SQLITE_DATA_RELEASE.md
@@ -1,0 +1,66 @@
+# SQLite Data Release
+
+## 目的
+
+此文件說明 CBDB SQLite 資料釋出流程，涵蓋本地產物、HuggingFace 上傳路徑與對外下載入口。
+
+## 產物與命名
+
+每次釋出會產生以下檔案：
+
+1. SQLite 資料庫檔案（本地）
+   - `db-data/cbdb_YYYYMMDD.sqlite3`
+2. Metadata（本地）
+   - `db-data/cbdb_YYYYMMDD.json`
+3. Zip 產物（本地）
+   - `db-data/cbdb_YYYYMMDD.zip`
+4. Public 下載指向（本地）
+   - `public/latest.zip`
+
+Metadata 內容包含：
+- `sha256`
+- `generated_at_utc`
+- `format`
+- `huggingface_path`
+- `huggingface_url`
+
+## HuggingFace 釋出路徑
+
+上傳時會放置在以下位置：
+
+1. 歷史版本
+   - `history/cbdb_YYYYMM/cbdb_YYYYMMDD.zip`
+2. 最新版本捷徑
+   - `latest.zip`
+3. Metadata
+   - `metadata/YYYY-MM/YYYY-MM-DD.json`
+4. 最新 metadata
+   - `latest.json`
+
+### 最新下載入口
+
+- `https://huggingface.co/datasets/cbdb/cbdb-sqlite/blob/main/latest.zip`
+
+## 釋出步驟
+
+1. 執行每週同步腳本
+
+```bash
+./scripts/weekly-sqlite-sync.sh
+```
+
+2. 腳本流程包含：
+
+- 先執行 `scripts/export-daily-sqlite.sh` 匯出資料與 metadata。
+- 產生 `cbdb_YYYYMMDD.zip`（內含 `cbdb_YYYYMMDD.sqlite3` 與當日 metadata）。
+- 上傳至 HuggingFace 指定路徑。
+- 在 HuggingFace 根目錄更新 `latest.zip` 與 `latest.json`。
+- 將當日 zip 複製為 `public/latest.zip`。
+
+## 注意事項
+
+- 若 `db-data/cbdb_YYYYMMDD.json` 不存在，zip 內只會包含 SQLite 檔案。
+- `public/latest.zip` 會被覆寫為當日釋出檔案。
+- 若需調整上傳路徑或命名，請同步更新：
+  - `scripts/export-daily-sqlite.sh`
+  - `scripts/weekly-sqlite-sync.sh`

--- a/scripts/export-daily-sqlite.sh
+++ b/scripts/export-daily-sqlite.sh
@@ -23,8 +23,13 @@ cd "$PROJECT_ROOT"
 OUTPUT_DIR="${OUTPUT_DIR:-db-data}"
 SOURCE_DB="${SOURCE_DB:-mysql}"
 DATE_SUFFIX=$(date +%Y%m%d)
-OUTPUT_FILE="${OUTPUT_DIR}/cbdb_daily_${DATE_SUFFIX}.sqlite3"
-OUTPUT_META_FILE="${OUTPUT_DIR}/cbdb_daily_${DATE_SUFFIX}.json"
+OUTPUT_FILE="${OUTPUT_DIR}/cbdb_${DATE_SUFFIX}.sqlite3"
+OUTPUT_META_FILE="${OUTPUT_DIR}/cbdb_${DATE_SUFFIX}.json"
+HF_BASE_URL="https://huggingface.co/datasets/cbdb/cbdb-sqlite/blob/main"
+HF_MONTH="cbdb_${DATE_SUFFIX:0:6}"
+HF_DATE="cbdb_${DATE_SUFFIX}"
+HF_ZIP_NAME="cbdb_${DATE_SUFFIX}.zip"
+HF_PATH="history/${HF_MONTH}/${HF_ZIP_NAME}"
 
 # 要導出的表格列表
 TABLES=(
@@ -218,9 +223,12 @@ if [ -f "$OUTPUT_FILE" ]; then
     GENERATED_AT_UTC=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     cat > "$OUTPUT_META_FILE" <<EOF
 {
+  "sqlite_filename": "cbdb_${DATE_SUFFIX}.sqlite3",
   "sha256": "${SHA256_SUM}",
   "generated_at_utc": "${GENERATED_AT_UTC}",
-  "format": "sqlite3"
+  "format": "sqlite3",
+  "huggingface_path": "${HF_PATH}",
+  "huggingface_url": "${HF_BASE_URL}/${HF_PATH}"
 }
 EOF
     echo "metadata: $OUTPUT_META_FILE"

--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -85,6 +85,7 @@ check_requirements
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="${PROJECT_ROOT}/db-data"
+PUBLIC_DIR="${PROJECT_ROOT}/public"
 HF_DATASET_REPO="cbdb/cbdb-sqlite"
 HF_STAGE_DIR=$(mktemp -d)
 
@@ -100,6 +101,10 @@ cleanup() {
     if [ -n "$SQLITE_FILE" ] && [ -f "$SQLITE_FILE" ]; then
         echo "刪除原始匯出檔: $SQLITE_FILE"
         rm -f "$SQLITE_FILE"
+    fi
+    if [ -n "$ZIP_FILE" ] && [ -f "$ZIP_FILE" ]; then
+        echo "刪除原始 zip: $ZIP_FILE"
+        rm -f "$ZIP_FILE"
     fi
     if [ -n "$META_FILE" ] && [ -f "$META_FILE" ]; then
         echo "刪除原始 metadata: $META_FILE"
@@ -124,7 +129,12 @@ bash scripts/export-daily-sqlite.sh
 
 # 找到今天產生的檔案
 DATE_SUFFIX=$(date +%Y%m%d)
-SQLITE_FILE="${WORK_DIR}/cbdb_daily_${DATE_SUFFIX}.sqlite3"
+SQLITE_FILE="${WORK_DIR}/cbdb_${DATE_SUFFIX}.sqlite3"
+ZIP_FILE="${WORK_DIR}/cbdb_${DATE_SUFFIX}.zip"
+ZIP_NAME="cbdb_${DATE_SUFFIX}.zip"
+HF_MONTH="cbdb_${DATE_SUFFIX:0:6}"
+HF_DATE="cbdb_${DATE_SUFFIX}"
+HF_ZIP_PATH="history/${HF_MONTH}/${ZIP_NAME}"
 
 if [ ! -f "$SQLITE_FILE" ]; then
     echo "錯誤: 找不到匯出檔案 $SQLITE_FILE"
@@ -135,38 +145,43 @@ echo "匯出檔案: $SQLITE_FILE"
 
 # Step 2: 複製並重新命名
 echo ""
-echo "[2/4] 複製並重新命名為 latest.db..."
-cp "$SQLITE_FILE" "${WORK_DIR}/latest.db"
+echo "[2/4] 準備打包來源..."
 
-# Step 3: 壓縮為 zip
+# Step 3: 壓縮為 zip（含 metadata）
 echo ""
-echo "[3/4] 壓縮為 latest.zip..."
-rm -f "${WORK_DIR}/latest.zip"
-zip -9 "${WORK_DIR}/latest.zip" "${WORK_DIR}/latest.db" > /dev/null
+echo "[3/4] 壓縮為 ${ZIP_NAME}..."
+rm -f "$ZIP_FILE"
+META_FILE="${WORK_DIR}/cbdb_${DATE_SUFFIX}.json"
+if [ -f "$META_FILE" ]; then
+    zip -9 "$ZIP_FILE" "$SQLITE_FILE" "$META_FILE" > /dev/null
+else
+    zip -9 "$ZIP_FILE" "$SQLITE_FILE" > /dev/null
+fi
 
-FILE_SIZE=$(ls -lh "${WORK_DIR}/latest.zip" | awk '{print $5}')
+FILE_SIZE=$(ls -lh "$ZIP_FILE" | awk '{print $5}')
 echo "壓縮完成，檔案大小: $FILE_SIZE"
 
 # Step 4: 上傳到 HuggingFace
 echo ""
 echo "[4/4] 上傳到 HuggingFace ${HF_DATASET_REPO}..."
 
-# 上傳 latest.zip
-META_FILE="${WORK_DIR}/cbdb_daily_${DATE_SUFFIX}.json"
+# 上傳 zip 與 metadata
 META_DATE="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}-${DATE_SUFFIX:6:2}"
 META_MONTH="${DATE_SUFFIX:0:4}-${DATE_SUFFIX:4:2}"
 META_PATH="metadata/${META_MONTH}/${META_DATE}.json"
 
 # 準備暫存目錄，模擬 repo 內的檔案結構
-cp "${WORK_DIR}/latest.zip" "${HF_STAGE_DIR}/latest.zip"
+mkdir -p "${HF_STAGE_DIR}/history/${HF_MONTH}"
+cp "$ZIP_FILE" "${HF_STAGE_DIR}/${HF_ZIP_PATH}"
+cp "$ZIP_FILE" "${HF_STAGE_DIR}/latest.zip"
 
 if [ -f "$META_FILE" ]; then
     mkdir -p "${HF_STAGE_DIR}/metadata/${META_MONTH}"
     cp "$META_FILE" "${HF_STAGE_DIR}/${META_PATH}"
     cp "$META_FILE" "${HF_STAGE_DIR}/latest.json"
-    echo "上傳 latest.zip、${META_PATH}、latest.json..."
+    echo "上傳 ${HF_ZIP_PATH}、latest.zip、${META_PATH}、latest.json..."
 else
-    echo "警告: 找不到 metadata 檔案 $META_FILE，僅上傳 latest.zip"
+    echo "警告: 找不到 metadata 檔案 $META_FILE，僅上傳 ${HF_ZIP_PATH} 與 latest.zip"
 fi
 
 # 上傳整個目錄（所有檔案在同一個 commit）
@@ -176,6 +191,11 @@ hf upload "$HF_DATASET_REPO" \
     --commit-message "Update CBDB SQLite (${META_DATE})"
 
 SYNC_STATUS="已上傳"
+
+echo ""
+echo "將 latest.zip 複製到 public 目錄..."
+mkdir -p "$PUBLIC_DIR"
+cp "$ZIP_FILE" "${PUBLIC_DIR}/latest.zip"
 
 echo ""
 echo "================================================"


### PR DESCRIPTION
- 更新每日匯出檔名與 metadata 欄位
- 改為輸出 cbdb_YYYYMMDD.zip 並對齊 HF 路徑
- zip 內含 sqlite 與 metadata
- 產生 public/latest.zip 供對外下載
- 新增 SQLite 釋出流程文件

## 釋出步驟

1. 執行每週同步腳本

```bash
./scripts/weekly-sqlite-sync.sh
```

2. 腳本流程包含：

- 先執行 `scripts/export-daily-sqlite.sh` 匯出資料與 metadata。
- 產生 `cbdb_YYYYMMDD.zip`（內含 `cbdb_YYYYMMDD.sqlite3` 與當日 metadata）。
- 上傳至 HuggingFace 指定路徑。
- 在 HuggingFace 根目錄更新 `latest.zip` 與 `latest.json`。
- 將當日 zip 複製為 `public/latest.zip`。