### PR TITLE
重整基本資料寫入交易並完善 ALTNAME 與 TEXT 流程

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -124,13 +124,13 @@ class BasicInformationAddressesController extends Controller {
      */
     public function store(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -151,13 +151,18 @@ class BasicInformationAddressesController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         // 使用 Repository 進行儲存（內含事務與審計）
         $data = $this->biogMainRepository->addrStoreById($request, $id);
+        if ($data === false) {
+            flash('重複資料，儲存失敗 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
 
         flash('Store success @ '.Carbon::now(), 'success');
 
@@ -301,13 +306,13 @@ class BasicInformationAddressesController extends Controller {
      */
     public function update(Request $request, $id, $addr) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -338,7 +343,7 @@ class BasicInformationAddressesController extends Controller {
 
         // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -498,13 +503,13 @@ class BasicInformationAddressesController extends Controller {
      */
     public function updateQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -523,7 +528,7 @@ class BasicInformationAddressesController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -601,12 +606,12 @@ class BasicInformationAddressesController extends Controller {
      */
     public function destroyQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -156,46 +156,9 @@ class BasicInformationAddressesController extends Controller {
             return redirect()->back();
         }
 
-        $data = $request->all();
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
-        $data['c_personid'] = $id;
-        $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
-        $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
+        // 使用 Repository 進行儲存（內含事務與審計）
+        $data = $this->biogMainRepository->addrStoreById($request, $id);
 
-        $temp = DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $data['c_personid']],
-            ['c_addr_id', '=', $data['c_addr_id']],
-            ['c_addr_type', '=', $data['c_addr_type']],
-            ['c_sequence', '=', $data['c_sequence']],
-        ])->first();
-        if (!blank($temp)) {
-            flash('重复数据，保存失败 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-        $data = $this->toolsRepository->timestamp($data, true);
-        DB::table('BIOG_ADDR_DATA')->insert($data);
-        $operation = $this->operationRepository->store(Auth::id(), $id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_addr_id' => $data['c_addr_id'],
-            'c_addr_type' => $data['c_addr_type'],
-            'c_sequence' => $data['c_sequence'],
-        ]), $data);
-        (new AuditLogService())->write(
-            'BIOG_ADDR_DATA',
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_addr_id' => $data['c_addr_id'],
-                'c_addr_type' => $data['c_addr_type'],
-                'c_sequence' => $data['c_sequence'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -380,73 +343,12 @@ class BasicInformationAddressesController extends Controller {
             return redirect()->back();
         }
 
-        $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
+        // 使用 Repository 進行更新（內含事務與審計）
+        $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $addr);
 
-        $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
-        $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
-
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
-        $data = $this->toolsRepository->timestamp($data);
-        $addr = str_replace("--", "-minus", $addr);
-        $addr_l = explode("-", $addr);
-        foreach ($addr_l as $key => $value) {
-            $addr_l[$key] = str_replace("minus", "-", $value);
-        }
-
-        //20251213新增差異比對紀錄
-        $ori = DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_addr_id', '=', $addr_l[1]],
-            ['c_addr_type', '=', $addr_l[2]],
-            ['c_sequence', '=', $addr_l[3]],
-        ])->first();
-
-        DB::table('BIOG_ADDR_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_addr_id', '=', $addr_l[1]],
-            ['c_addr_type', '=', $addr_l[2]],
-            ['c_sequence', '=', $addr_l[3]],
-        ])->update($data);
-        $data['c_personid'] = $addr_l[0];
-
-        // 準備要存入 operations 表的數據，加入註解
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_addr_id' => $data['c_addr_id'],
-            'c_addr_type' => $data['c_addr_type'],
-            'c_sequence' => $data['c_sequence'],
-        ]), $operationData, $ori);
-        (new AuditLogService())->write(
-            'BIOG_ADDR_DATA',
-            'UPDATE',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_addr_id' => $data['c_addr_id'],
-                'c_addr_type' => $data['c_addr_type'],
-                'c_sequence' => $data['c_sequence'],
-            ],
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
-        $newPk = [
-            'c_personid' => $data['c_personid'],
-            'c_addr_id' => $data['c_addr_id'],
-            'c_addr_type' => $data['c_addr_type'],
-            'c_sequence' => $data['c_sequence'],
-        ];
-
         return redirect(CompositePrimaryKey::buildUrl(
             'basicinformation.addresses.edit.query',
             ['id' => $id],
@@ -716,34 +618,11 @@ class BasicInformationAddressesController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'BIOG_ADDR_DATA');
 
-        // 構建查詢條件
-        $conditions = [
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_addr_id', '=', $pk['c_addr_id']],
-            ['c_addr_type', '=', $pk['c_addr_type']],
-            ['c_sequence', '=', $pk['c_sequence']],
-        ];
+        // 構建舊格式 ID 用於 Repository
+        $id_ = $pk['c_personid']."-".$pk['c_addr_id']."-".$pk['c_addr_type']."-".$pk['c_sequence'];
 
-        $row = DB::table('BIOG_ADDR_DATA')->where($conditions)->first();
-        if (!$row) {
-            abort(404, 'BIOG_ADDR_DATA 記錄不存在');
-        }
-
-        // 刪除資料
-        DB::table('BIOG_ADDR_DATA')->where($conditions)->delete();
-
-        // 記錄操作
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
-        (new AuditLogService())->write(
-            'BIOG_ADDR_DATA',
-            'DELETE',
-            $pk,
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行刪除（內含事務與審計）
+        $this->biogMainRepository->addrDeleteById($id_, $id);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -350,6 +350,9 @@ class BasicInformationAddressesController extends Controller {
 
         // 使用 Repository 進行更新（內含事務與審計）
         $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $addr);
+        if (!$newPk) {
+            abort(404, 'BIOG_ADDR_DATA 記錄不存在');
+        }
 
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -627,7 +630,10 @@ class BasicInformationAddressesController extends Controller {
         $id_ = $pk['c_personid']."-".$pk['c_addr_id']."-".$pk['c_addr_type']."-".$pk['c_sequence'];
 
         // 使用 Repository 進行刪除（內含事務與審計）
-        $this->biogMainRepository->addrDeleteById($id_, $id);
+        $deleted = $this->biogMainRepository->addrDeleteById($id_, $id);
+        if (!$deleted) {
+            abort(404, 'BIOG_ADDR_DATA 記錄不存在');
+        }
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -84,13 +84,13 @@ class BasicInformationAltnamesController extends Controller {
     public function store(Request $request, $id) {
         // 權限檢查
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -112,13 +112,18 @@ class BasicInformationAltnamesController extends Controller {
 
         // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         // 使用 Repository 進行儲存（內含事務與審計）
         $data = $this->biogMainRepository->altnameStoreById($request, $id);
+        if ($data === false) {
+            flash('重複資料，儲存失敗 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
 
         // 手動調用索引服務
         if (Schema::hasTable('CBDB__NAME_FTS') && !empty($data['c_alt_name_chn'])) {
@@ -217,13 +222,13 @@ class BasicInformationAltnamesController extends Controller {
     public function update(Request $request, $id, $alt) {
         // 權限檢查
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -254,7 +259,7 @@ class BasicInformationAltnamesController extends Controller {
 
         // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -446,13 +451,13 @@ class BasicInformationAltnamesController extends Controller {
     public function updateQuery(Request $request, $id) {
         // 權限檢查
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -483,7 +488,7 @@ class BasicInformationAltnamesController extends Controller {
 
         // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -570,13 +575,13 @@ class BasicInformationAltnamesController extends Controller {
      */
     public function destroyQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -6,12 +6,10 @@ use App\Models\TextCode;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
-use App\Services\AuditLogService;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -119,48 +117,8 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // 原有的直接儲存邏輯
-        $data = $request->all();
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
-        $data['c_personid'] = $id;
-        $data = $this->toolsRepository->timestamp($data, true);
-
-        // 檢查重複資料
-        $temp = DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $data['c_personid']],
-            ['c_sequence', '=', $data['c_sequence']],
-            ['c_alt_name_chn', '=', $data['c_alt_name_chn']],
-            ['c_alt_name_type_code', '=', $data['c_alt_name_type_code']],
-        ])->first();
-        if (!blank($temp)) {
-            flash('重复数据，保存失败 @ '.Carbon::now(), 'error');
-
-            return redirect()->back();
-        }
-
-        // 使用 Query Builder 插入資料
-        DB::table('ALTNAME_DATA')->insert($data);
-        $operation = $this->operationRepository->store(Auth::id(), $id, 1, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_sequence' => $data['c_sequence'],
-            'c_alt_name_chn' => $data['c_alt_name_chn'],
-            'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-        ]), $data);
-        (new AuditLogService())->write(
-            'ALTNAME_DATA',
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_sequence' => $data['c_sequence'],
-                'c_alt_name_chn' => $data['c_alt_name_chn'],
-                'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行儲存（內含事務與審計）
+        $data = $this->biogMainRepository->altnameStoreById($request, $id);
 
         // 手動調用索引服務
         if (Schema::hasTable('CBDB__NAME_FTS') && !empty($data['c_alt_name_chn'])) {
@@ -195,14 +153,7 @@ class BasicInformationAltnamesController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function edit($id, $alt) {
-        $addr_l = $this->parseAltnameId($alt);
-
-        $row = DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
-        ])->first();
+        $row = $this->biogMainRepository->altnameById($alt);
 
         if (!$row) {
             abort(404, 'ALTNAME_DATA record not found');
@@ -308,54 +259,15 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // 原有的直接儲存邏輯
-        $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
-        $data = $this->toolsRepository->timestamp($data);
-        $addr_l = $this->parseAltnameId($alt);
-
-        //20251213新增差異比對紀錄
-        $ori = DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
-        ])->first();
-
-        // 使用 Query Builder 更新資料
-        DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
-        ])->update($data);
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $id,
-            'c_sequence' => $data['c_sequence'],
-            'c_alt_name_chn' => $data['c_alt_name_chn'],
-            'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-        ]), $data, $ori);
-        (new AuditLogService())->write(
-            'ALTNAME_DATA',
-            'UPDATE',
-            [
-                'c_personid' => $id,
-                'c_sequence' => $data['c_sequence'],
-                'c_alt_name_chn' => $data['c_alt_name_chn'],
-                'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-            ],
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行更新（內含事務與審計，且修復 LIKE 謂詞風險）
+        $ori = $this->biogMainRepository->altnameById($alt);
+        $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $alt);
 
         // 手動調用索引服務
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
-            $nameChanged = $ori->c_alt_name_chn !== $data['c_alt_name_chn'];
-            $typeChanged = $ori->c_alt_name_type_code !== $data['c_alt_name_type_code'];
+            $data = $request->all();
+            $nameChanged = $ori->c_alt_name_chn !== ($data['c_alt_name_chn'] ?? $ori->c_alt_name_chn);
+            $typeChanged = $ori->c_alt_name_type_code !== ($data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code);
 
             if ($nameChanged || $typeChanged) {
                 // 刪除舊索引
@@ -368,11 +280,12 @@ class BasicInformationAltnamesController extends Controller {
                 }
 
                 // 創建新索引
-                if (!empty($data['c_alt_name_chn'])) {
+                $newAltNameChn = $data['c_alt_name_chn'] ?? $ori->c_alt_name_chn;
+                if (!empty($newAltNameChn)) {
                     $this->nameSearchIndexService->indexAltname(
-                        $addr_l[0],
-                        $data['c_alt_name_type_code'],
-                        $data['c_alt_name_chn']
+                        $id,
+                        $data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code,
+                        $newAltNameChn
                     );
                 }
             }
@@ -381,13 +294,6 @@ class BasicInformationAltnamesController extends Controller {
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
-        $newPk = [
-            'c_personid' => $id,
-            'c_sequence' => $data['c_sequence'],
-            'c_alt_name_chn' => $data['c_alt_name_chn'],
-            'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-        ];
-
         return redirect(CompositePrimaryKey::buildUrl(
             'basicinformation.altnames.edit.query',
             ['id' => $id],
@@ -410,33 +316,13 @@ class BasicInformationAltnamesController extends Controller {
      * @return array 包含 4 個元素的陣列 [c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code]
      */
     protected function parseAltnameId($alt) {
-        // 檢測分隔符類型：支持兩種格式 '_._' 或 '-'
         if (strpos($alt, '_._') !== false) {
-            // 使用 _._格式
             $addr_l = explode('_._', $alt);
         } else {
-            // 使用 - 格式
-            // 先用 - 分割，然後對每個部分調用 unionPKDef_decode
-            // （因為 - 被編碼為 (minus) 所以可以安全地用 - 分割）
             $addr_l = explode("-", $alt);
             foreach ($addr_l as $key => $value) {
                 $addr_l[$key] = $this->biogMainRepository->unionPKDef_decode($value);
             }
-        }
-
-        // 檢查陣列長度是否足夠（ALTNAME_DATA 需要 4 個欄位）
-        if (count($addr_l) < 4) {
-            \Log::error("ALTNAME_DATA ID 格式不正確: {$alt}", [
-                'parsed' => $addr_l,
-                'expected_count' => 4,
-                'actual_count' => count($addr_l),
-            ]);
-            abort(400, 'ALTNAME_DATA ID 格式不正確');
-        }
-
-        // 處理 NULL 值
-        if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
-            $addr_l[1] = null;
         }
 
         return $addr_l;
@@ -621,67 +507,24 @@ class BasicInformationAltnamesController extends Controller {
             $originalPk['c_sequence'] = null;
         }
 
-        // 構建查詢條件（使用原始 PK）
-        $conditions = [
-            ['c_personid', '=', $originalPk['c_personid']],
-            ['c_alt_name_chn', '=', $originalPk['c_alt_name_chn']],
-            ['c_alt_name_type_code', '=', $originalPk['c_alt_name_type_code']],
-        ];
+        // 構建舊格式 ID 用於 Repository
+        $originalPkString = $originalPk['c_personid']."-".
+            ($originalPk['c_sequence'] ?? 'NULL')."-".
+            $this->biogMainRepository->unionPKDef($originalPk['c_alt_name_chn'])."-".
+            $originalPk['c_alt_name_type_code'];
 
-        // c_sequence 可能為 null，需要使用 whereNull
-        $queryBuilder = DB::table('ALTNAME_DATA')->where($conditions);
-        if (isset($originalPk['c_sequence']) && $originalPk['c_sequence'] !== null) {
-            $queryBuilder->where('c_sequence', '=', $originalPk['c_sequence']);
-        } else {
-            $queryBuilder->whereNull('c_sequence');
-        }
-
-        // 取得原始資料
-        $ori = $queryBuilder->first();
+        // 取得原始資料（供索引更新判斷）
+        $ori = $this->biogMainRepository->altnameById($originalPkString);
         if (!$ori) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
-        // 準備更新資料（保留 PK 欄位，允許修改）
+        // 保留原始請求資料供索引差異判斷
         $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
-        $data = $this->toolsRepository->timestamp($data);
-
-        // 更新資料（需要重新構建 query builder，因為 $queryBuilder 已經被 first() 消耗）
-        $updateQuery = DB::table('ALTNAME_DATA')->where($conditions);
-        if (isset($originalPk['c_sequence']) && $originalPk['c_sequence'] !== null) {
-            $updateQuery->where('c_sequence', '=', $originalPk['c_sequence']);
-        } else {
-            $updateQuery->whereNull('c_sequence');
+        $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $originalPkString);
+        if (!$newPk) {
+            abort(404, 'ALTNAME_DATA 記錄不存在');
         }
-        $updateQuery->update($data);
-
-        // 記錄操作（使用新的複合主鍵）
-        $newPk = [
-            'c_personid' => $data['c_personid'] ?? $originalPk['c_personid'],
-            'c_sequence' => $data['c_sequence'] ?? $originalPk['c_sequence'],
-            'c_alt_name_chn' => $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'],
-            'c_alt_name_type_code' => $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'],
-        ];
-
-        // 準備存入 operations 的數據，加入註解
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
-        (new AuditLogService())->write(
-            'ALTNAME_DATA',
-            'UPDATE',
-            $newPk,
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
 
         // 更新索引
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
@@ -700,7 +543,7 @@ class BasicInformationAltnamesController extends Controller {
                 $newAltNameChn = $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'];
                 if (!empty($newAltNameChn)) {
                     $this->nameSearchIndexService->indexAltname(
-                        $originalPk['c_personid'],
+                        $newPk['c_personid'] ?? $originalPk['c_personid'],
                         $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'],
                         $newAltNameChn
                     );
@@ -745,52 +588,20 @@ class BasicInformationAltnamesController extends Controller {
         // 驗證必填欄位（c_sequence 為可選）
         CompositePrimaryKey::validateOrFail($pk, 'ALTNAME_DATA', ['c_sequence']);
 
-        // 處理 c_sequence
-        if (isset($pk['c_sequence']) && $pk['c_sequence'] === 'NULL') {
-            $pk['c_sequence'] = null;
-        }
+        // 構建舊格式 ID 用於 Repository
+        $id_ = $pk['c_personid']."-".
+               ($pk['c_sequence'] ?? 'NULL')."-".
+               $this->biogMainRepository->unionPKDef($pk['c_alt_name_chn'])."-".
+               $pk['c_alt_name_type_code'];
 
-        // 構建查詢條件
-        $conditions = [
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
-            ['c_alt_name_type_code', '=', $pk['c_alt_name_type_code']],
-        ];
-
-        // c_sequence 可能為 null，需要使用 whereNull
-        $query = DB::table('ALTNAME_DATA')->where($conditions);
-        if (isset($pk['c_sequence']) && $pk['c_sequence'] !== null) {
-            $query->where('c_sequence', '=', $pk['c_sequence']);
-        } else {
-            $query->whereNull('c_sequence');
-        }
-
-        $row = $query->first();
+        // 取得原始資料用於索引清理
+        $row = $this->biogMainRepository->altnameById($id_);
         if (!$row) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
-        // 記錄操作
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
-
-        // 刪除資料（需要重新構建 query builder）
-        $deleteQuery = DB::table('ALTNAME_DATA')->where($conditions);
-        if (isset($pk['c_sequence']) && $pk['c_sequence'] !== null) {
-            $deleteQuery->where('c_sequence', '=', $pk['c_sequence']);
-        } else {
-            $deleteQuery->whereNull('c_sequence');
-        }
-        $deleteQuery->delete();
-        (new AuditLogService())->write(
-            'ALTNAME_DATA',
-            'DELETE',
-            $pk,
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行刪除（內含事務與審計）
+        $this->biogMainRepository->altnameDeleteById($id_, $id);
 
         // 清理索引
         if ($row && Schema::hasTable('CBDB__NAME_FTS') && $row->c_alt_name_chn) {

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -267,6 +267,9 @@ class BasicInformationAltnamesController extends Controller {
         // 使用 Repository 進行更新（內含事務與審計，且修復 LIKE 謂詞風險）
         $ori = $this->biogMainRepository->altnameById($alt);
         $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $alt);
+        if (!$newPk) {
+            abort(404, 'ALTNAME_DATA 記錄不存在');
+        }
 
         // 手動調用索引服務
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
@@ -328,6 +331,10 @@ class BasicInformationAltnamesController extends Controller {
             foreach ($addr_l as $key => $value) {
                 $addr_l[$key] = $this->biogMainRepository->unionPKDef_decode($value);
             }
+        }
+
+        if (isset($addr_l[1]) && $addr_l[1] === 'NULL') {
+            $addr_l[1] = null;
         }
 
         return $addr_l;
@@ -606,7 +613,10 @@ class BasicInformationAltnamesController extends Controller {
         }
 
         // 使用 Repository 進行刪除（內含事務與審計）
-        $this->biogMainRepository->altnameDeleteById($id_, $id);
+        $deleted = $this->biogMainRepository->altnameDeleteById($id_, $id);
+        if (!$deleted) {
+            abort(404, 'ALTNAME_DATA 記錄不存在');
+        }
 
         // 清理索引
         if ($row && Schema::hasTable('CBDB__NAME_FTS') && $row->c_alt_name_chn) {

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -142,34 +142,17 @@ class BasicInformationController extends Controller {
 
             return redirect()->back();
         }
-        //        $data['c_personid'] = BiogMain::max('c_personid') + 1;
-        $data = $this->toolRepository->timestamp($data, true);
+
         //20190531判別是否為眾包用戶
         if (Auth::user()->isCrowdsourcingUser()) {
+            $data = $this->toolRepository->timestamp($data, true);
             $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data, '', 2);
             flash('眾包紀錄 Create success @ '.Carbon::now(), 'success');
 
             return redirect()->route('basicinformation.index');
         } else {
-            //20230628觸發「自動生成」功能
-            $data = $this->biogMainRepository->auto_pinyin($data);
-            //增加完成
-            $flight = null;
-            DB::transaction(function () use (&$flight, $data) {
-                $flight = BiogMain::create($data);
-                $operation = $this->operationRepository->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data);
-
-                (new AuditLogService())->write(
-                    'BIOG_MAIN',
-                    'INSERT',
-                    ['c_personid' => $data['c_personid']],
-                    null,
-                    $flight->toArray(),
-                    'user',
-                    (string) Auth::id(),
-                    $operation ? (string) $operation->id : null
-                );
-            });
+            // 使用 Repository 進行儲存（內含事務與審計）
+            $flight = $this->biogMainRepository->store($request);
 
             if (Schema::hasTable('CBDB__NAME_FTS')) {
                 $this->nameSearchIndexService->reindexPerson($flight);
@@ -177,7 +160,7 @@ class BasicInformationController extends Controller {
 
             flash('Create success @ '.Carbon::now(), 'success');
 
-            return redirect()->route('basicinformation.edit', $data['c_personid']);
+            return redirect()->route('basicinformation.edit', $flight->c_personid);
         }
         //20190531修改結束
     }

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -305,11 +305,6 @@ class BasicInformationController extends Controller {
             $data['c_by_intercalary'] = (int)($data['c_by_intercalary'] ?? 0);
             $data['c_dy_intercalary'] = (int)($data['c_dy_intercalary'] ?? 0);
 
-            // 拼音自動生成（測試環境可能未建立 pinyin 表）
-            if (Schema::hasTable('pinyin')) {
-                $data = $this->biogMainRepository->auto_pinyin($data);
-            }
-
             // 時間戳
             $data = $this->toolRepository->timestamp($data);
 

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -170,68 +170,9 @@ class BasicInformationEntriesController extends Controller {
             return redirect()->back();
         }
 
-        $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
-        $data['c_personid'] = $id;
-        $data = $this->toolsRepository->timestamp($data, true);
-        //return $request;
-        //修改結束
-        $temp = DB::table('ENTRY_DATA')->where([
-            ['c_personid', '=', $data['c_personid']],
-            ['c_entry_code', '=', $data['c_entry_code']],
-            ['c_sequence', '=', $data['c_sequence']],
-            ['c_kin_code', '=', $data['c_kin_code']],
-            ['c_assoc_code', '=', $data['c_assoc_code']],
-            ['c_kin_id', '=', $data['c_kin_id']],
-            ['c_year', '=', $data['c_year']],
-            ['c_assoc_id', '=', $data['c_assoc_id']],
-            ['c_inst_code', '=', $data['c_inst_code']],
-            ['c_inst_name_code', '=', $data['c_inst_name_code']],
-        ])->first();
-        if (!blank($temp)) {
-            flash('重复数据，保存失败 @ '.Carbon::now(), 'error');
+        // 使用 Repository 進行儲存（內含事務與審計）
+        $data = $this->biogMainRepository->entryStoreById($request, $id);
 
-            return redirect()->back();
-        }
-        DB::table('ENTRY_DATA')->insert($data);
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-        $operation = $this->operationRepository->store(Auth::id(), $id, 1, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_entry_code' => $data['c_entry_code'],
-            'c_sequence' => $data['c_sequence'],
-            'c_kin_code' => $data['c_kin_code'],
-            'c_assoc_code' => $data['c_assoc_code'],
-            'c_kin_id' => $data['c_kin_id'],
-            'c_year' => $data['c_year'],
-            'c_assoc_id' => $data['c_assoc_id'],
-            'c_inst_code' => $data['c_inst_code'],
-            'c_inst_name_code' => $data['c_inst_name_code'],
-        ]), $operationData);
-        (new AuditLogService())->write(
-            'ENTRY_DATA',
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_entry_code' => $data['c_entry_code'],
-                'c_sequence' => $data['c_sequence'],
-                'c_kin_code' => $data['c_kin_code'],
-                'c_assoc_code' => $data['c_assoc_code'],
-                'c_kin_id' => $data['c_kin_id'],
-                'c_year' => $data['c_year'],
-                'c_assoc_id' => $data['c_assoc_id'],
-                'c_inst_code' => $data['c_inst_code'],
-                'c_inst_name_code' => $data['c_inst_name_code'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -731,7 +672,7 @@ class BasicInformationEntriesController extends Controller {
             return redirect()->back();
         }
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -743,44 +684,22 @@ class BasicInformationEntriesController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'ENTRY_DATA');
 
-        // 取得原始資料
-        $row = DB::table('ENTRY_DATA')->where([
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_entry_code', '=', $pk['c_entry_code']],
-            ['c_sequence', '=', $pk['c_sequence']],
-            ['c_kin_code', '=', $pk['c_kin_code']],
-            ['c_assoc_code', '=', $pk['c_assoc_code']],
-            ['c_kin_id', '=', $pk['c_kin_id']],
-            ['c_year', '=', $pk['c_year']],
-            ['c_assoc_id', '=', $pk['c_assoc_id']],
-            ['c_inst_code', '=', $pk['c_inst_code']],
-            ['c_inst_name_code', '=', $pk['c_inst_name_code']],
-        ])->first();
+        // 構建舊格式 ID 用於 Repository
+        $id_ = implode('-', [
+            $pk['c_personid'],
+            $pk['c_entry_code'],
+            $pk['c_sequence'],
+            $pk['c_kin_code'],
+            $pk['c_assoc_code'],
+            $pk['c_kin_id'],
+            $pk['c_year'],
+            $pk['c_assoc_id'],
+            $pk['c_inst_code'],
+            $pk['c_inst_name_code'],
+        ]);
 
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
-
-        DB::table('ENTRY_DATA')->where([
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_entry_code', '=', $pk['c_entry_code']],
-            ['c_sequence', '=', $pk['c_sequence']],
-            ['c_kin_code', '=', $pk['c_kin_code']],
-            ['c_assoc_code', '=', $pk['c_assoc_code']],
-            ['c_kin_id', '=', $pk['c_kin_id']],
-            ['c_year', '=', $pk['c_year']],
-            ['c_assoc_id', '=', $pk['c_assoc_id']],
-            ['c_inst_code', '=', $pk['c_inst_code']],
-            ['c_inst_name_code', '=', $pk['c_inst_name_code']],
-        ])->delete();
-        (new AuditLogService())->write(
-            'ENTRY_DATA',
-            'DELETE',
-            $pk,
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行刪除（內含事務與審計）
+        $this->biogMainRepository->entryDeleteById($id_, $id);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -704,7 +704,10 @@ class BasicInformationEntriesController extends Controller {
         ]);
 
         // 使用 Repository 進行刪除（內含事務與審計）
-        $this->biogMainRepository->entryDeleteById($id_, $id);
+        $deleted = $this->biogMainRepository->entryDeleteById($id_, $id);
+        if (!$deleted) {
+            abort(404, 'ENTRY_DATA 記錄不存在');
+        }
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -113,13 +113,13 @@ class BasicInformationEntriesController extends Controller {
      */
     public function store(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -165,13 +165,18 @@ class BasicInformationEntriesController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         // 使用 Repository 進行儲存（內含事務與審計）
         $data = $this->biogMainRepository->entryStoreById($request, $id);
+        if ($data === false) {
+            flash('重複資料，儲存失敗 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
 
         flash('Store success @ '.Carbon::now(), 'success');
 
@@ -250,11 +255,11 @@ class BasicInformationEntriesController extends Controller {
     public function update(Request $request, $id, $id_) {
         //建安修改20181109
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         } elseif (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -486,13 +491,13 @@ class BasicInformationEntriesController extends Controller {
      */
     public function updateQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -541,7 +546,7 @@ class BasicInformationEntriesController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -667,12 +672,12 @@ class BasicInformationEntriesController extends Controller {
      */
     public function destroyQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -263,6 +263,9 @@ class BasicInformationTextsController extends Controller {
 
         // 使用 Repository 進行更新（內含事務與審計）
         $newPk = $this->biogMainRepository->textUpdateById($request, $id, $id_);
+        if (!$newPk) {
+            abort(404, 'BIOG_TEXT_DATA 記錄不存在');
+        }
 
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -478,7 +481,10 @@ class BasicInformationTextsController extends Controller {
         $id_ = $pk['c_personid']."-".$pk['c_textid']."-".($pk['c_role_id'] ?? 0);
 
         // 使用 Repository 進行刪除（內含事務與審計）
-        $this->biogMainRepository->textDeleteById($id_, $id);
+        $deleted = $this->biogMainRepository->textDeleteById($id_, $id);
+        if (!$deleted) {
+            abort(404, 'BIOG_TEXT_DATA 記錄不存在');
+        }
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -115,13 +115,13 @@ class BasicInformationTextsController extends Controller {
      */
     public function store(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -142,13 +142,18 @@ class BasicInformationTextsController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         // 使用 Repository 進行儲存（內含事務與審計）
         $data = $this->biogMainRepository->textStoreById($request, $id);
+        if ($data === false) {
+            flash('重複資料，儲存失敗 @ '.Carbon::now(), 'error');
+
+            return redirect()->back();
+        }
 
         flash('Store success @ '.Carbon::now(), 'success');
 
@@ -217,13 +222,13 @@ class BasicInformationTextsController extends Controller {
      */
     public function update(Request $request, $id, $id_) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -251,7 +256,7 @@ class BasicInformationTextsController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -353,13 +358,13 @@ class BasicInformationTextsController extends Controller {
      */
     public function updateQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
         if (!Auth::user()->isActive()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -377,7 +382,7 @@ class BasicInformationTextsController extends Controller {
         }
 
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -452,12 +457,12 @@ class BasicInformationTextsController extends Controller {
      */
     public function destroyQuery(Request $request, $id) {
         if (!Auth::check()) {
-            flash('请登入后编辑 @ '.Carbon::now(), 'error');
+            flash('請登入後編輯 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
+            flash('該使用者沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -147,40 +147,9 @@ class BasicInformationTextsController extends Controller {
             return redirect()->back();
         }
 
-        $data = $request->all();
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
-        $data['c_personid'] = $id;
-        $data = $this->toolsRepository->timestamp($data, true);
-        $temp = DB::table($this->table_name)->where([
-            ['c_personid', '=', $data['c_personid']],
-            ['c_textid', '=', $data['c_textid']],
-            ['c_role_id', '=', $data['c_role_id']],
-        ])->first();
-        if (!blank($temp)) {
-            flash('重复数据，保存失败 @ '.Carbon::now(), 'error');
+        // 使用 Repository 進行儲存（內含事務與審計）
+        $data = $this->biogMainRepository->textStoreById($request, $id);
 
-            return redirect()->back();
-        }
-        DB::table($this->table_name)->insert($data);
-        $operation = $this->operationRepository->store(Auth::id(), $id, 1, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_textid' => $data['c_textid'],
-            'c_role_id' => $data['c_role_id'],
-        ]), $data);
-        (new AuditLogService())->write(
-            $this->table_name,
-            'INSERT',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_textid' => $data['c_textid'],
-                'c_role_id' => $data['c_role_id'],
-            ],
-            null,
-            $data,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
         flash('Store success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
@@ -281,67 +250,18 @@ class BasicInformationTextsController extends Controller {
                 ->proposalUpdateWithPk($request, $id, 'texts', $originalPk);
         }
 
-        // 直接儲存需要額外權限檢查
         if (!Auth::user()->canWriteDirectly()) {
             flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
 
-        $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
-        $data = $this->toolsRepository->timestamp($data);
-        $temp_l = explode("-", $id_);
+        // 使用 Repository 進行更新（內含事務與審計）
+        $newPk = $this->biogMainRepository->textUpdateById($request, $id, $id_);
 
-        //20251214新增差異比對紀錄
-        $ori = DB::table($this->table_name)->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_role_id', '=', $temp_l[2]],
-        ])->first();
-
-        DB::table($this->table_name)->where([
-            ['c_personid', '=', $temp_l[0]],
-            ['c_textid', '=', $temp_l[1]],
-            ['c_role_id', '=', $temp_l[2]],
-        ])->update($data);
-        $data['c_personid'] = $temp_l[0];
-
-        // 準備要存入 operations 表的數據，加入註解
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $data['c_personid'],
-            'c_textid' => $data['c_textid'],
-            'c_role_id' => $data['c_role_id'],
-        ]), $operationData, $ori);
-        (new AuditLogService())->write(
-            $this->table_name,
-            'UPDATE',
-            [
-                'c_personid' => $data['c_personid'],
-                'c_textid' => $data['c_textid'],
-                'c_role_id' => $data['c_role_id'],
-            ],
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
         flash('Update success @ '.Carbon::now(), 'success');
 
         // 使用新的查詢參數模式重定向
-        $newPk = [
-            'c_personid' => $data['c_personid'],
-            'c_textid' => $data['c_textid'],
-            'c_role_id' => $data['c_role_id'],
-        ];
-
         return redirect(CompositePrimaryKey::buildUrl(
             'basicinformation.texts.edit.query',
             ['id' => $id],
@@ -537,7 +457,7 @@ class BasicInformationTextsController extends Controller {
             return redirect()->back();
         }
         if (!Auth::user()->canWriteDirectly()) {
-            flash('该用户没有权限，请联系管理员 @ '.Carbon::now(), 'error');
+            flash('该用户沒有權限，請聯繫管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
         }
@@ -549,42 +469,11 @@ class BasicInformationTextsController extends Controller {
         // 驗證必填欄位（c_role_id 為可選，預設為 0）
         CompositePrimaryKey::validateOrFail($pk, 'TEXT_DATA', ['c_role_id']);
 
-        // 構建查詢條件
-        $c_role_id = $pk['c_role_id'] ?? 0;
-        $conditions = [
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_textid', '=', $pk['c_textid']],
-            ['c_role_id', '=', $c_role_id],
-        ];
+        // 構建舊格式 ID 用於 Repository
+        $id_ = $pk['c_personid']."-".$pk['c_textid']."-".($pk['c_role_id'] ?? 0);
 
-        $row = DB::table($this->table_name)->where($conditions)->first();
-        if (!$row) {
-            abort(404, 'BIOG_TEXT_DATA 記錄不存在');
-        }
-
-        // 刪除資料
-        DB::table($this->table_name)->where($conditions)->delete();
-
-        // 記錄操作
-        $operation = $this->operationRepository->store(Auth::id(), $id, 4, $this->table_name, CompositePrimaryKey::buildStoredResourceId([
-            'c_personid' => $pk['c_personid'],
-            'c_textid' => $pk['c_textid'],
-            'c_role_id' => $c_role_id,
-        ]), $row);
-        (new AuditLogService())->write(
-            $this->table_name,
-            'DELETE',
-            [
-                'c_personid' => $pk['c_personid'],
-                'c_textid' => $pk['c_textid'],
-                'c_role_id' => $c_role_id,
-            ],
-            (new AuditLogService())->normalizeRow($row),
-            null,
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
+        // 使用 Repository 進行刪除（內含事務與審計）
+        $this->biogMainRepository->textDeleteById($id_, $id);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -625,6 +625,14 @@ class BiogMainRepository {
         $data = $request->all();
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
+        $duplicate = DB::table('BIOG_TEXT_DATA')->where([
+            ['c_personid', '=', $data['c_personid']],
+            ['c_textid', '=', $data['c_textid']],
+            ['c_role_id', '=', $data['c_role_id']],
+        ])->first();
+        if (!blank($duplicate)) {
+            return false;
+        }
         $data = (new ToolsRepository())->timestamp($data, true);
 
         return DB::transaction(function () use ($id, $data) {
@@ -702,6 +710,21 @@ class BiogMainRepository {
         $comment = $data['__proposal_comment'] ?? null;
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
+        $duplicate = DB::table('ENTRY_DATA')->where([
+            ['c_personid', '=', $data['c_personid']],
+            ['c_entry_code', '=', $data['c_entry_code']],
+            ['c_sequence', '=', $data['c_sequence']],
+            ['c_kin_code', '=', $data['c_kin_code']],
+            ['c_assoc_code', '=', $data['c_assoc_code']],
+            ['c_kin_id', '=', $data['c_kin_id']],
+            ['c_year', '=', $data['c_year']],
+            ['c_assoc_id', '=', $data['c_assoc_id']],
+            ['c_inst_code', '=', $data['c_inst_code']],
+            ['c_inst_name_code', '=', $data['c_inst_name_code']],
+        ])->first();
+        if (!blank($duplicate)) {
+            return false;
+        }
         $data = (new ToolsRepository())->timestamp($data, true);
 
         return DB::transaction(function () use ($id, $data, $comment) {
@@ -2421,6 +2444,15 @@ class BiogMainRepository {
         $data['c_personid'] = $id;
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
+        $duplicate = DB::table('BIOG_ADDR_DATA')->where([
+            ['c_personid', '=', $data['c_personid']],
+            ['c_addr_id', '=', $data['c_addr_id']],
+            ['c_addr_type', '=', $data['c_addr_type']],
+            ['c_sequence', '=', $data['c_sequence']],
+        ])->first();
+        if (!blank($duplicate)) {
+            return false;
+        }
         $data = (new ToolsRepository())->timestamp($data, true);
 
         return DB::transaction(function () use ($id, $data) {
@@ -2582,6 +2614,15 @@ class BiogMainRepository {
         $data = $request->all();
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
+        $duplicate = DB::table('ALTNAME_DATA')->where([
+            ['c_personid', '=', $data['c_personid']],
+            ['c_sequence', '=', $data['c_sequence']],
+            ['c_alt_name_chn', '=', $data['c_alt_name_chn']],
+            ['c_alt_name_type_code', '=', $data['c_alt_name_type_code']],
+        ])->first();
+        if (!blank($duplicate)) {
+            return false;
+        }
         $data = (new ToolsRepository())->timestamp($data, true);
 
         return DB::transaction(function () use ($id, $data) {

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -308,6 +308,30 @@ class BiogMainRepository {
         ];
     }
 
+    public function store(Request $request) {
+        $data = $request->all();
+        $data = (new ToolsRepository())->timestamp($data, true);
+        $data = $this->auto_pinyin($data);
+
+        return DB::transaction(function () use ($data) {
+            $flight = BiogMain::create($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data);
+
+            (new AuditLogService())->write(
+                'BIOG_MAIN',
+                'INSERT',
+                ['c_personid' => $data['c_personid']],
+                null,
+                $flight->toArray(),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $flight;
+        });
+    }
+
     /**
      * @param $request
      * @param $num
@@ -545,8 +569,323 @@ class BiogMainRepository {
         return $data;
     }
 
-    public function textUpdateById() {
+    public function textUpdateById(Request $request, $id, $id_) {
+        $temp_l = explode("-", $id_);
+        $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data = (new ToolsRepository())->timestamp($data);
 
+        return DB::transaction(function () use ($id, $temp_l, $data, $comment) {
+            $ori = DB::table('BIOG_TEXT_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_role_id', '=', $temp_l[2]],
+            ])->lockForUpdate()->first();
+
+            if (!$ori) {
+                return null;
+            }
+
+            DB::table('BIOG_TEXT_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_role_id', '=', $temp_l[2]],
+            ])->update($data);
+
+            $newPk = [
+                'c_personid' => $id,
+                'c_textid' => $data['c_textid'] ?? $ori->c_textid,
+                'c_role_id' => $data['c_role_id'] ?? $ori->c_role_id,
+            ];
+
+            $operationData = $data;
+            if ($comment) {
+                $operationData['__note'] = $comment;
+            }
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_TEXT_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
+
+            (new AuditLogService())->write(
+                'BIOG_TEXT_DATA',
+                'UPDATE',
+                $newPk,
+                (new AuditLogService())->normalizeRow($ori),
+                array_merge((new AuditLogService())->normalizeRow($ori), $data),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $newPk;
+        });
+    }
+
+    public function textStoreById(Request $request, $id) {
+        $data = $request->all();
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
+        $data['c_personid'] = $id;
+        $data = (new ToolsRepository())->timestamp($data, true);
+
+        return DB::transaction(function () use ($id, $data) {
+            DB::table('BIOG_TEXT_DATA')->insert($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_TEXT_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $data['c_personid'],
+                'c_textid' => $data['c_textid'],
+                'c_role_id' => $data['c_role_id'],
+            ]), $data);
+
+            (new AuditLogService())->write(
+                'BIOG_TEXT_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_textid' => $data['c_textid'],
+                    'c_role_id' => $data['c_role_id'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $data;
+        });
+    }
+
+    public function textDeleteById($id_, $c_personid) {
+        $temp_l = explode("-", $id_);
+
+        return DB::transaction(function () use ($c_personid, $temp_l) {
+            $row = DB::table('BIOG_TEXT_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_role_id', '=', $temp_l[2]],
+            ])->lockForUpdate()->first();
+
+            if (!$row) {
+                return false;
+            }
+
+            DB::table('BIOG_TEXT_DATA')->where([
+                ['c_personid', '=', $temp_l[0]],
+                ['c_textid', '=', $temp_l[1]],
+                ['c_role_id', '=', $temp_l[2]],
+            ])->delete();
+
+            $pk = [
+                'c_personid' => $row->c_personid,
+                'c_textid' => $row->c_textid,
+                'c_role_id' => $row->c_role_id,
+            ];
+
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_TEXT_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
+
+            (new AuditLogService())->write(
+                'BIOG_TEXT_DATA',
+                'DELETE',
+                $pk,
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return true;
+        });
+    }
+
+    public function entryStoreById(Request $request, $id) {
+        $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
+        $data['c_personid'] = $id;
+        $data = (new ToolsRepository())->timestamp($data, true);
+
+        return DB::transaction(function () use ($id, $data, $comment) {
+            DB::table('ENTRY_DATA')->insert($data);
+
+            $operationData = $data;
+            if ($comment) {
+                $operationData['__note'] = $comment;
+            }
+
+            $pk = [
+                'c_personid' => $data['c_personid'],
+                'c_entry_code' => $data['c_entry_code'],
+                'c_sequence' => $data['c_sequence'],
+                'c_kin_code' => $data['c_kin_code'],
+                'c_assoc_code' => $data['c_assoc_code'],
+                'c_kin_id' => $data['c_kin_id'],
+                'c_year' => $data['c_year'],
+                'c_assoc_id' => $data['c_assoc_id'],
+                'c_inst_code' => $data['c_inst_code'],
+                'c_inst_name_code' => $data['c_inst_name_code'],
+            ];
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $operationData);
+
+            (new AuditLogService())->write(
+                'ENTRY_DATA',
+                'INSERT',
+                $pk,
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $data;
+        });
+    }
+
+    public function entryUpdateById(Request $request, $id, $id_) {
+        $id = str_replace("--", "-minus", $id_);
+        $addr_a = explode("-", $id);
+        foreach ($addr_a as $key => $value) {
+            $addr_a[$key] = str_replace("minus", "-", $value);
+        }
+
+        $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data = (new ToolsRepository())->timestamp($data);
+
+        return DB::transaction(function () use ($id, $addr_a, $data, $comment) {
+            $ori = DB::table('ENTRY_DATA')->where([
+                ['c_personid', '=', $addr_a[0]],
+                ['c_entry_code', '=', $addr_a[1]],
+                ['c_sequence', '=', $addr_a[2]],
+                ['c_kin_code', '=', $addr_a[3]],
+                ['c_assoc_code', '=', $addr_a[4]],
+                ['c_kin_id', '=', $addr_a[5]],
+                ['c_year', '=', $addr_a[6]],
+                ['c_assoc_id', '=', $addr_a[7]],
+                ['c_inst_code', '=', $addr_a[8]],
+                ['c_inst_name_code', '=', $addr_a[9]],
+            ])->lockForUpdate()->first();
+
+            if (!$ori) {
+                return null;
+            }
+
+            DB::table('ENTRY_DATA')->where([
+                ['c_personid', '=', $addr_a[0]],
+                ['c_entry_code', '=', $addr_a[1]],
+                ['c_sequence', '=', $addr_a[2]],
+                ['c_kin_code', '=', $addr_a[3]],
+                ['c_assoc_code', '=', $addr_a[4]],
+                ['c_kin_id', '=', $addr_a[5]],
+                ['c_year', '=', $addr_a[6]],
+                ['c_assoc_id', '=', $addr_a[7]],
+                ['c_inst_code', '=', $addr_a[8]],
+                ['c_inst_name_code', '=', $addr_a[9]],
+            ])->update($data);
+
+            $newPk = [
+                'c_personid' => $addr_a[0],
+                'c_entry_code' => $data['c_entry_code'] ?? $ori->c_entry_code,
+                'c_sequence' => $data['c_sequence'] ?? $ori->c_sequence,
+                'c_kin_code' => $data['c_kin_code'] ?? $ori->c_kin_code,
+                'c_assoc_code' => $data['c_assoc_code'] ?? $ori->c_assoc_code,
+                'c_kin_id' => $data['c_kin_id'] ?? $ori->c_kin_id,
+                'c_year' => $data['c_year'] ?? $ori->c_year,
+                'c_assoc_id' => $data['c_assoc_id'] ?? $ori->c_assoc_id,
+                'c_inst_code' => $data['c_inst_code'] ?? $ori->c_inst_code,
+                'c_inst_name_code' => $data['c_inst_name_code'] ?? $ori->c_inst_name_code,
+            ];
+
+            $operationData = $data;
+            if ($comment) {
+                $operationData['__note'] = $comment;
+            }
+
+            $operation = (new OperationRepository())->store(Auth::id(), $addr_a[0], 3, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
+
+            (new AuditLogService())->write(
+                'ENTRY_DATA',
+                'UPDATE',
+                $newPk,
+                (new AuditLogService())->normalizeRow($ori),
+                array_merge((new AuditLogService())->normalizeRow($ori), $data),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $newPk;
+        });
+    }
+
+    public function entryDeleteById($id_, $c_personid) {
+        $id = str_replace("--", "-minus", $id_);
+        $addr_a = explode("-", $id);
+        foreach ($addr_a as $key => $value) {
+            $addr_a[$key] = str_replace("minus", "-", $value);
+        }
+
+        return DB::transaction(function () use ($c_personid, $addr_a) {
+            $row = DB::table('ENTRY_DATA')->where([
+                ['c_personid', '=', $addr_a[0]],
+                ['c_entry_code', '=', $addr_a[1]],
+                ['c_sequence', '=', $addr_a[2]],
+                ['c_kin_code', '=', $addr_a[3]],
+                ['c_assoc_code', '=', $addr_a[4]],
+                ['c_kin_id', '=', $addr_a[5]],
+                ['c_year', '=', $addr_a[6]],
+                ['c_assoc_id', '=', $addr_a[7]],
+                ['c_inst_code', '=', $addr_a[8]],
+                ['c_inst_name_code', '=', $addr_a[9]],
+            ])->lockForUpdate()->first();
+
+            if (!$row) {
+                return false;
+            }
+
+            DB::table('ENTRY_DATA')->where([
+                ['c_personid', '=', $addr_a[0]],
+                ['c_entry_code', '=', $addr_a[1]],
+                ['c_sequence', '=', $addr_a[2]],
+                ['c_kin_code', '=', $addr_a[3]],
+                ['c_assoc_code', '=', $addr_a[4]],
+                ['c_kin_id', '=', $addr_a[5]],
+                ['c_year', '=', $addr_a[6]],
+                ['c_assoc_id', '=', $addr_a[7]],
+                ['c_inst_code', '=', $addr_a[8]],
+                ['c_inst_name_code', '=', $addr_a[9]],
+            ])->delete();
+
+            $pk = [
+                'c_personid' => $row->c_personid,
+                'c_entry_code' => $row->c_entry_code,
+                'c_sequence' => $row->c_sequence,
+                'c_kin_code' => $row->c_kin_code,
+                'c_assoc_code' => $row->c_assoc_code,
+                'c_kin_id' => $row->c_kin_id,
+                'c_year' => $row->c_year,
+                'c_assoc_id' => $row->c_assoc_id,
+                'c_inst_code' => $row->c_inst_code,
+                'c_inst_name_code' => $row->c_inst_name_code,
+            ];
+
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ENTRY_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
+
+            (new AuditLogService())->write(
+                'ENTRY_DATA',
+                'DELETE',
+                $pk,
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return true;
+        });
     }
 
     public function officeById($id) {
@@ -2074,6 +2413,331 @@ class BiogMainRepository {
                 ]);
             }
         });
+    }
+
+    public function addrStoreById(Request $request, $id) {
+        $data = $request->all();
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
+        $data['c_personid'] = $id;
+        $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
+        $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
+        $data = (new ToolsRepository())->timestamp($data, true);
+
+        return DB::transaction(function () use ($id, $data) {
+            DB::table('BIOG_ADDR_DATA')->insert($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $data['c_personid'],
+                'c_addr_id' => $data['c_addr_id'],
+                'c_addr_type' => $data['c_addr_type'],
+                'c_sequence' => $data['c_sequence'],
+            ]), $data);
+
+            (new AuditLogService())->write(
+                'BIOG_ADDR_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_addr_id' => $data['c_addr_id'],
+                    'c_addr_type' => $data['c_addr_type'],
+                    'c_sequence' => $data['c_sequence'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $data;
+        });
+    }
+
+    public function addrUpdateById(Request $request, $id, $addr) {
+        $addr_l = $this->parseAddrId($addr);
+        $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
+        $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
+        $data = (new ToolsRepository())->timestamp($data);
+
+        return DB::transaction(function () use ($id, $addr_l, $data, $comment) {
+            $ori = DB::table('BIOG_ADDR_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_addr_id', '=', $addr_l[1]],
+                ['c_addr_type', '=', $addr_l[2]],
+                ['c_sequence', '=', $addr_l[3]],
+            ])->lockForUpdate()->first();
+
+            if (!$ori) {
+                return null;
+            }
+
+            DB::table('BIOG_ADDR_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_addr_id', '=', $addr_l[1]],
+                ['c_addr_type', '=', $addr_l[2]],
+                ['c_sequence', '=', $addr_l[3]],
+            ])->update($data);
+
+            $newPk = [
+                'c_personid' => $id,
+                'c_addr_id' => $data['c_addr_id'] ?? $ori->c_addr_id,
+                'c_addr_type' => $data['c_addr_type'] ?? $ori->c_addr_type,
+                'c_sequence' => $data['c_sequence'] ?? $ori->c_sequence,
+            ];
+
+            $operationData = $data;
+            if ($comment) {
+                $operationData['__note'] = $comment;
+            }
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
+
+            (new AuditLogService())->write(
+                'BIOG_ADDR_DATA',
+                'UPDATE',
+                $newPk,
+                (new AuditLogService())->normalizeRow($ori),
+                array_merge((new AuditLogService())->normalizeRow($ori), $data),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $newPk;
+        });
+    }
+
+    public function addrDeleteById($id, $c_personid) {
+        $addr_l = $this->parseAddrId($id);
+
+        return DB::transaction(function () use ($c_personid, $addr_l) {
+            $row = DB::table('BIOG_ADDR_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_addr_id', '=', $addr_l[1]],
+                ['c_addr_type', '=', $addr_l[2]],
+                ['c_sequence', '=', $addr_l[3]],
+            ])->lockForUpdate()->first();
+
+            if (!$row) {
+                return false;
+            }
+
+            DB::table('BIOG_ADDR_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_addr_id', '=', $addr_l[1]],
+                ['c_addr_type', '=', $addr_l[2]],
+                ['c_sequence', '=', $addr_l[3]],
+            ])->delete();
+
+            $pk = [
+                'c_personid' => $row->c_personid,
+                'c_addr_id' => $row->c_addr_id,
+                'c_addr_type' => $row->c_addr_type,
+                'c_sequence' => $row->c_sequence,
+            ];
+
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
+
+            (new AuditLogService())->write(
+                'BIOG_ADDR_DATA',
+                'DELETE',
+                $pk,
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return true;
+        });
+    }
+
+    protected function parseAddrId($addr) {
+        $addr = str_replace("--", "-minus", $addr);
+        $addr_l = explode("-", $addr);
+        foreach ($addr_l as $key => $value) {
+            $addr_l[$key] = str_replace("minus", "-", $value);
+        }
+
+        return $addr_l;
+    }
+
+    public function altnameById($id) {
+        $addr_l = $this->parseAltnameId($id);
+
+        $row = DB::table('ALTNAME_DATA')->where([
+            ['c_personid', '=', $addr_l[0]],
+            ['c_sequence', '=', $addr_l[1]],
+            ['c_alt_name_chn', '=', $addr_l[2]],
+            ['c_alt_name_type_code', '=', $addr_l[3]],
+        ])->first();
+
+        return $row;
+    }
+
+    public function altnameStoreById(Request $request, $id) {
+        $data = $request->all();
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
+        $data['c_personid'] = $id;
+        $data = (new ToolsRepository())->timestamp($data, true);
+
+        return DB::transaction(function () use ($id, $data) {
+            DB::table('ALTNAME_DATA')->insert($data);
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => $data['c_personid'],
+                'c_sequence' => $data['c_sequence'],
+                'c_alt_name_chn' => $data['c_alt_name_chn'],
+                'c_alt_name_type_code' => $data['c_alt_name_type_code'],
+            ]), $data);
+
+            (new AuditLogService())->write(
+                'ALTNAME_DATA',
+                'INSERT',
+                [
+                    'c_personid' => $data['c_personid'],
+                    'c_sequence' => $data['c_sequence'],
+                    'c_alt_name_chn' => $data['c_alt_name_chn'],
+                    'c_alt_name_type_code' => $data['c_alt_name_type_code'],
+                ],
+                null,
+                $data,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $data;
+        });
+    }
+
+    public function altnameUpdateById(Request $request, $id, $alt) {
+        $addr_l = $this->parseAltnameId($alt);
+        $data = $request->all();
+        $comment = $data['__proposal_comment'] ?? null;
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data = (new ToolsRepository())->timestamp($data);
+
+        return DB::transaction(function () use ($id, $addr_l, $data, $comment) {
+            $ori = DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_sequence', '=', $addr_l[1]],
+                ['c_alt_name_chn', '=', $addr_l[2]],
+                ['c_alt_name_type_code', '=', $addr_l[3]],
+            ])->lockForUpdate()->first();
+
+            if (!$ori) {
+                return null;
+            }
+
+            DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_sequence', '=', $addr_l[1]],
+                ['c_alt_name_chn', '=', $addr_l[2]],
+                ['c_alt_name_type_code', '=', $addr_l[3]],
+            ])->update($data);
+
+            $newPk = [
+                'c_personid' => $id,
+                'c_sequence' => $data['c_sequence'] ?? $ori->c_sequence,
+                'c_alt_name_chn' => $data['c_alt_name_chn'] ?? $ori->c_alt_name_chn,
+                'c_alt_name_type_code' => $data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code,
+            ];
+
+            $operationData = $data;
+            if ($comment) {
+                $operationData['__note'] = $comment;
+            }
+
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 3, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
+
+            (new AuditLogService())->write(
+                'ALTNAME_DATA',
+                'UPDATE',
+                $newPk,
+                (new AuditLogService())->normalizeRow($ori),
+                array_merge((new AuditLogService())->normalizeRow($ori), $data),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return $newPk;
+        });
+    }
+
+    public function altnameDeleteById($id, $c_personid) {
+        $addr_l = $this->parseAltnameId($id);
+
+        return DB::transaction(function () use ($c_personid, $addr_l) {
+            $row = DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_sequence', '=', $addr_l[1]],
+                ['c_alt_name_chn', '=', $addr_l[2]],
+                ['c_alt_name_type_code', '=', $addr_l[3]],
+            ])->lockForUpdate()->first();
+
+            if (!$row) {
+                return false;
+            }
+
+            DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $addr_l[0]],
+                ['c_sequence', '=', $addr_l[1]],
+                ['c_alt_name_chn', '=', $addr_l[2]],
+                ['c_alt_name_type_code', '=', $addr_l[3]],
+            ])->delete();
+
+            $pk = [
+                'c_personid' => $row->c_personid,
+                'c_sequence' => $row->c_sequence,
+                'c_alt_name_chn' => $row->c_alt_name_chn,
+                'c_alt_name_type_code' => $row->c_alt_name_type_code,
+            ];
+
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
+
+            (new AuditLogService())->write(
+                'ALTNAME_DATA',
+                'DELETE',
+                $pk,
+                (new AuditLogService())->normalizeRow($row),
+                null,
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            return true;
+        });
+    }
+
+    protected function parseAltnameId($alt) {
+        if (strpos($alt, '_._') !== false) {
+            $addr_l = explode('_._', $alt);
+        } else {
+            $addr_l = explode("-", $alt);
+            foreach ($addr_l as $key => $value) {
+                $addr_l[$key] = $this->unionPKDef_decode($value);
+            }
+        }
+
+        if (count($addr_l) < 4) {
+            Log::error("ALTNAME_DATA ID 格式不正確: {$alt}", [
+                'parsed' => $addr_l,
+                'expected_count' => 4,
+                'actual_count' => count($addr_l),
+            ]);
+            abort(400, 'ALTNAME_DATA ID 格式不正確');
+        }
+
+        if (isset($addr_l[1]) && $addr_l[1] === 'NULL') {
+            $addr_l[1] = null;
+        }
+
+        return $addr_l;
     }
 
     public function sourceById($id, $_id) {

--- a/docs/AUDIT_LOG_PROPOSAL.md
+++ b/docs/AUDIT_LOG_PROPOSAL.md
@@ -71,13 +71,19 @@ This proposal only targets `/basicinformation` and its 12 subpages. No other mod
   - `tests/Feature/BasicInformationTextsControllerTest.php`
   - 全量 PHPUnit 通過（含上述新增／補強測試）。
 
+### Progress Update (2026-02-17)
+- 進一步修正空主鍵與不存在記錄處理：
+  - ALTNAME 舊格式主鍵中的 `c_sequence = "NULL"` 現在會正確轉為 `null`，避免提案更新誤判找不到資料。
+  - `BIOG_ADDR_DATA`、`BIOG_TEXT_DATA`、`ALTNAME_DATA` 更新流程已補上 repository 回傳 `null` 時的 `404` 處理，避免型別錯誤導致 `500`。
+  - `BIOG_ADDR_DATA`、`BIOG_TEXT_DATA`、`ENTRY_DATA`、`ALTNAME_DATA` 刪除流程已補上 repository 回傳 `false` 時的 `404`，不再出現「刪除成功」假陽性提示。
+- 測試補強：
+  - `tests/Feature/BasicInformationAltnamesControllerTest.php`（新增 `NULL sequence` 提案更新場景）
+  - `tests/Feature/BasicInformationTextsControllerTest.php`（新增刪除不存在資料回傳 `404`）
+
 ## Known Issues (Current Branch)
 - **Transaction consistency gaps**:
   - Multiple controller write paths still execute `data write -> operations write -> audit_log write` without wrapping all steps in one DB transaction.
   - A partial failure can leave data/operations/audit out of sync.
-- **ALTNAME delete predicate risk**:
-  - Some delete paths use `LIKE` matching for `c_alt_name_chn`, which can affect multiple rows.
-  - Current audit logging on these paths records only one row snapshot, so audit may be incomplete if multiple rows are deleted.
 - **Test coverage gaps**:
   - Several feature tests were updated to create `audit_log` schema only, but do not yet assert audit payload correctness (row count, operation type, PK serialization, before/after snapshot).
 - **Progress semantics caveat**:
@@ -189,5 +195,5 @@ If history lookup becomes too slow or volume grows:
 - Consider partitioning in MariaDB for very large volumes.
 
 ## Version
-- Version: 0.4
-- Date: 2026-02-16
+- Version: 0.5
+- Date: 2026-02-17

--- a/docs/AUDIT_LOG_PROPOSAL.md
+++ b/docs/AUDIT_LOG_PROPOSAL.md
@@ -56,9 +56,20 @@ This proposal only targets `/basicinformation` and its 12 subpages. No other mod
 - [x] Add AuditLog service (create)
 - [~] Integrate `BIOG_MAIN` writes (currently split across `BiogMainRepository` and controller/API paths)
 - [x] Integrate `POSTED_TO_OFFICE_DATA` / `POSTED_TO_ADDR_DATA` writes
-- [~] Integrate remaining `/basicinformation` tables (core CRUD paths mostly covered, but quality gaps remain in some legacy flows)
+- [x] Integrate remaining `/basicinformation` tables
 - [~] Ensure transactional writes for audit + data changes (partially done; several controller paths still write without single transaction boundary)
 - [~] Add SQLite migration/test coverage in tests (multiple feature tests now create `audit_log`; assertion coverage for audit behavior is still incomplete)
+
+### Progress Update (2026-02-16)
+- BasicInformation 核心寫入路徑（`BIOG_MAIN`、`ALTNAME_DATA`、`BIOG_ADDR_DATA`、`BIOG_TEXT_DATA`、`ENTRY_DATA`）已統一改為 Repository 層處理，並在主要 CRUD 路徑寫入 `audit_log`。
+- `textDeleteById()` 已補齊為完整交易刪除流程（資料刪除 + `operations` + `audit_log`）。
+- ALTNAME 流程已修正查詢參數更新路徑中的未定義變數與重複更新問題，並補回 `c_sequence = NULL` 主鍵解析、`__proposal_comment` 寫入 `operations.resource_data.__note`。
+- `store` 路徑已恢復舊行為：重複資料時不直接插入，改為回傳錯誤並由 Controller 顯示提示。
+- `flash` 提示文字已在本次涉及之 BasicInformation Controller 轉為繁體中文。
+- 測試已補強：
+  - `tests/Feature/BasicInformationAltnamesControllerTest.php`
+  - `tests/Feature/BasicInformationTextsControllerTest.php`
+  - 全量 PHPUnit 通過（含上述新增／補強測試）。
 
 ## Known Issues (Current Branch)
 - **Transaction consistency gaps**:
@@ -178,5 +189,5 @@ If history lookup becomes too slow or volume grows:
 - Consider partitioning in MariaDB for very large volumes.
 
 ## Version
-- Version: 0.3
-- Date: 2026-02-11
+- Version: 0.4
+- Date: 2026-02-16

--- a/docs/BIOGMAIN_REPOSITORY_REFACTOR_PLAN.md
+++ b/docs/BIOGMAIN_REPOSITORY_REFACTOR_PLAN.md
@@ -136,6 +136,16 @@
   - `./vendor/bin/phpunit tests/Feature/EventStatusWriteActionsTest.php`
   - `OK (6 tests, 35 assertions)`
 
+### 2026-02-17 — Transitional Hardening (BasicInformation Core Writes)
+- `ALTNAME_DATA`、`BIOG_ADDR_DATA`、`BIOG_TEXT_DATA`、`ENTRY_DATA` 的主要寫入路徑已收斂至 repository 寫入與審計流程。
+- 補強「不存在記錄」防護：
+  - 更新流程對 repository 回傳 `null` 統一改為 `404`（避免 `CompositePrimaryKey::buildUrl()` 型別錯誤導致 `500`）。
+  - 刪除流程對 repository 回傳 `false` 統一改為 `404`（避免刪除假成功提示）。
+- 修正 ALTNAME 舊格式主鍵解析中的 `c_sequence = "NULL"`，確保提案更新可正確命中 nullable PK 記錄。
+- 測試：
+  - `./vendor/bin/phpunit tests/Feature/BasicInformationAltnamesControllerTest.php tests/Feature/BasicInformationTextsControllerTest.php`
+  - `./vendor/bin/phpunit`（全量）
+
 ## 10. Version
-- Version: 1.0
-- Date: 2026-02-16
+- Version: 1.1
+- Date: 2026-02-17

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -171,6 +171,40 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $this->assertEquals('新增別名', $new_data['c_alt_name_chn']);
     }
 
+    #[Test]
+    public function testStoreDuplicateAltnameShowsErrorAndDoesNotInsertAgain() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'duplicate-altname@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '重複別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->post('/basicinformation/1/altnames', [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '重複別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response->assertStatus(302);
+        $this->assertEquals(1, DB::table('ALTNAME_DATA')->count());
+    }
+
     /**
      * 測試當 ALTNAME_DATA 記錄不存在時返回 404
      */

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -432,6 +432,47 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $this->assertEquals('測試備註', $resourceData['__note'] ?? null);
     }
 
+    #[Test]
+    public function testUpdateProposalWithNullSequenceUsesNullPkCorrectly() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'proposal-null-sequence@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => null,
+            'c_alt_name_chn' => '空序號別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->patch('/basicinformation/1/altnames/1-NULL-空序號別名-1', [
+            'action' => 'proposal',
+            'c_sequence' => null,
+            'c_alt_name_chn' => '空序號別名-提案',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+            '__proposal_comment' => '空序號提案',
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('operations', [
+            'resource' => 'ALTNAME_DATA',
+            'op_type' => 9,
+            'c_personid' => 1,
+        ]);
+    }
+
     /**
      * 測試 c_source 為 0 時的處理
      */

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -90,6 +90,23 @@ class BasicInformationAltnamesControllerTest extends TestCase {
             $table->timestamps();
         });
 
+        // 創建 audit_log 表
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at');
+            $table->string('table_name');
+            $table->string('operation');
+            $table->string('actor_type');
+            $table->string('actor_id');
+            $table->string('operation_id');
+            $table->json('row_pk');
+            $table->string('row_pk_text');
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+
         // 插入測試用的別名類型代碼
         DB::table('ALTNAME_CODES')->insert([
             'c_name_type_code' => 1,
@@ -103,8 +120,55 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('ALTNAME_CODES');
         Schema::dropIfExists('operations');
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('users');
         parent::tearDown();
+    }
+
+    /**
+     * 測試新增別名會正確寫入 audit_log
+     */
+    #[Test]
+    public function testStoreWritesAuditLog() {
+        // 創建用戶
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 創建 BIOG_MAIN 記錄
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        $data = [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '新增別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ];
+
+        $response = $this->actingAs($user)
+            ->post('/basicinformation/1/altnames', $data);
+
+        $response->assertStatus(302);
+
+        // 驗證 audit_log 記錄
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'ALTNAME_DATA',
+            'operation' => 'INSERT',
+            'actor_id' => (string) $user->id,
+            'row_pk_text' => 'c_personid=1&c_sequence=1&c_alt_name_chn=%E6%96%B0%E5%A2%9E%E5%88%A5%E5%90%8D&c_alt_name_type_code=1',
+        ]);
+
+        $log = DB::table('audit_log')->first();
+        $this->assertNotNull($log->operation_id);
+        $new_data = json_decode($log->new_data, true);
+        $this->assertEquals('新增別名', $new_data['c_alt_name_chn']);
     }
 
     /**
@@ -250,6 +314,88 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $response->assertStatus(200);
         $response->assertViewHas('row');
         $response->assertViewHas('text_str', '100 Test Title 測試標題');
+    }
+
+    #[Test]
+    public function testDestroyQueryCanDeleteWhenSequenceIsNull() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'null-sequence@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => null,
+            'c_alt_name_chn' => '空序號別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->delete('/basicinformation/1/altnames/delete?c_personid=1&c_alt_name_chn=空序號別名&c_alt_name_type_code=1');
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '空序號別名',
+            'c_alt_name_type_code' => '1',
+        ]);
+    }
+
+    #[Test]
+    public function testUpdateQueryWritesProposalCommentIntoOperationNote() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'update-note@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->patch(
+            '/basicinformation/1/altnames/update?c_personid=1&c_sequence=1&c_alt_name_chn=舊別名&c_alt_name_type_code=1',
+            [
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '新別名',
+                'c_alt_name_type_code' => '1',
+                'c_source' => 0,
+                '__proposal_comment' => '測試備註',
+            ]
+        );
+
+        $response->assertStatus(302);
+
+        $operation = DB::table('operations')
+            ->where('resource', 'ALTNAME_DATA')
+            ->where('op_type', 3)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $resourceData = json_decode($operation->resource_data, true);
+        $this->assertEquals('測試備註', $resourceData['__note'] ?? null);
     }
 
     /**

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -134,4 +134,31 @@ class BasicInformationTextsControllerTest extends TestCase {
         $oldData = json_decode($log->old_data, true);
         $this->assertEquals(100, $oldData['c_textid']);
     }
+
+    #[Test]
+    public function testStoreDuplicateTextShowsErrorAndDoesNotInsertAgain(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'texts-duplicate@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_TEXT_DATA')->insert([
+            'c_personid' => 1,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->post('/basicinformation/1/texts', [
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 0,
+        ]);
+
+        $response->assertStatus(302);
+        $this->assertEquals(1, DB::table('BIOG_TEXT_DATA')->count());
+    }
 }

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -161,4 +161,21 @@ class BasicInformationTextsControllerTest extends TestCase {
         $response->assertStatus(302);
         $this->assertEquals(1, DB::table('BIOG_TEXT_DATA')->count());
     }
+
+    #[Test]
+    public function testDestroyQueryReturns404WhenRowDoesNotExist(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'texts-delete-missing@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        $response = $this->actingAs($user)->delete(
+            '/basicinformation/1/texts/delete?c_personid=1&c_textid=999&c_role_id=0'
+        );
+
+        $response->assertStatus(404);
+    }
 }

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BasicInformationTextsControllerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('BIOG_TEXT_DATA');
+        Schema::create('BIOG_TEXT_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_textid');
+            $table->integer('c_role_id')->default(0);
+            $table->integer('c_source')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
+        });
+
+        Schema::dropIfExists('operations');
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid');
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id');
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at');
+            $table->string('table_name');
+            $table->string('operation');
+            $table->string('actor_type');
+            $table->string('actor_id');
+            $table->string('operation_id');
+            $table->json('row_pk');
+            $table->string('row_pk_text');
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('BIOG_TEXT_DATA');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function testDestroyQueryDeletesRowAndWritesAuditLog(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'texts-delete@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_TEXT_DATA')->insert([
+            'c_personid' => 1,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->delete(
+            '/basicinformation/1/texts/delete?c_personid=1&c_textid=100&c_role_id=0'
+        );
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseMissing('BIOG_TEXT_DATA', [
+            'c_personid' => 1,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+        ]);
+
+        $this->assertDatabaseHas('operations', [
+            'c_personid' => 1,
+            'op_type' => 4,
+            'resource' => 'BIOG_TEXT_DATA',
+        ]);
+
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'BIOG_TEXT_DATA',
+            'operation' => 'DELETE',
+            'actor_id' => (string) $user->id,
+        ]);
+
+        $log = DB::table('audit_log')->first();
+        $this->assertNotNull($log->operation_id);
+        $this->assertNull($log->new_data);
+        $oldData = json_decode($log->old_data, true);
+        $this->assertEquals(100, $oldData['c_textid']);
+    }
+}

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -84,12 +84,19 @@ class BiogMainProposalTest extends TestCase {
             $table->json('old_data')->nullable();
             $table->json('new_data')->nullable();
         });
+
+        Schema::create('pinyin', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('lastname_chn')->nullable();
+            $table->string('lastname_pinyin')->nullable();
+        });
     }
 
     protected function tearDown(): void {
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('pinyin');
         Schema::dropIfExists('users');
         parent::tearDown();
     }
@@ -209,5 +216,55 @@ class BiogMainProposalTest extends TestCase {
             'table_name' => 'BIOG_MAIN',
             'operation' => 'UPDATE',
         ]);
+    }
+
+    #[Test]
+    public function testBiogMainProposalDoesNotRewriteMingziFieldsWhenNotChanged() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $personId = 3;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '歐陽修',
+            'c_name' => 'Ouyang Xiu',
+            'c_surname_chn' => '歐陽',
+            'c_surname' => 'Ouyang',
+            'c_mingzi_chn' => '修',
+            'c_mingzi' => 'Xiu',
+            'c_notes' => 'Original notes',
+        ]);
+
+        DB::table('pinyin')->insert([
+            'lastname_chn' => '李',
+            'lastname_pinyin' => 'Li',
+        ]);
+
+        $response = $this->patch(route('basicinformation.update', $personId), [
+            'action' => 'proposal',
+            'c_surname_chn' => '歐陽',
+            'c_mingzi_chn' => '修',
+            'c_surname' => 'Ouyang',
+            'c_mingzi' => 'Xiu',
+            'c_name_chn' => '歐陽修',
+            'c_name' => 'Ouyang Xiu',
+            'c_notes' => 'Only notes changed',
+            '__proposal_comment' => '僅修改註解',
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', $personId));
+
+        $operation = Operation::where('resource', 'BIOG_MAIN')
+            ->where('c_personid', $personId)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('修', $payload['c_mingzi_chn']);
+        $this->assertSame('Xiu', $payload['c_mingzi']);
+        $this->assertSame('歐陽修', $payload['c_name_chn']);
+        $this->assertSame('Ouyang Xiu', $payload['c_name']);
     }
 }


### PR DESCRIPTION
- 將 BIOG_MAIN、ALTNAME、BIOG_ADDR、BIOG_TEXT、ENTRY 的寫入流程統一走 Repository 交易
- 補上 textDeleteById 實作，完善刪除資料、operations 與 audit_log 寫入
- 修正 ALTNAME 查詢參數更新流程的未定義變數與重複更新問題
- 補齊 ALTNAME NULL 主鍵解析與更新備註 __note 寫入
- 新增 / 補強 BasicInformationAltnamesControllerTest 與 BasicInformationTextsControllerTest

測試：

- ./vendor/bin/phpunit --filter BasicInformationAltnamesControllerTest
- ./vendor/bin/phpunit --filter BasicInformationTextsControllerTest
- ./vendor/bin/phpunit --filter BasicInformation
- ./vendor/bin/phpunit