### PR TITLE
修正 buildUrl() 丟失 null 查詢參數導致別名編輯失敗

### DIFF
--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -540,8 +540,8 @@ class BasicInformationAltnamesController extends Controller {
 
         // 更新索引
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
-            $nameChanged = ($ori->c_alt_name_chn ?? null) !== ($data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn']);
-            $typeChanged = ($ori->c_alt_name_type_code ?? null) !== ($data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code']);
+            $nameChanged = ($ori->c_alt_name_chn ?? null) !== ($data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'] ?? null);
+            $typeChanged = ($ori->c_alt_name_type_code ?? null) !== ($data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'] ?? null);
 
             if ($nameChanged || $typeChanged) {
                 if ($ori->c_alt_name_chn) {
@@ -552,11 +552,11 @@ class BasicInformationAltnamesController extends Controller {
                     );
                 }
 
-                $newAltNameChn = $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'];
+                $newAltNameChn = $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'] ?? null;
                 if (!empty($newAltNameChn)) {
                     $this->nameSearchIndexService->indexAltname(
                         $newPk['c_personid'] ?? $originalPk['c_personid'],
-                        $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'],
+                        $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'] ?? null,
                         $newAltNameChn
                     );
                 }

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -170,8 +170,11 @@ class CompositePrimaryKey {
         array $queryParams,
         bool $absolute = false
     ): string {
+        // 將 null 值轉為 'NULL' 字串，避免 http_build_query 靜默丟棄
+        // （與 buildStoredResourceId() 保持一致的處理方式）
+        $encoded = array_map(fn ($v) => $v === null ? 'NULL' : $v, $queryParams);
         $url = route($route, $pathParams, $absolute);
-        $query = http_build_query($queryParams);
+        $query = http_build_query($encoded);
 
         return $query ? "{$url}?{$query}" : $url;
     }

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -44,13 +44,16 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         Schema::create('ALTNAME_DATA', function (Blueprint $table) {
             $table->integer('c_personid');
             $table->integer('c_sequence')->nullable();
+            $table->string('c_alt_name')->nullable();
             $table->string('c_alt_name_chn');
             $table->string('c_alt_name_type_code');
             $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->text('c_notes')->nullable();
             $table->string('c_created_by')->nullable();
-            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
-            $table->timestamp('c_modified_date')->nullable();
+            $table->string('c_modified_date')->nullable();
         });
 
         // 創建 TEXT_CODES 表
@@ -515,5 +518,97 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $response->assertStatus(200);
         $response->assertViewHas('row');
         $response->assertViewHas('text_str', '0 Zero Source 零來源');
+    }
+
+    /**
+     * 測試使用查詢參數模式編輯 c_sequence 為 NULL 的記錄
+     */
+    #[Test]
+    public function testEditQueryHandlesNullCSequence() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => null,
+            'c_alt_name_chn' => '別名測試',
+            'c_alt_name_type_code' => '1',
+            'c_source' => null,
+        ]);
+
+        // 使用查詢參數模式（c_sequence=NULL）
+        $response = $this->actingAs($user)
+            ->get('/basicinformation/1/altnames/edit?c_personid=1&c_sequence=NULL&c_alt_name_chn=別名測試&c_alt_name_type_code=1');
+
+        $response->assertStatus(200);
+        $response->assertViewHas('row');
+    }
+
+    /**
+     * 測試更新 c_sequence 為 NULL 的記錄不會拋出 Undefined array key
+     */
+    #[Test]
+    public function testUpdateQueryWithNullCSequenceDoesNotThrow() {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => null,
+            'c_alt_name_chn' => '別名測試',
+            'c_alt_name_type_code' => '1',
+            'c_source' => null,
+        ]);
+
+        // 透過查詢參數模式更新（c_sequence=NULL 在 URL 中）
+        $response = $this->actingAs($user)
+            ->patch('/basicinformation/1/altnames/update?c_personid=1&c_sequence=NULL&c_alt_name_chn=別名測試&c_alt_name_type_code=1', [
+                'c_sequence' => '',
+                'c_alt_name_chn' => '別名測試',
+                'c_alt_name_type_code' => '1',
+                'c_source' => '',
+                'c_notes' => '更新備註',
+            ]);
+
+        // 應成功重定向而非拋出 ErrorException
+        $response->assertRedirect();
+        $response->assertSessionHas('flash_notification');
+
+        // 驗證重定向 URL 包含 c_sequence=NULL
+        $redirectUrl = $response->headers->get('Location');
+        $this->assertStringContainsString('c_sequence=NULL', $redirectUrl);
+
+        // 跟隨重定向，確認編輯頁可正常載入（200）
+        $followResponse = $this->actingAs($user)->get($redirectUrl);
+        $followResponse->assertStatus(200);
+        $followResponse->assertViewHas('row');
+
+        // 驗證記錄已正確更新
+        $record = DB::table('ALTNAME_DATA')
+            ->where('c_personid', 1)
+            ->where('c_alt_name_chn', '別名測試')
+            ->first();
+
+        $this->assertNotNull($record);
     }
 }

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -105,6 +105,128 @@ class CompositePrimaryKeyTest extends TestCase {
     }
 
     /** @test */
+    public function build_url_preserves_null_values_as_null_string(): void {
+        // buildUrl() 應將 null 值轉為 'NULL' 字串，避免 http_build_query 丟棄
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.altnames.edit.query',
+            ['id' => 12345],
+            [
+                'c_personid' => 12345,
+                'c_sequence' => null,
+                'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10,
+            ]
+        );
+
+        // c_sequence=NULL 應保留在 URL 中
+        $this->assertStringContainsString('c_sequence=NULL', $url);
+        $this->assertStringContainsString('c_personid=12345', $url);
+        $this->assertStringContainsString('c_alt_name_type_code=10', $url);
+    }
+
+    /** @test */
+    public function build_url_preserves_null_for_addresses_route(): void {
+        // BIOG_ADDR_DATA 的 c_sequence 也可為 null
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.addresses.edit.query',
+            ['id' => 100],
+            [
+                'c_personid' => 100,
+                'c_addr_id' => 50,
+                'c_addr_type' => 1,
+                'c_sequence' => null,
+            ]
+        );
+
+        $this->assertStringContainsString('c_sequence=NULL', $url);
+        $this->assertStringContainsString('c_personid=100', $url);
+        $this->assertStringContainsString('c_addr_id=50', $url);
+        $this->assertStringContainsString('c_addr_type=1', $url);
+    }
+
+    /** @test */
+    public function build_url_preserves_null_for_events_route(): void {
+        // EVENTS_DATA 的 c_sequence 也可為 null
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.events.edit.query',
+            ['id' => 200],
+            [
+                'c_personid' => 200,
+                'c_sequence' => null,
+                'c_event_code' => 5,
+            ]
+        );
+
+        $this->assertStringContainsString('c_sequence=NULL', $url);
+        $this->assertStringContainsString('c_personid=200', $url);
+        $this->assertStringContainsString('c_event_code=5', $url);
+    }
+
+    /** @test */
+    public function build_url_preserves_null_for_statuses_route(): void {
+        // STATUS_DATA 的 c_sequence 也可為 null
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.statuses.edit.query',
+            ['id' => 300],
+            [
+                'c_personid' => 300,
+                'c_sequence' => null,
+                'c_status_code' => 10,
+            ]
+        );
+
+        $this->assertStringContainsString('c_sequence=NULL', $url);
+        $this->assertStringContainsString('c_personid=300', $url);
+        $this->assertStringContainsString('c_status_code=10', $url);
+    }
+
+    /** @test */
+    public function build_url_preserves_multiple_null_values(): void {
+        // ENTRY_DATA 有多個可能為 null 的欄位
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.entries.edit.query',
+            ['id' => 400],
+            [
+                'c_personid' => 400,
+                'c_entry_code' => 36,
+                'c_sequence' => null,
+                'c_kin_code' => null,
+                'c_assoc_code' => 0,
+                'c_kin_id' => null,
+                'c_year' => 1000,
+                'c_assoc_id' => 0,
+                'c_inst_code' => 0,
+                'c_inst_name_code' => 0,
+            ]
+        );
+
+        $this->assertStringContainsString('c_sequence=NULL', $url);
+        $this->assertStringContainsString('c_kin_code=NULL', $url);
+        $this->assertStringContainsString('c_kin_id=NULL', $url);
+        // 非 null 值不受影響
+        $this->assertStringContainsString('c_assoc_code=0', $url);
+        $this->assertStringContainsString('c_year=1000', $url);
+    }
+
+    /** @test */
+    public function build_url_does_not_alter_non_null_values(): void {
+        $url = CompositePrimaryKey::buildUrl(
+            'basicinformation.altnames.edit.query',
+            ['id' => 12345],
+            [
+                'c_personid' => 12345,
+                'c_sequence' => 0,
+                'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10,
+            ]
+        );
+
+        // c_sequence=0 應保持為 0（不被轉為 'NULL'）
+        $this->assertStringContainsString('c_sequence=0', $url);
+        $this->assertStringNotContainsString('c_sequence=NULL', $url);
+    }
+
+    /** @test */
     public function it_encodes_special_chars_in_query_params(): void {
         // 測試特殊字符（負號、斜線等）被正確編碼
         $params = [


### PR DESCRIPTION
## Summary

- 修正 `CompositePrimaryKey::buildUrl()` 使用 `http_build_query()` 靜默丟棄 null 值的問題，導致 `c_sequence=NULL` 從 URL 中消失
- 修正 `AltnamesController::updateQuery()` 索引更新區段缺少 `?? null` 防禦性 fallback，在 PHP 8.4 下觸發 `Undefined array key "c_sequence"` ErrorException
- 補齊 `buildUrl()` null 處理的單元測試，涵蓋 altnames、addresses、events、statuses、entries 等多模組路由
- 增強 `updateQuery` 功能測試：驗證 redirect URL 含 `c_sequence=NULL` 並 follow redirect 確認編輯頁 200 正常載入

## Test plan

- [x] `./vendor/bin/phpunit --filter CompositePrimaryKeyTest`（含 4 個新增 null 回歸測試）
- [x] `./vendor/bin/phpunit --filter BasicInformationAltnamesControllerTest`（含增強的 redirect follow 測試）
- [x] `./vendor/bin/phpunit`（全部 562 測試通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)