### PR TITLE
修正 cron 環境下找不到 hf CLI 的問題

### DIFF
--- a/scripts/weekly-sqlite-sync.sh
+++ b/scripts/weekly-sqlite-sync.sh
@@ -33,6 +33,11 @@ if [ -z "$HOME" ]; then
     fi
 fi
 
+# 確保 pipx/pip 安裝的工具（如 hf CLI）可被找到（cron 環境 PATH 可能不含 ~/.local/bin）
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
 # 前置檢查：確認必要工具已安裝
 check_requirements() {
     local missing=()


### PR DESCRIPTION
## Summary
- cron 環境的 PATH 極度精簡，不包含 `~/.local/bin`，導致 `pipx install huggingface-hub` 安裝的 `hf` CLI 無法被找到
- 在 `check_requirements` 前將 `$HOME/.local/bin` 加入 PATH，與既有的 HOME 設定邏輯（第 27-34 行）互補
- 同類問題曾在 PR #788、#790 中針對 git/gh CLI 修復過

## Test plan
- [x] 部署後在伺服器以 `env -i HOME=$HOME SHELL=/bin/bash /bin/bash scripts/weekly-sqlite-sync.sh` 模擬 cron 環境驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)