### PR TITLE
修正 auto_pinyin() 在無姓氏時 c_name 產生前導空格

### DIFF
--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -2361,7 +2361,9 @@ class BiogMainRepository {
             // 標準化異體字（僅用於拼音轉換，不修改原始名字）
             $normalizedMingzi = VariantCharNormalizer::normalize($c_mingzi_chn);
             $c_mingzi = ucfirst(Pinyin::getPinyin($normalizedMingzi)) ?? '';
-            $c_name = $c_surname.' '.$c_mingzi;
+            $c_name = $c_mingzi;
+            $data['c_surname_chn'] = '';
+            $data['c_surname'] = '';
             $data['c_mingzi_chn'] = $c_mingzi_chn;
             $data['c_mingzi'] = $c_mingzi;
             $data['c_name'] = $c_name;

--- a/tests/Unit/AutoPinyinTest.php
+++ b/tests/Unit/AutoPinyinTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\BiogMainRepository;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 測試 BiogMainRepository::auto_pinyin() 的姓名拼音自動生成邏輯。
+ *
+ * 覆蓋場景：
+ *   1. 有姓氏：姓＋名正確拆分，c_name 以空格連結
+ *   2. 無姓氏：c_name 不應包含前導空格，c_surname / c_surname_chn 應為空字串
+ *   3. 單字名（即姓佔整個名字，名為空）
+ */
+class AutoPinyinTest extends TestCase {
+    private BiogMainRepository $repository;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // 建立最小化的 pinyin 表供姓氏查詢
+        Schema::dropIfExists('pinyin');
+        Schema::create('pinyin', function (Blueprint $table) {
+            $table->string('lastname_chn');
+            $table->string('lastname_pinyin');
+        });
+
+        // 插入測試姓氏
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
+            ['lastname_chn' => '歐陽', 'lastname_pinyin' => 'Ouyang'],
+        ]);
+
+        $this->repository = new BiogMainRepository();
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('pinyin');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function testWithSurnameSplitsCorrectly(): void {
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '王安石']);
+
+        $this->assertSame('王', $result['c_surname_chn']);
+        $this->assertSame('Wang', $result['c_surname']);
+        $this->assertSame('安石', $result['c_mingzi_chn']);
+        $this->assertNotEmpty($result['c_mingzi']);
+        $this->assertSame('Wang ' . $result['c_mingzi'], $result['c_name']);
+    }
+
+    #[Test]
+    public function testWithoutSurnameNoLeadingSpace(): void {
+        // 使用一個不在 pinyin 表中的名字，確保走「無姓氏」分支
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '某僧']);
+
+        // 核心斷言：c_name 不應有前導空格
+        $this->assertStringNotContainsString(' ', $result['c_name'], 'c_name 不應包含空格');
+        $this->assertSame($result['c_mingzi'], $result['c_name']);
+        $this->assertSame('', $result['c_surname_chn']);
+        $this->assertSame('', $result['c_surname']);
+        $this->assertSame('某僧', $result['c_mingzi_chn']);
+    }
+
+    #[Test]
+    public function testCompoundSurname(): void {
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '歐陽修']);
+
+        $this->assertSame('歐陽', $result['c_surname_chn']);
+        $this->assertSame('Ouyang', $result['c_surname']);
+        $this->assertSame('修', $result['c_mingzi_chn']);
+        $this->assertSame('Ouyang ' . $result['c_mingzi'], $result['c_name']);
+    }
+
+    #[Test]
+    public function testSingleCharNameMatchesSurname(): void {
+        // 單字名恰好是姓氏 → 姓氏匹配成功，名為空字串
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '王']);
+
+        $this->assertSame('王', $result['c_surname_chn']);
+        $this->assertSame('Wang', $result['c_surname']);
+        $this->assertSame('', $result['c_mingzi_chn']);
+    }
+}


### PR DESCRIPTION
## Summary
- `auto_pinyin()` 的「無姓氏」分支中，`c_name` 以 `$c_surname . ' ' . $c_mingzi` 拼接，當 `$c_surname` 為空時會產生前導空格（如 `" Moumingshi"`）
- 修正為直接使用 `$c_mingzi`，並同步清空 `c_surname_chn` / `c_surname`，使兩個分支的輸出行為一致
- 補充四組單元測試覆蓋：有姓氏、無姓氏、複姓、單字名

## Test plan
- [x] `./vendor/bin/phpunit --filter AutoPinyinTest`（4 tests, 17 assertions）
- [x] `./vendor/bin/phpunit`（541 tests 全部通過）
- [x] `./vendor/bin/php-cs-fixer fix`（格式化通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)