### PR TITLE
統一任官操作的 operation_id 關聯

### DIFF
--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -438,22 +438,13 @@ class OfficePostingRepository {
             ]);
 
             if (!empty($addressRows)) {
-                $addrOperation = (new OperationRepository())->store(
-                    Auth::id(),
-                    $id,
-                    1,
-                    'POSTED_TO_ADDR_DATA',
-                    $officeResourceId,
-                    ['rows' => $addressRows]
-                );
-
                 $addrAuditRows = DB::table('POSTED_TO_ADDR_DATA')
                     ->where('c_personid', $id)
                     ->where('c_posting_id', $data['c_posting_id'])
                     ->where('c_office_id', $data['c_office_id'])
                     ->get();
 
-                $addrOperationId = $addrOperation ? (string) $addrOperation->id : null;
+                $addrOperationId = $officeOperation ? (string) $officeOperation->id : null;
                 foreach ($addrAuditRows as $row) {
                     $rowData = $auditLog->normalizeRow($row);
                     $rowPk = $auditLog->buildRowPkFromData('POSTED_TO_ADDR_DATA', $rowData);
@@ -526,33 +517,6 @@ class OfficePostingRepository {
             ]);
 
             (new OperationRepository())->store(Auth::id(), $id, 1, 'POSTED_TO_OFFICE_DATA', $officeResourceId, $data);
-
-            $addressRows = DB::table('POSTED_TO_ADDR_DATA')
-                ->where('c_personid', $id)
-                ->where('c_posting_id', $data['c_posting_id'])
-                ->where('c_office_id', $data['c_office_id'])
-                ->get()
-                ->map(function ($row) {
-                    return [
-                        'c_personid' => (int) $row->c_personid,
-                        'c_posting_id' => (int) $row->c_posting_id,
-                        'c_office_id' => (int) $row->c_office_id,
-                        'c_addr_id' => (int) $row->c_addr_id,
-                    ];
-                })
-                ->values()
-                ->all();
-
-            if (!empty($addressRows)) {
-                (new OperationRepository())->store(
-                    Auth::id(),
-                    $id,
-                    1,
-                    'POSTED_TO_ADDR_DATA',
-                    $officeResourceId,
-                    ['rows' => $addressRows]
-                );
-            }
 
             return $officeResourceId;
         });

--- a/tests/Feature/BasicInformationOfficesSaveAsTest.php
+++ b/tests/Feature/BasicInformationOfficesSaveAsTest.php
@@ -185,7 +185,7 @@ class BasicInformationOfficesSaveAsTest extends TestCase {
             'resource_id' => 'c_office_id=30&c_posting_id=2',
             'op_type' => 1,
         ]);
-        $this->assertDatabaseHas('operations', [
+        $this->assertDatabaseMissing('operations', [
             'resource' => 'POSTED_TO_ADDR_DATA',
             'resource_id' => 'c_office_id=30&c_posting_id=2',
             'op_type' => 1,

--- a/tests/Feature/OfficePostingStoreTest.php
+++ b/tests/Feature/OfficePostingStoreTest.php
@@ -142,10 +142,25 @@ class OfficePostingStoreTest extends TestCase {
             'op_type' => 1,
         ]);
 
-        $this->assertDatabaseHas('operations', [
+        $this->assertDatabaseMissing('operations', [
             'resource' => 'POSTED_TO_ADDR_DATA',
             'resource_id' => 'c_office_id=10&c_posting_id=1',
             'op_type' => 1,
+        ]);
+
+        $officeOperation = DB::table('operations')
+            ->where('resource', 'POSTED_TO_OFFICE_DATA')
+            ->where('resource_id', 'c_office_id=10&c_posting_id=1')
+            ->first();
+        $this->assertNotNull($officeOperation);
+
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'POSTED_TO_OFFICE_DATA',
+            'operation_id' => (string) $officeOperation->id,
+        ]);
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'POSTED_TO_ADDR_DATA',
+            'operation_id' => (string) $officeOperation->id,
         ]);
     }
 


### PR DESCRIPTION
- 調整 officeStoreById 與 officeCloneById，不再額外建立 POSTED_TO_ADDR_DATA operation
- 地址 audit_log 改為沿用 POSTED_TO_OFFICE_DATA 的 operation_id
- 更新 OfficePostingStoreTest 與 BasicInformationOfficesSaveAsTest 斷言

測試：
- 已執行 OfficePostingStoreTest、OfficeAddressOperationLoggingTest、BasicInformationOfficesSaveAsTest