### PR TITLE
移除 /basicinformation 舊版 show 與 destroy 資源路由 

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -199,13 +199,6 @@ class BasicInformationAddressesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -204,9 +204,6 @@ class BasicInformationAddressesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -413,60 +410,6 @@ class BasicInformationAddressesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $addr) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $addr = str_replace("--", "-minus", $addr);
-        $addr_l = explode("-", $addr);
-        foreach ($addr_l as $key => $value) {
-            $addr_l[$key] = str_replace("minus", "-", $value);
-        }
-        $row = DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_addr_id', '=', $addr_l[1]],
-            ['c_addr_type', '=', $addr_l[2]],
-            ['c_sequence', '=', $addr_l[3]],
-        ])->first();
-
-        DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_addr_id', '=', $addr_l[1]],
-            ['c_addr_type', '=', $addr_l[2]],
-            ['c_sequence', '=', $addr_l[3]],
-        ])->delete();
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $addr_l[0],
-            'c_addr_id' => $addr_l[1],
-            'c_addr_type' => $addr_l[2],
-            'c_sequence' => $addr_l[3],
-        ]), $row);
-        (new AuditLogService())->write(
-            'BIOG_ADDR_DATA',
-            'DELETE',
-            [
-                'c_personid' => $addr_l[0],
-                'c_addr_id' => $addr_l[1],
-                'c_addr_type' => $addr_l[2],
-                'c_sequence' => $addr_l[3],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.addresses.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -197,9 +197,6 @@ class BasicInformationAltnamesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -408,63 +405,6 @@ class BasicInformationAltnamesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $alt) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $addr_l = $this->parseAltnameId($alt);
-
-        $row = DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
-        ])->first();
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'ALTNAME_DATA', $alt, $row);
-
-        // 使用 Query Builder 刪除資料
-        DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
-        ])->delete();
-        (new AuditLogService())->write(
-            'ALTNAME_DATA',
-            'DELETE',
-            [
-                'c_personid' => $addr_l[0],
-                'c_sequence' => $addr_l[1],
-                'c_alt_name_chn' => $addr_l[2],
-                'c_alt_name_type_code' => $addr_l[3],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-
-        // 手動調用索引服務清理索引
-        if ($row && Schema::hasTable('CBDB__NAME_FTS') && $row->c_alt_name_chn) {
-            $this->nameSearchIndexService->removeAltname(
-                $row->c_personid,
-                $row->c_alt_name_type_code,
-                $row->c_alt_name_chn
-            );
-        }
-
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.altnames.index', ['basicinformation' => $id]);
-    }
 
     /**
      * 解析別名複合主鍵 ID

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -192,13 +192,6 @@ class BasicInformationAltnamesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -197,9 +197,6 @@ class BasicInformationAssocController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -308,21 +305,6 @@ class BasicInformationAssocController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->assocDeleteById($id_, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.assoc.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -192,13 +192,6 @@ class BasicInformationAssocController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -247,9 +247,6 @@ class BasicInformationEntriesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -443,85 +440,6 @@ class BasicInformationEntriesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        //建安修改20191112
-        //$this->biogMainRepository->entryDeleteById($id_, $id);
-        $id_ = str_replace("--", "-minus", $id_);
-        $addr_a = explode("-", $id_);
-        foreach ($addr_a as $key => $value) {
-            $addr_a[$key] = str_replace("minus", "-", $value);
-        }
-        $row = DB::table('ENTRY_DATA')->where([
-            ['c_personid', '=', $addr_a[0]],
-            ['c_entry_code', '=', $addr_a[1]],
-            ['c_sequence', '=', $addr_a[2]],
-            ['c_kin_code', '=', $addr_a[3]],
-            ['c_assoc_code', '=', $addr_a[4]],
-            ['c_kin_id', '=', $addr_a[5]],
-            ['c_year', '=', $addr_a[6]],
-            ['c_assoc_id', '=', $addr_a[7]],
-            ['c_inst_code', '=', $addr_a[8]],
-            ['c_inst_name_code', '=', $addr_a[9]],
-        ])->first();
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $addr_a[0],
-            'c_entry_code' => $addr_a[1],
-            'c_sequence' => $addr_a[2],
-            'c_kin_code' => $addr_a[3],
-            'c_assoc_code' => $addr_a[4],
-            'c_kin_id' => $addr_a[5],
-            'c_year' => $addr_a[6],
-            'c_assoc_id' => $addr_a[7],
-            'c_inst_code' => $addr_a[8],
-            'c_inst_name_code' => $addr_a[9],
-        ]), $row);
-        DB::table('ENTRY_DATA')->where([
-            ['c_personid', '=', $addr_a[0]],
-            ['c_entry_code', '=', $addr_a[1]],
-            ['c_sequence', '=', $addr_a[2]],
-            ['c_kin_code', '=', $addr_a[3]],
-            ['c_assoc_code', '=', $addr_a[4]],
-            ['c_kin_id', '=', $addr_a[5]],
-            ['c_year', '=', $addr_a[6]],
-            ['c_assoc_id', '=', $addr_a[7]],
-            ['c_inst_code', '=', $addr_a[8]],
-            ['c_inst_name_code', '=', $addr_a[9]],
-        ])->delete();
-        (new AuditLogService())->write(
-            'ENTRY_DATA',
-            'DELETE',
-            [
-                'c_personid' => $addr_a[0],
-                'c_entry_code' => $addr_a[1],
-                'c_sequence' => $addr_a[2],
-                'c_kin_code' => $addr_a[3],
-                'c_assoc_code' => $addr_a[4],
-                'c_kin_id' => $addr_a[5],
-                'c_year' => $addr_a[6],
-                'c_assoc_id' => $addr_a[7],
-                'c_inst_code' => $addr_a[8],
-                'c_inst_name_code' => $addr_a[9],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.entries.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -242,13 +242,6 @@ class BasicInformationEntriesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -139,13 +139,6 @@ class BasicInformationEventsController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -144,9 +144,6 @@ class BasicInformationEventsController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -230,21 +227,6 @@ class BasicInformationEventsController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->eventDeleteById($id_, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.events.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -139,13 +139,6 @@ class BasicInformationKinshipController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -144,9 +144,6 @@ class BasicInformationKinshipController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -236,21 +233,6 @@ class BasicInformationKinshipController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->kinshipDeleteById($id_, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.kinship.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -184,13 +184,6 @@ class BasicInformationOfficesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -189,9 +189,6 @@ class BasicInformationOfficesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -460,21 +457,6 @@ class BasicInformationOfficesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $office) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->officeDeleteById($office, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.offices.index', ['basicinformation' => $id]);
-    }
 
     /**
      * @param array $array

--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -133,13 +133,6 @@ class BasicInformationPossessionController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -138,9 +138,6 @@ class BasicInformationPossessionController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -218,21 +215,6 @@ class BasicInformationPossessionController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->possessionDeleteById($id_, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.possession.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -166,13 +166,6 @@ class BasicInformationSocialInstController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -171,9 +171,6 @@ class BasicInformationSocialInstController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -313,42 +310,6 @@ class BasicInformationSocialInstController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        //建安修改20191113
-        //$this->biogMainRepository->socialInstDeleteById($id_, $id);
-        $addr_l = explode("-", $id_);
-        $row = DB::table('BIOG_INST_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_inst_code', '=', $addr_l[1]],
-            ['c_inst_name_code', '=', $addr_l[2]],
-            ['c_bi_role_code', '=', $addr_l[3]],
-        ])->first();
-
-        $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $addr_l[0],
-            'c_inst_code' => $addr_l[1],
-            'c_inst_name_code' => $addr_l[2],
-            'c_bi_role_code' => $addr_l[3],
-        ]), $row);
-        DB::table('BIOG_INST_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_inst_code', '=', $addr_l[1]],
-            ['c_inst_name_code', '=', $addr_l[2]],
-            ['c_bi_role_code', '=', $addr_l[3]],
-        ])->delete();
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.socialinst.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -3,10 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Repositories\BiogMainRepository;
+use App\Repositories\OperationRepository;
+use App\Services\AuditLogService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class BasicInformationSourcesController extends Controller {
     /**
@@ -270,7 +273,8 @@ class BasicInformationSourcesController extends Controller {
 
         // 使用 Repository 查詢（格式：c_personid-c_textid-c_pages）
         $c_pages = $pk['c_pages'] ?? '';
-        $id_ = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$c_pages;
+        $encodedPages = $this->biogMainRepository->unionPKDef($c_pages);
+        $id_ = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$encodedPages;
         $res = $this->biogMainRepository->sourceById($id, $id_);
 
         // 處理 personLabel
@@ -339,7 +343,8 @@ class BasicInformationSourcesController extends Controller {
 
         // 構建舊格式 ID（格式：c_personid-c_textid-c_pages）
         $c_pages = $pk['c_pages'] ?? '';
-        $id_ = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$c_pages;
+        $encodedPages = $this->biogMainRepository->unionPKDef($c_pages);
+        $id_ = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$encodedPages;
 
         // 使用 Repository 更新
         $data = $this->biogMainRepository->sourceUpdateById($request, $id, $id_);
@@ -386,11 +391,50 @@ class BasicInformationSourcesController extends Controller {
         // 驗證必填欄位（c_pages 為可選）
         CompositePrimaryKey::validateOrFail($pk, 'BIOG_SOURCE_DATA', ['c_pages']);
 
-        // 構建舊格式 ID（格式：c_personid-c_textid-c_pages）
-        $c_pages = $pk['c_pages'] ?? '';
-        $id_ = $pk['c_personid'].'-'.$pk['c_textid'].'-'.$c_pages;
+        $cPages = $pk['c_pages'] ?? '';
+        $row = DB::table('BIOG_SOURCE_DATA')->where([
+            ['c_personid', '=', $pk['c_personid']],
+            ['c_textid', '=', $pk['c_textid']],
+            ['c_pages', '=', $cPages],
+        ])->first();
 
-        $this->biogMainRepository->sourceDeleteById($id, $id_);
+        if (!$row) {
+            abort(404, 'BIOG_SOURCE_DATA 記錄不存在');
+        }
+
+        DB::table('BIOG_SOURCE_DATA')->where([
+            ['c_personid', '=', $pk['c_personid']],
+            ['c_textid', '=', $pk['c_textid']],
+            ['c_pages', '=', $cPages],
+        ])->delete();
+
+        $operation = (new OperationRepository())->store(
+            Auth::id(),
+            $id,
+            4,
+            'BIOG_SOURCE_DATA',
+            CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $pk['c_personid'],
+                'c_textid' => $pk['c_textid'],
+                'c_pages' => $cPages,
+            ]),
+            $row
+        );
+
+        (new AuditLogService())->write(
+            'BIOG_SOURCE_DATA',
+            'DELETE',
+            [
+                'c_personid' => $pk['c_personid'],
+                'c_textid' => $pk['c_textid'],
+                'c_pages' => $cPages,
+            ],
+            (new AuditLogService())->normalizeRow($row),
+            null,
+            'user',
+            (string) Auth::id(),
+            $operation ? (string) $operation->id : null
+        );
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -155,10 +155,6 @@ class BasicInformationSourcesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -246,21 +242,6 @@ class BasicInformationSourcesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->sourceDeleteById($id, $id_);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.sources.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -153,13 +153,6 @@ class BasicInformationSourcesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -139,13 +139,6 @@ class BasicInformationStatusesController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -144,9 +144,6 @@ class BasicInformationStatusesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -230,21 +227,6 @@ class BasicInformationStatusesController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $this->biogMainRepository->statuseDeleteById($id_, $id);
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.statuses.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -183,13 +183,6 @@ class BasicInformationTextsController extends Controller {
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  int  $id

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -188,9 +188,6 @@ class BasicInformationTextsController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
-        //
-    }
 
     /**
      * Show the form for editing the specified resource.
@@ -310,50 +307,6 @@ class BasicInformationTextsController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id, $id_) {
-        if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $temp_l = explode("-", $id_);
-        $row = DB::table($this->table_name)->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_role_id', '=', $temp_l[2]],
-        ])->first();
-        DB::table($this->table_name)->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_role_id', '=', $temp_l[2]],
-        ])->delete();
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $temp_l[0],
-            'c_textid' => $temp_l[1],
-            'c_role_id' => $temp_l[2],
-        ]), $row);
-        (new AuditLogService())->write(
-            $this->table_name,
-            'DELETE',
-            [
-                'c_personid' => $temp_l[0],
-                'c_textid' => $temp_l[1],
-                'c_role_id' => $temp_l[2],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-        flash('Delete success @ '.Carbon::now(), 'success');
-
-        return redirect()->route('basicinformation.texts.index', ['basicinformation' => $id]);
-    }
 
     // ===================================================================
     // 查詢參數模式方法（推薦使用）

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,18 +145,18 @@ Route::delete('basicinformation/{id}/offices/delete', 'BasicInformationOfficesCo
     ->name('basicinformation.offices.destroy.query');
 
 // 資源路由（放在查詢參數路由之後，作為後備）
-Route::resource('basicinformation.addresses', 'BasicInformationAddressesController');
-Route::resource('basicinformation.altnames', 'BasicInformationAltnamesController');
-Route::resource('basicinformation.texts', 'BasicInformationTextsController');
-Route::resource('basicinformation.offices', 'BasicInformationOfficesController');
-Route::resource('basicinformation.assoc', 'BasicInformationAssocController');
-Route::resource('basicinformation.entries', 'BasicInformationEntriesController');
-Route::resource('basicinformation.events', 'BasicInformationEventsController');
-Route::resource('basicinformation.kinship', 'BasicInformationKinshipController');
-Route::resource('basicinformation.statuses', 'BasicInformationStatusesController');
-Route::resource('basicinformation.possession', 'BasicInformationPossessionController');
-Route::resource('basicinformation.socialinst', 'BasicInformationSocialInstController');
-Route::resource('basicinformation.sources', 'BasicInformationSourcesController');
+Route::resource('basicinformation.addresses', 'BasicInformationAddressesController')->except(['show', 'destroy']);
+Route::resource('basicinformation.altnames', 'BasicInformationAltnamesController')->except(['show', 'destroy']);
+Route::resource('basicinformation.texts', 'BasicInformationTextsController')->except(['show', 'destroy']);
+Route::resource('basicinformation.offices', 'BasicInformationOfficesController')->except(['show', 'destroy']);
+Route::resource('basicinformation.assoc', 'BasicInformationAssocController')->except(['show', 'destroy']);
+Route::resource('basicinformation.entries', 'BasicInformationEntriesController')->except(['show', 'destroy']);
+Route::resource('basicinformation.events', 'BasicInformationEventsController')->except(['show', 'destroy']);
+Route::resource('basicinformation.kinship', 'BasicInformationKinshipController')->except(['show', 'destroy']);
+Route::resource('basicinformation.statuses', 'BasicInformationStatusesController')->except(['show', 'destroy']);
+Route::resource('basicinformation.possession', 'BasicInformationPossessionController')->except(['show', 'destroy']);
+Route::resource('basicinformation.socialinst', 'BasicInformationSocialInstController')->except(['show', 'destroy']);
+Route::resource('basicinformation.sources', 'BasicInformationSourcesController')->except(['show', 'destroy']);
 
 // BiogMain 提案路由
 Route::post('basicinformation/{personid}/{resource}/proposal', 'BasicInformationProposalController@proposalStore')

--- a/tests/Feature/CompositePrimaryKeyRoutesTest.php
+++ b/tests/Feature/CompositePrimaryKeyRoutesTest.php
@@ -150,23 +150,33 @@ class CompositePrimaryKeyRoutesTest extends TestCase {
     }
 
     /**
-     * 測試舊的 resource 路由仍然存在（向後兼容）
+     * 測試新路由策略：保留 edit/update，移除舊 destroy resource 路由
      */
     #[Test]
-    public function legacy_resource_routes_still_exist(): void {
-        $resourceRoutes = [
+    public function resource_routes_follow_new_destroy_policy(): void {
+        $keptResourceRoutes = [
             'basicinformation.offices.edit',
             'basicinformation.offices.update',
-            'basicinformation.offices.destroy',
             'basicinformation.altnames.edit',
             'basicinformation.altnames.update',
+        ];
+
+        foreach ($keptResourceRoutes as $routeName) {
+            $this->assertTrue(
+                \Illuminate\Support\Facades\Route::has($routeName),
+                "Route '{$routeName}' should be defined"
+            );
+        }
+
+        $removedDestroyRoutes = [
+            'basicinformation.offices.destroy',
             'basicinformation.altnames.destroy',
         ];
 
-        foreach ($resourceRoutes as $routeName) {
-            $this->assertTrue(
+        foreach ($removedDestroyRoutes as $routeName) {
+            $this->assertFalse(
                 \Illuminate\Support\Facades\Route::has($routeName),
-                "Legacy route '{$routeName}' should still be defined for backwards compatibility"
+                "Legacy route '{$routeName}' should be removed"
             );
         }
     }

--- a/tests/Feature/FormUrlEncodingTest.php
+++ b/tests/Feature/FormUrlEncodingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Support\CompositePrimaryKey;
 use App\Models\User;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -653,9 +654,19 @@ class FormUrlEncodingTest extends TestCase {
         ]);
 
         // 刪除記錄 - 使用編碼後的 URL
-        // .//?- 編碼後變成 .(slash)(slash)(question)(minus)
+        // 查詢參數模式由 Laravel 原生 URL 編碼處理特殊字元
+        $deleteUrl = CompositePrimaryKey::buildUrl(
+            'basicinformation.sources.destroy.query',
+            ['id' => $this->testPersonId],
+            [
+                'c_personid' => $this->testPersonId,
+                'c_textid' => 100,
+                'c_pages' => './/?-',
+            ]
+        );
+
         $response = $this->actingAs($this->user)
-            ->delete("/basicinformation/{$this->testPersonId}/sources/{$this->testPersonId}-100-.(slash)(slash)(question)(minus)");
+            ->delete($deleteUrl);
 
         $response->assertRedirect();
 

--- a/tests/Feature/FormUrlEncodingTest.php
+++ b/tests/Feature/FormUrlEncodingTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Support\CompositePrimaryKey;
 use App\Models\User;
+use App\Support\CompositePrimaryKey;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;

--- a/tests/Feature/NameSearchIndexAutoSyncTest.php
+++ b/tests/Feature/NameSearchIndexAutoSyncTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\BiogMain;
 use App\Models\User;
+use App\Support\CompositePrimaryKey;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
@@ -385,8 +386,19 @@ class NameSearchIndexAutoSyncTest extends TestCase {
         );
 
         // 刪除別名（生產路由），並讓控制器負責清理索引
+        $deleteUrl = CompositePrimaryKey::buildUrl(
+            'basicinformation.altnames.destroy.query',
+            ['id' => 2003],
+            [
+                'c_personid' => 2003,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '太白',
+                'c_alt_name_type_code' => 4,
+            ]
+        );
+
         $this->actingAs($user)
-            ->delete('/basicinformation/2003/altnames/2003-1-太白-4')
+            ->delete($deleteUrl)
             ->assertStatus(302);
 
         // 檢查別名索引已刪除


### PR DESCRIPTION
show 和 destroy 已經分別被 showQuery 和 destroyQuery 替代。

原版本實作中有一些隱蔽的錯誤（如：altname 刪除時用 LIKE %keyword% 匹配可能會誤刪紀錄），刪掉路由後就不會觸發了。