### PR TITLE
修正 HuggingFace 認證檢查並增強版本兼容性

### DIFF
--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -54,9 +54,25 @@ check_requirements() {
     fi
 
     # 檢查 HuggingFace 認證（支持 hf auth login 或 HF_TOKEN 環境變數）
-    # 使用 hf auth whoami 驗證認證有效性（會檢查 HF_TOKEN 或 ~/.cache/huggingface/token）
-    if ! hf auth whoami &> /dev/null; then
-        echo "錯誤: HuggingFace 認證失敗或 token 無效"
+    # 嘗試驗證認證有效性（支持不同版本的 hf CLI）
+    local auth_ok=false
+
+    # 方法 1: hf auth whoami（新版本標準命令）
+    if hf auth whoami &> /dev/null; then
+        auth_ok=true
+    # 方法 2: hf whoami（部分版本使用此命令）
+    elif hf whoami &> /dev/null; then
+        auth_ok=true
+    # 方法 3: 檢查 token 檔案或環境變數（fallback，無法驗證有效性）
+    elif [ -n "$HF_TOKEN" ] || [ -f "$HOME/.cache/huggingface/token" ]; then
+        echo "警告: 無法驗證 HuggingFace token 有效性（whoami 命令不可用）"
+        echo "將在 hf upload 時進行實際驗證"
+        echo ""
+        auth_ok=true
+    fi
+
+    if [ "$auth_ok" = false ]; then
+        echo "錯誤: 未找到 HuggingFace 認證"
         echo ""
         echo "請使用以下任一方式設定："
         echo "  1. hf auth login（推薦）"
@@ -64,11 +80,6 @@ check_requirements() {
         echo ""
         echo "Token 可在此建立: https://huggingface.co/settings/tokens"
         echo "需要的權限: Repositories → Write"
-        echo ""
-        echo "如果已設定 token，請確認："
-        echo "  - Token 未過期"
-        echo "  - Token 具有 'write' 權限"
-        echo "  - 網路連線正常"
         exit 1
     fi
 }

--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -54,14 +54,21 @@ check_requirements() {
     fi
 
     # 檢查 HuggingFace 認證（支持 hf auth login 或 HF_TOKEN 環境變數）
-    if [ -z "$HF_TOKEN" ] && ! hf auth status &> /dev/null; then
-        echo "錯誤: 未找到 HuggingFace 認證"
+    # 使用 hf auth whoami 驗證認證有效性（會檢查 HF_TOKEN 或 ~/.cache/huggingface/token）
+    if ! hf auth whoami &> /dev/null; then
+        echo "錯誤: HuggingFace 認證失敗或 token 無效"
+        echo ""
         echo "請使用以下任一方式設定："
-        echo "  1. hf auth login（推薦，token 安全存儲於 ~/.cache/huggingface/）"
+        echo "  1. hf auth login（推薦）"
         echo "  2. export HF_TOKEN=hf_你的token"
         echo ""
         echo "Token 可在此建立: https://huggingface.co/settings/tokens"
         echo "需要的權限: Repositories → Write"
+        echo ""
+        echo "如果已設定 token，請確認："
+        echo "  - Token 未過期"
+        echo "  - Token 具有 'write' 權限"
+        echo "  - 網路連線正常"
         exit 1
     fi
 }


### PR DESCRIPTION
## Summary

修正 `weekly-sqlite-sync.sh` 腳本中的 HuggingFace 認證檢查邏輯，解決在生產環境中 `hf auth status` 命令失敗的問題。

### 主要變更

1. **修正認證檢查命令**（提交 a4e496e）
   - 將不可靠的 `hf auth status` 改為 `hf auth whoami`
   - 添加詳細的錯誤排查指引

2. **增加版本兼容性**（提交 8545679）
   - 實作三層 fallback 機制以支援不同版本的 hf CLI
   - 層級 1: `hf auth whoami`（新版本標準命令）
   - 層級 2: `hf whoami`（部分舊版本使用）
   - 層級 3: 檢查 token 檔案（無法驗證有效性但至少確認存在）
   - 當使用 fallback 時會顯示警告訊息

### 解決的問題

- 生產環境中執行 `hf auth login` 成功但腳本仍報錯「未找到 HuggingFace 認證」
- 不同版本 hf CLI 的認證驗證命令不一致導致的兼容性問題

### 技術優勢

- ✅ 最大兼容性：支援各種版本的 hf CLI
- ✅ 優先驗證：優先使用能實際驗證 token 的命令
- ✅ 渐進降級：無法驗證時給出警告但繼續執行
- ✅ 清晰反饋：明確告知使用者當前使用的驗證方式

🤖 Generated with [Claude Code](https://claude.com/claude-code)