### PR TITLE
補齊 ALTNAME_DATA 操作還原的 c_alt_name_chn 定位條件 (#834 Phase 0)

### DIFF
--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -30,6 +30,8 @@ class BasicInformationProposalController extends Controller {
         ],
         'altnames' => [
             'table' => 'ALTNAME_DATA',
+            // NOTE (#834): 資料庫 PK 為 3-key，c_sequence 非 PK；
+            // 暫維持 4-key 以相容歷史格式，Phase 2 將移除 c_sequence。
             'key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
             'controller' => 'BasicInformationAltnamesController',
             'route_prefix' => 'basicinformation.altnames',

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -876,9 +876,10 @@ class OperationsController extends Controller {
 
         $personId = $decoded['c_personid'] ?? null;
         $sequence = $decoded['c_sequence'] ?? null;
+        $altNameChn = $decoded['c_alt_name_chn'] ?? null;
         $typeCode = $decoded['c_alt_name_type_code'] ?? null;
 
-        if ($personId === null || $sequence === null || $typeCode === null) {
+        if ($personId === null || $sequence === null || $altNameChn === null || $typeCode === null) {
             // 優先嘗試 query-string 格式（新格式）
             $namedParts = CompositePrimaryKey::parseStoredResourceId(
                 $operation['resource_id'] ?? '',
@@ -893,12 +894,16 @@ class OperationsController extends Controller {
                     $val = $namedParts['c_sequence'];
                     $sequence = ($val === 'NULL') ? null : (int) $val;
                 }
+                if ($altNameChn === null && isset($namedParts['c_alt_name_chn'])) {
+                    $val = $namedParts['c_alt_name_chn'];
+                    $altNameChn = ($val === 'NULL') ? null : $val;
+                }
                 if ($typeCode === null && isset($namedParts['c_alt_name_type_code'])) {
                     $val = $namedParts['c_alt_name_type_code'];
                     $typeCode = ($val === 'NULL') ? null : (int) $val;
                 }
             } else {
-                // 回退到舊格式位置解析
+                // 回退到舊格式位置解析（4-key: personid-sequence-alt_name_chn-type_code）
                 $parts = $this->parseCompoundKey($operation['resource_id'] ?? null);
                 if ($personId === null && isset($parts[0]) && is_numeric($parts[0])) {
                     $personId = (int) $parts[0];
@@ -906,19 +911,25 @@ class OperationsController extends Controller {
                 if ($sequence === null && isset($parts[1]) && is_numeric($parts[1])) {
                     $sequence = (int) $parts[1];
                 }
+                if ($altNameChn === null && isset($parts[2])) {
+                    $altNameChn = $parts[2];
+                }
                 if ($typeCode === null && isset($parts[3]) && is_numeric($parts[3])) {
                     $typeCode = (int) $parts[3];
                 }
             }
         }
 
-        if ($personId === null || $sequence === null || $typeCode === null) {
+        // NOTE (#834): 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
+        // c_sequence 非 PK。暫維持 4-key 查詢以相容歷史格式，Phase 2 將統一切為 3-key。
+        if ($personId === null || $sequence === null || $altNameChn === null || $typeCode === null) {
             return null;
         }
 
         return DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $personId],
             ['c_sequence', '=', $sequence],
+            ['c_alt_name_chn', '=', $altNameChn],
             ['c_alt_name_type_code', '=', $typeCode],
         ])->first();
     }
@@ -927,7 +938,10 @@ class OperationsController extends Controller {
         $map = [
             'BIOG_MAIN' => ['c_personid'],
             'BIOG_ADDR_DATA' => ['c_personid','c_addr_id','c_addr_type','c_sequence'],
-            'ALTNAME_DATA' => ['c_personid','c_sequence','c_alt_name_type_code'],
+            // NOTE: 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
+            // c_sequence 非 PK 欄位。此處暫維持 4-key 以相容現有 resource_id 格式，
+            // 待 Phase 2 (#834) 統一切為 3-key。
+            'ALTNAME_DATA' => ['c_personid','c_sequence','c_alt_name_chn','c_alt_name_type_code'],
             'BIOG_TEXT_DATA' => ['c_personid','c_textid','c_role_id'],
             'POSTED_TO_OFFICE_DATA' => ['c_office_id','c_posting_id'],
             'OFFICE_CODES' => ['c_office_id'],

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -2597,6 +2597,13 @@ class BiogMainRepository {
         return $addr_l;
     }
 
+    /**
+     * 依複合主鍵取得 ALTNAME_DATA 記錄
+     *
+     * NOTE (#834): 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
+     * c_sequence 非 PK。此方法暫維持 4-key 查詢以相容歷史格式，
+     * 待 Phase 2 統一切為 3-key。
+     */
     public function altnameById($id) {
         $addr_l = $this->parseAltnameId($id);
 

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -25,9 +25,14 @@ class CompositePrimaryKey {
         'BIOG_MAIN' => [
             'c_personid',
         ],
+        // ⚠️ ALTNAME_DATA 定位 key 收斂計畫 (#834)
+        // 資料庫 PK 為 3-key: (c_personid, c_alt_name_chn, c_alt_name_type_code)
+        // c_sequence 為一般排序欄位，不參與定位。
+        // 此處暫維持 4-key 以相容歷史 resource_id / URL 格式，
+        // 待 Phase 2 切為 3-key: ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code']
         'ALTNAME_DATA' => [
             'c_personid',
-            'c_sequence',
+            'c_sequence',       // 非 PK，Phase 2 將移除
             'c_alt_name_chn',
             'c_alt_name_type_code',
         ],

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -53,6 +53,7 @@ class OperationsAltnameResolverTest extends TestCase {
             'resource_data' => json_encode([
                 'c_personid' => 123,
                 'c_sequence' => 1,
+                'c_alt_name_chn' => '張-一',
                 'c_alt_name_type_code' => 10,
             ]),
         ];
@@ -129,9 +130,10 @@ class OperationsAltnameResolverTest extends TestCase {
         // $current 和 $fallback 都不含完整 key，迫使 buildKeyConditions 解析 resource_id
         $conditions = $controller->publicBuildKeyConditions($op, [], []);
 
-        $this->assertCount(3, $conditions); // ALTNAME_DATA schema 有 3 個 key columns
+        $this->assertCount(4, $conditions); // ALTNAME_DATA key columns: c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code
         $this->assertSame('123', $conditions['c_personid']);
         $this->assertNull($conditions['c_sequence']); // 'NULL' 應轉為 PHP null
+        $this->assertSame('張三', $conditions['c_alt_name_chn']);
         $this->assertSame('10', $conditions['c_alt_name_type_code']);
 
         Schema::dropIfExists('operations');


### PR DESCRIPTION
## Summary
- **Bug fix**: `resourceKeyColumns()` 原列 3 欄（`c_personid`, `c_sequence`, `c_alt_name_type_code`）漏掉 `c_alt_name_chn`（資料庫 PK 的一部分），已補為 4-key
- **Bug fix**: `fetchAltnameCurrentRow()` 同樣漏掉 `c_alt_name_chn` 的提取與 WHERE 條件，已從 `resource_data`、`parseStoredResourceId`、`parseCompoundKey` 三條路徑補齊
- **Phase 0 文件對齊**: `CompositePrimaryKey::SCHEMAS`、`ProposalController`、`BiogMainRepository` 加註 3-key 收斂計畫標記（#834）

## 受影響檔案
| 檔案 | 變更 |
|------|------|
| `OperationsController.php` | `resourceKeyColumns()` 補 `c_alt_name_chn`；`fetchAltnameCurrentRow()` 補 `c_alt_name_chn` 提取與查詢 |
| `CompositePrimaryKey.php` | `SCHEMAS['ALTNAME_DATA']` 加註 #834 Phase 0 標記 |
| `BasicInformationProposalController.php` | `key_columns` 加註 #834 標記 |
| `BiogMainRepository.php` | `altnameById()` 加註 #834 標記 |
| `OperationsAltnameResolverTest.php` | 斷言從 3→4 conditions；`resource_data` 補齊 `c_alt_name_chn` |

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/OperationsAltnameResolverTest.php` — 3 tests pass
- [x] `vendor/bin/phpunit tests/Feature/BasicInformationAltnamesControllerTest.php` — 12 tests pass
- [x] `vendor/bin/phpunit` — 562 tests, 2128 assertions, 0 failures

Closes 的一部分: #834 (Phase 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)