### PR TITLE
建立 ALTNAME_DATA 3-key 相容層（#834 Phase 1）

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -177,29 +177,37 @@ class OperationsController extends Controller {
                                 }
                             }
 
-                            // 檢查陣列長度是否足夠（ALTNAME_DATA 需要 4 個欄位）
-                            if (count($addr_l) < 4) {
+                            $addrCount = count($addr_l);
+                            if ($addrCount >= 4) {
+                                // 4-key 格式：c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code
+                                if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
+                                    $addr_l[1] = null;
+                                }
+                                $arr3 = DB::table('ALTNAME_DATA')->where([
+                                    ['c_personid', '=', $addr_l[0]],
+                                    ['c_sequence', '=', $addr_l[1]],
+                                    ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
+                                    ['c_alt_name_type_code', '=', $addr_l[3]],
+                                ])->first();
+                            } elseif ($addrCount === 3) {
+                                // Phase 1 相容 (#834)：3-key 格式 (c_personid, c_alt_name_chn, c_alt_name_type_code)
+                                $arr3 = DB::table('ALTNAME_DATA')->where([
+                                    ['c_personid', '=', $addr_l[0]],
+                                    ['c_alt_name_chn', '=', $addr_l[1]],
+                                    ['c_alt_name_type_code', '=', $addr_l[2]],
+                                ])->first();
+                            } else {
                                 // 記錄錯誤並跳過此筆資料
                                 \Log::warning("ALTNAME_DATA resource_id 格式不正確: {$resource_id}", [
                                     'parsed' => $addr_l,
-                                    'expected_count' => 4,
-                                    'actual_count' => count($addr_l),
+                                    'expected_count' => '3 or 4',
+                                    'actual_count' => $addrCount,
                                     'operation_id' => $listsArr['data'][$x]['id'] ?? null,
                                 ]);
                                 $arr3 = null;
 
                                 break;
                             }
-
-                            if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
-                                $addr_l[1] = null;
-                            }
-                            $arr3 = DB::table('ALTNAME_DATA')->where([
-                                ['c_personid', '=', $addr_l[0]],
-                                ['c_sequence', '=', $addr_l[1]],
-                                ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-                                ['c_alt_name_type_code', '=', $addr_l[3]],
-                            ])->first();
                             $arr3 = json_encode($arr3);
                             $arr3 = json_decode($arr3, true);
 
@@ -921,17 +929,28 @@ class OperationsController extends Controller {
         }
 
         // NOTE (#834): 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
-        // c_sequence 非 PK。暫維持 4-key 查詢以相容歷史格式，Phase 2 將統一切為 3-key。
-        if ($personId === null || $sequence === null || $altNameChn === null || $typeCode === null) {
-            return null;
+        // c_sequence 非 PK。
+
+        // 4-key 查詢：所有欄位皆有值時（相容歷史 4-key resource_id）
+        if ($personId !== null && $sequence !== null && $altNameChn !== null && $typeCode !== null) {
+            return DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $personId],
+                ['c_sequence', '=', $sequence],
+                ['c_alt_name_chn', '=', $altNameChn],
+                ['c_alt_name_type_code', '=', $typeCode],
+            ])->first();
         }
 
-        return DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $personId],
-            ['c_sequence', '=', $sequence],
-            ['c_alt_name_chn', '=', $altNameChn],
-            ['c_alt_name_type_code', '=', $typeCode],
-        ])->first();
+        // Phase 1 相容 (#834)：c_sequence 未知時，以 DB 3-key 查詢
+        if ($personId !== null && $altNameChn !== null && $typeCode !== null) {
+            return DB::table('ALTNAME_DATA')->where([
+                ['c_personid', '=', $personId],
+                ['c_alt_name_chn', '=', $altNameChn],
+                ['c_alt_name_type_code', '=', $typeCode],
+            ])->first();
+        }
+
+        return null;
     }
 
     protected function resourceKeyColumns($resource) {

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -121,6 +121,17 @@ class CompositePrimaryKey {
     ];
 
     /**
+     * ALTNAME_DATA 實際資料庫主鍵（3-key）
+     *
+     * 資料庫 PK 為 (c_personid, c_alt_name_chn, c_alt_name_type_code)，
+     * c_sequence 不參與定位。此常數用於 Phase 1 相容層：
+     * 當 resource_id 不含 c_sequence 時，以此 schema 進行解析。
+     *
+     * @see https://github.com/cbdb-project/cbdb-online-main-server/issues/834
+     */
+    private const ALTNAME_DB_PRIMARY_KEY = ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'];
+
+    /**
      * resource_id 的 schema 別名對應
      *
      * 某些資料表的 resource_id 刻意沿用其他表的格式（共用編輯頁面），
@@ -416,6 +427,13 @@ class CompositePrimaryKey {
             if (!empty($parsed) && count(array_intersect($schema, array_keys($parsed))) === count($schema)) {
                 return array_intersect_key($parsed, array_flip($schema));
             }
+            // ALTNAME_DATA Phase 1 相容 (#834)：接受不含 c_sequence 的 3-key query-string
+            if (strtoupper($effectiveTable) === 'ALTNAME_DATA' && !empty($parsed)) {
+                $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
+                if (count(array_intersect($dbPk, array_keys($parsed))) === count($dbPk)) {
+                    return array_intersect_key($parsed, array_flip($dbPk));
+                }
+            }
         }
 
         $expectedCount = count($schema);
@@ -425,6 +443,13 @@ class CompositePrimaryKey {
             $parts = explode('_._', $resourceId);
             if (count($parts) >= $expectedCount) {
                 return array_combine($schema, array_slice($parts, 0, $expectedCount));
+            }
+            // ALTNAME_DATA Phase 1 相容 (#834)：接受 3-key _._  格式
+            if (strtoupper($effectiveTable) === 'ALTNAME_DATA') {
+                $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
+                if (count($parts) === count($dbPk)) {
+                    return array_combine($dbPk, $parts);
+                }
             }
 
             return null;
@@ -462,7 +487,24 @@ class CompositePrimaryKey {
             return $p;
         }, $parts2);
 
-        return self::combinePartsWithSchema($parts2, $schema, $table);
+        $result2 = self::combinePartsWithSchema($parts2, $schema, $table);
+        if ($result2 !== null) {
+            return $result2;
+        }
+
+        // ALTNAME_DATA Phase 1 相容 (#834)：以 DB 3-key 重試 dash 格式
+        if (strtoupper($effectiveTable) === 'ALTNAME_DATA') {
+            $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
+            $dbPkCount = count($dbPk);
+            if (count($parts) === $dbPkCount) {
+                return array_combine($dbPk, $parts);
+            }
+            if (count($parts2) === $dbPkCount) {
+                return array_combine($dbPk, $parts2);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/OperationsIndexDiffTest.php
+++ b/tests/Feature/OperationsIndexDiffTest.php
@@ -6,6 +6,7 @@ use App\Models\Operation;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -100,6 +101,7 @@ BLADE
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ALTNAME_DATA');
         Schema::dropIfExists('OFFICE_TYPE_TREE');
         Schema::dropIfExists('OFFICE_CODE_TYPE_REL');
         Schema::dropIfExists('OFFICE_CODES');
@@ -107,6 +109,19 @@ BLADE
         Schema::dropIfExists('users');
 
         parent::tearDown();
+    }
+
+    /**
+     * 建立 ALTNAME_DATA 測試表並插入測試資料
+     */
+    protected function createAltnameTable(): void {
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->nullable();
+            $table->integer('c_alt_name_type_code');
+            $table->string('c_alt_name')->nullable();
+            $table->string('c_alt_name_chn')->nullable();
+        });
     }
 
     protected function actingAsAdmin(): User {
@@ -152,5 +167,201 @@ BLADE
 
         $response = $this->get('/operations');
         $response->assertStatus(200)->assertSee('最近編輯列表');
+    }
+
+    // -------------------------------------------------------
+    // Phase 1 (#834)：ALTNAME 3-key 舊格式分支差異比對測試
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_operations_index_altname_3key_dash_format_diff(): void {
+        // 驗證 index() 中 ALTNAME_DATA 舊格式 switch/case 的 3-key dash 路徑
+        // 能正確查到 DB 資料列並計算差異比對
+        $this->actingAsAdmin();
+        $this->createAltnameTable();
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 123,
+            'c_sequence' => 2,
+            'c_alt_name_type_code' => 10,
+            'c_alt_name' => 'Zi Jing',
+            'c_alt_name_chn' => '張三',
+        ]);
+
+        // 3-key dash format: c_personid-c_alt_name_chn-c_alt_name_type_code
+        Operation::create([
+            'user_id' => 1,
+            'c_personid' => 123,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '123-張三-10',
+            'resource_data' => json_encode([
+                'c_personid' => 123,
+                'c_sequence' => 2,
+                'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10,
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 123,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10,
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $response = $this->get('/operations');
+        $response->assertStatus(200);
+
+        // 驗證 controller 正確查到 DB 資料並計算差異
+        $lists = $response->viewData('lists');
+        $this->assertNotEmpty($lists);
+        $diff = $lists[0]->getAttribute('resource_diff');
+        $this->assertNotNull($diff, '3-key dash 格式應能查到 DB 資料並產生差異比對');
+    }
+
+    #[Test]
+    public function test_operations_index_altname_3key_dot_format_diff(): void {
+        // 驗證 index() 中 ALTNAME_DATA 舊格式 switch/case 的 3-key _._  路徑
+        $this->actingAsAdmin();
+        $this->createAltnameTable();
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 456,
+            'c_sequence' => 0,
+            'c_alt_name_type_code' => 5,
+            'c_alt_name' => 'Hao',
+            'c_alt_name_chn' => '測試',
+        ]);
+
+        // 3-key _._  format: c_personid_._c_alt_name_chn_._c_alt_name_type_code
+        Operation::create([
+            'user_id' => 1,
+            'c_personid' => 456,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '456_._測試_._5',
+            'resource_data' => json_encode([
+                'c_personid' => 456,
+                'c_sequence' => 0,
+                'c_alt_name_chn' => '測試',
+                'c_alt_name_type_code' => 5,
+                'c_alt_name' => 'Hao',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 456,
+                'c_sequence' => 0,
+                'c_alt_name_chn' => '測試',
+                'c_alt_name_type_code' => 5,
+                'c_alt_name' => 'Old',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $response = $this->get('/operations');
+        $response->assertStatus(200);
+
+        $lists = $response->viewData('lists');
+        $this->assertNotEmpty($lists);
+        $diff = $lists[0]->getAttribute('resource_diff');
+        $this->assertNotNull($diff, '3-key _._  格式應能查到 DB 資料並產生差異比對');
+    }
+
+    #[Test]
+    public function test_operations_index_altname_3key_dash_with_encoded_minus_diff(): void {
+        // 驗證 c_alt_name_chn 含負號時，3-key dash 格式仍能正確比對
+        $this->actingAsAdmin();
+        $this->createAltnameTable();
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 789,
+            'c_sequence' => 1,
+            'c_alt_name_type_code' => 3,
+            'c_alt_name' => 'Test',
+            'c_alt_name_chn' => '張-三',
+        ]);
+
+        // 「張-三」在 dash 格式中編碼為「張(minus)三」
+        Operation::create([
+            'user_id' => 1,
+            'c_personid' => 789,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '789-張(minus)三-3',
+            'resource_data' => json_encode([
+                'c_personid' => 789,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '張-三',
+                'c_alt_name_type_code' => 3,
+                'c_alt_name' => 'Test',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 789,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '張-三',
+                'c_alt_name_type_code' => 3,
+                'c_alt_name' => 'Old',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $response = $this->get('/operations');
+        $response->assertStatus(200);
+
+        $lists = $response->viewData('lists');
+        $this->assertNotEmpty($lists);
+        $diff = $lists[0]->getAttribute('resource_diff');
+        $this->assertNotNull($diff, '3-key dash 含 (minus) 編碼應能查到 DB 資料並產生差異比對');
+    }
+
+    #[Test]
+    public function test_operations_index_altname_4key_legacy_still_works(): void {
+        // 確認既有 4-key 舊格式不受 Phase 1 影響
+        $this->actingAsAdmin();
+        $this->createAltnameTable();
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 100,
+            'c_sequence' => 1,
+            'c_alt_name_type_code' => 10,
+            'c_alt_name' => 'Ming',
+            'c_alt_name_chn' => '李四',
+        ]);
+
+        // 4-key dash format: c_personid-c_sequence-c_alt_name_chn-c_alt_name_type_code
+        Operation::create([
+            'user_id' => 1,
+            'c_personid' => 100,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '100-1-李四-10',
+            'resource_data' => json_encode([
+                'c_personid' => 100,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '李四',
+                'c_alt_name_type_code' => 10,
+                'c_alt_name' => 'Ming',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 100,
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '李四',
+                'c_alt_name_type_code' => 10,
+                'c_alt_name' => 'Old',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $response = $this->get('/operations');
+        $response->assertStatus(200);
+
+        $lists = $response->viewData('lists');
+        $this->assertNotEmpty($lists);
+        $diff = $lists[0]->getAttribute('resource_diff');
+        $this->assertNotNull($diff, '既有 4-key 格式應繼續正常運作');
     }
 }

--- a/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
+++ b/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\CompositePrimaryKey;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * ALTNAME_DATA 3-key 相容層測試 (#834 Phase 1)
+ *
+ * 確保 parseStoredResourceId() 同時支援歷史 4-key 與未來 3-key 格式，
+ * 涵蓋 query-string、_._、dash 三種分隔符。
+ */
+class CompositePrimaryKeyAltnameCompatTest extends TestCase {
+    // -------------------------------------------------------
+    // query-string 格式
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_parse_altname_3key_query_string(): void {
+        $resourceId = 'c_personid=123&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+    }
+
+    #[Test]
+    public function test_parse_altname_4key_query_string_still_works(): void {
+        $resourceId = 'c_personid=123&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(4, $result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('1', $result['c_sequence']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+    }
+
+    #[Test]
+    public function test_parse_altname_4key_query_string_with_null_sentinel(): void {
+        $resourceId = 'c_personid=200&c_sequence=NULL&c_alt_name_chn=%E6%B8%AC%E8%A9%A6&c_alt_name_type_code=5';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(4, $result);
+        $this->assertSame('NULL', $result['c_sequence']);
+    }
+
+    // -------------------------------------------------------
+    // _._  格式
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_parse_altname_3key_dot_format(): void {
+        $resourceId = '123_._張三_._10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+    }
+
+    #[Test]
+    public function test_parse_altname_4key_dot_format_still_works(): void {
+        $resourceId = '123_._1_._張三_._10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(4, $result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('1', $result['c_sequence']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+    }
+
+    // -------------------------------------------------------
+    // dash 格式
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_parse_altname_3key_dash_format(): void {
+        $resourceId = '123-張三-10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+    }
+
+    #[Test]
+    public function test_parse_altname_3key_dash_format_with_encoded_minus(): void {
+        // c_alt_name_chn 含負號：「張-三」編碼為 張(minus)三
+        $resourceId = '123-張(minus)三-10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('張-三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+    }
+
+    #[Test]
+    public function test_parse_altname_3key_dash_format_with_old_double_dash(): void {
+        // 舊格式：「張-三」編碼為 張--三
+        $resourceId = '123-張--三-10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('張-三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+    }
+
+    #[Test]
+    public function test_parse_altname_4key_dash_format_still_works(): void {
+        $resourceId = '123-1-張三-10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertCount(4, $result);
+        $this->assertSame('123', $result['c_personid']);
+        $this->assertSame('1', $result['c_sequence']);
+        $this->assertSame('張三', $result['c_alt_name_chn']);
+        $this->assertSame('10', $result['c_alt_name_type_code']);
+    }
+
+    // -------------------------------------------------------
+    // 非 ALTNAME 表不受影響
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_non_altname_table_not_affected_by_3key_fallback(): void {
+        // BIOG_ADDR_DATA 需要 4-key，給 3 個 parts 應返回 null
+        $resourceId = '123_._456_._10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'BIOG_ADDR_DATA');
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function test_non_altname_table_3part_dash_returns_null(): void {
+        // BIOG_ADDR_DATA 需要 4-key，給 3 個 dash parts 也應返回 null
+        $resourceId = '123-456-10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'BIOG_ADDR_DATA');
+
+        $this->assertNull($result);
+    }
+
+    // -------------------------------------------------------
+    // 邊界情境
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_parse_altname_3key_query_string_with_special_chars(): void {
+        // c_alt_name_chn 含斜線：「張/三」
+        $resourceId = 'c_personid=123&c_alt_name_chn=%E5%BC%B5%2F%E4%B8%89&c_alt_name_type_code=10';
+        $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
+
+        $this->assertNotNull($result);
+        $this->assertSame('張/三', $result['c_alt_name_chn']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+    }
+
+    #[Test]
+    public function test_parse_altname_2parts_returns_null(): void {
+        // 只有 2 個 parts，無論哪種格式都不應匹配
+        $this->assertNull(CompositePrimaryKey::parseStoredResourceId('123-10', 'ALTNAME_DATA'));
+        $this->assertNull(CompositePrimaryKey::parseStoredResourceId('123_._10', 'ALTNAME_DATA'));
+    }
+}

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -68,7 +68,9 @@ class OperationsAltnameResolverTest extends TestCase {
     #[Test]
     public function test_fetch_altname_handles_null_sentinel_in_query_string_resource_id(): void {
         // 當 resource_data 缺少欄位，且 resource_id 用新格式包含 NULL sentinel 時，
-        // fetchAltnameCurrentRow 不應將 'NULL' 強轉為 (int)0
+        // c_sequence=NULL 經解析後為 PHP null。
+        // Phase 1 (#834)：c_sequence 為 null 時改走 3-key 查詢（DB PK），
+        // 因此能正確定位到該筆資料（不論 c_sequence 實際值為何）。
         DB::table('ALTNAME_DATA')->insert([
             'c_personid' => 200,
             'c_sequence' => 0,
@@ -94,9 +96,12 @@ class OperationsAltnameResolverTest extends TestCase {
 
         $row = $controller->resolveAltname($operationPayload);
 
-        // c_sequence=NULL 應解析為 null，WHERE c_sequence IS NULL 不會匹配到 c_sequence=0
-        // 因此 row 應為 null（因為資料庫中 c_sequence=0，不是 NULL）
-        $this->assertNull($row);
+        // Phase 1：c_sequence 為 null → 3-key 回退查詢，以 DB PK 定位
+        // (c_personid=200, c_alt_name_chn=測試, c_alt_name_type_code=5) 能唯一找到該列
+        $this->assertNotNull($row);
+        $this->assertEquals(200, $row->c_personid);
+        $this->assertSame('測試', $row->c_alt_name_chn);
+        $this->assertEquals(0, $row->c_sequence);
     }
 
     #[Test]
@@ -135,6 +140,94 @@ class OperationsAltnameResolverTest extends TestCase {
         $this->assertNull($conditions['c_sequence']); // 'NULL' 應轉為 PHP null
         $this->assertSame('張三', $conditions['c_alt_name_chn']);
         $this->assertSame('10', $conditions['c_alt_name_type_code']);
+
+        Schema::dropIfExists('operations');
+    }
+
+    // -------------------------------------------------------
+    // Phase 1 (#834)：3-key 相容層測試
+    // -------------------------------------------------------
+
+    #[Test]
+    public function test_fetch_altname_current_row_with_3key_query_string(): void {
+        // 3-key query-string 格式（不含 c_sequence），應以 DB 3-key 查到正確資料列
+        $controller = new class (new OperationRepository()) extends OperationsController {
+            public function resolveAltname(array $payload) {
+                return $this->fetchAltnameCurrentRow($payload);
+            }
+        };
+
+        $operationPayload = [
+            'resource_id' => 'c_personid=123&c_alt_name_chn=%E5%BC%B5%2D%E4%B8%80&c_alt_name_type_code=10',
+            'resource_data' => json_encode([
+                'c_personid' => 123,
+            ]),
+        ];
+
+        $row = $controller->resolveAltname($operationPayload);
+
+        $this->assertNotNull($row);
+        $this->assertSame('張-一', $row->c_alt_name_chn);
+        $this->assertSame('Zi Jing', $row->c_alt_name);
+    }
+
+    #[Test]
+    public function test_fetch_altname_current_row_with_3key_dash_format(): void {
+        // 3-key dash 格式：c_personid-c_alt_name_chn-c_alt_name_type_code
+        $controller = new class (new OperationRepository()) extends OperationsController {
+            public function resolveAltname(array $payload) {
+                return $this->fetchAltnameCurrentRow($payload);
+            }
+        };
+
+        // 「張-一」在 dash 格式中編碼為 張(minus)一
+        $operationPayload = [
+            'resource_id' => '123-張(minus)一-10',
+            'resource_data' => json_encode([]),
+        ];
+
+        $row = $controller->resolveAltname($operationPayload);
+
+        $this->assertNotNull($row);
+        $this->assertSame('張-一', $row->c_alt_name_chn);
+        $this->assertEquals(1, $row->c_sequence);
+    }
+
+    #[Test]
+    public function test_build_key_conditions_with_3key_altname_resource_id(): void {
+        // 3-key resource_id → buildKeyConditions 應返回 3 個 condition
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->timestamps();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->tinyInteger('rate')->default(0);
+        });
+
+        $controller = new class (new OperationRepository()) extends OperationsController {
+            public function publicBuildKeyConditions(Operation $op, array $current, array $fallback) {
+                return $this->buildKeyConditions($op, $current, $fallback);
+            }
+        };
+
+        $op = new Operation();
+        $op->resource = 'ALTNAME_DATA';
+        $op->resource_id = 'c_personid=123&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
+
+        $conditions = $controller->publicBuildKeyConditions($op, [], []);
+
+        // 3-key resource_id → parseStoredResourceId 返回 3 個欄位
+        // buildKeyConditions 中只有 3 個欄位在 namedParsed 中，c_sequence 無法從任何來源取得
+        $this->assertSame('123', $conditions['c_personid']);
+        $this->assertSame('張三', $conditions['c_alt_name_chn']);
+        $this->assertSame('10', $conditions['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $conditions);
 
         Schema::dropIfExists('operations');
     }


### PR DESCRIPTION
## Summary

- 讓 `resource_id` 解析器（`parseStoredResourceId()`）同時支援歷史 4-key 與未來 3-key 格式，涵蓋 query-string、`_._`、dash 三種分隔符
- `OperationsController::index()` ALTNAME 舊格式分支支援 3-part 解析
- `fetchAltnameCurrentRow()` 在 `c_sequence` 為 null 時改走 DB 3-key 查詢
- 不改變主流程寫入行為（SCHEMAS 維持 4-key、BiogMainRepository / Controller / Proposal 不修改）

## 變更檔案

| 檔案 | 說明 |
|---|---|
| `app/Support/CompositePrimaryKey.php` | 新增 `ALTNAME_DB_PRIMARY_KEY` 常數；`parseStoredResourceId()` 三種格式加入 3-key 回退 |
| `app/Http/Controllers/OperationsController.php` | `index()` ALTNAME 分支支援 3-part；`fetchAltnameCurrentRow()` 3-key 查詢 |
| `tests/Unit/CompositePrimaryKeyAltnameCompatTest.php` | 新增 13 個測試（3-key/4-key × 三種格式 + 邊界情境） |
| `tests/Unit/OperationsAltnameResolverTest.php` | 擴充 3 個新測試 + 更新 1 個既有測試 |
| `tests/Feature/OperationsIndexDiffTest.php` | 擴充 4 個 Feature 測試覆蓋列表頁差異比對 |

## Test plan

- [x] 582 tests, 2205 assertions 全部通過
- [x] php-cs-fixer 格式檢查通過
- [x] 線上環境驗證 Operations 列表頁歷史 ALTNAME 記錄仍可正常顯示

Closes phase 1 of #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)