### PR TITLE
修正提案主鍵配置並同步更新審核流程文件

### DIFF
--- a/APPROVAL_FLOWS.md
+++ b/APPROVAL_FLOWS.md
@@ -16,9 +16,18 @@
 - `/codes/{table}` 新增、編輯頁面。
 - `/basicinformation/{id}` 基本資料編輯頁（BIOG_MAIN）。
 - `/basicinformation/{id}` 子資源：
-  - `altnames`
-  - `addresses`
-  - `texts`
+  - `altnames` (ALTNAME_DATA)
+  - `addresses` (BIOG_ADDR_DATA)
+  - `texts` (BIOG_TEXT_DATA)
+  - `statuses` (STATUS_DATA)
+  - `possessions` (POSSESSION_DATA)
+  - `offices` (POSTED_TO_OFFICE_DATA)
+  - `assoc` (ASSOC_DATA)
+  - `entries` (ENTRY_DATA)
+  - `events` (EVENTS_DATA)
+  - `kinship` (KIN_DATA)
+  - `socialinst` (BIOG_INST_DATA)
+  - `sources` (BIOG_SOURCE_DATA)
 - 刪除提案目前不開放。
 - 只有活躍帳號 (`is_active == 1`) 才能送出提案或直接儲存；只讀代碼表不提供提案按鈕。
 

--- a/BIOGMAIN_APPROVAL_FLOWS_PLAN.md
+++ b/BIOGMAIN_APPROVAL_FLOWS_PLAN.md
@@ -6,9 +6,9 @@
 ## 1. 基本資訊
 
 - 文檔性質：實作狀態（Status）
-- 文檔版本：4.0
+- 文檔版本：4.1
 - 創建日期：2025-11-27
-- 最後更新：2026-02-14
+- 最後更新：2026-02-15
 
 ## 2. 目前實作概覽
 
@@ -54,15 +54,15 @@
 | `ALTNAME_DATA` | 已實作 | 提案提交與審核流程可用（含複合主鍵處理）。 |
 | `BIOG_ADDR_DATA` | 已實作 | 提案提交與審核流程可用（含複合主鍵處理）。 |
 | `BIOG_TEXT_DATA` | 已實作 | 提案提交與審核流程可用（含複合主鍵處理）。 |
-| `STATUS_DATA` | 部分實作 | 已在 `BasicInformationProposalController` 配置資源，但頁面入口尚未全面接入。 |
-| `POSSESSION_DATA` | 部分實作 | 已在 `BasicInformationProposalController` 配置資源，但頁面入口尚未全面接入。 |
-| `POSTED_TO_OFFICE_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `ASSOC_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `ENTRY_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `EVENTS_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `KIN_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `BIOG_INST_DATA` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
-| `SOURCES` | 未接入提案入口 | 目前未納入 basicinformation 提案提交流程。 |
+| `STATUS_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `POSSESSION_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `POSTED_TO_OFFICE_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `ASSOC_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `ENTRY_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `EVENTS_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `KIN_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `BIOG_INST_DATA` | 已實作 | 提案提交與審核流程可用。 |
+| `BIOG_SOURCE_DATA` | 已實作 | 提案提交與審核流程可用。 |
 
 ## 4. 測試覆蓋（已存在）
 
@@ -75,11 +75,34 @@
 
 ## 5. 已知缺口
 
-1. basicinformation 仍有多個子資源未接上 `action=proposal` 入口（見第 3 節）。
-2. 提案者「修改/撤回」目前沿用 `CodesController` 的提案管理路由與頁面，流程可用但命名層面仍偏向 codes。
-3. 若後續要完整覆蓋 13 類資源，需補齊各子頁控制器入口與對應 Feature 測試。
+1. 提案者「修改/撤回」目前沿用 `CodesController` 的提案管理路由與頁面，流程可用但命名層面仍偏向 codes。
+2. 仍需持續維護各資源的 `__key_columns` 與實際 schema 一致性，避免提案審核階段出現主鍵誤判。
 
-## 6. 後續維護規則
+## 6. 近期修正紀錄（2026-02-15）
+
+1. 提案主鍵配置修正
+- `BasicInformationProposalController` 的資源主鍵配置已校正為與 schema 一致：
+  - `POSSESSION_DATA`：`['c_possession_record_id']`
+  - `BIOG_TEXT_DATA`：`['c_personid', 'c_textid', 'c_role_id']`
+  - `BIOG_ADDR_DATA`：`['c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence']`
+- 影響：後續新提交提案的 `resource_data.__key_columns` 與 `resource_id` 生成邏輯一致，降低審核時誤判風險。
+
+2. 單一數值主鍵提案補號
+- 在 `BasicInformationProposalController::proposalStore()` 增加單一數值主鍵的自動補號（max + 1）流程。
+- 目的：避免 `POSSESSION_DATA` 等單主鍵資源在未帶主鍵時寫入錯誤提案資料。
+
+3. Codes 模組主鍵覆寫補齊
+- `CodesController::$tablePrimaryKeyOverrides` 新增 `POSSESSION_DATA => ['c_possession_record_id']`。
+- 目的：確保 `/codes/POSSESSION_DATA` 的提案主鍵判定與資料表一致。
+
+4. 測試補強
+- `tests/Feature/BasicInformationProposalTest.php`
+  - 新增 `POSSESSION_DATA` 提案自動補號與 `__key_columns` 驗證。
+  - 新增提案資源主鍵配置一致性檢查（addresses/texts/possessions）。
+- `tests/Feature/CodesControllerTest.php`
+  - 新增 `/codes/POSSESSION_DATA/proposal` 主鍵覆寫流程驗證。
+
+## 7. 後續維護規則
 
 - 每次新增一個 basicinformation 子資源的 proposal 入口，需同步更新：
   - 本文件第 3 節狀態表

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -127,11 +127,35 @@ class BasicInformationAddressesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
+
+        // 數據預處理
+        $request->merge([
+            'c_addr_id' => ($request->input('c_addr_id') == -999) ? '0' : ($request->input('c_addr_id') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'addresses');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
         $data = $request->all();
         $data = Arr::except($data, ['_token']);
         $data['c_personid'] = $id;
@@ -324,6 +348,12 @@ class BasicInformationAddressesController extends Controller {
 
             return redirect()->back();
         }
+
+        // 數據預處理
+        $request->merge([
+            'c_addr_id' => ($request->input('c_addr_id') == -999) ? '0' : ($request->input('c_addr_id') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');
@@ -572,7 +602,7 @@ class BasicInformationAddressesController extends Controller {
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，請聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -97,6 +97,12 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
+        // 數據預處理
+        $request->merge([
+            'c_alt_name_type_code' => ($request->input('c_alt_name_type_code') == -999) ? '0' : ($request->input('c_alt_name_type_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
@@ -271,6 +277,12 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
+        // 數據預處理
+        $request->merge([
+            'c_alt_name_type_code' => ($request->input('c_alt_name_type_code') == -999) ? '0' : ($request->input('c_alt_name_type_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
@@ -291,7 +303,7 @@ class BasicInformationAltnamesController extends Controller {
 
         // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -405,7 +417,7 @@ class BasicInformationAltnamesController extends Controller {
         } else {
             // 使用 - 格式
             // 先用 - 分割，然後對每個部分調用 unionPKDef_decode
-            // （因為 - 被編碼為 (minus)，所以可以安全地用 - 分割）
+            // （因為 - 被編碼為 (minus) 所以可以安全地用 - 分割）
             $addr_l = explode("-", $alt);
             foreach ($addr_l as $key => $value) {
                 $addr_l[$key] = $this->biogMainRepository->unionPKDef_decode($value);
@@ -568,7 +580,7 @@ class BasicInformationAltnamesController extends Controller {
             $originalPk = [];
             foreach ($schema as $field) {
                 $value = $request->query($field);
-                if ($value !== null && $value !== '') {
+                if ($value !== null) {
                     $originalPk[$field] = $value;
                 }
             }
@@ -596,7 +608,7 @@ class BasicInformationAltnamesController extends Controller {
         $originalPk = [];
         foreach ($schema as $field) {
             $value = $request->query($field);
-            if ($value !== null && $value !== '') {
+            if ($value !== null) {
                 $originalPk[$field] = $value;
             }
         }

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -135,27 +135,49 @@ class BasicInformationAssocController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
-        //20210315修正$c_inst_name_code預設為0
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+
+        // 數據預處理：分割 c_inst_code
+        // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 處理年份缺省值，確保符合複合主鍵要求
+            // 注意：c_text_title 允許為空字串，不需要強制填充 [n/a]，以免破壞現有空值資料的匹配
+            if ($request->input('c_assoc_first_year') === null || $request->input('c_assoc_first_year') === '') {
+                $request->merge(['c_assoc_first_year' => '-9999']);
+            }
+
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'assoc');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
         }
         //return $request;
         //修改結束
@@ -236,28 +258,29 @@ class BasicInformationAssocController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
+            $c_inst_name_code = '0';
+        }
+
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        //20210309在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
-        //20210315修正$c_inst_name_code預設為0
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
-            $c_inst_name_code = '0';
-        }
 
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
-        }
         //return $request;
         //修改結束
         $data = $this->biogMainRepository->assocUpdateById($request, $id_, $id);
@@ -388,25 +411,56 @@ class BasicInformationAssocController extends Controller {
 
             return redirect()->back();
         }
-        if (!Auth::user()->canWriteDirectly()) {
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
-        // 處理 c_inst_code
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 處理年份缺省值
+            if ($request->input('c_assoc_first_year') === null || $request->input('c_assoc_first_year') === '') {
+                $request->merge(['c_assoc_first_year' => '-9999']);
+            }
+
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['ASSOC_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'assoc', $originalPk);
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
         }
 
         // 從查詢參數提取複合主鍵

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -420,17 +420,21 @@ class BasicInformationController extends Controller {
 
             return redirect()->back();
         }
-        $data = BiogMain::find($id)->toArray();
-        $new_id = BiogMain::max('c_personid') + 1;
-        $data['c_personid'] = $new_id;
-        $data = $this->toolRepository->timestamp($data, true); //建檔資訊
-        $data['c_modified_by'] = $data['c_modified_date'] = '';
+
+        $auditLogService = new AuditLogService();
         $flight = null;
-        DB::transaction(function () use (&$flight, $data, $new_id) {
+        $new_id = BiogMain::max('c_personid') + 1;
+
+        DB::transaction(function () use (&$flight, $id, $new_id, $auditLogService) {
+            $data = BiogMain::find($id)->toArray();
+            $data['c_personid'] = $new_id;
+            $data = $this->toolRepository->timestamp($data, true); //建檔資訊
+            $data['c_modified_by'] = $data['c_modified_date'] = '';
+
             $flight = BiogMain::create($data);
             $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
 
-            (new AuditLogService())->write(
+            $auditLogService->write(
                 'BIOG_MAIN',
                 'INSERT',
                 ['c_personid' => $new_id],
@@ -440,169 +444,303 @@ class BasicInformationController extends Controller {
                 (string) Auth::id(),
                 $operation ? (string) $operation->id : null
             );
+
+            if (Schema::hasTable('CBDB__NAME_FTS')) {
+                $this->nameSearchIndexService->reindexPerson($flight);
+            }
+
+            //擴充複製訊息：地址，出處，親屬，社會關係，社會機構，社會區分
+            //地址
+            $addr = DB::table('BIOG_ADDR_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($addr as $addr_data) {
+                $addr_data = (array)$addr_data;
+                $addr_data['c_personid'] = $new_id;
+                $addr_data = Arr::except($addr_data, ['_token']);
+                $addr_data = $this->toolRepository->timestamp($addr_data, true); //建檔資訊
+                DB::table('BIOG_ADDR_DATA')->insert($addr_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $addr_data['c_personid'],
+                    'c_addr_id' => $addr_data['c_addr_id'],
+                    'c_addr_type' => $addr_data['c_addr_type'],
+                    'c_sequence' => $addr_data['c_sequence'],
+                ]), $addr_data);
+
+                $auditLogService->write(
+                    'BIOG_ADDR_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $addr_data['c_personid'],
+                        'c_addr_id' => $addr_data['c_addr_id'],
+                        'c_addr_type' => $addr_data['c_addr_type'],
+                        'c_sequence' => $addr_data['c_sequence'],
+                    ],
+                    null,
+                    $addr_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            //出處
+            $source = DB::table('BIOG_SOURCE_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($source as $source_data) {
+                $source_data = (array)$source_data;
+                $source_data['c_personid'] = $new_id;
+                $source_data = Arr::except($source_data, ['_token']);
+                DB::table('BIOG_SOURCE_DATA')->insert($source_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $source_data['c_personid'],
+                    'c_textid' => $source_data['c_textid'],
+                    'c_pages' => $source_data['c_pages'],
+                ]), $source_data);
+
+                $auditLogService->write(
+                    'BIOG_SOURCE_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $source_data['c_personid'],
+                        'c_textid' => $source_data['c_textid'],
+                        'c_pages' => $source_data['c_pages'],
+                    ],
+                    null,
+                    $source_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            //親屬
+            $kin = DB::table('KIN_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($kin as $kin_data) {
+                $kin_data = (array)$kin_data;
+                $kin_data['c_personid'] = $new_id;
+                $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
+                DB::table('KIN_DATA')->insert($kin_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $kin_data['c_personid'],
+                    'c_kin_id' => $kin_data['c_kin_id'],
+                    'c_kin_code' => $kin_data['c_kin_code'],
+                ]), $kin_data);
+
+                $auditLogService->write(
+                    'KIN_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $kin_data['c_personid'],
+                        'c_kin_id' => $kin_data['c_kin_id'],
+                        'c_kin_code' => $kin_data['c_kin_code'],
+                    ],
+                    null,
+                    $kin_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            $kin_pair = DB::table('KIN_DATA')->where([
+                ['c_kin_id', '=', $id],
+            ])->get();
+            foreach ($kin_pair as $kin_data) {
+                $kin_data = (array)$kin_data;
+                $kin_pair_id = $kin_data['c_personid'];
+                $kin_data['c_kin_id'] = $new_id;
+                $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
+                DB::table('KIN_DATA')->insert($kin_data);
+                $operation = $this->operationRepository->store(Auth::id(), $kin_pair_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $kin_data['c_personid'],
+                    'c_kin_id' => $kin_data['c_kin_id'],
+                    'c_kin_code' => $kin_data['c_kin_code'],
+                ]), $kin_data);
+
+                $auditLogService->write(
+                    'KIN_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $kin_data['c_personid'],
+                        'c_kin_id' => $kin_data['c_kin_id'],
+                        'c_kin_code' => $kin_data['c_kin_code'],
+                    ],
+                    null,
+                    $kin_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            //社會關係
+            $assoc = DB::table('ASSOC_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($assoc as $assoc_data) {
+                $assoc_data = (array)$assoc_data;
+                $assoc_data['c_personid'] = $new_id;
+                $assoc_data['c_kin_id'] = 0;
+                $assoc_data['c_kin_code'] = 0;
+                $assoc_data['c_assoc_kin_id'] = 0;
+                $assoc_data['c_assoc_kin_code'] = 0;
+                $assoc_data['c_tertiary_personid'] = 0;
+                $assoc_data['c_tertiary_type_notes'] = null;
+                $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
+                DB::table('ASSOC_DATA')->insert($assoc_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $assoc_data['c_personid'],
+                    'c_assoc_code' => $assoc_data['c_assoc_code'],
+                    'c_assoc_id' => $assoc_data['c_assoc_id'],
+                    'c_kin_code' => $assoc_data['c_kin_code'],
+                    'c_kin_id' => $assoc_data['c_kin_id'],
+                    'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                    'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                    'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                    'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+                ]), $assoc_data);
+
+                $auditLogService->write(
+                    'ASSOC_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $assoc_data['c_personid'],
+                        'c_assoc_code' => $assoc_data['c_assoc_code'],
+                        'c_assoc_id' => $assoc_data['c_assoc_id'],
+                        'c_kin_code' => $assoc_data['c_kin_code'],
+                        'c_kin_id' => $assoc_data['c_kin_id'],
+                        'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                        'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                        'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                        'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+                    ],
+                    null,
+                    $assoc_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            $assoc_pair = DB::table('ASSOC_DATA')->where([
+                ['c_assoc_id', '=', $id],
+            ])->get();
+            foreach ($assoc_pair as $assoc_data) {
+                $assoc_data = (array)$assoc_data;
+                $assoc_pair_id = $assoc_data['c_personid'];
+                $assoc_data['c_assoc_id'] = $new_id;
+                $assoc_data['c_kin_id'] = 0;
+                $assoc_data['c_kin_code'] = 0;
+                $assoc_data['c_assoc_kin_id'] = 0;
+                $assoc_data['c_assoc_kin_code'] = 0;
+                $assoc_data['c_tertiary_personid'] = 0;
+                $assoc_data['c_tertiary_type_notes'] = null;
+                $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
+                DB::table('ASSOC_DATA')->insert($assoc_data);
+                $operation = $this->operationRepository->store(Auth::id(), $assoc_pair_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $assoc_data['c_personid'],
+                    'c_assoc_code' => $assoc_data['c_assoc_code'],
+                    'c_assoc_id' => $assoc_data['c_assoc_id'],
+                    'c_kin_code' => $assoc_data['c_kin_code'],
+                    'c_kin_id' => $assoc_data['c_kin_id'],
+                    'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                    'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                    'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                    'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+                ]), $assoc_data);
+
+                $auditLogService->write(
+                    'ASSOC_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $assoc_data['c_personid'],
+                        'c_assoc_code' => $assoc_data['c_assoc_code'],
+                        'c_assoc_id' => $assoc_data['c_assoc_id'],
+                        'c_kin_code' => $assoc_data['c_kin_code'],
+                        'c_kin_id' => $assoc_data['c_kin_id'],
+                        'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
+                        'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
+                        'c_text_title' => $assoc_data['c_text_title'] ?? '',
+                        'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
+                    ],
+                    null,
+                    $assoc_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            //社交機構
+            $inst = DB::table('BIOG_INST_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($inst as $inst_data) {
+                $inst_data = (array)$inst_data;
+                $inst_data['c_personid'] = $new_id;
+                $inst_data = Arr::except($inst_data, ['_token']);
+                $inst_data = $this->toolRepository->timestamp($inst_data, true); //建檔資訊
+                DB::table('BIOG_INST_DATA')->insert($inst_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $inst_data['c_personid'],
+                    'c_inst_code' => $inst_data['c_inst_code'],
+                    'c_inst_name_code' => $inst_data['c_inst_name_code'],
+                    'c_bi_role_code' => $inst_data['c_bi_role_code'],
+                ]), $inst_data);
+
+                $auditLogService->write(
+                    'BIOG_INST_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $inst_data['c_personid'],
+                        'c_inst_code' => $inst_data['c_inst_code'],
+                        'c_inst_name_code' => $inst_data['c_inst_name_code'],
+                        'c_bi_role_code' => $inst_data['c_bi_role_code'],
+                    ],
+                    null,
+                    $inst_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
+
+            //社會區分
+            $status = DB::table('STATUS_DATA')->where([
+                ['c_personid', '=', $id],
+            ])->get();
+            foreach ($status as $status_data) {
+                $status_data = (array)$status_data;
+                $status_data['c_personid'] = $new_id;
+                $status_data = Arr::except($status_data, ['_token']);
+                $status_data = $this->toolRepository->timestamp($status_data, true); //建檔資訊
+                DB::table('STATUS_DATA')->insert($status_data);
+                $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
+                    'c_personid' => $status_data['c_personid'],
+                    'c_sequence' => $status_data['c_sequence'],
+                    'c_status_code' => $status_data['c_status_code'],
+                ]), $status_data);
+
+                $auditLogService->write(
+                    'STATUS_DATA',
+                    'INSERT',
+                    [
+                        'c_personid' => $status_data['c_personid'],
+                        'c_sequence' => $status_data['c_sequence'],
+                        'c_status_code' => $status_data['c_status_code'],
+                    ],
+                    null,
+                    $status_data,
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+            }
         });
-
-        if (Schema::hasTable('CBDB__NAME_FTS')) {
-            $this->nameSearchIndexService->reindexPerson($flight);
-        }
-
-        //擴充複製訊息：地址，出處，親屬，社會關係，社會機構，社會區分
-        //地址
-        $addr = DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($addr as $addr_data) {
-            $addr_data = (array)$addr_data;
-            $addr_data['c_personid'] = $new_id;
-            $addr_data = Arr::except($addr_data, ['_token']);
-            $addr_data = $this->toolRepository->timestamp($addr_data, true); //建檔資訊
-            DB::table('BIOG_ADDR_DATA')->insert($addr_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $addr_data['c_personid'],
-                'c_addr_id' => $addr_data['c_addr_id'],
-                'c_addr_type' => $addr_data['c_addr_type'],
-                'c_sequence' => $addr_data['c_sequence'],
-            ]), $addr_data);
-        }
-
-        //出處
-        $source = DB::table('BIOG_SOURCE_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($source as $source_data) {
-            $source_data = (array)$source_data;
-            $source_data['c_personid'] = $new_id;
-            $source_data = Arr::except($source_data, ['_token']);
-            DB::table('BIOG_SOURCE_DATA')->insert($source_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $source_data['c_personid'],
-                'c_textid' => $source_data['c_textid'],
-                'c_pages' => $source_data['c_pages'],
-            ]), $source_data);
-        }
-
-        //親屬
-        $kin = DB::table('KIN_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($kin as $kin_data) {
-            $kin_data = (array)$kin_data;
-            $kin_data['c_personid'] = $new_id;
-            $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
-            DB::table('KIN_DATA')->insert($kin_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $kin_data['c_personid'],
-                'c_kin_id' => $kin_data['c_kin_id'],
-                'c_kin_code' => $kin_data['c_kin_code'],
-            ]), $kin_data);
-        }
-
-        $kin_pair = DB::table('KIN_DATA')->where([
-            ['c_kin_id', '=', $id],
-        ])->get();
-        foreach ($kin_pair as $kin_data) {
-            $kin_data = (array)$kin_data;
-            $kin_pair_id = $kin_data['c_personid'];
-            $kin_data['c_kin_id'] = $new_id;
-            $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
-            DB::table('KIN_DATA')->insert($kin_data);
-            $this->operationRepository->store(Auth::id(), $kin_pair_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $kin_data['c_personid'],
-                'c_kin_id' => $kin_data['c_kin_id'],
-                'c_kin_code' => $kin_data['c_kin_code'],
-            ]), $kin_data);
-        }
-
-        //社會關係
-        $assoc = DB::table('ASSOC_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($assoc as $assoc_data) {
-            $assoc_data = (array)$assoc_data;
-            $assoc_data['c_personid'] = $new_id;
-            $assoc_data['c_kin_id'] = 0;
-            $assoc_data['c_kin_code'] = 0;
-            $assoc_data['c_assoc_kin_id'] = 0;
-            $assoc_data['c_assoc_kin_code'] = 0;
-            $assoc_data['c_tertiary_personid'] = 0;
-            $assoc_data['c_tertiary_type_notes'] = null;
-            $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
-            DB::table('ASSOC_DATA')->insert($assoc_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $assoc_data['c_personid'],
-                'c_assoc_code' => $assoc_data['c_assoc_code'],
-                'c_assoc_id' => $assoc_data['c_assoc_id'],
-                'c_kin_code' => $assoc_data['c_kin_code'],
-                'c_kin_id' => $assoc_data['c_kin_id'],
-                'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
-                'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
-                'c_text_title' => $assoc_data['c_text_title'] ?? '',
-                'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
-            ]), $assoc_data);
-        }
-
-        $assoc_pair = DB::table('ASSOC_DATA')->where([
-            ['c_assoc_id', '=', $id],
-        ])->get();
-        foreach ($assoc_pair as $assoc_data) {
-            $assoc_data = (array)$assoc_data;
-            $assoc_pair_id = $assoc_data['c_personid'];
-            $assoc_data['c_assoc_id'] = $new_id;
-            $assoc_data['c_kin_id'] = 0;
-            $assoc_data['c_kin_code'] = 0;
-            $assoc_data['c_assoc_kin_id'] = 0;
-            $assoc_data['c_assoc_kin_code'] = 0;
-            $assoc_data['c_tertiary_personid'] = 0;
-            $assoc_data['c_tertiary_type_notes'] = null;
-            $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
-            DB::table('ASSOC_DATA')->insert($assoc_data);
-            $this->operationRepository->store(Auth::id(), $assoc_pair_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $assoc_data['c_personid'],
-                'c_assoc_code' => $assoc_data['c_assoc_code'],
-                'c_assoc_id' => $assoc_data['c_assoc_id'],
-                'c_kin_code' => $assoc_data['c_kin_code'],
-                'c_kin_id' => $assoc_data['c_kin_id'],
-                'c_assoc_kin_code' => $assoc_data['c_assoc_kin_code'],
-                'c_assoc_kin_id' => $assoc_data['c_assoc_kin_id'],
-                'c_text_title' => $assoc_data['c_text_title'] ?? '',
-                'c_assoc_first_year' => $assoc_data['c_assoc_first_year'] ?? '-9999',
-            ]), $assoc_data);
-        }
-
-        //社交機構
-        $inst = DB::table('BIOG_INST_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($inst as $inst_data) {
-            $inst_data = (array)$inst_data;
-            $inst_data['c_personid'] = $new_id;
-            $inst_data = Arr::except($inst_data, ['_token']);
-            $inst_data = $this->toolRepository->timestamp($inst_data, true); //建檔資訊
-            DB::table('BIOG_INST_DATA')->insert($inst_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $inst_data['c_personid'],
-                'c_inst_code' => $inst_data['c_inst_code'],
-                'c_inst_name_code' => $inst_data['c_inst_name_code'],
-                'c_bi_role_code' => $inst_data['c_bi_role_code'],
-            ]), $inst_data);
-        }
-
-        //社會區分
-        $status = DB::table('STATUS_DATA')->where([
-            ['c_personid', '=', $id],
-        ])->get();
-        foreach ($status as $status_data) {
-            $status_data = (array)$status_data;
-            $status_data['c_personid'] = $new_id;
-            $status_data = Arr::except($status_data, ['_token']);
-            $status_data = $this->toolRepository->timestamp($status_data, true); //建檔資訊
-            DB::table('STATUS_DATA')->insert($status_data);
-            $this->operationRepository->store(Auth::id(), $new_id, 1, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
-                'c_personid' => $status_data['c_personid'],
-                'c_sequence' => $status_data['c_sequence'],
-                'c_status_code' => $status_data['c_status_code'],
-            ]), $status_data);
-        }
 
         //擴充結束
         flash('Create success @ '.Carbon::now(), 'success');
@@ -627,8 +765,12 @@ class BasicInformationController extends Controller {
             return redirect()->back();
         }
         $ori = $this->biogMainRepository->byPersonId($id);
+        if (!$ori) {
+            abort(404);
+        }
         $biog = BiogMain::find($id);
         $biog->c_name_chn = '<待删除>';
+
         //20190605判別是否為眾包用戶
         if (Auth::user()->isCrowdsourcingUser()) {
             $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_MAIN', $id, $biog, $ori, 2);
@@ -636,12 +778,25 @@ class BasicInformationController extends Controller {
 
             return redirect()->route('basicinformation.index');
         } else {
-            $biog->save();
-            $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_MAIN', $id, $biog, $ori);
+            DB::transaction(function () use ($biog, $id, $ori) {
+                $biog->save();
+                $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_MAIN', $id, $biog, $ori);
 
-            if (Schema::hasTable('CBDB__NAME_FTS')) {
-                $this->nameSearchIndexService->reindexPerson($biog);
-            }
+                (new AuditLogService())->write(
+                    'BIOG_MAIN',
+                    'UPDATE',
+                    ['c_personid' => $id],
+                    $ori->toArray(),
+                    $biog->toArray(),
+                    'user',
+                    (string) Auth::id(),
+                    $operation ? (string) $operation->id : null
+                );
+
+                if (Schema::hasTable('CBDB__NAME_FTS')) {
+                    $this->nameSearchIndexService->reindexPerson($biog);
+                }
+            });
 
             flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -171,7 +171,7 @@ class BasicInformationEntriesController extends Controller {
         }
 
         $data = $request->all();
-        $data = Arr::except($data, ['_token', 'action']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data = $this->toolsRepository->timestamp($data, true);
         //return $request;
@@ -350,7 +350,7 @@ class BasicInformationEntriesController extends Controller {
         ]);
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token', 'action']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
         //return $request;
         //修改結束
@@ -610,7 +610,7 @@ class BasicInformationEntriesController extends Controller {
         CompositePrimaryKey::validateOrFail($originalPk, 'ENTRY_DATA');
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
 
 

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -116,46 +116,64 @@ class BasicInformationEntriesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        //20181217建安遮除原本儲存方式，改以[别名]方式儲存。
-        /*
-        $_id = $this->biogMainRepository->entryStoreById($request, $id);
-        flash('Store success @ '.Carbon::now(), 'success');
-        return redirect()->route('basicinformation.entries.edit', [
-            'basicinformation' => $id,
-            'entry' => $_id,
-        ]);
-        */
+
+        // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
+        // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
-        $data['c_personid'] = $id;
-        $data = $this->toolsRepository->timestamp($data, true);
-        //20181217新增片段，api回傳值有-999需要轉為0
-        $data['c_entry_code'] = $data['c_entry_code'] == -999 ? '0' : $data['c_entry_code'];
-        $data['c_entry_addr_id'] = $data['c_entry_addr_id'] == -999 ? '0' : $data['c_entry_addr_id'];
-        $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
-        $data['c_assoc_code'] = $data['c_assoc_code'] == -999 ? '0' : $data['c_assoc_code'];
-        $data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
-        $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
-        //新增結束
-        //20210804在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位，$c_inst_name_code預設為0
+        $data['c_entry_code'] = ($data['c_entry_code'] ?? 0) == -999 ? '0' : ($data['c_entry_code'] ?? '0');
+        $data['c_entry_addr_id'] = ($data['c_entry_addr_id'] ?? 0) == -999 ? '0' : ($data['c_entry_addr_id'] ?? '0');
+        $data['c_kin_code'] = ($data['c_kin_code'] ?? 0) == -999 ? '0' : ($data['c_kin_code'] ?? '0');
+        $data['c_assoc_code'] = ($data['c_assoc_code'] ?? 0) == -999 ? '0' : ($data['c_assoc_code'] ?? '0');
+        $data['c_inst_code'] = ($data['c_inst_code'] ?? 0) == -999 ? '0' : ($data['c_inst_code'] ?? '0');
+        $data['c_source'] = ($data['c_source'] ?? 0) == -999 ? '0' : ($data['c_source'] ?? '0');
+
         $temp = explode("-", $data['c_inst_code']);
         $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        // 如果沒有分割出 c_inst_name_code，則預設為 0
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $data['c_inst_code'] = $c_inst_code;
-            $data['c_inst_name_code'] = $c_inst_name_code;
+        // 將預處理後的數據合併回 Request，以便 proposalStore 正確接收
+        $request->merge([
+            'c_entry_code' => $data['c_entry_code'],
+            'c_entry_addr_id' => $data['c_entry_addr_id'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+            'c_source' => $data['c_source'],
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'entries');
         }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        $data = $request->all();
+        $data = Arr::except($data, ['_token', 'action']);
+        $data['c_personid'] = $id;
+        $data = $this->toolsRepository->timestamp($data, true);
         //return $request;
         //修改結束
         $temp = DB::table('ENTRY_DATA')->where([
@@ -303,31 +321,37 @@ class BasicInformationEntriesController extends Controller {
             'entry' => $id_,
         ]);
         */
+        // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
-        $data = $this->toolsRepository->timestamp($data);
-        //20181217新增片段，api回傳值有-999需要轉為0
-        $data['c_entry_code'] = $data['c_entry_code'] == -999 ? '0' : $data['c_entry_code'];
-        $data['c_entry_addr_id'] = $data['c_entry_addr_id'] == -999 ? '0' : $data['c_entry_addr_id'];
-        $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
-        $data['c_assoc_code'] = $data['c_assoc_code'] == -999 ? '0' : $data['c_assoc_code'];
-        $data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
-        $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
-        //新增結束
-        //20210804在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位，$c_inst_name_code預設為0
+        $data['c_entry_code'] = ($data['c_entry_code'] ?? 0) == -999 ? '0' : ($data['c_entry_code'] ?? '0');
+        $data['c_entry_addr_id'] = ($data['c_entry_addr_id'] ?? 0) == -999 ? '0' : ($data['c_entry_addr_id'] ?? '0');
+        $data['c_kin_code'] = ($data['c_kin_code'] ?? 0) == -999 ? '0' : ($data['c_kin_code'] ?? '0');
+        $data['c_assoc_code'] = ($data['c_assoc_code'] ?? 0) == -999 ? '0' : ($data['c_assoc_code'] ?? '0');
+        $data['c_inst_code'] = ($data['c_inst_code'] ?? 0) == -999 ? '0' : ($data['c_inst_code'] ?? '0');
+        $data['c_source'] = ($data['c_source'] ?? 0) == -999 ? '0' : ($data['c_source'] ?? '0');
+
         $temp = explode("-", $data['c_inst_code']);
         $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $data['c_inst_code'] = $c_inst_code;
-            $data['c_inst_name_code'] = $c_inst_name_code;
-        }
+        $request->merge([
+            'c_entry_code' => $data['c_entry_code'],
+            'c_entry_addr_id' => $data['c_entry_addr_id'],
+            'c_kin_code' => $data['c_kin_code'],
+            'c_assoc_code' => $data['c_assoc_code'],
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+            'c_source' => $data['c_source'],
+        ]);
+
+        $data = $request->all();
+        $data = Arr::except($data, ['_method', '_token', 'action']);
+        $data = $this->toolsRepository->timestamp($data);
         //return $request;
         //修改結束
         $id_ = str_replace("--", "-minus", $id_);
@@ -515,6 +539,56 @@ class BasicInformationEntriesController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
+        // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
+        $request->merge([
+            'c_entry_code' => ($request->input('c_entry_code') == -999) ? '0' : ($request->input('c_entry_code') ?? '0'),
+            'c_entry_addr_id' => ($request->input('c_entry_addr_id') == -999) ? '0' : ($request->input('c_entry_addr_id') ?? '0'),
+            'c_kin_code' => ($request->input('c_kin_code') == -999) ? '0' : ($request->input('c_kin_code') ?? '0'),
+            'c_assoc_code' => ($request->input('c_assoc_code') == -999) ? '0' : ($request->input('c_assoc_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
+            $c_inst_name_code = '0';
+        }
+
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['ENTRY_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'entries', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
@@ -527,7 +601,7 @@ class BasicInformationEntriesController extends Controller {
         $originalPk = [];
         foreach ($schema as $field) {
             $value = $request->query($field);
-            if ($value !== null && $value !== '') {
+            if ($value !== null) {
                 $originalPk[$field] = $value;
             }
         }
@@ -539,28 +613,6 @@ class BasicInformationEntriesController extends Controller {
         $data = Arr::except($data, ['_method', '_token']);
         $data = $this->toolsRepository->timestamp($data);
 
-        // 處理 -999 轉為 0
-        $data['c_entry_code'] = $data['c_entry_code'] == -999 ? '0' : $data['c_entry_code'];
-        $data['c_entry_addr_id'] = $data['c_entry_addr_id'] == -999 ? '0' : $data['c_entry_addr_id'];
-        $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
-        $data['c_assoc_code'] = $data['c_assoc_code'] == -999 ? '0' : $data['c_assoc_code'];
-        $data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
-        $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
-
-        // 處理 c_inst_code 分割
-        $temp = explode("-", $data['c_inst_code']);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
-            $c_inst_name_code = '0';
-        }
-
-        if ($c_inst_name_code != '') {
-            $data['c_inst_code'] = $c_inst_code;
-            $data['c_inst_name_code'] = $c_inst_name_code;
-        }
 
         // 取得原始資料（使用原始 PK）
         $ori = DB::table('ENTRY_DATA')->where([

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -171,6 +171,7 @@ class BasicInformationEntriesController extends Controller {
         }
 
         $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data = $this->toolsRepository->timestamp($data, true);
@@ -194,6 +195,10 @@ class BasicInformationEntriesController extends Controller {
             return redirect()->back();
         }
         DB::table('ENTRY_DATA')->insert($data);
+        $operationData = $data;
+        if ($comment) {
+            $operationData['__note'] = $comment;
+        }
         $operation = $this->operationRepository->store(Auth::id(), $id, 1, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
             'c_personid' => $data['c_personid'],
             'c_entry_code' => $data['c_entry_code'],
@@ -205,7 +210,7 @@ class BasicInformationEntriesController extends Controller {
             'c_assoc_id' => $data['c_assoc_id'],
             'c_inst_code' => $data['c_inst_code'],
             'c_inst_name_code' => $data['c_inst_name_code'],
-        ]), $data);
+        ]), $operationData);
         (new AuditLogService())->write(
             'ENTRY_DATA',
             'INSERT',
@@ -350,6 +355,7 @@ class BasicInformationEntriesController extends Controller {
         ]);
 
         $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
         //return $request;
@@ -386,6 +392,10 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_code', '=', $addr_a[8]],
             ['c_inst_name_code', '=', $addr_a[9]],
         ])->update($data);
+        $operationData = $data;
+        if ($comment) {
+            $operationData['__note'] = $comment;
+        }
         $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
             'c_personid' => $id,
             'c_entry_code' => $data['c_entry_code'],
@@ -397,7 +407,7 @@ class BasicInformationEntriesController extends Controller {
             'c_assoc_id' => $data['c_assoc_id'],
             'c_inst_code' => $data['c_inst_code'],
             'c_inst_name_code' => $data['c_inst_name_code'],
-        ]), $data, $ori);
+        ]), $operationData, $ori);
         (new AuditLogService())->write(
             'ENTRY_DATA',
             'UPDATE',
@@ -610,6 +620,7 @@ class BasicInformationEntriesController extends Controller {
         CompositePrimaryKey::validateOrFail($originalPk, 'ENTRY_DATA');
 
         $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
 
@@ -646,6 +657,10 @@ class BasicInformationEntriesController extends Controller {
             ['c_inst_name_code', '=', $originalPk['c_inst_name_code']],
         ])->update($data);
 
+        $operationData = $data;
+        if ($comment) {
+            $operationData['__note'] = $comment;
+        }
         $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
             'c_personid' => $id,
             'c_entry_code' => $data['c_entry_code'],
@@ -657,7 +672,7 @@ class BasicInformationEntriesController extends Controller {
             'c_assoc_id' => $data['c_assoc_id'],
             'c_inst_code' => $data['c_inst_code'],
             'c_inst_name_code' => $data['c_inst_name_code'],
-        ]), $data, $ori);
+        ]), $operationData, $ori);
         (new AuditLogService())->write(
             'ENTRY_DATA',
             'UPDATE',

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -107,7 +107,30 @@ class BasicInformationEventsController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_event_code' => ($request->input('c_event_code') == -999) ? '0' : ($request->input('c_event_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'events');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
@@ -290,6 +313,38 @@ class BasicInformationEventsController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_event_code' => ($request->input('c_event_code') == -999) ? '0' : ($request->input('c_event_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['EVENTS_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'events', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -107,7 +107,31 @@ class BasicInformationKinshipController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_kin_code' => ($request->input('c_kin_code') == -999) ? '0' : ($request->input('c_kin_code') ?? '0'),
+            'c_kin_id' => ($request->input('c_kin_id') == -999) ? '0' : ($request->input('c_kin_id') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'kinship');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
@@ -298,6 +322,39 @@ class BasicInformationKinshipController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_kin_code' => ($request->input('c_kin_code') == -999) ? '0' : ($request->input('c_kin_code') ?? '0'),
+            'c_kin_id' => ($request->input('c_kin_id') == -999) ? '0' : ($request->input('c_kin_id') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['KIN_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'kinship', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -122,27 +122,43 @@ class BasicInformationOfficesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        //20211020在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
-        //20211020修正$c_inst_name_code預設為0
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+
+        // 數據預處理：分割 c_inst_code
+        // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'offices');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
         }
         //return $request;
         //修改結束
@@ -228,27 +244,27 @@ class BasicInformationOfficesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
         }
-        //20211020在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位
-        //20211020修正$c_inst_name_code預設為0
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
         }
 
         //return $request;
@@ -461,6 +477,47 @@ class BasicInformationOfficesController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
+            $c_inst_name_code = '0';
+        }
+
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['POSTED_TO_OFFICE_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'offices', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
@@ -476,23 +533,6 @@ class BasicInformationOfficesController extends Controller {
 
         // 構建舊格式 ID（格式：c_office_id-c_posting_id）
         $id_ = $pk['c_office_id'].'-'.$pk['c_posting_id'];
-
-        // 處理 c_inst_code
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
-            $c_inst_name_code = '0';
-        }
-
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
-        }
 
         try {
             $result = $this->biogMainRepository->officeUpdateById($request, $id_, $id);

--- a/app/Http/Controllers/BasicInformationPossessionController.php
+++ b/app/Http/Controllers/BasicInformationPossessionController.php
@@ -107,7 +107,31 @@ class BasicInformationPossessionController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_measure_code' => ($request->input('c_measure_code') == -999) ? '0' : ($request->input('c_measure_code') ?? '0'),
+            'c_possession_act_code' => ($request->input('c_possession_act_code') == -999) ? '0' : ($request->input('c_possession_act_code') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'possessions');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
@@ -277,6 +301,39 @@ class BasicInformationPossessionController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_measure_code' => ($request->input('c_measure_code') == -999) ? '0' : ($request->input('c_measure_code') ?? '0'),
+            'c_possession_act_code' => ($request->input('c_possession_act_code') == -999) ? '0' : ($request->input('c_possession_act_code') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['POSSESSION_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'possessions', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -73,6 +73,7 @@ class BasicInformationProposalController extends Controller {
         'assoc' => [
             'table' => 'ASSOC_DATA',
             'key_columns' => ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'],
+            'optional_key_columns' => ['c_text_title'],
             'controller' => 'BasicInformationAssocController',
             'route_prefix' => 'basicinformation.assoc',
             'display_name' => '社會關係',
@@ -135,6 +136,7 @@ class BasicInformationProposalController extends Controller {
         $config = $this->getResourceConfig($resourceType);
         $table = $config['table'];
         $keyColumns = $config['key_columns'];
+        $optionalKeyColumns = $config['optional_key_columns'] ?? [];
 
         // 提取表單數據
         $payload = $this->extractFormData($request);
@@ -142,7 +144,7 @@ class BasicInformationProposalController extends Controller {
         $payload = $this->assignSingleNumericPrimaryKeyIfNeeded($table, $keyColumns, $payload);
 
         // 驗證主鍵完整性
-        if (!$this->hasPrimaryKeyValues($keyColumns, $payload)) {
+        if (!$this->hasPrimaryKeyValues($keyColumns, $payload, $optionalKeyColumns)) {
             flash('提案失敗：請確認主鍵欄位已填寫完整。', 'error');
 
             return redirect()->back()->withInput();
@@ -421,8 +423,11 @@ class BasicInformationProposalController extends Controller {
     /**
      * 檢查主鍵完整性
      */
-    protected function hasPrimaryKeyValues($keyColumns, $row) {
+    protected function hasPrimaryKeyValues($keyColumns, $row, array $optionalKeyColumns = []) {
         foreach ($keyColumns as $column) {
+            if (in_array($column, $optionalKeyColumns, true)) {
+                continue;
+            }
             if (!array_key_exists($column, $row) || $row[$column] === null || $row[$column] === '') {
                 return false;
             }

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -37,33 +37,81 @@ class BasicInformationProposalController extends Controller {
         ],
         'addresses' => [
             'table' => 'BIOG_ADDR_DATA',
-            'key_columns' => ['c_personid', 'c_addr_id', 'c_sequence', 'c_addr_type'],
+            'key_columns' => ['c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence'],
             'controller' => 'BasicInformationAddressesController',
             'route_prefix' => 'basicinformation.addresses',
             'display_name' => '地址',
         ],
         'texts' => [
             'table' => 'BIOG_TEXT_DATA',
-            'key_columns' => ['c_personid', 'c_textid', 'c_year_year', 'c_text_role_code'],
+            'key_columns' => ['c_personid', 'c_textid', 'c_role_id'],
             'controller' => 'BasicInformationTextsController',
             'route_prefix' => 'basicinformation.texts',
             'display_name' => '著述',
         ],
         'statuses' => [
             'table' => 'STATUS_DATA',
-            'key_columns' => ['c_personid', 'c_status_code', 'c_sequence'],
+            'key_columns' => ['c_personid', 'c_sequence', 'c_status_code'],
             'controller' => 'BasicInformationStatusesController',
             'route_prefix' => 'basicinformation.statuses',
             'display_name' => '身份',
         ],
         'possessions' => [
             'table' => 'POSSESSION_DATA',
-            'key_columns' => ['c_personid', 'c_poss_code', 'c_sequence'],
+            'key_columns' => ['c_possession_record_id'],
             'controller' => 'BasicInformationPossessionController',
             'route_prefix' => 'basicinformation.possession',
             'display_name' => '所有物',
         ],
-        // 其他資源配置待後續添加
+        'offices' => [
+            'table' => 'POSTED_TO_OFFICE_DATA',
+            'key_columns' => ['c_office_id', 'c_posting_id'],
+            'controller' => 'BasicInformationOfficesController',
+            'route_prefix' => 'basicinformation.offices',
+            'display_name' => '官名',
+        ],
+        'assoc' => [
+            'table' => 'ASSOC_DATA',
+            'key_columns' => ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'],
+            'controller' => 'BasicInformationAssocController',
+            'route_prefix' => 'basicinformation.assoc',
+            'display_name' => '社會關係',
+        ],
+        'entries' => [
+            'table' => 'ENTRY_DATA',
+            'key_columns' => ['c_personid', 'c_entry_code', 'c_sequence', 'c_kin_code', 'c_assoc_code', 'c_kin_id', 'c_year', 'c_assoc_id', 'c_inst_code', 'c_inst_name_code'],
+            'controller' => 'BasicInformationEntriesController',
+            'route_prefix' => 'basicinformation.entries',
+            'display_name' => '入仕',
+        ],
+        'events' => [
+            'table' => 'EVENTS_DATA',
+            'key_columns' => ['c_personid', 'c_sequence', 'c_event_code'],
+            'controller' => 'BasicInformationEventsController',
+            'route_prefix' => 'basicinformation.events',
+            'display_name' => '事件',
+        ],
+        'kinship' => [
+            'table' => 'KIN_DATA',
+            'key_columns' => ['c_personid', 'c_kin_id', 'c_kin_code'],
+            'controller' => 'BasicInformationKinshipController',
+            'route_prefix' => 'basicinformation.kinship',
+            'display_name' => '親屬',
+        ],
+        'socialinst' => [
+            'table' => 'BIOG_INST_DATA',
+            'key_columns' => ['c_personid', 'c_inst_code', 'c_inst_name_code', 'c_bi_role_code'],
+            'controller' => 'BasicInformationSocialInstController',
+            'route_prefix' => 'basicinformation.socialinst',
+            'display_name' => '社交機構',
+        ],
+        'sources' => [
+            'table' => 'BIOG_SOURCE_DATA',
+            'key_columns' => ['c_personid', 'c_textid', 'c_pages'],
+            'controller' => 'BasicInformationSourcesController',
+            'route_prefix' => 'basicinformation.sources',
+            'display_name' => '出處',
+        ],
     ];
 
     public function __construct(
@@ -91,6 +139,7 @@ class BasicInformationProposalController extends Controller {
         // 提取表單數據
         $payload = $this->extractFormData($request);
         $payload['c_personid'] = $personid;
+        $payload = $this->assignSingleNumericPrimaryKeyIfNeeded($table, $keyColumns, $payload);
 
         // 驗證主鍵完整性
         if (!$this->hasPrimaryKeyValues($keyColumns, $payload)) {
@@ -450,7 +499,7 @@ class BasicInformationProposalController extends Controller {
         }
 
         if (!Auth::user()->isActive()) {
-            abort(403, '該用戶沒有權限，請聯繫管理員');
+            abort(403, '该用户没有权限，请联系管理员');
         }
     }
 
@@ -463,7 +512,37 @@ class BasicInformationProposalController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            abort(403, '該用戶沒有權限，請聯繫管理員');
+            abort(403, '该用户没有权限，请联系管理员');
         }
+    }
+
+    protected function assignSingleNumericPrimaryKeyIfNeeded(string $table, array $keyColumns, array $payload): array {
+        if (count($keyColumns) !== 1) {
+            return $payload;
+        }
+
+        $keyColumn = $keyColumns[0];
+        $keyValue = $payload[$keyColumn] ?? null;
+        if ($keyValue !== null && $keyValue !== '') {
+            return $payload;
+        }
+
+        try {
+            $max = DB::table($table)->max($keyColumn);
+        } catch (\Throwable $e) {
+            return $payload;
+        }
+
+        if ($max === null) {
+            $payload[$keyColumn] = 1;
+
+            return $payload;
+        }
+
+        if (is_numeric($max)) {
+            $payload[$keyColumn] = (int) $max + 1;
+        }
+
+        return $payload;
     }
 }

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -115,26 +115,48 @@ class BasicInformationSocialInstController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        //20210804在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位，$c_inst_name_code預設為0
-        $temp = explode("-", $request->c_inst_code);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
+
+        // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
+        // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
+        $request->merge([
+            'c_bi_role_code' => ($request->input('c_bi_role_code') == -999) ? '0' : ($request->input('c_bi_role_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
             $c_inst_name_code = '0';
         }
 
-        if ($c_inst_name_code != '') {
-            $request->c_inst_code = $c_inst_code;
-            $request->c_inst_name_code = $c_inst_name_code;
-            $request->merge(['c_inst_code' => $c_inst_code]);
-            $request->merge(['c_inst_name_code' => $c_inst_name_code]);
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'socialinst');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
         }
         //return $request;
         //修改結束
@@ -210,38 +232,38 @@ class BasicInformationSocialInstController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_bi_role_code' => ($request->input('c_bi_role_code') == -999) ? '0' : ($request->input('c_bi_role_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
+            $c_inst_name_code = '0';
+        }
+
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
-        /*
-        //原本的寫法，保留做為參考。
-        $this->biogMainRepository->socialInstUpdateById($request, $id_, $id);
-        flash('Update success @ '.Carbon::now(), 'success');
-        return redirect()->route('basicinformation.socialinst.edit', [
-            'basicinformation' => $id,
-            'socialinst' => $id_,
-        ]);
-        */
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
+        $data = Arr::except($data, ['_method', '_token', 'action']);
         $data = $this->toolsRepository->timestamp($data);
-        //20210804在這裡處理c_inst_code傳遞過來的值，分別儲存至c_inst_code與c_inst_name_code欄位，$c_inst_name_code預設為0
-        $temp = explode("-", $data['c_inst_code']);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
-            $c_inst_name_code = '0';
-        }
-
-        if ($c_inst_name_code != '') {
-            $data['c_inst_code'] = $c_inst_code;
-            $data['c_inst_name_code'] = $c_inst_name_code;
-        }
         //return $request;
         //修改結束 //20211020修改增加c_bi_begin_year與c_bi_end_year
         $addr_l = explode("-", $id_);
@@ -373,6 +395,47 @@ class BasicInformationSocialInstController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理：分割 c_inst_code
+        $temp = explode("-", $request->input('c_inst_code', ''));
+        $c_inst_code = $temp[0] ?: '0';
+        $c_inst_name_code = $temp[1] ?? '0';
+
+        if (empty($temp[1])) {
+            $c_inst_code = $c_inst_code ?: '0';
+            $c_inst_name_code = '0';
+        }
+
+        $request->merge([
+            'c_inst_code' => $c_inst_code,
+            'c_inst_name_code' => $c_inst_name_code,
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['BIOG_INST_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'socialinst', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
@@ -385,7 +448,7 @@ class BasicInformationSocialInstController extends Controller {
         $originalPk = [];
         foreach ($schema as $field) {
             $value = $request->query($field);
-            if ($value !== null && $value !== '') {
+            if ($value !== null) {
                 $originalPk[$field] = $value;
             }
         }
@@ -394,23 +457,8 @@ class BasicInformationSocialInstController extends Controller {
         CompositePrimaryKey::validateOrFail($originalPk, 'BIOG_INST_DATA');
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
+        $data = Arr::except($data, ['_method', '_token', 'action']);
         $data = $this->toolsRepository->timestamp($data);
-
-        // 處理 c_inst_code 分割
-        $temp = explode("-", $data['c_inst_code']);
-        $c_inst_code = $temp[0];
-        if (!empty($temp[1])) {
-            $c_inst_name_code = $temp[1];
-        } else {
-            $c_inst_code = '0';
-            $c_inst_name_code = '0';
-        }
-
-        if ($c_inst_name_code != '') {
-            $data['c_inst_code'] = $c_inst_code;
-            $data['c_inst_name_code'] = $c_inst_name_code;
-        }
 
         // 取得原始資料（使用原始 PK）
         $ori = DB::table('BIOG_INST_DATA')->where([

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -121,7 +121,29 @@ class BasicInformationSourcesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'sources');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
@@ -312,6 +334,37 @@ class BasicInformationSourcesController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['BIOG_SOURCE_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'sources', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -108,7 +108,30 @@ class BasicInformationStatusesController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_status_code' => ($request->input('c_status_code') == -999) ? '0' : ($request->input('c_status_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'statuses');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
@@ -331,6 +354,38 @@ class BasicInformationStatusesController extends Controller {
 
             return redirect()->back();
         }
+
+        if (!Auth::user()->isActive()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
+        // 數據預處理
+        $request->merge([
+            'c_status_code' => ($request->input('c_status_code') == -999) ? '0' : ($request->input('c_status_code') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            $schema = CompositePrimaryKey::SCHEMAS['STATUS_DATA'];
+            $originalPk = [];
+            foreach ($schema as $field) {
+                $value = $request->query($field);
+                if ($value !== null) {
+                    $originalPk[$field] = $value;
+                }
+            }
+
+            // 使用新的查詢參數模式，直接傳遞主鍵陣列
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalUpdateWithPk($request, $id, 'statuses', $originalPk);
+        }
+
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -118,11 +118,35 @@ class BasicInformationTextsController extends Controller {
             flash('请登入后编辑 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
-        } elseif (!Auth::user()->canWriteDirectly()) {
+        }
+
+        if (!Auth::user()->isActive()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
+
+        // 數據預處理
+        $request->merge([
+            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
+
+        // 檢查動作類型
+        $action = $request->input('action', 'save');
+
+        if ($action === 'proposal') {
+            // 轉發到提案控制器
+            return app(\App\Http\Controllers\BasicInformationProposalController::class)
+                ->proposalStore($request, $id, 'texts');
+        }
+
+        if (!Auth::user()->canWriteDirectly()) {
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
+
         $data = $request->all();
         $data = Arr::except($data, ['_token']);
         $data['c_personid'] = $id;
@@ -230,10 +254,16 @@ class BasicInformationTextsController extends Controller {
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
+
+        // 數據預處理
+        $request->merge([
+            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+        ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');
@@ -409,7 +439,7 @@ class BasicInformationTextsController extends Controller {
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，請聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -357,6 +357,7 @@ class CodesController extends Controller {
     protected $tablePrimaryKeyOverrides = [
         'CBDB__NAME_FTS' => ['id'],
         'CBDB__TRAD_SIMP_MAP' => ['trad_char'],
+        'POSSESSION_DATA' => ['c_possession_record_id'],
         'TEXT_CODES' => ['c_textid'],
     ];
     /**

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -53,29 +53,29 @@ class OperationsProposalController extends Controller {
         $comment = trim((string) $request->input('review_comment', ''));
 
         try {
-            $appliedRow = DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original) {
+            DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original, $operation, $comment) {
                 if ($opType === Operation::TYPE_PROPOSAL_CREATE) {
-                    return $this->applyCreateProposal($table, $data, $keyColumns);
+                    $appliedRow = $this->applyCreateProposal($table, $data, $keyColumns);
+                } else {
+                    $appliedRow = $this->applyUpdateProposal($table, $data, $keyColumns, $original);
                 }
 
-                return $this->applyUpdateProposal($table, $data, $keyColumns, $original);
+                $this->logFinalOperation($operation, $appliedRow, $original, $opType);
+                $this->writeAuditLogForApproval($operation, $appliedRow, $original, $opType);
+                $this->updateProposalStatus(
+                    $operation,
+                    'approved',
+                    $comment,
+                    $opType === Operation::TYPE_PROPOSAL_CREATE ? $appliedRow : null,
+                    $keyColumns,
+                    $opType === Operation::TYPE_PROPOSAL_CREATE
+                );
             });
         } catch (\Throwable $e) {
             flash('審核失敗：'.$e->getMessage(), 'error');
 
             return redirect()->back();
         }
-
-        $this->logFinalOperation($operation, $appliedRow, $original, $opType);
-        $this->writeAuditLogForApproval($operation, $appliedRow, $original, $opType);
-        $this->updateProposalStatus(
-            $operation,
-            'approved',
-            $comment,
-            $opType === Operation::TYPE_PROPOSAL_CREATE ? $appliedRow : null,
-            $keyColumns,
-            $opType === Operation::TYPE_PROPOSAL_CREATE
-        );
 
         flash('提案已核准並套用至資料表 @ '.Carbon::now(), 'success');
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -814,6 +814,10 @@ class BiogMainRepository {
             ['c_kin_id', '=', $temp_l[1]],
             ['c_kin_code', '=', $temp_l[2]],
         ])->first();
+        if (!$row) {
+            return ['err' => 0];
+        }
+
         $data = $request->all();
         $kin_pair = $data['c_kinship_pair'];
         $kin_id = $data['c_kin_id'];
@@ -825,60 +829,47 @@ class BiogMainRepository {
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data);
-        //dump($data);
-        DB::table('KIN_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_kin_id', '=', $temp_l[1]],
-            ['c_kin_code', '=', $temp_l[2]],
-        ])->update($data);
+
         $ori_data = $data;
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $id,
-            'c_kin_id' => $data['c_kin_id'],
-            'c_kin_code' => $data['c_kin_code'],
-        ]), $data, $row);
-        $operationId = $operation ? (string) $operation->id : null;
-        $auditLog->write(
-            'KIN_DATA',
-            'UPDATE',
-            [
-                'c_personid' => $data['c_personid'],
+        $sumCount = 0;
+
+        DB::transaction(function () use (&$ori_data, &$sumCount, $id, $id_, $temp_l, $row, $data, $kin_pair, $kin_id, $c_autogen_notes, $old_kin_id, $old_kin_code, $auditLog) {
+            DB::table('KIN_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_kin_id', '=', $temp_l[1]],
+                ['c_kin_code', '=', $temp_l[2]],
+            ])->update($data);
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $id,
                 'c_kin_id' => $data['c_kin_id'],
                 'c_kin_code' => $data['c_kin_code'],
-            ],
-            $auditLog->normalizeRow($row),
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operationId
-        );
-        $data['c_kin_code'] = $kin_pair;
-        $data['c_personid'] = $kin_id;
-        $data = Arr::except($data, ['c_kin_id']);
-        //dump($data);
-        //dd(DB::table('KIN_DATA')->where([['c_kin_id',$id], ['c_personid', $old_kin_id]])->first());
-        #20240710修正對應親屬的查詢方式，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢
-        #20240710提前做一次查詢，檢查資料庫是否有0筆資料或多筆資料。
-        $kin_code_pair = KinshipCode::find($old_kin_code);
-        $sumQuery = DB::table('KIN_DATA')->where(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
-            $query->where('c_kin_id', $id)
-                ->where('c_personid', $old_kin_id)
-                ->where('c_autogen_notes', $c_autogen_notes)
-                ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
-        });
+            ]), $data, $row);
+            $operationId = $operation ? (string) $operation->id : null;
 
-        if (!empty($kin_code_pair->c_kin_pair2)) {
-            $sumQuery->orWhere(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
-                $query->where('c_kin_id', $id)
-                    ->where('c_personid', $old_kin_id)
-                    ->where('c_autogen_notes', $c_autogen_notes)
-                    ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
-            });
-        }
+            $auditLog->write(
+                'KIN_DATA',
+                'UPDATE',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_kin_id' => $data['c_kin_id'],
+                    'c_kin_code' => $data['c_kin_code'],
+                ],
+                $auditLog->normalizeRow($row),
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operationId
+            );
 
-        $sum = $sumQuery->get();
-        if (count($sum) == 1) {
-            $updateQuery = DB::table('KIN_DATA')->where(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
+            $data_mirror = $data;
+            $data_mirror['c_kin_code'] = $kin_pair;
+            $data_mirror['c_personid'] = $kin_id;
+            $data_mirror = Arr::except($data_mirror, ['c_kin_id']);
+
+            #20240710修正對應親屬的查詢方式，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢
+            $kin_code_pair = KinshipCode::find($old_kin_code);
+            $sumQuery = DB::table('KIN_DATA')->where(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
                 $query->where('c_kin_id', $id)
                     ->where('c_personid', $old_kin_id)
                     ->where('c_autogen_notes', $c_autogen_notes)
@@ -886,7 +877,7 @@ class BiogMainRepository {
             });
 
             if (!empty($kin_code_pair->c_kin_pair2)) {
-                $updateQuery->orWhere(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
+                $sumQuery->orWhere(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
                     $query->where('c_kin_id', $id)
                         ->where('c_personid', $old_kin_id)
                         ->where('c_autogen_notes', $c_autogen_notes)
@@ -894,30 +885,51 @@ class BiogMainRepository {
                 });
             }
 
-            $mirroredRows = (clone $updateQuery)->get();
-            $updateQuery->update($data);
-        } else {
-            $updateQuery = DB::table('KIN_DATA')->where([['c_kin_id',$id], ['c_personid', $old_kin_id], ['c_autogen_notes', $c_autogen_notes]]);
-            $mirroredRows = (clone $updateQuery)->get();
-            $updateQuery->update($data);
-        }
+            $sum = $sumQuery->get();
+            $sumCount = count($sum);
+            if ($sumCount == 1) {
+                $updateQuery = DB::table('KIN_DATA')->where(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
+                    $query->where('c_kin_id', $id)
+                        ->where('c_personid', $old_kin_id)
+                        ->where('c_autogen_notes', $c_autogen_notes)
+                        ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
+                });
 
-        foreach ($mirroredRows as $mirroredRow) {
-            $oldMirroredData = $auditLog->normalizeRow($mirroredRow);
-            $newMirroredData = array_merge($oldMirroredData, $data);
+                if (!empty($kin_code_pair->c_kin_pair2)) {
+                    $updateQuery->orWhere(function ($query) use ($id, $old_kin_id, $c_autogen_notes, $kin_code_pair) {
+                        $query->where('c_kin_id', $id)
+                            ->where('c_personid', $old_kin_id)
+                            ->where('c_autogen_notes', $c_autogen_notes)
+                            ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
+                    });
+                }
 
-            $auditLog->write(
-                'KIN_DATA',
-                'UPDATE',
-                $auditLog->buildRowPkFromData('KIN_DATA', $newMirroredData),
-                $oldMirroredData,
-                $newMirroredData,
-                'user',
-                (string) Auth::id(),
-                $operationId
-            );
-        }
-        $ori_data['err'] = count($sum) ?? 0;
+                $mirroredRows = (clone $updateQuery)->get();
+                $updateQuery->update($data_mirror);
+            } else {
+                $updateQuery = DB::table('KIN_DATA')->where([['c_kin_id',$id], ['c_personid', $old_kin_id], ['c_autogen_notes', $c_autogen_notes]]);
+                $mirroredRows = (clone $updateQuery)->get();
+                $updateQuery->update($data_mirror);
+            }
+
+            foreach ($mirroredRows as $mirroredRow) {
+                $oldMirroredData = $auditLog->normalizeRow($mirroredRow);
+                $newMirroredData = array_merge($oldMirroredData, $data_mirror);
+
+                $auditLog->write(
+                    'KIN_DATA',
+                    'UPDATE',
+                    $auditLog->buildRowPkFromData('KIN_DATA', $newMirroredData),
+                    $oldMirroredData,
+                    $newMirroredData,
+                    'user',
+                    (string) Auth::id(),
+                    $operationId
+                );
+            }
+        });
+
+        $ori_data['err'] = $sumCount;
 
         return $ori_data;
     }
@@ -932,54 +944,58 @@ class BiogMainRepository {
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
-        DB::table('KIN_DATA')->insert($data);
-        $ori_Data = $data;
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_kin_id' => $data['c_kin_id'],
-            'c_kin_code' => $data['c_kin_code'],
-        ]), $data);
-        $operationId = $operation ? (string) $operation->id : null;
-        $auditLog->write(
-            'KIN_DATA',
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_kin_id' => $data['c_kin_id'],
-                'c_kin_code' => $data['c_kin_code'],
-            ],
-            null,
-            $ori_Data,
-            'user',
-            (string) Auth::id(),
-            $operationId
-        );
-        $data['c_kin_code'] = $kin_pair;
-        $data['c_personid'] = $data['c_kin_id'];
-        $data['c_kin_id'] = $id;
-        DB::table('KIN_DATA')->insert($data);
-        $auditLog->write(
-            'KIN_DATA',
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_kin_id' => $data['c_kin_id'],
-                'c_kin_code' => $data['c_kin_code'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operationId
-        );
 
-        //return $tts;
+        $ori_Data = $data;
+
+        DB::transaction(function () use ($id, $data, $kin_pair, $auditLog, &$ori_Data) {
+            DB::table('KIN_DATA')->insert($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $data['c_personid'],
+                'c_kin_id' => $data['c_kin_id'],
+                'c_kin_code' => $data['c_kin_code'],
+            ]), $data);
+            $operationId = $operation ? (string) $operation->id : null;
+            $auditLog->write(
+                'KIN_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_kin_id' => $data['c_kin_id'],
+                    'c_kin_code' => $data['c_kin_code'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operationId
+            );
+
+            $data_mirror = $data;
+            $data_mirror['c_kin_code'] = $kin_pair;
+            $data_mirror['c_personid'] = $data['c_kin_id'];
+            $data_mirror['c_kin_id'] = $id;
+            DB::table('KIN_DATA')->insert($data_mirror);
+            $auditLog->write(
+                'KIN_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data_mirror['c_personid'],
+                    'c_kin_id' => $data_mirror['c_kin_id'],
+                    'c_kin_code' => $data_mirror['c_kin_code'],
+                ],
+                null,
+                $data_mirror,
+                'user',
+                (string) Auth::id(),
+                $operationId
+            );
+        });
+
         return $ori_Data;
     }
 
     public function kinshipDeleteById($id, $id_) {
         $auditLog = new AuditLogService();
-        $operationRepository = new OperationRepository();
         $id = str_replace("--", "-minus", $id);
         $temp_l = explode("-", $id);
         foreach ($temp_l as $key => $value) {
@@ -992,117 +1008,123 @@ class BiogMainRepository {
             ['c_kin_code', '=', $temp_l[2]],
         ])->first();
 
-        #20240710修正對應親屬的查詢方式，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢
-        $old_kin_code = $row->c_kin_code;
-        $kin_code_pair = KinshipCode::find($old_kin_code);
+        if (!$row) {
+            return;
+        }
 
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 4, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $temp_l[0],
-            'c_kin_id' => $temp_l[1],
-            'c_kin_code' => $temp_l[2],
-        ]), $row);
-        $operationId = $operation ? (string) $operation->id : null;
-        $auditLog->write(
-            'KIN_DATA',
-            'DELETE',
-            [
+        DB::transaction(function () use ($id, $temp_l, $row, $auditLog) {
+            #20240710修正對應親屬的查詢方式，依據KINSHIP_CODES的c_kin_pair1和c_kin_pair2查詢
+            $old_kin_code = $row->c_kin_code;
+            $kin_code_pair = KinshipCode::find($old_kin_code);
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 4, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $temp_l[0],
                 'c_kin_id' => $temp_l[1],
                 'c_kin_code' => $temp_l[2],
-            ],
-            $auditLog->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operationId
-        );
-
-        $row2Query = DB::table('KIN_DATA')->where(function ($query) use ($row, $kin_code_pair) {
-            $query->where('c_kin_id', $row->c_personid)
-                ->where('c_personid', $row->c_kin_id)
-                ->where('c_autogen_notes', $row->c_autogen_notes)
-                ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
-        });
-
-        if (!empty($kin_code_pair->c_kin_pair2)) {
-            $row2Query->orWhere(function ($query) use ($row, $kin_code_pair) {
-                $query->where('c_kin_id', $row->c_personid)
-                    ->where('c_personid', $row->c_kin_id)
-                    ->where('c_autogen_notes', $row->c_autogen_notes)
-                    ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
-            });
-        }
-
-        $row2 = $row2Query->first();
-
-        DB::table('KIN_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_kin_id', '=', $temp_l[1]],
-            ['c_kin_code', '=', $temp_l[2]],
-        ])->delete();
-
-        //先檢查$row2是否存在，再檢查$row2->c_modified_date是否為null，依照c_kin_id, c_personid, c_source, c_created_date, c_modified_date查詢後進行刪除反向關係。
-        if ($row2 !== null && is_null($row2->c_modified_date)) {
-            $deleteQuery = DB::table('KIN_DATA')->where(function ($query) use ($row2, $kin_code_pair) {
-                $query->where('c_kin_id', $row2->c_kin_id)
-                    ->where('c_personid', $row2->c_personid)
-                    ->where('c_source', $row2->c_source)
-                    ->where('c_autogen_notes', $row2->c_autogen_notes)
-                    ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
-            });
-
-            if (!empty($kin_code_pair->c_kin_pair2)) {
-                $deleteQuery->orWhere(function ($query) use ($row2, $kin_code_pair) {
-                    $query->where('c_kin_id', $row2->c_kin_id)
-                        ->where('c_personid', $row2->c_personid)
-                        ->where('c_source', $row2->c_source)
-                        ->where('c_autogen_notes', $row2->c_autogen_notes)
-                        ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
-                });
-            }
-
-            $mirroredRows = (clone $deleteQuery)->get();
-            $deleteQuery->delete();
-        } elseif ($row2 !== null) {
-            $deleteQuery = DB::table('KIN_DATA')->where(function ($query) use ($row2, $kin_code_pair) {
-                $query->where('c_kin_id', $row2->c_kin_id)
-                    ->where('c_personid', $row2->c_personid)
-                    ->where('c_source', $row2->c_source)
-                    ->where('c_autogen_notes', $row2->c_autogen_notes)
-                    ->where('c_kin_code', $kin_code_pair->c_kin_pair1)
-                    ->where('c_modified_date', $row2->c_modified_date);
-            });
-
-            if (!empty($kin_code_pair->c_kin_pair2)) {
-                $deleteQuery->orWhere(function ($query) use ($row2, $kin_code_pair) {
-                    $query->where('c_kin_id', $row2->c_kin_id)
-                        ->where('c_personid', $row2->c_personid)
-                        ->where('c_source', $row2->c_source)
-                        ->where('c_autogen_notes', $row2->c_autogen_notes)
-                        ->where('c_kin_code', $kin_code_pair->c_kin_pair2)
-                        ->where('c_modified_date', $row2->c_modified_date);
-                });
-            }
-
-            $mirroredRows = (clone $deleteQuery)->get();
-            $deleteQuery->delete();
-        } else {
-            $mirroredRows = collect();
-        }
-
-        foreach ($mirroredRows as $mirroredRow) {
-            $mirroredRowData = $auditLog->normalizeRow($mirroredRow);
+            ]), $row);
+            $operationId = $operation ? (string) $operation->id : null;
             $auditLog->write(
                 'KIN_DATA',
                 'DELETE',
-                $auditLog->buildRowPkFromData('KIN_DATA', $mirroredRowData),
-                $mirroredRowData,
+                [
+                    'c_personid' => $temp_l[0],
+                    'c_kin_id' => $temp_l[1],
+                    'c_kin_code' => $temp_l[2],
+                ],
+                $auditLog->normalizeRow($row),
                 null,
                 'user',
                 (string) Auth::id(),
                 $operationId
             );
-        }
+
+            $row2Query = DB::table('KIN_DATA')->where(function ($query) use ($row, $kin_code_pair) {
+                $query->where('c_kin_id', $row->c_personid)
+                    ->where('c_personid', $row->c_kin_id)
+                    ->where('c_autogen_notes', $row->c_autogen_notes)
+                    ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
+            });
+
+            if (!empty($kin_code_pair->c_kin_pair2)) {
+                $row2Query->orWhere(function ($query) use ($row, $kin_code_pair) {
+                    $query->where('c_kin_id', $row->c_personid)
+                        ->where('c_personid', $row->c_kin_id)
+                        ->where('c_autogen_notes', $row->c_autogen_notes)
+                        ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
+                });
+            }
+
+            $row2 = $row2Query->first();
+
+            DB::table('KIN_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_kin_id', '=', $temp_l[1]],
+                ['c_kin_code', '=', $temp_l[2]],
+            ])->delete();
+
+            //先檢查$row2是否存在，再檢查$row2->c_modified_date是否為null，依照c_kin_id, c_personid, c_source, c_created_date, c_modified_date查詢後進行刪除反向關係。
+            if ($row2 !== null && is_null($row2->c_modified_date)) {
+                $deleteQuery = DB::table('KIN_DATA')->where(function ($query) use ($row2, $kin_code_pair) {
+                    $query->where('c_kin_id', $row2->c_kin_id)
+                        ->where('c_personid', $row2->c_personid)
+                        ->where('c_source', $row2->c_source)
+                        ->where('c_autogen_notes', $row2->c_autogen_notes)
+                        ->where('c_kin_code', $kin_code_pair->c_kin_pair1);
+                });
+
+                if (!empty($kin_code_pair->c_kin_pair2)) {
+                    $deleteQuery->orWhere(function ($query) use ($row2, $kin_code_pair) {
+                        $query->where('c_kin_id', $row2->c_kin_id)
+                            ->where('c_personid', $row2->c_personid)
+                            ->where('c_source', $row2->c_source)
+                            ->where('c_autogen_notes', $row2->c_autogen_notes)
+                            ->where('c_kin_code', $kin_code_pair->c_kin_pair2);
+                    });
+                }
+
+                $mirroredRows = (clone $deleteQuery)->get();
+                $deleteQuery->delete();
+            } elseif ($row2 !== null) {
+                $deleteQuery = DB::table('KIN_DATA')->where(function ($query) use ($row2, $kin_code_pair) {
+                    $query->where('c_kin_id', $row2->c_kin_id)
+                        ->where('c_personid', $row2->c_personid)
+                        ->where('c_source', $row2->c_source)
+                        ->where('c_autogen_notes', $row2->c_autogen_notes)
+                        ->where('c_kin_code', $kin_code_pair->c_kin_pair1)
+                        ->where('c_modified_date', $row2->c_modified_date);
+                });
+
+                if (!empty($kin_code_pair->c_kin_pair2)) {
+                    $deleteQuery->orWhere(function ($query) use ($row2, $kin_code_pair) {
+                        $query->where('c_kin_id', $row2->c_kin_id)
+                            ->where('c_personid', $row2->c_personid)
+                            ->where('c_source', $row2->c_source)
+                            ->where('c_autogen_notes', $row2->c_autogen_notes)
+                            ->where('c_kin_code', $kin_code_pair->c_kin_pair2)
+                            ->where('c_modified_date', $row2->c_modified_date);
+                    });
+                }
+
+                $mirroredRows = (clone $deleteQuery)->get();
+                $deleteQuery->delete();
+            } else {
+                $mirroredRows = collect();
+            }
+
+            foreach ($mirroredRows as $mirroredRow) {
+                $mirroredRowData = $auditLog->normalizeRow($mirroredRow);
+                $auditLog->write(
+                    'KIN_DATA',
+                    'DELETE',
+                    $auditLog->buildRowPkFromData('KIN_DATA', $mirroredRowData),
+                    $mirroredRowData,
+                    null,
+                    'user',
+                    (string) Auth::id(),
+                    $operationId
+                );
+            }
+        });
     }
 
     public function possessionById($id) {
@@ -1128,71 +1150,81 @@ class BiogMainRepository {
 
     public function possessionUpdateById(Request $request, $id, $id_) {
         $data = $request->all();
-        $this->insertAddrPo($data['c_addr_id'], $id_, $id);
+        $c_addr_id = $data['c_addr_id'];
         $data = Arr::except($data, ['_method', '_token', 'c_addr_id']);
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data);
         $ori = DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id_)->first();
-        DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id_)->update($data);
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'POSSESSION_DATA', $id_, $data, $ori);
-        (new AuditLogService())->write(
-            'POSSESSION_DATA',
-            'UPDATE',
-            ['c_possession_record_id' => $id_],
-            (new AuditLogService())->normalizeRow($ori),
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        if (!$ori) {
+            return;
+        }
+
+        DB::transaction(function () use ($id, $id_, $data, $c_addr_id, $ori) {
+            $this->insertAddrPo($c_addr_id, $id_, $id);
+            DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id_)->update($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'POSSESSION_DATA', $id_, $data, $ori);
+            (new AuditLogService())->write(
+                'POSSESSION_DATA',
+                'UPDATE',
+                ['c_possession_record_id' => $id_],
+                (new AuditLogService())->normalizeRow($ori),
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
     }
 
     public function possessionStoreById(Request $request, $id) {
         $data = $request->all();
         $data['c_possession_record_id'] = DB::table('POSSESSION_DATA')->max('c_possession_record_id') + 1;
         $data['c_personid'] = $id;
-        //20210205因為資料表關聯欄位的設定，資料新增的流程需要往後移動。
-        //$this->insertAddrPo($data['c_addr_id'], $data['c_possession_record_id'], $data['c_personid']);
-        $addr = [];
         $addr = $data['c_addr_id'];
-        //修改段落
         $data = Arr::except($data, ['_token', 'c_addr_id']);
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
-        DB::table('POSSESSION_DATA')->insert($data);
-        //移動到這裡
-        $this->insertAddrPo($addr, $data['c_possession_record_id'], $data['c_personid']);
-        //修改結束
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'POSSESSION_DATA', $data['c_possession_record_id'], $data);
-        (new AuditLogService())->write(
-            'POSSESSION_DATA',
-            'INSERT',
-            ['c_possession_record_id' => $data['c_possession_record_id']],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+
+        DB::transaction(function () use ($id, $data, $addr) {
+            DB::table('POSSESSION_DATA')->insert($data);
+            $this->insertAddrPo($addr, $data['c_possession_record_id'], $data['c_personid']);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'POSSESSION_DATA', $data['c_possession_record_id'], $data);
+            (new AuditLogService())->write(
+                'POSSESSION_DATA',
+                'INSERT',
+                ['c_possession_record_id' => $data['c_possession_record_id']],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         return $data['c_possession_record_id'];
     }
 
     public function possessionDeleteById($id, $c_personid) {
         $row = DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id)->first();
-        DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id)->delete();
-        DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $row->c_possession_record_id)->delete();
-        $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSSESSION_DATA', $id, $row);
-        (new AuditLogService())->write(
-            'POSSESSION_DATA',
-            'DELETE',
-            ['c_possession_record_id' => $id],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        if (!$row) {
+            return;
+        }
+
+        DB::transaction(function () use ($id, $c_personid, $row) {
+            DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id)->delete();
+            DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $row->c_possession_record_id)->delete();
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSSESSION_DATA', $id, $row);
+            (new AuditLogService())->write(
+                'POSSESSION_DATA',
+                'DELETE',
+                ['c_possession_record_id' => $id],
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
     }
 
     public function socialInstById($id) {
@@ -1265,30 +1297,35 @@ class BiogMainRepository {
         $data = Arr::except($data, ['_token']);
         $data['c_source'] = ($data['c_source'] == -999) ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
-        $tts = DB::table('BIOG_INST_DATA')->insertGetId($data);
-        //新增的聯合主鍵 //20211022修改增加c_inst_code與c_inst_name_code
-        $newid = CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_inst_code' => $data['c_inst_code'],
-            'c_inst_name_code' => $data['c_inst_name_code'],
-            'c_bi_role_code' => $data['c_bi_role_code'],
-        ]);
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_INST_DATA', $newid, $data);
-        (new AuditLogService())->write(
-            'BIOG_INST_DATA',
-            'INSERT',
-            [
+
+        $newid = '';
+
+        DB::transaction(function () use ($id, $data, &$newid) {
+            DB::table('BIOG_INST_DATA')->insert($data);
+            //新增的聯合主鍵 //20211022修改增加c_inst_code與c_inst_name_code
+            $newid = CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $data['c_personid'],
                 'c_inst_code' => $data['c_inst_code'],
                 'c_inst_name_code' => $data['c_inst_name_code'],
                 'c_bi_role_code' => $data['c_bi_role_code'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+            ]);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_INST_DATA', $newid, $data);
+            (new AuditLogService())->write(
+                'BIOG_INST_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_inst_code' => $data['c_inst_code'],
+                    'c_inst_name_code' => $data['c_inst_name_code'],
+                    'c_bi_role_code' => $data['c_bi_role_code'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         return $newid;
     }
@@ -1315,15 +1352,6 @@ class BiogMainRepository {
                 ->where('c_inst_name_code', $addr_l[2])
                 ->where('c_bi_role_code', $addr_l[3])
                 ->first();
-
-            if ($row) {
-                DB::table('BIOG_INST_DATA')
-                    ->where('c_personid', $addr_l[0])
-                    ->where('c_inst_code', $addr_l[1])
-                    ->where('c_inst_name_code', $addr_l[2])
-                    ->where('c_bi_role_code', $addr_l[3])
-                    ->delete();
-            }
         }
 
         // 如果新格式找不到，嘗試舊版 2-field 格式（c_personid 和 c_bi_role_code）
@@ -1332,26 +1360,29 @@ class BiogMainRepository {
                 ->where('c_personid', $addr_l[0])
                 ->where('c_bi_role_code', $addr_l[1])
                 ->first();
-
-            if ($row) {
-                DB::table('BIOG_INST_DATA')
-                    ->where('c_personid', $addr_l[0])
-                    ->where('c_bi_role_code', $addr_l[1])
-                    ->delete();
-            }
         }
 
-        // 記錄操作（即使 $row 為 null 也記錄，以便追蹤失敗的刪除嘗試）
-        $instResourceId = $row
-            ? CompositePrimaryKey::buildStoredResourceId([
+        if (!$row) {
+            return;
+        }
+
+        DB::transaction(function () use ($id, $c_personid, $row) {
+            DB::table('BIOG_INST_DATA')
+                ->where('c_personid', $row->c_personid)
+                ->where('c_inst_code', $row->c_inst_code)
+                ->where('c_inst_name_code', $row->c_inst_name_code)
+                ->where('c_bi_role_code', $row->c_bi_role_code)
+                ->delete();
+
+            // 記錄操作
+            $instResourceId = CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $row->c_personid,
                 'c_inst_code' => $row->c_inst_code,
                 'c_inst_name_code' => $row->c_inst_name_code,
                 'c_bi_role_code' => $row->c_bi_role_code,
-            ])
-            : $id;
-        $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_INST_DATA', $instResourceId, $row);
-        if ($row) {
+            ]);
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_INST_DATA', $instResourceId, $row);
+
             (new AuditLogService())->write(
                 'BIOG_INST_DATA',
                 'DELETE',
@@ -1367,7 +1398,7 @@ class BiogMainRepository {
                 (string) Auth::id(),
                 $operation ? (string) $operation->id : null
             );
-        }
+        });
     }
 
     public function eventById($id) {
@@ -1675,6 +1706,11 @@ class BiogMainRepository {
                 $c_text_title = $temp_l[7] ?? '';
             }
         }
+
+        if (!$row) {
+            return [];
+        }
+
         $data = $request->all();
         $data = $this->formatSelect($data);
         $assoc_pair = $data['c_assocship_pair'];
@@ -1687,53 +1723,31 @@ class BiogMainRepository {
         //20210910增加$old_c_assocship_pair用來查詢對應的資料
         $old_c_assoc_code = $row->c_assoc_code;
         $old_c_assocship_pair = AssocCode::where('c_assoc_code', '=', $old_c_assoc_code)->first();
-        $old_c_assocship_pair1 = $old_c_assocship_pair['c_assoc_pair'];
-        $old_c_assocship_pair2 = $old_c_assocship_pair['c_assoc_pair2'];
-        //20190118筆記 原程式移除c_assoc_id的值,當社會關係人修改時,資料就不能成對.
-        //$data = Arr::except($data, ['_method', '_token', 'c_assocship_pair', 'c_assoc_id']);
+        $old_c_assocship_pair1 = $old_c_assocship_pair['c_assoc_pair'] ?? null;
+        $old_c_assocship_pair2 = $old_c_assocship_pair['c_assoc_pair2'] ?? null;
+
         $data = Arr::except($data, ['_method', '_token', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
-        #20250411 ASSOC_DATA 表 c_assoc_year 欄位重構遮除c_assoc_intercalary(原本資料有null)
-        #$data['c_assoc_intercalary'] = (int)($data['c_assoc_intercalary']);
-        //20210204增加儲存c_inst_name_code
-        //$data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
-        //新增結束
-        #20260126「出處」缺省值製作，若「出處」為空，則自動填充為[n/a]，避免複合主鍵 ID 中出現 -- 導致解析問題。
-        if (empty($data['c_text_title'])) {
-            $data['c_text_title'] = '[n/a]';
-        }
         $data = (new ToolsRepository())->timestamp($data);
-        DB::table('ASSOC_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_assoc_code', '=', $temp_l[1]],
-            ['c_assoc_id', '=', $temp_l[2]],
-            //20191028進行聯合主鍵的擴充修改
-            ['c_kin_code', '=', $temp_l[3]],
-            ['c_kin_id', '=', $temp_l[4]],
-            ['c_assoc_kin_code', '=', $temp_l[5]],
-            ['c_assoc_kin_id', '=', $temp_l[6]],
-            ['c_text_title', '=', $c_text_title],
-            ['c_assoc_first_year', '=', $c_assoc_first_year],
-        ])->update($data);
+
         $ori_data = $data;
-        $data['c_personid'] = $c_personid;
-        // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
-        // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_assoc_code' => $data['c_assoc_code'],
-            'c_assoc_id' => $data['c_assoc_id'],
-            'c_kin_code' => $data['c_kin_code'],
-            'c_kin_id' => $data['c_kin_id'],
-            'c_assoc_kin_code' => $data['c_assoc_kin_code'],
-            'c_assoc_kin_id' => $data['c_assoc_kin_id'],
-            'c_text_title' => $data['c_text_title'] ?? '',
-            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
-        ]), $data, $row);
-        (new AuditLogService())->write(
-            'ASSOC_DATA',
-            'UPDATE',
-            [
-                'c_personid' => $data['c_personid'],
+
+        DB::transaction(function () use (&$ori_data, $c_personid, $temp_l, $c_text_title, $c_assoc_first_year, $row, $data, $kin_pair, $assoc_kin_pair, $assoc_pair, $assoc_id, $old_assoc_id, $old_c_text_title, $old_c_assoc_first_year, $old_c_assocship_pair1, $old_c_assocship_pair2) {
+            DB::table('ASSOC_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_assoc_code', '=', $temp_l[1]],
+                ['c_assoc_id', '=', $temp_l[2]],
+                //20191028進行聯合主鍵的擴充修改
+                ['c_kin_code', '=', $temp_l[3]],
+                ['c_kin_id', '=', $temp_l[4]],
+                ['c_assoc_kin_code', '=', $temp_l[5]],
+                ['c_assoc_kin_id', '=', $temp_l[6]],
+                ['c_text_title', '=', $c_text_title],
+                ['c_assoc_first_year', '=', $c_assoc_first_year],
+            ])->update($data);
+
+            // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $c_personid,
                 'c_assoc_code' => $data['c_assoc_code'],
                 'c_assoc_id' => $data['c_assoc_id'],
                 'c_kin_code' => $data['c_kin_code'],
@@ -1742,38 +1756,54 @@ class BiogMainRepository {
                 'c_assoc_kin_id' => $data['c_assoc_kin_id'],
                 'c_text_title' => $data['c_text_title'] ?? '',
                 'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-        //20210702取得成對資料原本的c_kin_code
-        $data['c_kin_code'] = $kin_pair;
-        $data['c_assoc_kin_code'] = $assoc_kin_pair;
-        //新增結束
-        //20210708增加[親屬關係人]與[社會關係人親屬]的[姓名]欄位調整為對應關係
-        $data['c_kin_id'] = $c_personid;
-        $data['c_assoc_kin_id'] = $c_personid;
-        //新增結束
-        $data['c_assoc_code'] = $assoc_pair;
-        $data['c_personid'] = $assoc_id;
-        $data = Arr::except($data, ['c_assoc_id']);
-        //20190118筆記 修改這邊的更新功能.
-        //DB::table('ASSOC_DATA')->where([['c_assoc_id',$id], ['c_personid', $assoc_id]])->update($data);
-        // 修正：更新配對記錄時需要包含 c_assoc_first_year，避免當存在相同 c_text_title 但不同 year 時更新錯誤的記錄
-        DB::table('ASSOC_DATA')->where([
-            ['c_assoc_id', '=', $c_personid],
-            ['c_personid', '=', $old_assoc_id],
-            ['c_text_title', '=', $old_c_text_title],
-            ['c_assoc_first_year', '=', $old_c_assoc_first_year],
-        ])
-        ->where(function ($query) use ($old_c_assocship_pair1, $old_c_assocship_pair2) {
-            $query->where('c_assoc_code', '=', $old_c_assocship_pair1)
-                ->orWhere('c_assoc_code', '=', $old_c_assocship_pair2);
-        })
-        ->update($data);
+            ]), $data, $row);
+
+            (new AuditLogService())->write(
+                'ASSOC_DATA',
+                'UPDATE',
+                [
+                    'c_personid' => $c_personid,
+                    'c_assoc_code' => $data['c_assoc_code'],
+                    'c_assoc_id' => $data['c_assoc_id'],
+                    'c_kin_code' => $data['c_kin_code'],
+                    'c_kin_id' => $data['c_kin_id'],
+                    'c_assoc_kin_code' => $data['c_assoc_kin_code'],
+                    'c_assoc_kin_id' => $data['c_assoc_kin_id'],
+                    'c_text_title' => $data['c_text_title'] ?? '',
+                    'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
+                ],
+                (new AuditLogService())->normalizeRow($row),
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            $data_mirror = $data;
+            $data_mirror['c_kin_code'] = $kin_pair;
+            $data_mirror['c_assoc_kin_code'] = $assoc_kin_pair;
+            $data_mirror['c_kin_id'] = $c_personid;
+            $data_mirror['c_assoc_kin_id'] = $c_personid;
+            $data_mirror['c_assoc_code'] = $assoc_pair;
+            $data_mirror['c_personid'] = $assoc_id;
+            $data_mirror = Arr::except($data_mirror, ['c_assoc_id']);
+
+            DB::table('ASSOC_DATA')->where([
+                ['c_assoc_id', '=', $c_personid],
+                ['c_personid', '=', $old_assoc_id],
+                ['c_text_title', '=', $old_c_text_title],
+                ['c_assoc_first_year', '=', $old_c_assoc_first_year],
+            ])
+            ->where(function ($query) use ($old_c_assocship_pair1, $old_c_assocship_pair2) {
+                if ($old_c_assocship_pair1 !== null) {
+                    $query->where('c_assoc_code', '=', $old_c_assocship_pair1);
+                }
+                if ($old_c_assocship_pair2 !== null) {
+                    $query->orWhere('c_assoc_code', '=', $old_c_assocship_pair2);
+                }
+            })
+            ->update($data_mirror);
+        });
 
         return $ori_data;
     }
@@ -1786,39 +1816,19 @@ class BiogMainRepository {
         $assoc_kin_pair = $data['c_assoc_kinship_pair'];
         $data['c_personid'] = $id;
         $data = Arr::except($data, ['_token', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
-        #20250411 ASSOC_DATA 表 c_assoc_year 欄位重構遮除c_assoc_intercalary(原本資料有null)
-        #$data['c_assoc_intercalary'] = (int)($data['c_assoc_intercalary']);
-        //20210204增加儲存c_inst_name_code
-        //$data['c_inst_name_code'] = SocialInstCode::where('c_inst_code', $data['c_inst_code'])->first()->c_inst_name_code;
-        //新增結束
+
         #20250417「社會關係始年」缺省值製作，若「社會關係始年」為空，則自動填充為-9999。
         if ($data['c_assoc_first_year'] == '') {  #這個判斷式只會將「社會關係始年」為空白時，填充為-9999，如果使用者填寫0，會維持0的值而不更動。
             $data['c_assoc_first_year'] = '-9999';
         }
-        #20260126「出處」缺省值製作，若「出處」為空，則自動填充為[n/a]，避免複合主鍵 ID 中出現 -- 導致解析問題。
-        if (empty($data['c_text_title'])) {
-            $data['c_text_title'] = '[n/a]';
-        }
         $data = (new ToolsRepository())->timestamp($data, true);
-        DB::table('ASSOC_DATA')->insert($data);
+
         $ori_Data = $data;
-        // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
-        // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_assoc_code' => $data['c_assoc_code'],
-            'c_assoc_id' => $data['c_assoc_id'],
-            'c_kin_code' => $data['c_kin_code'],
-            'c_kin_id' => $data['c_kin_id'],
-            'c_assoc_kin_code' => $data['c_assoc_kin_code'],
-            'c_assoc_kin_id' => $data['c_assoc_kin_id'],
-            'c_text_title' => $data['c_text_title'] ?? '',
-            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
-        ]), $data);
-        (new AuditLogService())->write(
-            'ASSOC_DATA',
-            'INSERT',
-            [
+
+        DB::transaction(function () use ($id, $data, $assoc_pair, $kin_pair, $assoc_kin_pair, &$ori_Data) {
+            DB::table('ASSOC_DATA')->insert($data);
+            // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $data['c_personid'],
                 'c_assoc_code' => $data['c_assoc_code'],
                 'c_assoc_id' => $data['c_assoc_id'],
@@ -1828,25 +1838,40 @@ class BiogMainRepository {
                 'c_assoc_kin_id' => $data['c_assoc_kin_id'],
                 'c_text_title' => $data['c_text_title'] ?? '',
                 'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
-        $data['c_assoc_code'] = $assoc_pair;
-        $data['c_personid'] = $data['c_assoc_id'];
-        $data['c_assoc_id'] = $id;
-        //20210702增加成對親屬關係
-        $data['c_kin_code'] = $kin_pair;
-        $data['c_assoc_kin_code'] = $assoc_kin_pair;
-        //新增結束
-        //20210708增加[親屬關係人]與[社會關係人親屬]的[姓名]欄位調整為對應關係
-        $data['c_kin_id'] = $id;
-        $data['c_assoc_kin_id'] = $id;
-        //新增結束
-        DB::table('ASSOC_DATA')->insert($data);
+            ]), $data);
+
+            (new AuditLogService())->write(
+                'ASSOC_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_assoc_code' => $data['c_assoc_code'],
+                    'c_assoc_id' => $data['c_assoc_id'],
+                    'c_kin_code' => $data['c_kin_code'],
+                    'c_kin_id' => $data['c_kin_id'],
+                    'c_assoc_kin_code' => $data['c_assoc_kin_code'],
+                    'c_assoc_kin_id' => $data['c_assoc_kin_id'],
+                    'c_text_title' => $data['c_text_title'] ?? '',
+                    'c_assoc_first_year' => $data['c_assoc_first_year'] ?? '-9999',
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            $data_mirror = $data;
+            $data_mirror['c_assoc_code'] = $assoc_pair;
+            $data_mirror['c_personid'] = $data['c_assoc_id'];
+            $data_mirror['c_assoc_id'] = $id;
+            $data_mirror['c_kin_code'] = $kin_pair;
+            $data_mirror['c_assoc_kin_code'] = $assoc_kin_pair;
+            $data_mirror['c_kin_id'] = $id;
+            $data_mirror['c_assoc_kin_id'] = $id;
+
+            DB::table('ASSOC_DATA')->insert($data_mirror);
+        });
 
         return $ori_Data;
     }
@@ -1926,17 +1951,20 @@ class BiogMainRepository {
                 $c_text_title = $temp_l[7] ?? '';
             }
         }
-        // 修正：查找配對記錄時使用多層次策略
-        // 1. 如果 c_kin_id 和 c_assoc_kin_id 都是 0，反向記錄也應該是 0（對稱情況）
-        // 2. 否則使用 paired c_assoc_code 來精確匹配
-        // 3. 如果沒有配對映射且非 0,0 情況，為避免誤刪不嘗試反向刪除
-        $row2 = null;
-        $reverseDeleteSkipReason = null;
 
-        // 修正：必須檢查 $row 是否存在，記錄可能不存在（malformed ID 或已刪除）
-        if ($row) {
+        if (!$row) {
+            return;
+        }
+
+        DB::transaction(function () use ($id, $c_personid, $temp_l, $c_text_title, $c_assoc_first_year, $row) {
+            // 修正：查找配對記錄時使用多層次策略
+            // 1. 如果 c_kin_id 和 c_assoc_kin_id 都是 0，反向記錄也應該是 0（對稱情況）
+            // 2. 否則使用 paired c_assoc_code 來精確匹配
+            // 3. 如果沒有配對映射且非 0,0 情況，為避免誤刪不嘗試反向刪除
+            $row2 = null;
+            $reverseDeleteSkipReason = null;
+
             // 策略 1：如果 c_kin_id = 0 且 c_assoc_kin_id = 0，直接用這些值匹配反向記錄
-            // 注意：此策略僅處理對稱情況，若原記錄非 0,0，則依賴策略 2 的配對代碼
             if ($row->c_kin_id == 0 && $row->c_assoc_kin_id == 0) {
                 $row2 = DB::table('ASSOC_DATA')->where([
                     ['c_personid', $row->c_assoc_id],
@@ -1951,12 +1979,9 @@ class BiogMainRepository {
             // 策略 2：如果策略 1 沒找到，使用 paired c_assoc_code 匹配
             if (!$row2) {
                 $assocCodePair = AssocCode::where('c_assoc_code', '=', $row->c_assoc_code)->first();
-                // 修正：AssocCode::first() 可能返回 null，需要先檢查
                 $assocPair1 = $assocCodePair?->c_assoc_pair;
                 $assocPair2 = $assocCodePair?->c_assoc_pair2;
 
-                // 只有在有配對代碼時才嘗試查找反向記錄
-                // 如果沒有配對映射，為避免誤刪錯誤的記錄，不執行反向刪除
                 if ($assocPair1 !== null || $assocPair2 !== null) {
                     $row2Query = DB::table('ASSOC_DATA')->where([
                         ['c_personid', $row->c_assoc_id],
@@ -1974,28 +1999,23 @@ class BiogMainRepository {
                     });
                     $row2 = $row2Query->first();
                 } else {
-                    // 記錄跳過原因：沒有配對代碼且非 0,0 情況
                     $reverseDeleteSkipReason = 'no_pair_mapping';
                 }
             }
-        } else {
-            // 記錄跳過原因：原記錄不存在
-            $reverseDeleteSkipReason = 'source_record_not_found';
-        }
-        DB::table('ASSOC_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_assoc_code', '=', $temp_l[1]],
-            ['c_assoc_id', '=', $temp_l[2]],
-            //20191028進行聯合主鍵的擴充修改
-            ['c_kin_code', '=', $temp_l[3]],
-            ['c_kin_id', '=', $temp_l[4]],
-            ['c_assoc_kin_code', '=', $temp_l[5]],
-            ['c_assoc_kin_id', '=', $temp_l[6]],
-            ['c_text_title', '=', $c_text_title],
-            ['c_assoc_first_year', '=', $c_assoc_first_year],
-        ])->delete();
-        $assocResourceId = $row
-            ? CompositePrimaryKey::buildStoredResourceId([
+
+            DB::table('ASSOC_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_assoc_code', '=', $temp_l[1]],
+                ['c_assoc_id', '=', $temp_l[2]],
+                ['c_kin_code', '=', $temp_l[3]],
+                ['c_kin_id', '=', $temp_l[4]],
+                ['c_assoc_kin_code', '=', $temp_l[5]],
+                ['c_assoc_kin_id', '=', $temp_l[6]],
+                ['c_text_title', '=', $c_text_title],
+                ['c_assoc_first_year', '=', $c_assoc_first_year],
+            ])->delete();
+
+            $assocResourceId = CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $row->c_personid,
                 'c_assoc_code' => $row->c_assoc_code,
                 'c_assoc_id' => $row->c_assoc_id,
@@ -2005,10 +2025,9 @@ class BiogMainRepository {
                 'c_assoc_kin_id' => $row->c_assoc_kin_id,
                 'c_text_title' => $row->c_text_title ?? '',
                 'c_assoc_first_year' => $row->c_assoc_first_year ?? '-9999',
-            ])
-            : $id;
-        $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ASSOC_DATA', $assocResourceId, $row);
-        if ($row) {
+            ]);
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ASSOC_DATA', $assocResourceId, $row);
+
             (new AuditLogService())->write(
                 'ASSOC_DATA',
                 'DELETE',
@@ -2029,34 +2048,32 @@ class BiogMainRepository {
                 (string) Auth::id(),
                 $operation ? (string) $operation->id : null
             );
-        }
 
-        // 檢查$row2是否存在後再刪除反向關係
-        // 修正：使用完整主鍵欄位進行刪除，避免誤刪其他記錄
-        if ($row2 !== null) {
-            DB::table('ASSOC_DATA')->where([
-                ['c_personid', $row2->c_personid],
-                ['c_assoc_id', $row2->c_assoc_id],
-                ['c_assoc_code', $row2->c_assoc_code],
-                ['c_kin_code', $row2->c_kin_code],
-                ['c_kin_id', $row2->c_kin_id],
-                ['c_assoc_kin_code', $row2->c_assoc_kin_code],
-                ['c_assoc_kin_id', $row2->c_assoc_kin_id],
-                ['c_text_title', $row2->c_text_title],
-                ['c_assoc_first_year', $row2->c_assoc_first_year],
-            ])->delete();
-        } elseif ($reverseDeleteSkipReason !== null) {
-            // 記錄跳過反向刪除的原因，便於審計和問題排查
-            Log::info('[ASSOC_DATA] 跳過反向記錄刪除', [
-                'reason' => $reverseDeleteSkipReason,
-                'forward_id' => $id,
-                'c_personid' => $temp_l[0] ?? null,
-                'c_assoc_id' => $temp_l[2] ?? null,
-                'c_assoc_code' => $temp_l[1] ?? null,
-                'c_kin_id' => $row?->c_kin_id,
-                'c_assoc_kin_id' => $row?->c_assoc_kin_id,
-            ]);
-        }
+            // 檢查$row2是否存在後再刪除反向關係
+            if ($row2 !== null) {
+                DB::table('ASSOC_DATA')->where([
+                    ['c_personid', $row2->c_personid],
+                    ['c_assoc_id', $row2->c_assoc_id],
+                    ['c_assoc_code', $row2->c_assoc_code],
+                    ['c_kin_code', $row2->c_kin_code],
+                    ['c_kin_id', $row2->c_kin_id],
+                    ['c_assoc_kin_code', $row2->c_assoc_kin_code],
+                    ['c_assoc_kin_id', $row2->c_assoc_kin_id],
+                    ['c_text_title', $row2->c_text_title],
+                    ['c_assoc_first_year', $row2->c_assoc_first_year],
+                ])->delete();
+            } elseif ($reverseDeleteSkipReason !== null) {
+                Log::info('[ASSOC_DATA] 跳過反向記錄刪除', [
+                    'reason' => $reverseDeleteSkipReason,
+                    'forward_id' => $id,
+                    'c_personid' => $temp_l[0] ?? null,
+                    'c_assoc_id' => $temp_l[2] ?? null,
+                    'c_assoc_code' => $temp_l[1] ?? null,
+                    'c_kin_id' => $row->c_kin_id,
+                    'c_assoc_kin_id' => $row->c_assoc_kin_id,
+                ]);
+            }
+        });
     }
 
     public function sourceById($id, $_id) {
@@ -2096,6 +2113,10 @@ class BiogMainRepository {
             ['c_textid', '=', $temp_l[1]],
             ['c_pages', '=', $temp_l[2]],
         ])->first();
+        if (!$row) {
+            return [];
+        }
+
         $data = $request->all();
         $data = Arr::except($data, ['_method', '_token']);
         $data['c_personid'] = $id;
@@ -2103,34 +2124,39 @@ class BiogMainRepository {
         $data['c_textid'] = $data['c_textid'] == -999 ? '0' : $data['c_textid'];
         $data['c_main_source'] = (int)$data['c_main_source'];
         $data['c_self_bio'] = (int)$data['c_self_bio'];
-        $c_modified_by = Auth::user()->name;
+        $c_modified_by = Auth::user()->name ?? Auth::id();
         $c_modified_date = Carbon::now();
         $data['c_modified_by'] = $c_modified_by;
         $data['c_modified_date'] = $c_modified_date;
-        DB::table('BIOG_SOURCE_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_pages', '=', $temp_l[2]],
-        ])->update($data);
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_textid' => $data['c_textid'],
-            'c_pages' => $data['c_pages'],
-        ]), $data, $row);
-        (new AuditLogService())->write(
-            'BIOG_SOURCE_DATA',
-            'UPDATE',
-            [
+
+        DB::transaction(function () use ($id, $temp_l, $row, $data) {
+            DB::table('BIOG_SOURCE_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_pages', '=', $temp_l[2]],
+            ])->update($data);
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $data['c_personid'],
                 'c_textid' => $data['c_textid'],
                 'c_pages' => $data['c_pages'],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+            ]), $data, $row);
+
+            (new AuditLogService())->write(
+                'BIOG_SOURCE_DATA',
+                'UPDATE',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_textid' => $data['c_textid'],
+                    'c_pages' => $data['c_pages'],
+                ],
+                (new AuditLogService())->normalizeRow($row),
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         return $data;
     }
@@ -2143,30 +2169,33 @@ class BiogMainRepository {
         $data['c_textid'] = $data['c_textid'] == -999 ? '0' : $data['c_textid'];
         $data['c_main_source'] = (int)$data['c_main_source'];
         $data['c_self_bio'] = (int)$data['c_self_bio'];
-        $c_created_by = Auth::user()->name;
+        $c_created_by = Auth::user()->name ?? Auth::id();
         $c_created_date = Carbon::now();
         $data['c_created_by'] = $c_created_by;
         $data['c_created_date'] = $c_created_date;
-        DB::table('BIOG_SOURCE_DATA')->insert($data);
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_textid' => $data['c_textid'],
-            'c_pages' => $data['c_pages'],
-        ]), $data);
-        (new AuditLogService())->write(
-            'BIOG_SOURCE_DATA',
-            'INSERT',
-            [
+
+        DB::transaction(function () use ($id, $data) {
+            DB::table('BIOG_SOURCE_DATA')->insert($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $data['c_personid'],
                 'c_textid' => $data['c_textid'],
                 'c_pages' => $data['c_pages'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+            ]), $data);
+            (new AuditLogService())->write(
+                'BIOG_SOURCE_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_textid' => $data['c_textid'],
+                    'c_pages' => $data['c_pages'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
 
         return $data;
     }
@@ -2185,30 +2214,37 @@ class BiogMainRepository {
             ['c_textid', '=', $temp_l[1]],
             ['c_pages', '=', $temp_l[2]],
         ])->first();
-        DB::table('BIOG_SOURCE_DATA')->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_pages', '=', $temp_l[2]],
-        ])->delete();
-        $operation = (new OperationRepository())->store(Auth::id(), $id, 4, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $temp_l[0],
-            'c_textid' => $temp_l[1],
-            'c_pages' => $temp_l[2],
-        ]), $row);
-        (new AuditLogService())->write(
-            'BIOG_SOURCE_DATA',
-            'DELETE',
-            [
+
+        if (!$row) {
+            return;
+        }
+
+        DB::transaction(function () use ($id, $temp_l, $row) {
+            DB::table('BIOG_SOURCE_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_pages', '=', $temp_l[2]],
+            ])->delete();
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 4, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $temp_l[0],
                 'c_textid' => $temp_l[1],
                 'c_pages' => $temp_l[2],
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+            ]), $row);
+            (new AuditLogService())->write(
+                'BIOG_SOURCE_DATA',
+                'DELETE',
+                [
+                    'c_personid' => $temp_l[0],
+                    'c_textid' => $temp_l[1],
+                    'c_pages' => $temp_l[2],
+                ],
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        });
     }
 
     protected function addr_str($id) {

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -151,7 +151,7 @@ class CompositePrimaryKey {
     public static function fromRequest(Request $request, array $fields): array {
         return array_filter(
             $request->only($fields),
-            fn ($value) => $value !== null && $value !== ''
+            fn ($value) => $value !== null
         );
     }
 
@@ -206,8 +206,8 @@ class CompositePrimaryKey {
                 continue;
             }
 
-            // 必填欄位必須存在且不為空
-            if (!isset($pk[$field]) || $pk[$field] === '' || $pk[$field] === null) {
+            // 必填欄位必須存在且不為 NULL
+            if (!array_key_exists($field, $pk) || $pk[$field] === null) {
                 return false;
             }
         }
@@ -236,8 +236,8 @@ class CompositePrimaryKey {
                 continue;
             }
 
-            // 必填欄位必須存在且不為空
-            if (!isset($pk[$field]) || $pk[$field] === '' || $pk[$field] === null) {
+            // 必填欄位必須存在且不為 NULL
+            if (!array_key_exists($field, $pk) || $pk[$field] === null) {
                 $missing[] = $field;
             }
         }

--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -1,5 +1,6 @@
 {{-- 共享表单组件 - Assoc --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
 
     // 处理编辑模式的数据 - 必须在构建 formAction 之前执行
@@ -8,9 +9,17 @@
         $row->c_notes = unionPKDef($row->c_notes);
     }
 
-    $formAction = $isEdit
-        ? route('basicinformation.assoc.update', ['basicinformation' => $id, 'assoc' => $row->c_personid.'-'.$row->c_assoc_code.'-'.$row->c_assoc_id.'-'.$row->c_kin_code.'-'.$row->c_kin_id.'-'.$row->c_assoc_kin_code.'-'.$row->c_assoc_kin_id.'-'.$row->c_text_title])
-        : route('basicinformation.assoc.store', ['basicinformation' => $id]);
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.assoc.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.assoc.update', ['basicinformation' => $id, 'assoc' => $row->c_personid.'-'.$row->c_assoc_code.'-'.$row->c_assoc_id.'-'.$row->c_kin_code.'-'.$row->c_kin_id.'-'.$row->c_assoc_kin_code.'-'.$row->c_assoc_kin_id.'-'.$row->c_text_title]);
+    } else {
+        $formAction = route('basicinformation.assoc.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -325,8 +334,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.assoc.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/entries/_form.blade.php
+++ b/resources/views/biogmains/entries/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - Entries --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.entries.update', ['basicinformation' => $id, 'entry' => $row->c_personid.'-'.$row->c_entry_code.'-'.$row->c_sequence.'-'.$row->c_kin_code.'-'.$row->c_assoc_code.'-'.$row->c_kin_id.'-'.$row->c_year.'-'.$row->c_assoc_id.'-'.$row->c_inst_code.'-'.$row->c_inst_name_code])
-        : route('basicinformation.entries.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.entries.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.entries.update', ['basicinformation' => $id, 'entry' => $row->c_personid.'-'.$row->c_entry_code.'-'.$row->c_sequence.'-'.$row->c_kin_code.'-'.$row->c_assoc_code.'-'.$row->c_kin_id.'-'.$row->c_year.'-'.$row->c_assoc_id.'-'.$row->c_inst_code.'-'.$row->c_inst_name_code]);
+    } else {
+        $formAction = route('basicinformation.entries.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -218,8 +228,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.entries.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -1,9 +1,11 @@
 {{-- 共享表单组件 - Events --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
+
     if ($isEdit && isset($pk)) {
         // 查詢參數模式：使用完整複合主鍵
-        $formAction = \App\Support\CompositePrimaryKey::buildUrl(
+        $formAction = CompositePrimaryKey::buildUrl(
             'basicinformation.events.update.query',
             ['id' => $id],
             $pk
@@ -144,8 +146,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.events.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/kinship/_form.blade.php
+++ b/resources/views/biogmains/kinship/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - Kinship --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.kinship.update', ['basicinformation' => $id, 'kinship' => $row->c_personid.'-'.$row->c_kin_id.'-'.$row->c_kin_code])
-        : route('basicinformation.kinship.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.kinship.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.kinship.update', ['basicinformation' => $id, 'kinship' => $row->c_personid.'-'.$row->c_kin_id.'-'.$row->c_kin_code]);
+    } else {
+        $formAction = route('basicinformation.kinship.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -105,8 +115,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.kinship.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - Offices --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.offices.update', ['basicinformation' => $id, 'office' => $row->c_office_id.'-'.$row->c_posting_id])
-        : route('basicinformation.offices.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.offices.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.offices.update', ['basicinformation' => $id, 'office' => $row->c_office_id.'-'.$row->c_posting_id]);
+    } else {
+        $formAction = route('basicinformation.offices.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form id="{{ $isEdit ? 'office-edit-form' : '' }}" action="{{ $formAction }}" method="post">
@@ -253,11 +263,35 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary" id="{{ $isEdit ? 'office-edit-submit' : '' }}">Submit</button>
-            @if($isEdit)
-                <a href="../../../../basicinformation/{{ $row->c_personid }}/offices/{{ $row->c_office_id.'-'.$row->c_posting_id }}/saveas" class="btn btn-success" style="margin-left:40px;">save as</a>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" id="{{ $isEdit ? 'office-edit-submit' : '' }}" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                    @if($isEdit)
+                        <a href="../../../../basicinformation/{{ $row->c_personid }}/offices/{{ $row->c_office_id.'-'.$row->c_posting_id }}/saveas" class="btn btn-success" style="margin-left:40px;">save as</a>
+                    @endif
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
             @endif
+
+            <a href="{{ route('basicinformation.offices.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/possession/_form.blade.php
+++ b/resources/views/biogmains/possession/_form.blade.php
@@ -1,11 +1,19 @@
 {{-- 共享表单组件 - Possession --}}
 @php
     use App\Support\CompositePrimaryKey;
-
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? CompositePrimaryKey::buildUrl('basicinformation.possession.update.query', ['id' => $id], ['c_possession_record_id' => $row->c_possession_record_id])
-        : route('basicinformation.possession.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.possession.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = CompositePrimaryKey::buildUrl('basicinformation.possession.update.query', ['id' => $id], ['c_possession_record_id' => $row->c_possession_record_id]);
+    } else {
+        $formAction = route('basicinformation.possession.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -131,8 +139,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.possession.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/socialinst/_form.blade.php
+++ b/resources/views/biogmains/socialinst/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - SocialInst --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.socialinst.update', ['basicinformation' => $id, 'socialinst' => $row->c_personid.'-'.$row->c_inst_code.'-'.$row->c_inst_name_code.'-'.$row->c_bi_role_code])
-        : route('basicinformation.socialinst.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.socialinst.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.socialinst.update', ['basicinformation' => $id, 'socialinst' => $row->c_personid.'-'.$row->c_inst_code.'-'.$row->c_inst_name_code.'-'.$row->c_bi_role_code]);
+    } else {
+        $formAction = route('basicinformation.socialinst.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -111,8 +121,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.socialinst.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/sources/_form.blade.php
+++ b/resources/views/biogmains/sources/_form.blade.php
@@ -1,5 +1,6 @@
 {{-- 共享表单组件 - Sources --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
 
     // 处理编辑模式的数据 - 必须在构建 formAction 之前执行
@@ -10,9 +11,17 @@
         $isWikiSource = in_array($row->c_textid, $wikiSourceIds);
     }
 
-    $formAction = $isEdit
-        ? route('basicinformation.sources.update', ['basicinformation' => $id, 'source' => $row->c_personid.'-'.$row->c_textid.'-'.$row->c_pages])
-        : route('basicinformation.sources.store', ['basicinformation' => $id]);
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.sources.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.sources.update', ['basicinformation' => $id, 'source' => $row->c_personid.'-'.$row->c_textid.'-'.$row->c_pages]);
+    } else {
+        $formAction = route('basicinformation.sources.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -101,8 +110,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.sources.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/resources/views/biogmains/statuses/_form.blade.php
+++ b/resources/views/biogmains/statuses/_form.blade.php
@@ -1,9 +1,19 @@
 {{-- 共享表单组件 - Statuses --}}
 @php
+    use App\Support\CompositePrimaryKey;
     $isEdit = isset($row);
-    $formAction = $isEdit
-        ? route('basicinformation.statuses.update', ['basicinformation' => $id, 'status' => $row->c_personid.'-'.$row->c_sequence.'-'.$row->c_status_code])
-        : route('basicinformation.statuses.store', ['basicinformation' => $id]);
+
+    if ($isEdit && isset($pk)) {
+        $formAction = CompositePrimaryKey::buildUrl(
+            'basicinformation.statuses.update.query',
+            ['id' => $id],
+            $pk
+        );
+    } elseif ($isEdit) {
+        $formAction = route('basicinformation.statuses.update', ['basicinformation' => $id, 'status' => $row->c_personid.'-'.$row->c_sequence.'-'.$row->c_status_code]);
+    } else {
+        $formAction = route('basicinformation.statuses.store', ['basicinformation' => $id]);
+    }
 @endphp
 
 <form action="{{ $formAction }}" method="post">
@@ -116,8 +126,32 @@
     />
 
     <div class="form-group row">
+        <label for="__proposal_comment" class="col-sm-2 col-form-label">修改說明 / 提案理由</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="__proposal_comment" rows="3" placeholder="請簡述本次修改的原因（直接儲存或提交提案時均會記錄此說明）"></textarea>
+            <small class="text-muted">此說明將記錄於操作歷史中。提交提案時必填，直接儲存時可選填。</small>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <div class="offset-sm-2 col-sm-10">
-            <button type="submit" class="btn btn-secondary">Submit</button>
+            @if(Auth::check() && Auth::user()->isActive())
+                <!-- 直接儲存按鈕（非眾包用戶可見） -->
+                @if(Auth::user()->canWriteDirectly())
+                    <button type="submit" name="action" value="save" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 直接儲存
+                    </button>
+                @endif
+
+                <!-- 提交提案按鈕（所有活躍用戶可見） -->
+                <button type="submit" name="action" value="proposal" class="btn btn-info">
+                    <i class="fa fa-paper-plane"></i> 提交提案
+                </button>
+            @endif
+
+            <a href="{{ route('basicinformation.statuses.index', ['basicinformation' => $id]) }}" class="btn btn-secondary">
+                <i class="fa fa-times"></i> 取消
+            </a>
         </div>
     </div>
 </form>

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\BasicInformationProposalController;
 use App\Models\Operation;
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
@@ -105,9 +106,20 @@ class BasicInformationProposalTest extends TestCase {
             $table->string('c_modified_by')->nullable();
             $table->timestamp('c_modified_date')->nullable();
         });
+
+        Schema::dropIfExists('POSSESSION_DATA');
+        Schema::create('POSSESSION_DATA', function (Blueprint $table) {
+            $table->integer('c_personid')->nullable();
+            $table->integer('c_possession_record_id')->nullable();
+            $table->integer('c_sequence')->nullable();
+            $table->integer('c_possession_act_code')->nullable();
+            $table->string('c_possession_desc')->nullable();
+            $table->string('c_possession_desc_chn')->nullable();
+        });
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('POSSESSION_DATA');
         Schema::dropIfExists('ALTNAME_DATA');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('users');
@@ -221,6 +233,63 @@ class BasicInformationProposalTest extends TestCase {
         $this->assertSame('pending', $payload['__review_status']);
         $this->assertSame('新增測試別名', $payload['__proposal_meta']['comment']);
         $this->assertSame(['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'], $payload['__key_columns']);
+    }
+
+    #[Test]
+    public function testPossessionProposalStoreAssignsRecordIdAndUsesSingleKeyColumn() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        DB::table('POSSESSION_DATA')->insert([
+            'c_personid' => 99,
+            'c_possession_record_id' => 2,
+            'c_sequence' => 1,
+            'c_possession_act_code' => 1,
+            'c_possession_desc' => 'existing',
+            'c_possession_desc_chn' => '既有',
+        ]);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'possessions',
+        ]), [
+            'c_sequence' => 1,
+            'c_possession_act_code' => 0,
+            'c_possession_desc' => '提案財產',
+            'c_possession_desc_chn' => '提案財產中文',
+            '__proposal_comment' => '新增所有物',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'POSSESSION_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame(3, $payload['c_possession_record_id']);
+        $this->assertSame(['c_possession_record_id'], $payload['__key_columns']);
+    }
+
+    #[Test]
+    public function testProposalResourceConfigUsesExpectedPrimaryKeys() {
+        $config = (new \ReflectionClass(BasicInformationProposalController::class))
+            ->getDefaultProperties()['resourceConfigs'];
+
+        $this->assertSame(
+            ['c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence'],
+            $config['addresses']['key_columns']
+        );
+        $this->assertSame(
+            ['c_personid', 'c_textid', 'c_role_id'],
+            $config['texts']['key_columns']
+        );
+        $this->assertSame(
+            ['c_possession_record_id'],
+            $config['possessions']['key_columns']
+        );
     }
 
     #[Test]

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -23,7 +23,7 @@ class CodesControllerTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        config(['codes.tables' => ['TEST_CODES', 'TEXT_CODES']]);
+        config(['codes.tables' => ['TEST_CODES', 'TEXT_CODES', 'POSSESSION_DATA']]);
         config(['codes.connection' => null]);
 
         $compiledPath = base_path('tests/storage/views');
@@ -37,11 +37,13 @@ class CodesControllerTest extends TestCase {
             [
                 'TEST_CODES' => [],
                 'TEXT_CODES' => [],
+                'POSSESSION_DATA' => [],
                 'operations' => [],
             ],
             [
                 'TEST_CODES' => ['code_id', 'code_sub', 'description'],
                 'TEXT_CODES' => ['c_textid', 'c_title', 'c_title_chn', 'c_bibl_cat_code', 'c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'],
+                'POSSESSION_DATA' => ['c_personid', 'c_possession_record_id', 'c_sequence', 'c_possession_act_code', 'c_possession_desc'],
                 'operations' => ['id', 'user_id', 'resource', 'resource_id', 'op_type', 'resource_data', 'resource_original', 'created_at', 'updated_at'],
             ]
         );
@@ -50,13 +52,14 @@ class CodesControllerTest extends TestCase {
 
         $this->app->instance(CodesRepository::class, new class () extends CodesRepository {
             public function allowedTables(): array {
-                return ['TEST_CODES', 'TEXT_CODES'];
+                return ['TEST_CODES', 'TEXT_CODES', 'POSSESSION_DATA'];
             }
 
             public function allowedTableMap(): array {
                 return [
                     'TEST_CODES' => 'TEST_CODES',
                     'TEXT_CODES' => 'TEXT_CODES',
+                    'POSSESSION_DATA' => 'POSSESSION_DATA',
                 ];
             }
         });
@@ -241,6 +244,31 @@ class CodesControllerTest extends TestCase {
         $this->assertEquals(Carbon::now()->timestamp, $parsedTime->timestamp, '', 1);
 
         Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function testProposalStoreUsesPrimaryKeyOverrideForPossessionData() {
+        $user = new User([
+            'name' => 'active',
+            'email' => 'active-override@example.com',
+            'confirmation_token' => Str::random(32),
+        ]);
+        $user->id = 21;
+        $user->is_active = 1;
+        $this->actingAs($user);
+
+        $response = $this->post('/codes/POSSESSION_DATA/proposal', [
+            'c_possession_record_id' => 3,
+            'c_possession_desc' => 'proposal row',
+            '__proposal_comment' => 'pk override',
+        ]);
+
+        $response->assertRedirect('/codes/POSSESSION_DATA');
+        $this->assertCount(1, $this->operationSpy->calls);
+        $call = $this->operationSpy->calls[0];
+        $this->assertSame(Operation::TYPE_PROPOSAL_CREATE, $call['op_type']);
+        $this->assertSame('POSSESSION_DATA', $call['resource']);
+        $this->assertSame(['c_possession_record_id'], $call['resource_data']['__key_columns']);
     }
 
     #[Test]

--- a/tests/Feature/ProposalNormalizationTest.php
+++ b/tests/Feature/ProposalNormalizationTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ProposalNormalizationTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        // 使用 SQLite 記憶體資料庫進行測試
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->boolean('is_active')->default(0);
+            $table->boolean('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('ASSOC_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code');
+            $table->integer('c_assoc_id');
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_assoc_kin_code')->default(0);
+            $table->integer('c_assoc_kin_id')->default(0);
+            $table->string('c_text_title')->default('');
+            $table->integer('c_assoc_first_year')->default(-9999);
+            $table->string('c_notes')->nullable();
+        });
+
+        Schema::create('ENTRY_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_entry_code');
+            $table->integer('c_sequence');
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_assoc_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_year')->default(0);
+            $table->integer('c_assoc_id')->default(0);
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->integer('c_source')->default(0);
+        });
+    }
+
+    protected function makeActiveUser(): User {
+        return User::create([
+            'name' => 'activeuser',
+            'email' => 'active@example.com',
+            'is_active' => 1,
+            'is_admin' => 0,
+        ]);
+    }
+
+    /**
+     * 驗證 P2: ASSOC_DATA 提案正確處理空字串 c_text_title
+     */
+    #[Test]
+    public function testAssocProposalWithEmptyTextTitle() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 插入一條 c_text_title 為空字串的原始資料
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => 100,
+            'c_assoc_code' => 1,
+            'c_assoc_id' => 2,
+            'c_text_title' => '', // 空字串
+            'c_assoc_first_year' => 1000,
+        ]);
+
+        // 模擬修改提案
+        // URL 包含 c_text_title= (空字串)
+        $response = $this->patch(route('basicinformation.assoc.update.query', [
+            'id' => 100,
+            'action' => 'proposal',
+            'c_personid' => 100,
+            'c_assoc_code' => 1,
+            'c_assoc_id' => 2,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => '', // 關鍵：空字串 PK 欄位
+            'c_assoc_first_year' => 1000,
+        ]), [
+            'c_notes' => '更新後的備註',
+            '__proposal_comment' => '測試空字串 PK',
+        ]);
+
+        $response->assertRedirect();
+
+        // 驗證提案是否成功建立，且 c_text_title 被正確識別
+        $operation = Operation::where('resource', 'ASSOC_DATA')->first();
+        $this->assertNotNull($operation, '提案未建立，可能是 PK 匹配失敗');
+
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('更新後的備註', $payload['c_notes']);
+
+        // 驗證 resource_id 包含 c_text_title 的空字串 (應被編碼為 NULL 或空，取決於 buildCompositeId)
+        // 在 BasicInformationProposalController 中，'' 或 null 會被轉為 'NULL'
+        $this->assertStringContainsString('NULL', $operation->resource_id);
+    }
+
+    /**
+     * 驗證 P1: ENTRY_DATA 提案正確處理合併後的 c_inst_code (123-4)
+     */
+    #[Test]
+    public function testEntryProposalWithCombinedInstitutionId() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 測試新增提案，提供所有必要的 PK 欄位
+        $response = $this->post(route('basicinformation.entries.store', [
+            'basicinformation' => 100,
+            'action' => 'proposal',
+        ]), [
+            'c_entry_code' => 1,
+            'c_sequence' => 1,
+            'c_kin_code' => 0,
+            'c_assoc_code' => 0,
+            'c_kin_id' => 0,
+            'c_year' => 0,
+            'c_assoc_id' => 0,
+            'c_inst_code' => '123-4', // 關鍵：合併格式
+            '__proposal_comment' => '測試合併機構 ID',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'ENTRY_DATA')->first();
+        $this->assertNotNull($operation, '提案未建立，可能是 PK 驗證失敗');
+
+        $payload = json_decode($operation->resource_data, true);
+        // 驗證機構 ID 是否已被正確分割
+        $this->assertEquals('123', $payload['c_inst_code']);
+        $this->assertEquals('4', $payload['c_inst_name_code']);
+    }
+
+    /**
+     * 驗證 -999 轉為 0 的正規化
+     */
+    #[Test]
+    public function testEntryProposalWithNegative999Normalization() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 測試新增提案，提供所有必要的 PK 欄位
+        $response = $this->post(route('basicinformation.entries.store', [
+            'basicinformation' => 100,
+            'action' => 'proposal',
+        ]), [
+            'c_entry_code' => 1,
+            'c_sequence' => 1,
+            'c_kin_code' => 0,
+            'c_assoc_code' => 0,
+            'c_kin_id' => 0,
+            'c_year' => 0,
+            'c_assoc_id' => 0,
+            'c_inst_code' => '0-0',
+            'c_source' => -999, // 關鍵：-999 應轉為 0
+            '__proposal_comment' => '測試 -999 正規化',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'ENTRY_DATA')->first();
+        $this->assertNotNull($operation, '提案未建立，可能是 PK 驗證失敗');
+
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertEquals('0', $payload['c_source']);
+    }
+}

--- a/tests/Feature/ProposalNormalizationTest.php
+++ b/tests/Feature/ProposalNormalizationTest.php
@@ -284,5 +284,13 @@ class ProposalNormalizationTest extends TestCase {
             'c_inst_code' => 0,
             'c_inst_name_code' => 0,
         ]);
+
+        $operation = Operation::where('resource', 'ENTRY_DATA')
+            ->where('op_type', 1)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('這個欄位不應寫入 ENTRY_DATA', $payload['__note'] ?? null);
     }
 }

--- a/tests/Feature/ProposalNormalizationTest.php
+++ b/tests/Feature/ProposalNormalizationTest.php
@@ -42,6 +42,21 @@ class ProposalNormalizationTest extends TestCase {
             $table->timestamps();
         });
 
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name');
+            $table->string('operation');
+            $table->string('actor_type');
+            $table->string('actor_id');
+            $table->string('operation_id');
+            $table->text('row_pk')->nullable();
+            $table->text('row_pk_text')->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+
         Schema::create('ASSOC_DATA', function (Blueprint $table) {
             $table->integer('c_personid');
             $table->integer('c_assoc_code');
@@ -67,6 +82,11 @@ class ProposalNormalizationTest extends TestCase {
             $table->integer('c_inst_code')->default(0);
             $table->integer('c_inst_name_code')->default(0);
             $table->integer('c_source')->default(0);
+            $table->integer('c_entry_addr_id')->default(0);
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
         });
     }
 
@@ -127,6 +147,38 @@ class ProposalNormalizationTest extends TestCase {
         // 驗證 resource_id 包含 c_text_title 的空字串 (應被編碼為 NULL 或空，取決於 buildCompositeId)
         // 在 BasicInformationProposalController 中，'' 或 null 會被轉為 'NULL'
         $this->assertStringContainsString('NULL', $operation->resource_id);
+    }
+
+    /**
+     * 驗證 ASSOC_DATA 新增提案允許空字串 c_text_title
+     */
+    #[Test]
+    public function testAssocCreateProposalAllowsEmptyTextTitle() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 100,
+            'resource' => 'assoc',
+        ]), [
+            'c_assoc_code' => 1,
+            'c_assoc_id' => 2,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => '',
+            'c_assoc_first_year' => 1000,
+            '__proposal_comment' => '空標題提案',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'ASSOC_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($operation, 'ASSOC_DATA 空標題新增提案未建立');
     }
 
     /**
@@ -196,5 +248,41 @@ class ProposalNormalizationTest extends TestCase {
 
         $payload = json_decode($operation->resource_data, true);
         $this->assertEquals('0', $payload['c_source']);
+    }
+
+    /**
+     * 驗證 ENTRY_DATA 直接儲存會忽略 __proposal_comment 欄位
+     */
+    #[Test]
+    public function testEntryDirectSaveIgnoresProposalCommentField() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.entries.store', [
+            'basicinformation' => 100,
+            'action' => 'save',
+        ]), [
+            'action' => 'save',
+            'c_entry_code' => 1,
+            'c_sequence' => 1,
+            'c_kin_code' => 0,
+            'c_assoc_code' => 0,
+            'c_kin_id' => 0,
+            'c_year' => 0,
+            'c_assoc_id' => 0,
+            'c_inst_code' => '0-0',
+            'c_source' => 0,
+            '__proposal_comment' => '這個欄位不應寫入 ENTRY_DATA',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('ENTRY_DATA', [
+            'c_personid' => 100,
+            'c_entry_code' => 1,
+            'c_sequence' => 1,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+        ]);
     }
 }

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -65,7 +65,7 @@ class CompositePrimaryKeyTest extends TestCase {
     }
 
     /** @test */
-    public function it_filters_out_empty_values_from_request(): void {
+    public function it_filters_out_null_but_preserves_empty_strings_from_request(): void {
         $request = new Request([
             'c_personid' => 12345,
             'c_sequence' => '',
@@ -76,9 +76,10 @@ class CompositePrimaryKeyTest extends TestCase {
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $pk = CompositePrimaryKey::fromRequest($request, $schema);
 
-        // 空字串和 null 應該被過濾掉
+        // NULL 應該被過濾掉，但空字串應該保留（支援某些表的主鍵欄位可以為空）
         $this->assertEquals([
             'c_personid' => 12345,
+            'c_sequence' => '',
             'c_alt_name_chn' => '張三',
         ], $pk);
     }


### PR DESCRIPTION
- 修正 `BasicInformationProposalController` 的提案主鍵配置：
    - `POSSESSION_DATA` 改為 `c_possession_record_id`
    - `BIOG_TEXT_DATA` 改為 `c_personid + c_textid + c_role_id`
    - `BIOG_ADDR_DATA` 主鍵欄位順序對齊 schema
- 新增單一數值主鍵提案自動補號邏輯，避免提案缺主鍵或主鍵衝突
- 補上 `CodesController` 的 `POSSESSION_DATA` 主鍵覆寫，確保 `/codes` 提案判定一致
- 補強回歸測試（提案主鍵配置、POSSESSION 提案流程、codes 提案流程）
- 更新 `BIOGMAIN_APPROVAL_FLOWS_PLAN.md`：
    - 記錄本次主鍵修正與測試補強
    - 更新文檔版本、最後更新日期與章節編號
    - 清理已過時的已知缺口描述

測試：
- `./vendor/bin/phpunit --filter BasicInformationProposalTest`
- `./vendor/bin/phpunit --filter CodesControllerTest`
- `./vendor/bin/phpunit --filter OperationsProposalControllerTest`

参见：https://github.com/frankslin/cbdb-online-main-server/pull/9