### PR TITLE
為 cbdbapi/person HTML 檢視的出處頁碼加入超鏈接

### DIFF
--- a/app/Http/Controllers/CbdbApiController.php
+++ b/app/Http/Controllers/CbdbApiController.php
@@ -521,7 +521,9 @@ SQL;
 SELECT (SELECT c_title_chn FROM TEXT_CODES WHERE c_textid = BIOG_SOURCE_DATA.c_textid) AS Source,
        c_textid AS SourceId,
        c_pages AS Pages,
-       c_notes AS Notes
+       c_notes AS Notes,
+       (SELECT c_url_api FROM TEXT_CODES WHERE c_textid = BIOG_SOURCE_DATA.c_textid) AS UrlApi,
+       (SELECT c_url_api_coda FROM TEXT_CODES WHERE c_textid = BIOG_SOURCE_DATA.c_textid) AS UrlApiCoda
 FROM BIOG_SOURCE_DATA
 WHERE c_personid = ?
 SQL;

--- a/resources/views/cbdbapi/person.blade.php
+++ b/resources/views/cbdbapi/person.blade.php
@@ -485,7 +485,13 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
                 pieces.push(sourceLabel);
             }
             if (item.Pages) {
-                pieces.push('頁 ' + escapeHtml(item.Pages));
+                if (item.UrlApi) {
+                    var urlPart = encodeURIComponent(item.Pages);
+                    var fullUrl = item.UrlApi + urlPart + (item.UrlApiCoda || '');
+                    pieces.push('頁 <a href="' + escapeHtml(fullUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(item.Pages) + '</a>');
+                } else {
+                    pieces.push('頁 ' + escapeHtml(item.Pages));
+                }
             }
             itemHtml += (pieces.length ? pieces.join('，') : '<span class="empty">（空）</span>');
             if (item.Notes) {

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -70,6 +70,8 @@ class CbdbApiPersonTest extends TestCase {
             $table->integer('c_source')->nullable();
             $table->string('c_pages')->nullable();
             $table->text('c_notes')->nullable();
+            $table->string('c_url_api')->nullable();
+            $table->string('c_url_api_coda')->nullable();
         });
 
         Schema::create('BIOG_SOURCE_DATA', function (Blueprint $table) {
@@ -495,6 +497,48 @@ class CbdbApiPersonTest extends TestCase {
             ]);
     }
 
+    #[Test]
+    public function test_sources_include_url_api_fields(): void {
+        $this->seedPersonFixture();
+
+        $response = $this->getJson('/cbdbapi/person.php?id=1001&o=json');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $sources = data_get($data, 'Package.PersonAuthority.PersonInfo.Person.PersonSources.Source', []);
+
+        $this->assertNotEmpty($sources);
+        $this->assertSame('https://example.com/page/', $sources[0]['UrlApi']);
+        $this->assertSame('?view=full', $sources[0]['UrlApiCoda']);
+    }
+
+    #[Test]
+    public function test_sources_without_url_api_return_empty_string(): void {
+        $this->seedPersonFixture();
+
+        // Insert a second TEXT_CODES without c_url_api
+        \DB::table('TEXT_CODES')->insert([
+            'c_textid' => 3002,
+            'c_title_chn' => '新唐書',
+        ]);
+        \DB::table('BIOG_SOURCE_DATA')->insert([
+            'c_personid' => 1001,
+            'c_textid' => 3002,
+            'c_pages' => '55',
+        ]);
+
+        $response = $this->getJson('/cbdbapi/person.php?id=1001&o=json');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $sources = data_get($data, 'Package.PersonAuthority.PersonInfo.Person.PersonSources.Source', []);
+
+        $noUrlSource = collect($sources)->firstWhere('SourceId', '3002');
+        $this->assertNotNull($noUrlSource);
+        $this->assertSame('', $noUrlSource['UrlApi']);
+        $this->assertSame('', $noUrlSource['UrlApiCoda']);
+    }
+
     protected function seedPersonFixture(): void {
         \DB::table('BIOG_MAIN')->insert([
             'c_personid' => 1001,
@@ -519,6 +563,8 @@ class CbdbApiPersonTest extends TestCase {
         \DB::table('TEXT_CODES')->insert([
             'c_textid' => 3001,
             'c_title_chn' => '舊唐書',
+            'c_url_api' => 'https://example.com/page/',
+            'c_url_api_coda' => '?view=full',
         ]);
 
         \DB::table('BIOG_SOURCE_DATA')->insert([


### PR DESCRIPTION
## Summary
- 將 `cbdbapi/person.php?id=XXX` HTML 頁面中「出處」區塊的頁碼，從純文字改為可點擊的超鏈接（與 `biogmains/sources/index` 頁面行為一致）
- SQL 查詢新增 `UrlApi` / `UrlApiCoda` 欄位，JavaScript 端據此組合完整 URL
- 修正 URL 編碼邏輯（無條件 `encodeURIComponent`）與安全屬性（`rel="noopener noreferrer"`）
- 補齊測試 fixture 與新增 2 個測試案例

## Test plan
- [x] `./vendor/bin/phpunit --filter CbdbApiPersonTest`（16/16 通過）
- [x] 在瀏覽器開啟 `cbdbapi/person.php?id=54845`，確認出處頁碼顯示為超鏈接且可正確跳轉
- [x] 確認無 `c_url_api` 的出處仍顯示為純文字

🤖 Generated with [Claude Code](https://claude.com/claude-code)