### PR TITLE
統一提案註解寫入操作記錄並補齊過濾

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -157,7 +157,7 @@ class BasicInformationAddressesController extends Controller {
         }
 
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);

--- a/app/Http/Controllers/BasicInformationSocialInstController.php
+++ b/app/Http/Controllers/BasicInformationSocialInstController.php
@@ -262,7 +262,7 @@ class BasicInformationSocialInstController extends Controller {
         }
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token', 'action']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
         //return $request;
         //修改結束 //20211020修改增加c_bi_begin_year與c_bi_end_year
@@ -457,7 +457,7 @@ class BasicInformationSocialInstController extends Controller {
         CompositePrimaryKey::validateOrFail($originalPk, 'BIOG_INST_DATA');
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token', 'action']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = $this->toolsRepository->timestamp($data);
 
         // 取得原始資料（使用原始 PK）

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -148,7 +148,7 @@ class BasicInformationTextsController extends Controller {
         }
 
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data = $this->toolsRepository->timestamp($data, true);
         $temp = DB::table($this->table_name)->where([

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -60,6 +60,7 @@ class OperationsController extends Controller {
         //將物件轉為陣列進行陣列比對
         $listsArr = $this->operationRepository->objectToArray($lists);
         $dataRows = isset($listsArr['data']) && is_array($listsArr['data']) ? $listsArr['data'] : [];
+        $auditLogsByOperation = $this->loadAuditLogsByOperation($dataRows);
         $all = count($dataRows);
         for ($x = 0;$x < $all;$x++) {
             $c_personid = '';
@@ -67,6 +68,8 @@ class OperationsController extends Controller {
             $resource = $dataRows[$x]['resource'];
             $arr1 = $dataRows[$x]['resource_data'];
             $arr2 = $dataRows[$x]['resource_original'];
+            $operationId = (string) ($dataRows[$x]['id'] ?? '');
+            $lists[$x]->setAttribute('audit_logs', $auditLogsByOperation[$operationId] ?? []);
             //20191225實時比對的程式判斷
             if (!empty($c_personid = $dataRows[$x]['c_personid']) && $dataRows[$x]['resource'] == "BIOG_MAIN") {
                 $arr3 = BiogMain::find($c_personid)->toArray();
@@ -1006,5 +1009,135 @@ class OperationsController extends Controller {
         $result = $key;
 
         return $result;
+    }
+
+    protected function loadAuditLogsByOperation(array $dataRows): array {
+        if (empty($dataRows) || !Schema::hasTable('audit_log')) {
+            return [];
+        }
+
+        $operationIds = [];
+        foreach ($dataRows as $row) {
+            if (!isset($row['id'])) {
+                continue;
+            }
+            $operationIds[] = (string) $row['id'];
+        }
+        $operationIds = array_values(array_unique($operationIds));
+        if (empty($operationIds)) {
+            return [];
+        }
+
+        $logs = DB::table('audit_log')
+            ->whereIn('operation_id', $operationIds)
+            ->orderBy('id')
+            ->get([
+                'id',
+                'operation_id',
+                'table_name',
+                'operation',
+                'row_pk_text',
+                'old_data',
+                'new_data',
+            ]);
+
+        $grouped = [];
+        foreach ($logs as $log) {
+            $operationId = (string) ($log->operation_id ?? '');
+            if ($operationId === '') {
+                continue;
+            }
+
+            $oldData = $this->decodeJsonNullable($log->old_data ?? null);
+            $newData = $this->decodeJsonNullable($log->new_data ?? null);
+
+            $grouped[$operationId][] = [
+                'id' => (int) $log->id,
+                'table_name' => (string) $log->table_name,
+                'operation' => (string) $log->operation,
+                'row_pk_text' => (string) $log->row_pk_text,
+                'diff' => $this->buildAuditDiff($oldData, $newData),
+            ];
+        }
+
+        return $grouped;
+    }
+
+    protected function decodeJsonNullable($payload): ?array {
+        if ($payload === null || $payload === '') {
+            return null;
+        }
+
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (is_string($payload)) {
+            $decoded = json_decode($payload, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    protected function buildAuditDiff(?array $oldData, ?array $newData): ?array {
+        $oldArr = is_array($oldData) ? $oldData : [];
+        $newArr = is_array($newData) ? $newData : [];
+        $allKeys = array_unique(array_merge(array_keys($oldArr), array_keys($newArr)));
+        if (empty($allKeys)) {
+            return null;
+        }
+
+        $formatValue = function ($value) {
+            if (is_array($value) || is_object($value)) {
+                return json_encode($value, JSON_UNESCAPED_UNICODE);
+            }
+            if ($value === null) {
+                return '(null)';
+            }
+            if (is_bool($value)) {
+                return $value ? 'true' : 'false';
+            }
+
+            return (string) $value;
+        };
+
+        $normalizeValue = function ($value) {
+            if (is_array($value) || is_object($value)) {
+                return json_encode($value);
+            }
+            if ($value === null) {
+                return '';
+            }
+            if (is_bool($value)) {
+                return $value ? '1' : '0';
+            }
+
+            return trim((string) $value);
+        };
+
+        $rows = [];
+        foreach ($allKeys as $key) {
+            if (in_array($key, ['_method', '_token'], true)) {
+                continue;
+            }
+            $beforeRaw = array_key_exists($key, $oldArr) ? $oldArr[$key] : null;
+            $afterRaw = array_key_exists($key, $newArr) ? $newArr[$key] : null;
+            if ($normalizeValue($beforeRaw) === $normalizeValue($afterRaw)) {
+                continue;
+            }
+            $rows[] = [
+                'field' => $key,
+                'before' => $formatValue($beforeRaw),
+                'after' => $formatValue($afterRaw),
+                'current' => '(未取得)',
+                'matches_current' => false,
+                'matches_before' => false,
+            ];
+        }
+
+        return !empty($rows) ? ['rows' => $rows] : null;
     }
 }

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Schema;
 
 class OperationsController extends Controller {
     protected $operationRepository;
+    protected array $auditCurrentRowCache = [];
 
     public function __construct(OperationRepository $operationRepository) {
         $this->operationRepository = $operationRepository;
@@ -1036,6 +1037,7 @@ class OperationsController extends Controller {
                 'operation_id',
                 'table_name',
                 'operation',
+                'row_pk',
                 'row_pk_text',
                 'old_data',
                 'new_data',
@@ -1050,13 +1052,15 @@ class OperationsController extends Controller {
 
             $oldData = $this->decodeJsonNullable($log->old_data ?? null);
             $newData = $this->decodeJsonNullable($log->new_data ?? null);
+            $rowPk = $this->decodeJsonNullable($log->row_pk ?? null);
+            $currentData = $this->resolveAuditCurrentRow((string) $log->table_name, $rowPk);
 
             $grouped[$operationId][] = [
                 'id' => (int) $log->id,
                 'table_name' => (string) $log->table_name,
                 'operation' => (string) $log->operation,
                 'row_pk_text' => (string) $log->row_pk_text,
-                'diff' => $this->buildAuditDiff($oldData, $newData),
+                'diff' => $this->buildAuditDiff($oldData, $newData, $currentData),
             ];
         }
 
@@ -1082,9 +1086,10 @@ class OperationsController extends Controller {
         return null;
     }
 
-    protected function buildAuditDiff(?array $oldData, ?array $newData): ?array {
+    protected function buildAuditDiff(?array $oldData, ?array $newData, ?array $currentData = null): ?array {
         $oldArr = is_array($oldData) ? $oldData : [];
         $newArr = is_array($newData) ? $newData : [];
+        $currentArr = is_array($currentData) ? $currentData : [];
         $allKeys = array_unique(array_merge(array_keys($oldArr), array_keys($newArr)));
         if (empty($allKeys)) {
             return null;
@@ -1128,16 +1133,45 @@ class OperationsController extends Controller {
             if ($normalizeValue($beforeRaw) === $normalizeValue($afterRaw)) {
                 continue;
             }
+            $currentExists = array_key_exists($key, $currentArr);
+            $currentRaw = $currentExists ? $currentArr[$key] : null;
             $rows[] = [
                 'field' => $key,
                 'before' => $formatValue($beforeRaw),
                 'after' => $formatValue($afterRaw),
-                'current' => '(未取得)',
-                'matches_current' => false,
-                'matches_before' => false,
+                'current' => $currentExists ? $formatValue($currentRaw) : '(未取得)',
+                'matches_current' => $currentExists && $normalizeValue($afterRaw) === $normalizeValue($currentRaw),
+                'matches_before' => $currentExists && $normalizeValue($beforeRaw) === $normalizeValue($currentRaw),
             ];
         }
 
         return !empty($rows) ? ['rows' => $rows] : null;
+    }
+
+    protected function resolveAuditCurrentRow(string $tableName, ?array $rowPk): ?array {
+        $tableName = trim($tableName);
+        if ($tableName === '' || empty($rowPk) || !Schema::hasTable($tableName)) {
+            return null;
+        }
+
+        $cacheKey = $tableName . '|' . json_encode($rowPk, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (array_key_exists($cacheKey, $this->auditCurrentRowCache)) {
+            return $this->auditCurrentRowCache[$cacheKey];
+        }
+
+        $query = DB::table($tableName);
+        foreach ($rowPk as $column => $value) {
+            if ($value === null || $value === 'NULL') {
+                $query->whereNull($column);
+            } else {
+                $query->where($column, '=', $value);
+            }
+        }
+
+        $row = $query->first();
+        $normalized = $row ? json_decode(json_encode($row), true) : null;
+        $this->auditCurrentRowCache[$cacheKey] = $normalized;
+
+        return $normalized;
     }
 }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -824,7 +824,7 @@ class BiogMainRepository {
         $c_autogen_notes = $row->c_autogen_notes;
         $old_kin_id = $row->c_kin_id;
         $old_kin_code = $row->c_kin_code;
-        $data = Arr::except($data, ['_token', '_method', 'c_kinship_pair']);
+        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'c_kinship_pair']);
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
@@ -938,7 +938,7 @@ class BiogMainRepository {
         $auditLog = new AuditLogService();
         $data = $request->all();
         $kin_pair = $data['c_kinship_pair'];
-        $data = Arr::except($data, ['_token', 'c_kinship_pair']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_kinship_pair']);
         $data['c_personid'] = $id;
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
@@ -1151,7 +1151,7 @@ class BiogMainRepository {
     public function possessionUpdateById(Request $request, $id, $id_) {
         $data = $request->all();
         $c_addr_id = $data['c_addr_id'];
-        $data = Arr::except($data, ['_method', '_token', 'c_addr_id']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_addr_id']);
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data);
         $ori = DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id_)->first();
@@ -1181,7 +1181,7 @@ class BiogMainRepository {
         $data['c_possession_record_id'] = DB::table('POSSESSION_DATA')->max('c_possession_record_id') + 1;
         $data['c_personid'] = $id;
         $addr = $data['c_addr_id'];
-        $data = Arr::except($data, ['_token', 'c_addr_id']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_addr_id']);
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
 
@@ -1294,7 +1294,7 @@ class BiogMainRepository {
     public function socialInstStoreById(Request $request, $id) {
         $data = $request->all();
         $data['c_personid'] = $id;
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_source'] = ($data['c_source'] == -999) ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data, true);
 
@@ -1726,7 +1726,7 @@ class BiogMainRepository {
         $old_c_assocship_pair1 = $old_c_assocship_pair['c_assoc_pair'] ?? null;
         $old_c_assocship_pair2 = $old_c_assocship_pair['c_assoc_pair2'] ?? null;
 
-        $data = Arr::except($data, ['_method', '_token', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
         $data = (new ToolsRepository())->timestamp($data);
 
         $ori_data = $data;
@@ -1815,7 +1815,7 @@ class BiogMainRepository {
         $kin_pair = $data['c_kinship_pair'];
         $assoc_kin_pair = $data['c_assoc_kinship_pair'];
         $data['c_personid'] = $id;
-        $data = Arr::except($data, ['_token', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
 
         #20250417「社會關係始年」缺省值製作，若「社會關係始年」為空，則自動填充為-9999。
         if ($data['c_assoc_first_year'] == '') {  #這個判斷式只會將「社會關係始年」為空白時，填充為-9999，如果使用者填寫0，會維持0的值而不更動。
@@ -2118,7 +2118,7 @@ class BiogMainRepository {
         }
 
         $data = $request->all();
-        $data = Arr::except($data, ['_method', '_token']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         // Select2 對 id=0 處理有問題，API 中 c_textid=0 會被轉換為 -999，需轉回 0
         $data['c_textid'] = $data['c_textid'] == -999 ? '0' : $data['c_textid'];
@@ -2163,7 +2163,7 @@ class BiogMainRepository {
 
     public function sourceStoreById(Request $request, $id) {
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         // Select2 對 id=0 處理有問題，API 中 c_textid=0 會被轉換為 -999，需轉回 0
         $data['c_textid'] = $data['c_textid'] == -999 ? '0' : $data['c_textid'];

--- a/app/Repositories/EventStatusRepository.php
+++ b/app/Repositories/EventStatusRepository.php
@@ -52,7 +52,7 @@ class EventStatusRepository {
             ['c_status_code', '=', $temp_l[2]],
         ])->first();
         $data = $request->all();
-        $data = Arr::except($data, ['_token', '_method']);
+        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment']);
         $data['c_status_code'] = $data['c_status_code'] == -999 ? '0' : $data['c_status_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data);
@@ -86,7 +86,7 @@ class EventStatusRepository {
 
     public function statuseStoreById(Request $request, $id) {
         $data = $request->all();
-        $data = Arr::except($data, ['_token']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
         $data['c_status_code'] = $data['c_status_code'] == -999 ? '0' : $data['c_status_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
@@ -217,7 +217,7 @@ class EventStatusRepository {
             $data['c_event_code']
         );
 
-        $data = Arr::except($data, ['_method', '_token', 'c_addr_id']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_addr_id']);
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository())->timestamp($data);
         $updateQuery = DB::table('EVENTS_DATA')
@@ -256,7 +256,7 @@ class EventStatusRepository {
         $data = $this->formatSelect($data);
         $data['c_personid'] = $id;
         $this->insertAddrEvent($data['c_addr_id'], $id, $data['c_sequence'], $data['c_event_code']);
-        $data = Arr::except($data, ['_token', 'c_addr_id']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_addr_id']);
         $data['c_intercalary'] = (int)($data['c_intercalary']);
         $data = (new ToolsRepository())->timestamp($data, true);
         DB::table('EVENTS_DATA')->insert($data);

--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -45,7 +45,7 @@ class OfficePostingRepository {
         $hasAddressChange = $incomingAddr !== null
             && $this->selectionListHasChanges($incomingAddr, $existingAddresses, -999);
 
-        $data = Arr::except($data, ['_method', '_token', 'c_addr', 'c_addr_cleared', '_id', '_postingid', '_officeid', 'ai_fill_log_id']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_addr', 'c_addr_cleared', '_id', '_postingid', '_officeid', 'ai_fill_log_id']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
         $data['c_office_id'] = $data['c_office_id'] == -999 ? '0' : $data['c_office_id'];
@@ -362,7 +362,7 @@ class OfficePostingRepository {
             $auditLog = new AuditLogService();
             $payload = $request->all();
             $c_addr = $payload['c_addr'] ?? [];
-            $data = Arr::except($payload, ['_token', 'c_addr', 'c_addr_cleared', 'ai_fill_log_id']);
+            $data = Arr::except($payload, ['_token', 'action', '__proposal_comment', 'c_addr', 'c_addr_cleared', 'ai_fill_log_id']);
 
             $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
             $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);

--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -68,6 +68,7 @@ class OfficePostingRepository {
             $auditLog = new AuditLogService();
             $previousOfficeId = (int) ($ori['c_office_id'] ?? $_officeid);
             $currentOfficeId = $previousOfficeId;
+            $officeOperation = null;
             if ($hasPostingChange) {
                 $timestamped = (new ToolsRepository())->timestamp($data);
 
@@ -269,15 +270,18 @@ class OfficePostingRepository {
                     'c_posting_id' => $_postingid,
                 ]);
 
-                $addrOperation = (new OperationRepository())->store(
-                    Auth::id(),
-                    $c_personid,
-                    3,
-                    'POSTED_TO_ADDR_DATA',
-                    $addrResourceId,
-                    ['rows' => $afterRows],
-                    ['rows' => $beforeRows]
-                );
+                $addrOperation = $officeOperation;
+                if ($addrOperation === null) {
+                    $addrOperation = (new OperationRepository())->store(
+                        Auth::id(),
+                        $c_personid,
+                        3,
+                        'POSTED_TO_ADDR_DATA',
+                        $addrResourceId,
+                        ['rows' => $afterRows],
+                        ['rows' => $beforeRows]
+                    );
+                }
 
                 $addrAfterAuditRows = DB::table('POSTED_TO_ADDR_DATA')
                     ->where('c_personid', $_id)

--- a/app/Repositories/OperationRepository.php
+++ b/app/Repositories/OperationRepository.php
@@ -29,6 +29,7 @@ class OperationRepository {
      * @return mixed
      */
     public function store($user_id, $c_personid, $op_type, $resource, $resource_id, $resource_data, $ori = '', $crowdsourcing_status = 0) {
+        $resource_data = $this->attachProposalNote($resource_data);
         $operation = new Operation();
         $operation->user_id = $user_id;
         $operation->c_personid = $c_personid;
@@ -45,6 +46,34 @@ class OperationRepository {
         $operation->save();
 
         return $operation;
+    }
+
+    protected function attachProposalNote($resourceData) {
+        if (!is_array($resourceData)) {
+            return $resourceData;
+        }
+
+        if (array_key_exists('__proposal_comment', $resourceData)) {
+            unset($resourceData['__proposal_comment']);
+        }
+
+        if (array_key_exists('__note', $resourceData) && trim((string) $resourceData['__note']) !== '') {
+            return $resourceData;
+        }
+
+        $comment = '';
+
+        try {
+            $comment = trim((string) request()->input('__proposal_comment', ''));
+        } catch (\Throwable $e) {
+            $comment = '';
+        }
+
+        if ($comment !== '') {
+            $resourceData['__note'] = $comment;
+        }
+
+        return $resourceData;
     }
 
     public function hasPendingCreateProposal(string $resource, string $resourceId, ?int $excludeId = null): bool {

--- a/docs/BIOGMAIN_REPOSITORY_REFACTOR_PLAN.md
+++ b/docs/BIOGMAIN_REPOSITORY_REFACTOR_PLAN.md
@@ -1,156 +1,141 @@
-# BiogMainRepository Refactor Plan
+# BasicInformation Write Architecture Refactor Plan
 
-## Goal
-在不改變既有行為的前提下，逐步降低 `BiogMainRepository`（目前約 3182 行）複雜度，並把邏輯按「業務流程」拆分，而非按資料表拆分。
+## 1. Goal
+在不改變既有對外行為的前提下，將 BasicInformation 寫入流程從「大型 repository + 混合語義記錄」重構為「workflow 分層 + 單一操作語義」。
 
-## Scope and Non-Goals
-- 本計畫以重構為主，不做功能擴充。
+核心目標：
+- 降低 `BiogMainRepository` 複雜度。
+- 以 workflow（業務流程）為單位拆分寫入責任，而非按資料表分割。
+- 明確區分 `operations`（操作語義）與 `audit_log`（資料變更明細）的責任邊界。
+
+## 2. Scope and Non-Goals
+### Scope
+- BasicInformation 各子模組寫入路徑（Office、Status、Event、Assoc、Kinship、Entry、Possession、SocialInst、Source、Texts、Addresses、Altnames）。
+- Repository 與 Controller 的責任重整。
+- `operations` / `audit_log` 產生點與關聯方式整理。
+
+### Non-Goals
+- 不做功能擴充。
 - 不變更資料庫 schema。
-- 不變更既有路由與 API 合約。
-- 不變更使用者可見 UI 行為。
+- 不改既有路由、API 合約與 UI 互動行為。
 
-## Current State Snapshot (2026-02-12)
-- `BiogMainRepository` 仍為單一大型類別，包含 Basic Info / Office / Relations / Events / Sources 等多模組方法。
-- `officeStoreById`、`officeUpdateById`、`officeDeleteById` 仍在 `BiogMainRepository`，但已具備：
-  - 單一交易中同步 `POSTING_DATA`、`POSTED_TO_OFFICE_DATA`、`POSTED_TO_ADDR_DATA`
-  - `operations` 寫入（含 `POSTED_TO_ADDR_DATA` 的 `rows` before/after）
-  - `audit_log` 寫入
-  - `resource_id` 使用 `c_office_id=...&c_posting_id=...` 格式
-- 控制器仍直接依賴 `BiogMainRepository`（`BasicInformationOfficesController`），且 `saveas()` 內仍有一段與 repository 重複的寫入流程。
-- 既有測試已覆蓋 Office 核心流程（`OfficePostingStoreTest`、`OfficeAddressOperationLoggingTest`、`OfficeIdChangeAddressLossTest`），可作為重構安全網。
+## 3. Architecture Principles
+### 3.1 Workflow-Based Split (Not Table-Based)
+跨表寫入（例如任官）本質上是單一 workflow，需在同一交易內維持一致性。  
+因此採「一個 workflow 一個 entry point」原則，避免「一表一 repository」造成交易與邏輯碎片化。
 
-## Why Workflow-Based Split (Not Table-Based)
-Office 流程橫跨多表且要求交易一致性、操作記錄一致性、稽核一致性。若按「一表一 repository」拆分，會把同一交易流程拆散，風險高。  
-因此維持「一個 workflow 一個 entry point」原則。
+### 3.2 Operation vs Audit Layering (2026-02-16 Consensus)
+為避免「一次使用者操作對應多筆 operations」的語義混亂，記錄責任需分層：
 
-## Target Architecture
-命名比照現有 repository 風格（功能導向、簡潔命名）：
+- Controller / Application 層（互動語義層）：
+  - 定義一次使用者操作邊界。
+  - 建立 `operations` 主記錄（operation-level）。
+  - 原則：一次互動操作對應一筆主 `operations`（除非規格明確例外）。
 
+- Repository 層（資料持久層）：
+  - 處理 underlying tables 寫入、交易與資料一致性。
+  - 建立 `audit_log` 明細（table-level / row-level before-after）。
+  - 原則：一筆 `operations` 可對應多筆 `audit_log`。
+
+## 4. Current State Snapshot (2026-02-16)
+- `BiogMainRepository` 仍為大型 façade，但已完成部分 workflow 內部拆分與委派。
+- Office workflow 已抽出至 `OfficePostingRepository`，並支援同交易中同步三表與審計資料。
+- Status/Event workflow 已抽出至 `EventStatusRepository`。
+- `/operations` 已可用 `audit_log.operation_id` 聚合顯示多筆明細 diff。
+- 仍處於過渡期：部分路徑尚由 Repository 直接寫 `operations`，需逐步上移到語義層。
+
+## 5. Target Architecture
+### 5.1 Repository Layout (Workflow-Oriented)
 1. `OfficePostingRepository`
 2. `RelationshipRepository`
 3. `EventStatusRepository`
 4. `EntryRepository`
 5. `PossessionRepository`
 6. `SocialInstitutionRepository`
-7. `BiogSourceRepository`（或 `SourceRepository`，避免與其他 source 模組混淆）
+7. `BiogSourceRepository`（或 `SourceRepository`）
 
-`BiogMainRepository` 保留「人物自身」相關職責，不另拆 `BasicInfoRepository`：
+`BiogMainRepository` 最終保留：
 - `BIOG_MAIN` 主記錄讀寫
-- 以人物為中心的聚合查詢（`byPersonId`、`byIdWith*`）
-- 人名與拼音相關邏輯（例如 `namesByQuery`、`auto_pinyin`）
+- 人物聚合查詢（`byPersonId`、`byIdWith*`）
+- 人名/拼音等人物中心邏輯
+- 作為過渡期 façade（逐步縮小）
 
-過渡期由 `BiogMainRepository` 作 façade，逐步轉呼叫新 repository，避免一次性改動大量 controller/test。
+### 5.2 Logging Responsibility
+- `operations`：Controller / Application service 產生。
+- `audit_log`：Repository 產生。
+- 透過 operation context（同一 operation id）串接一筆主操作與多筆資料明細。
 
-## Refactor Phases (Updated)
+## 6. Migration Roadmap
+### Phase A — Baseline Lock
+- 固定核心回歸測試（Office 為首要守門）。
+- 建立主要寫入方法呼叫清單，明確影響面。
 
-### Phase A — Baseline Lock (Must Do First)
-- 固定 Office 流程回歸測試作為守門：
-  - `tests/Feature/OfficePostingStoreTest.php`
-  - `tests/Feature/OfficeAddressOperationLoggingTest.php`
-  - `tests/Feature/OfficeIdChangeAddressLossTest.php`
-- 以 `rg` 建立方法呼叫清單（特別是 `office*ById`）並記錄遷移範圍。
+### Phase B — Office Workflow Extraction
+- 搬移 `officeStoreById` / `officeUpdateById` / `officeDeleteById` 與 helper 至 `OfficePostingRepository`。
+- `BiogMainRepository` 保留同名方法，轉呼叫新 repository。
 
-**Acceptance**
-- 上述測試在重構前全綠，作為 baseline。
+### Phase C — Controller Duplicate Removal
+- 將 `BasicInformationOfficesController::saveas()` 重複寫入收斂到 repository（`officeCloneById`）。
 
-**Execution Record (Completed, 2026-02-12)**
-- 測試命令：
-  - `./vendor/bin/phpunit tests/Feature/OfficePostingStoreTest.php tests/Feature/OfficeAddressOperationLoggingTest.php tests/Feature/OfficeIdChangeAddressLossTest.php`
-- 結果：
-  - `OK (17 tests, 59 assertions)`
-- `office*ById` 直接呼叫點（遷移影響面）：
-  - `app/Http/Controllers/BasicInformationOfficesController.php`
-  - `tests/Feature/OfficePostingStoreTest.php`
-  - `tests/Feature/OfficeAddressOperationLoggingTest.php`
-  - `tests/Feature/OfficeIdChangeAddressLossTest.php`
-- `office*ById` 定義位置（待 Phase B 搬移）：
-  - `app/Repositories/BiogMainRepository.php`
+### Phase D — Remaining Workflows (Incremental Batches)
+1. Status + Event  
+2. Assoc + Kinship  
+3. Entry + Possession + SocialInst + Source
 
-### Phase B — Office Workflow Internal Extraction (No External Behavior Change)
-- 新增 `OfficePostingRepository`，搬移：
-  - `officeStoreById`
-  - `officeUpdateById`
-  - `officeDeleteById`
-  - `insertAddr` / `updateAddr` 等 Office 專用 helper
-- `BiogMainRepository` 保留同名 public 方法，僅轉呼叫新 repository。
-- 保持以下行為完全一致：
-  - 回傳 `resource_id` 字串格式
-  - `ValidationException` 拋出時機
-  - `operations` 與 `audit_log` 內容結構
-  - 交易邊界（單一 `DB::transaction`）
+每批遵循「先內部搬移，後替換呼叫點」。
 
-**Acceptance**
-- Phase A 三個測試維持全綠。
-- `BasicInformationOfficesController` 不需改動即可通過既有流程。
+### Phase E — Operation Layer Realignment
+- 將 `operations` 主記錄建立點逐步上移至 Controller / Application service。
+- Repository 端最終收斂為只寫 `audit_log` 明細。
+- 驗證準則：一次操作 = 1 筆 `operations` + N 筆 `audit_log`。
 
-### Phase C — Remove Duplicate Office Write Logic from Controller
-- 將 `BasicInformationOfficesController::saveas()` 的交易寫入流程收斂到 Office workflow repository（新增 `officeCloneById` 之類方法）。
-- 移除 controller 內重複 `insertAddr` 寫法，避免雙實作漂移。
+### Phase F — Final Cleanup
+- 清理 `BiogMainRepository` 過渡方法與註記。
+- 同步更新文檔（本檔、`AGENTS.md`、必要的 CHANGELOG）。
 
-**Acceptance**
-- `saveas()` 行為與既有 UI 流程一致。
-- 新增/補強對 `saveas` 的 Feature 測試（至少涵蓋新增 posting + address + operation）。
+## 7. Risks and Mitigations
+- 風險：交易被拆散，導致跨表不一致。  
+  對策：workflow repository 僅暴露交易入口，不暴露碎片 API。
 
-### Phase D — Extract Remaining Workflows (One Module at a Time)
-- 依風險與耦合度分批搬移：
-  1. Status + Event
-  2. Assoc + Kinship
-  3. Entry + Possession + SocialInst + Source
-- 每批均採「先搬內部、後替換呼叫點」策略，避免大爆炸。
+- 風險：`resource_id` / `resource_data` 格式漂移，影響比對與復原。  
+  對策：持續使用 `CompositePrimaryKey` 與既有斷言測試。
 
-**Acceptance**
-- 每批搬移後，受影響測試與 smoke test 維持綠燈。
+- 風險：過渡期雙軌寫入（Controller 與 Repository）造成語義分叉。  
+  對策：先引入 operation context，再分批上移 `operations` 產生點。
 
-### Phase E — Final Cleanup
-- 移除 `BiogMainRepository` 中已完全轉移的方法與過渡註記。
-- 更新架構文檔（本檔、必要時補 `AGENTS.md` / `CHANGELOG.md`）。
-## Risks and Mitigations (Reality-Based)
-- 風險：交易被拆開，導致三表資料不一致  
-  對策：workflow 類別只暴露交易入口，不暴露碎片化寫入 API。
-- 風險：`operations.resource_id` 或 `resource_data` 格式漂移，影響復原/審計  
-  對策：沿用既有 helper（`CompositePrimaryKey`）與既有測試斷言。
-- 風險：控制器仍有重複寫入邏輯，重構後兩邊行為分叉  
-  對策：優先完成 Phase C，確保 Office 寫入單一實作來源。
-
-## Tracking
-- 本檔為實施計畫文件，可隨重構進度更新。
-- 每完成一個 phase，請在 PR 描述附上：
+## 8. Quality Gates
+- 受影響模組必跑對應 Feature 測試。
+- 每個 phase 完成時需提供：
   - 受影響方法清單
   - 新增/調整測試清單
-  - 與 baseline 的差異說明（應為「無行為差異」或明確列出差異）
+  - 與 baseline 差異說明（無行為差異或明確列差異）
 
-### Execution Record (Completed, 2026-02-13)
-- Phase B 已完成：
-  - `officeStoreById`、`officeUpdateById`、`officeDeleteById` 搬移至 `app/Repositories/OfficePostingRepository.php`
-  - `insertAddr`、`updateAddr` 搬移至 `app/Repositories/OfficePostingRepository.php`
-  - `BiogMainRepository` 保留同名公開方法並轉呼叫 `OfficePostingRepository`
-- 驗證結果：
+## 9. Execution Records
+### 2026-02-12 — Phase A Completed
+- 測試：
   - `./vendor/bin/phpunit tests/Feature/OfficePostingStoreTest.php tests/Feature/OfficeAddressOperationLoggingTest.php tests/Feature/OfficeIdChangeAddressLossTest.php`
   - `OK (17 tests, 59 assertions)`
+- 完成 Office 寫入呼叫點盤點。
 
-### Execution Record (Completed, 2026-02-13)
-- Phase C 已完成：
-  - `BasicInformationOfficesController::saveas()` 改為呼叫 repository（`officeCloneById`）
-  - 新增 `OfficePostingRepository::officeCloneById()` 收斂另存交易寫入流程
-  - 移除 controller 內重複的 `insertAddr` 寫入方法
-  - 另存流程的 `operations.resource_id` 對齊 `CompositePrimaryKey::buildStoredResourceId()` 格式
-- 驗證結果：
+### 2026-02-13 — Phase B Completed
+- `officeStoreById` / `officeUpdateById` / `officeDeleteById` 及 helper 搬移至 `OfficePostingRepository`。
+- `BiogMainRepository` 改為委派。
+- 測試維持全綠（同 Phase A 套件）。
+
+### 2026-02-13 — Phase C Completed
+- `BasicInformationOfficesController::saveas()` 收斂至 `officeCloneById`。
+- 移除 controller 內重複地址寫入邏輯。
+- 測試：
   - `./vendor/bin/phpunit tests/Feature/OfficePostingStoreTest.php tests/Feature/OfficeAddressOperationLoggingTest.php tests/Feature/OfficeIdChangeAddressLossTest.php tests/Feature/BasicInformationOfficesSaveAsTest.php`
   - `OK (18 tests, 66 assertions)`
 
-### Execution Record (In Progress, 2026-02-14)
-- Phase D 第一階段完成：
-  - `STATUS_DATA` 相關方法遷移至 `app/Repositories/EventStatusRepository.php`
-  - `EVENTS_DATA` 相關方法（含 `EVENTS_ADDR` 輔助方法）遷移至 `app/Repositories/EventStatusRepository.php`
-  - `BiogMainRepository` 已完成 Status 與 Event 相關公開方法的委派呼叫
-- 驗證結果：
+### 2026-02-14 — Phase D Batch 1 Completed
+- `STATUS_DATA` / `EVENTS_DATA`（含 `EVENTS_ADDR`）遷移至 `EventStatusRepository`。
+- `BiogMainRepository` 完成委派。
+- 測試：
   - `./vendor/bin/phpunit tests/Feature/EventStatusWriteActionsTest.php`
   - `OK (6 tests, 35 assertions)`
-  - `./vendor/bin/phpunit --filter "CompositePrimaryKeyRoutesTest|BasicInformationPagesLoadTest"`
-  - `OK (27 tests, 106 assertions)`（另有既有 PHPUnit deprecations）
-  - `./vendor/bin/phpunit --filter "EventStatusWriteActionsTest|CompositePrimaryKeyRoutesTest|BasicInformationPagesLoadTest"`
-  - `OK (33 tests, 141 assertions)`（另有既有 PHPUnit deprecations）
 
-## Version
-- Version: 0.5
-- Date: 2026-02-14
+## 10. Version
+- Version: 1.0
+- Date: 2026-02-16

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -109,10 +109,25 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 <a href="{{ $personLink }}">{{ $item->biogmain->c_name_chn.' '.$item->biogmain->c_name }}</a>
                             @endif
                             </td>
-                            <td>{{ $item->resource }}</td>
+                            @php
+                                $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
+                                $auditTableNames = [];
+                                foreach ($auditLogs as $audit) {
+                                    $tableName = trim((string) ($audit['table_name'] ?? ''));
+                                    if ($tableName !== '') {
+                                        $auditTableNames[] = $tableName;
+                                    }
+                                }
+                                $auditTableNames = array_values(array_unique($auditTableNames));
+                                $resourceDisplay = !empty($auditTableNames)
+                                    ? implode(' / ', $auditTableNames)
+                                    : (string) $item->resource;
+                            @endphp
+                            <td>
+                                {{ $resourceDisplay }}
+                            </td>
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
-                                $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
                                 $hasAuditLogs = !empty($auditLogs);
                                 $hasDiffContent = false;
                                 if (is_array($diffSource)) {

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -112,6 +112,8 @@ $item->resource_data = unionPKDef($item->resource_data);
                             <td>{{ $item->resource }}</td>
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
+                                $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
+                                $hasAuditLogs = !empty($auditLogs);
                                 $hasDiffContent = false;
                                 if (is_array($diffSource)) {
                                     if (($diffSource['type'] ?? null) === 'POSTED_TO_ADDR_DATA') {
@@ -180,7 +182,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 }
                             @endphp
                                 @php
-                                    $canCompare = $hasDiffContent && (int)$item->op_type !== 4;
+                                    $canCompare = ($hasAuditLogs || $hasDiffContent) && (int)$item->op_type !== 4;
                                 @endphp
                             <td>
                                 @if($isProposal)
@@ -262,9 +264,23 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         <button type="button" class="close" data-dismiss="modal">&times;</button>
                                       </div>
                                       <div class="modal-body" style="word-break: break-all;">
-                                        <div>
-                                        @include('components.diff-table', ['diff' => $diffSource])
-                                        </div>
+                                        @if($hasAuditLogs)
+                                            <div class="text-muted small" style="margin-bottom: 8px;">審計記錄（{{ count($auditLogs) }} 筆）</div>
+                                            @foreach($auditLogs as $audit)
+                                                <div class="border rounded p-2" style="margin-bottom: 10px;">
+                                                    <div class="small" style="margin-bottom: 6px;">
+                                                        <strong>{{ $audit['table_name'] ?? '未知資料表' }}</strong>
+                                                        · {{ strtoupper($audit['operation'] ?? 'UNKNOWN') }}
+                                                        · <span class="text-monospace">{{ $audit['row_pk_text'] ?? '' }}</span>
+                                                    </div>
+                                                    @include('components.diff-table', ['diff' => $audit['diff'] ?? null])
+                                                </div>
+                                            @endforeach
+                                        @else
+                                            <div>
+                                            @include('components.diff-table', ['diff' => $diffSource])
+                                            </div>
+                                        @endif
                                       </div>
                                       <div class="modal-footer">
                                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -128,6 +128,40 @@ class BasicInformationSourcesControllerTest extends TestCase {
     }
 
     #[Test]
+    public function testSourceStoreAndUpdateIgnoreProposalMetaFields(): void {
+        $repository = new BiogMainRepository();
+
+        $storeRequest = new Request([
+            'c_textid' => 777,
+            'c_pages' => 'pp-1',
+            'c_notes' => 'first',
+            'c_main_source' => 1,
+            'c_self_bio' => 0,
+            'action' => 'save',
+            '__proposal_comment' => 'should not touch SQL',
+        ]);
+
+        $repository->sourceStoreById($storeRequest, 2468);
+        $storedRow = DB::table('BIOG_SOURCE_DATA')->first();
+        $this->assertSame('first', $storedRow->c_notes);
+
+        Auth::guard()->setUser($this->makeUser(12, 'Updater User'));
+        $updateRequest = new Request([
+            'c_textid' => 777,
+            'c_pages' => 'pp-1',
+            'c_notes' => 'second',
+            'c_main_source' => 0,
+            'c_self_bio' => 1,
+            'action' => 'save',
+            '__proposal_comment' => 'still should not touch SQL',
+        ]);
+
+        $repository->sourceUpdateById($updateRequest, 2468, '2468-777-pp(minus)1');
+        $updatedRow = DB::table('BIOG_SOURCE_DATA')->first();
+        $this->assertSame('second', $updatedRow->c_notes);
+    }
+
+    #[Test]
     public function testSourceUpdatePreservesCreationAndSetsModification(): void {
         $repository = new BiogMainRepository();
         $initialRequest = new Request([

--- a/tests/Feature/EventStatusWriteActionsTest.php
+++ b/tests/Feature/EventStatusWriteActionsTest.php
@@ -36,6 +36,8 @@ class EventStatusWriteActionsTest extends TestCase {
             'c_sequence' => 1,
             'c_status_code' => 2,
             'c_source' => -999,
+            'action' => 'save',
+            '__proposal_comment' => 'should be ignored',
         ]);
 
         $response->assertRedirect(route('basicinformation.statuses.edit.query', [
@@ -59,6 +61,14 @@ class EventStatusWriteActionsTest extends TestCase {
             'op_type' => 1,
         ]);
 
+        $op = \DB::table('operations')
+            ->where('resource', 'STATUS_DATA')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($op);
+        $opPayload = json_decode($op->resource_data, true);
+        $this->assertSame('should be ignored', $opPayload['__note'] ?? null);
+
         $this->assertDatabaseHas('audit_log', [
             'table_name' => 'STATUS_DATA',
             'operation' => 'INSERT',
@@ -80,6 +90,8 @@ class EventStatusWriteActionsTest extends TestCase {
             'c_sequence' => 1,
             'c_status_code' => 2,
             'c_source' => 10,
+            'action' => 'save',
+            '__proposal_comment' => 'should be ignored',
         ]);
 
         $response->assertRedirect(route('basicinformation.statuses.edit.query', [
@@ -150,6 +162,8 @@ class EventStatusWriteActionsTest extends TestCase {
             'c_intercalary' => 1,
             'c_source' => 9,
             'c_addr_id' => [100, -999],
+            'action' => 'save',
+            '__proposal_comment' => 'should be ignored',
         ]);
 
         $response->assertRedirect(route('basicinformation.events.edit.query', [
@@ -211,6 +225,8 @@ class EventStatusWriteActionsTest extends TestCase {
             'c_intercalary' => 0,
             'c_source' => 10,
             'c_addr_id' => [200],
+            'action' => 'save',
+            '__proposal_comment' => 'should be ignored',
         ]);
 
         $response->assertRedirect(route('basicinformation.events.edit.query', [

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -233,6 +233,11 @@ class OfficePostingStoreTest extends TestCase {
             'resource_id' => 'c_office_id=20&c_posting_id=1',
             'op_type' => 3,
         ]);
+        $this->assertDatabaseMissing('operations', [
+            'resource' => 'POSTED_TO_ADDR_DATA',
+            'resource_id' => 'c_office_id=20&c_posting_id=1',
+            'op_type' => 3,
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -150,6 +150,32 @@ class OfficePostingStoreTest extends TestCase {
     }
 
     #[Test]
+    public function testOfficeStoreIgnoresProposalMetaFields(): void {
+        $repository = new BiogMainRepository();
+        $request = $this->makeRequest([
+            'action' => 'save',
+            '__proposal_comment' => 'should not be persisted to office table',
+        ]);
+        $this->app->instance('request', $request);
+
+        $repository->officeStoreById($request, 321);
+
+        $this->assertDatabaseHas('POSTED_TO_OFFICE_DATA', [
+            'c_posting_id' => 1,
+            'c_personid' => 321,
+            'c_office_id' => 10,
+        ]);
+
+        $officeOperation = DB::table('operations')
+            ->where('resource', 'POSTED_TO_OFFICE_DATA')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($officeOperation);
+        $payload = json_decode($officeOperation->resource_data, true);
+        $this->assertSame('should not be persisted to office table', $payload['__note'] ?? null);
+    }
+
+    #[Test]
     public function testOfficeStoreRollsBackPostingDataWhenAnExceptionOccurs(): void {
         /** @var OfficePostingRepository&\Mockery\MockInterface $repository */
         $repository = Mockery::mock(OfficePostingRepository::class)->makePartial();
@@ -206,6 +232,41 @@ class OfficePostingStoreTest extends TestCase {
             'resource' => 'POSTED_TO_OFFICE_DATA',
             'resource_id' => 'c_office_id=20&c_posting_id=1',
             'op_type' => 3,
+        ]);
+    }
+
+    #[Test]
+    public function testOfficeUpdateIgnoresProposalMetaFields(): void {
+        $repo = new BiogMainRepository();
+        $repo->officeStoreById($this->makeRequest([
+            'c_office_id' => 22,
+            'c_addr' => [2],
+        ]), 901);
+
+        $updateRequest = new Request([
+            '_method' => 'PATCH',
+            '_token' => 'token',
+            'action' => 'save',
+            '__proposal_comment' => 'not a db column',
+            'c_addr' => [2],
+            '_id' => 901,
+            '_postingid' => 1,
+            '_officeid' => 22,
+            'c_personid' => 901,
+            'c_office_id' => 22,
+            'c_fy_intercalary' => 1,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        $result = $repo->officeUpdateById($updateRequest, 1, 901);
+
+        $this->assertFalse($result['no_changes']);
+        $this->assertDatabaseHas('POSTED_TO_OFFICE_DATA', [
+            'c_posting_id' => 1,
+            'c_office_id' => 22,
+            'c_personid' => 901,
+            'c_fy_intercalary' => 1,
         ]);
     }
 

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -51,6 +51,28 @@ class OperationsIndexLinksTest extends TestCase {
             $table->string('c_name')->nullable();
             $table->timestamps();
         });
+
+        Schema::create('POSTED_TO_OFFICE_DATA', function ($table) {
+            $table->integer('c_office_id');
+            $table->integer('c_posting_id');
+            $table->integer('c_personid')->nullable();
+            $table->integer('c_fy_intercalary')->nullable();
+        });
+
+        Schema::create('audit_log', function ($table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
     }
 
     #[Test]
@@ -184,5 +206,74 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertDontSee('/codes/TEXT_CODES/68942/edit', false);
         // 但应该显示 resource_id
         $response->assertSee('68942');
+    }
+
+    #[Test]
+    public function test_operations_index_shows_multiple_audit_records_for_one_operation() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'audit@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => 'c_office_id=10&c_posting_id=1',
+            'resource_data' => json_encode(['c_office_id' => 10, 'c_posting_id' => 1, 'c_fy_intercalary' => 1]),
+            'resource_original' => json_encode(['c_office_id' => 10, 'c_posting_id' => 1, 'c_fy_intercalary' => 0]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_office_id' => 10,
+            'c_posting_id' => 1,
+            'c_personid' => 123,
+            'c_fy_intercalary' => 1,
+        ]);
+
+        $operationId = (string) $operation->id;
+        $now = now()->format('Y-m-d H:i:s');
+
+        \Illuminate\Support\Facades\DB::table('audit_log')->insert([
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'POSTED_TO_OFFICE_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => $operationId,
+                'row_pk' => json_encode(['c_office_id' => 10, 'c_posting_id' => 1], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_office_id=10&c_posting_id=1',
+                'old_data' => json_encode(['c_fy_intercalary' => 0], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_fy_intercalary' => 1], JSON_UNESCAPED_UNICODE),
+            ],
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'POSTED_TO_ADDR_DATA',
+                'operation' => 'INSERT',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => $operationId,
+                'row_pk' => json_encode(['c_personid' => 123, 'c_posting_id' => 1, 'c_office_id' => 10, 'c_addr_id' => 99], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=123&c_posting_id=1&c_office_id=10&c_addr_id=99',
+                'old_data' => null,
+                'new_data' => json_encode(['c_personid' => 123, 'c_posting_id' => 1, 'c_office_id' => 10, 'c_addr_id' => 99], JSON_UNESCAPED_UNICODE),
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('審計記錄（2 筆）');
+        $response->assertSee('POSTED_TO_OFFICE_DATA');
+        $response->assertSee('POSTED_TO_ADDR_DATA');
     }
 }


### PR DESCRIPTION
- 在 OperationRepository::store 統一將 __proposal_comment 寫入 resource_data.__note
- 補齊 offices/statuses/events/kinship/assoc/possession/sources/socialinst/texts/addresses 的 action/__proposal_comment 過濾
- /operations 介面改以 audit_log.operation_id 聚合顯示多筆審計 diff
- 新增與調整 Feature 測試覆蓋上述流程
- 測試: phpunit tests/Feature/OfficePostingStoreTest.php tests/Feature/EventStatusWriteActionsTest.php tests/Feature/BasicInformationSourcesControllerTest.php tests/Feature/OperationsIndexLinksTest.php tests/Feature/OperationsIndexDiffTest.php