### PR TITLE
將 ALTNAME_DATA 主流程切到 3-key 主鍵 (#834 Phase 2)

### DIFF
--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -136,10 +136,9 @@ class BasicInformationAltnamesController extends Controller {
 
         flash('Store success @ '.Carbon::now(), 'success');
 
-        // 使用新的查詢參數模式重定向
+        // (#834 Phase 2): 使用 3-key 重定向，c_sequence 不參與定位
         $newPk = [
             'c_personid' => $data['c_personid'],
-            'c_sequence' => $data['c_sequence'],
             'c_alt_name_chn' => $data['c_alt_name_chn'],
             'c_alt_name_type_code' => $data['c_alt_name_type_code'],
         ];
@@ -243,16 +242,9 @@ class BasicInformationAltnamesController extends Controller {
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // 解析舊格式的複合主鍵，轉換為陣列
-            $addr_l = $this->parseAltnameId($alt);
-            $originalPk = [
-                'c_personid' => $addr_l[0],
-                'c_sequence' => $addr_l[1],
-                'c_alt_name_chn' => $addr_l[2],
-                'c_alt_name_type_code' => $addr_l[3],
-            ];
+            // (#834 Phase 2): 使用 3-key 關聯陣列
+            $originalPk = $this->parseAltnameId($alt);
 
-            // 使用新的查詢參數模式，直接傳遞主鍵陣列
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
                 ->proposalUpdateWithPk($request, $id, 'altnames', $originalPk);
         }
@@ -317,27 +309,15 @@ class BasicInformationAltnamesController extends Controller {
      */
 
     /**
-     * 解析別名複合主鍵 ID
-     * 支持兩種分隔符格式：'_._' (新格式) 和 '-' (舊格式)
+     * 解析別名複合主鍵 ID 為 3-key 關聯陣列
+     *
+     * (#834 Phase 2): 委派給 Repository，支援歷史 4-key 與新 3-key 格式。
      *
      * @param string $alt 複合主鍵 ID
-     * @return array 包含 4 個元素的陣列 [c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code]
+     * @return array 3-key 關聯陣列 ['c_personid' => ..., 'c_alt_name_chn' => ..., 'c_alt_name_type_code' => ...]
      */
     protected function parseAltnameId($alt) {
-        if (strpos($alt, '_._') !== false) {
-            $addr_l = explode('_._', $alt);
-        } else {
-            $addr_l = explode("-", $alt);
-            foreach ($addr_l as $key => $value) {
-                $addr_l[$key] = $this->biogMainRepository->unionPKDef_decode($value);
-            }
-        }
-
-        if (isset($addr_l[1]) && $addr_l[1] === 'NULL') {
-            $addr_l[1] = null;
-        }
-
-        return $addr_l;
+        return $this->biogMainRepository->parseAltnameId($alt);
     }
 
     // ===================================================================
@@ -356,39 +336,19 @@ class BasicInformationAltnamesController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function editQuery(Request $request, $id) {
-        // 從查詢參數提取複合主鍵
+        // (#834 Phase 2): 從查詢參數提取 3-key
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $pk = CompositePrimaryKey::fromRequest($request, $schema);
 
         // 驗證必填欄位
-        $required = ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'];
-        foreach ($required as $field) {
-            if (!isset($pk[$field]) || $pk[$field] === '') {
-                abort(400, "缺少必要參數：{$field}");
-            }
-        }
+        CompositePrimaryKey::validateOrFail($pk, 'ALTNAME_DATA');
 
-        // 處理 c_sequence 可能為 'NULL' 或 null 的情況
-        if (isset($pk['c_sequence']) && $pk['c_sequence'] === 'NULL') {
-            $pk['c_sequence'] = null;
-        }
-
-        // 構建查詢條件
-        $conditions = [
+        // 構建 3-key 查詢條件
+        $row = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $pk['c_personid']],
             ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
             ['c_alt_name_type_code', '=', $pk['c_alt_name_type_code']],
-        ];
-
-        // c_sequence 可能為 null，需要使用 whereNull
-        $query = DB::table('ALTNAME_DATA')->where($conditions);
-        if (isset($pk['c_sequence']) && $pk['c_sequence'] !== null) {
-            $query->where('c_sequence', '=', $pk['c_sequence']);
-        } else {
-            $query->whereNull('c_sequence');
-        }
-
-        $row = $query->first();
+        ])->first();
 
         if (!$row) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
@@ -473,7 +433,7 @@ class BasicInformationAltnamesController extends Controller {
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+            // (#834 Phase 2): 從 URL 查詢字串取得 3-key 原始 PK
             $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
             $originalPk = [];
             foreach ($schema as $field) {
@@ -483,12 +443,6 @@ class BasicInformationAltnamesController extends Controller {
                 }
             }
 
-            // 處理 c_sequence 可能為 'NULL' 的情況
-            if (isset($originalPk['c_sequence']) && $originalPk['c_sequence'] === 'NULL') {
-                $originalPk['c_sequence'] = null;
-            }
-
-            // 使用新的查詢參數模式，直接傳遞主鍵陣列
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
                 ->proposalUpdateWithPk($request, $id, 'altnames', $originalPk);
         }
@@ -500,8 +454,7 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // 從 URL 查詢字串提取原始 PK（用於定位記錄）
-        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
+        // (#834 Phase 2): 從 URL 查詢字串提取 3-key 原始 PK
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $originalPk = [];
         foreach ($schema as $field) {
@@ -511,29 +464,17 @@ class BasicInformationAltnamesController extends Controller {
             }
         }
 
-        // 驗證必填欄位（c_sequence 為可選）
-        CompositePrimaryKey::validateOrFail($originalPk, 'ALTNAME_DATA', ['c_sequence']);
-
-        // 處理 c_sequence
-        if (isset($originalPk['c_sequence']) && $originalPk['c_sequence'] === 'NULL') {
-            $originalPk['c_sequence'] = null;
-        }
-
-        // 構建舊格式 ID 用於 Repository
-        $originalPkString = $originalPk['c_personid']."-".
-            ($originalPk['c_sequence'] ?? 'NULL')."-".
-            $this->biogMainRepository->unionPKDef($originalPk['c_alt_name_chn'])."-".
-            $originalPk['c_alt_name_type_code'];
+        CompositePrimaryKey::validateOrFail($originalPk, 'ALTNAME_DATA');
 
         // 取得原始資料（供索引更新判斷）
-        $ori = $this->biogMainRepository->altnameById($originalPkString);
+        $ori = $this->biogMainRepository->altnameById($originalPk);
         if (!$ori) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
         // 保留原始請求資料供索引差異判斷
         $data = $request->all();
-        $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $originalPkString);
+        $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $originalPk);
         if (!$newPk) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
@@ -593,27 +534,19 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // (#834 Phase 2): 從查詢參數提取 3-key
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $pk = CompositePrimaryKey::fromRequest($request, $schema);
-
-        // 驗證必填欄位（c_sequence 為可選）
-        CompositePrimaryKey::validateOrFail($pk, 'ALTNAME_DATA', ['c_sequence']);
-
-        // 構建舊格式 ID 用於 Repository
-        $id_ = $pk['c_personid']."-".
-               ($pk['c_sequence'] ?? 'NULL')."-".
-               $this->biogMainRepository->unionPKDef($pk['c_alt_name_chn'])."-".
-               $pk['c_alt_name_type_code'];
+        CompositePrimaryKey::validateOrFail($pk, 'ALTNAME_DATA');
 
         // 取得原始資料用於索引清理
-        $row = $this->biogMainRepository->altnameById($id_);
+        $row = $this->biogMainRepository->altnameById($pk);
         if (!$row) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
         // 使用 Repository 進行刪除（內含事務與審計）
-        $deleted = $this->biogMainRepository->altnameDeleteById($id_, $id);
+        $deleted = $this->biogMainRepository->altnameDeleteById($pk, $id);
         if (!$deleted) {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -30,9 +31,8 @@ class BasicInformationProposalController extends Controller {
         ],
         'altnames' => [
             'table' => 'ALTNAME_DATA',
-            // NOTE (#834): 資料庫 PK 為 3-key，c_sequence 非 PK；
-            // 暫維持 4-key 以相容歷史格式，Phase 2 將移除 c_sequence。
-            'key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            // (#834 Phase 2): 3-key，c_sequence 不參與定位
+            'key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             'controller' => 'BasicInformationAltnamesController',
             'route_prefix' => 'basicinformation.altnames',
             'display_name' => '別名',
@@ -369,28 +369,56 @@ class BasicInformationProposalController extends Controller {
 
     /**
      * 構建複合主鍵 ID
+     *
+     * 使用 query-string 格式（http_build_query），與 CompositePrimaryKey::buildStoredResourceId() 一致，
+     * 所有特殊字符（中文、連字符等）自動 URL 編碼，消除舊 dash 分隔符的解析歧義。
      */
     protected function buildCompositeId($keyColumns, $data) {
-        $parts = [];
+        $pk = [];
         foreach ($keyColumns as $column) {
-            $value = $data[$column] ?? '';
-            // 處理 NULL 值
-            if ($value === null || $value === '') {
-                $value = 'NULL';
+            $value = $data[$column] ?? null;
+            if ($value === '') {
+                $value = null;
             }
-            // 處理特殊字符（連字符）
-            $value = str_replace('-', 'minus', (string) $value);
-            $parts[] = $value;
+            $pk[$column] = $value;
         }
 
-        return implode('-', $parts);
+        return CompositePrimaryKey::buildStoredResourceId($pk);
     }
 
     /**
      * 解析複合主鍵 ID
+     *
+     * 支援兩種格式：
+     * - query-string 格式（新）：c_personid=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10
+     * - dash 分隔格式（舊，@deprecated）：1-張三-10
      */
     protected function parseCompositeId($id, $keyColumns) {
-        // 使用現有的 unionPKDef_decode
+        // 嘗試 query-string 解析：若所有 keyColumn 都出現在結果中，視為 query-string 格式
+        parse_str($id, $parsed);
+        $allKeysPresent = true;
+        foreach ($keyColumns as $col) {
+            if (!array_key_exists($col, $parsed)) {
+                $allKeysPresent = false;
+
+                break;
+            }
+        }
+
+        if ($allKeysPresent) {
+            $conditions = [];
+            foreach ($keyColumns as $column) {
+                $value = $parsed[$column];
+                if ($value === 'NULL') {
+                    $value = null;
+                }
+                $conditions[$column] = $value;
+            }
+
+            return $conditions;
+        }
+
+        // 舊格式：dash 分隔
         $id = $this->biogMainRepository->unionPKDef_decode($id);
 
         $parts = explode('-', $id);
@@ -482,10 +510,26 @@ class BasicInformationProposalController extends Controller {
             return false;
         }
 
+        // 新格式（query-string）
         $resourceId = $this->buildCompositeId($keyColumns, $data);
 
+        // 舊格式（dash 分隔 + bare minus 編碼），用於匹配歷史 pending 提案
+        $legacyParts = [];
+        foreach ($keyColumns as $column) {
+            $value = $data[$column] ?? null;
+            $legacyParts[] = ($value === null || $value === '')
+                ? 'NULL'
+                : str_replace('-', 'minus', (string) $value);
+        }
+        $legacyResourceId = implode('-', $legacyParts);
+
+        $candidateIds = [$resourceId];
+        if ($legacyResourceId !== $resourceId) {
+            $candidateIds[] = $legacyResourceId;
+        }
+
         $operations = Operation::where('resource', $table)
-            ->where('resource_id', $resourceId)
+            ->whereIn('resource_id', $candidateIds)
             ->where('op_type', $opType)
             ->get();
 

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -157,56 +157,24 @@ class OperationsController extends Controller {
 
                             break;
                         case "ALTNAME_DATA":
-                            //20251201先遮除原本存取方式，改使用聯合主鍵解析
-                            //$arr3 = $this->fetchAltnameCurrentRow($listsArr['data'][$x]);
-
-                            // 檢測分隔符類型：支持兩種格式 '_._' (CodesController) 或 '-' (BasicInformationProposalController)
-                            if (strpos($resource_id, '_._') !== false) {
-                                // 使用 _._格式
-                                $addr_l = explode('_._', $resource_id);
-                            } else {
-                                // 使用 - 格式
-                                $alt = str_replace("--", "-minus", $resource_id);
-                                //聯合主鍵保留字弱點防禦函式，解析保留字。
-                                $alt = $this->unionPKDef_decode($alt);
-                                $addr_l = explode("-", $alt);
-                                foreach ($addr_l as $key => $value) {
-                                    // 注意：必須先處理 (minus) 再處理 minus
-                                    $value = str_replace("(minus)", "-", $value);
-                                    $addr_l[$key] = str_replace("minus", "-", $value);
+                            // (#834 Phase 2): 使用 CompositePrimaryKey 解析 resource_id（支援歷史 4-key 與新 3-key），
+                            // 返回 3-key 查詢
+                            $parsedAlt = CompositePrimaryKey::parseStoredResourceId($resource_id, 'ALTNAME_DATA');
+                            if ($parsedAlt !== null) {
+                                $altQuery = DB::table('ALTNAME_DATA');
+                                foreach ($parsedAlt as $col => $val) {
+                                    if ($val === 'NULL' || $val === null) {
+                                        $altQuery->whereNull($col);
+                                    } else {
+                                        $altQuery->where($col, '=', $val);
+                                    }
                                 }
-                            }
-
-                            $addrCount = count($addr_l);
-                            if ($addrCount >= 4) {
-                                // 4-key 格式：c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code
-                                if (isset($addr_l[1]) && $addr_l[1] == 'NULL') {
-                                    $addr_l[1] = null;
-                                }
-                                $arr3 = DB::table('ALTNAME_DATA')->where([
-                                    ['c_personid', '=', $addr_l[0]],
-                                    ['c_sequence', '=', $addr_l[1]],
-                                    ['c_alt_name_chn', 'like', '%'.$addr_l[2].'%'],
-                                    ['c_alt_name_type_code', '=', $addr_l[3]],
-                                ])->first();
-                            } elseif ($addrCount === 3) {
-                                // Phase 1 相容 (#834)：3-key 格式 (c_personid, c_alt_name_chn, c_alt_name_type_code)
-                                $arr3 = DB::table('ALTNAME_DATA')->where([
-                                    ['c_personid', '=', $addr_l[0]],
-                                    ['c_alt_name_chn', '=', $addr_l[1]],
-                                    ['c_alt_name_type_code', '=', $addr_l[2]],
-                                ])->first();
+                                $arr3 = $altQuery->first();
                             } else {
-                                // 記錄錯誤並跳過此筆資料
                                 \Log::warning("ALTNAME_DATA resource_id 格式不正確: {$resource_id}", [
-                                    'parsed' => $addr_l,
-                                    'expected_count' => '3 or 4',
-                                    'actual_count' => $addrCount,
                                     'operation_id' => $listsArr['data'][$x]['id'] ?? null,
                                 ]);
                                 $arr3 = null;
-
-                                break;
                             }
                             $arr3 = json_encode($arr3);
                             $arr3 = json_decode($arr3, true);
@@ -878,17 +846,19 @@ class OperationsController extends Controller {
         return $segments;
     }
 
+    /**
+     * (#834 Phase 2): 使用 3-key 查詢 ALTNAME_DATA 現行資料列
+     */
     protected function fetchAltnameCurrentRow(array $operation) {
         $decoded = $this->decodeJson($operation['resource_data'] ?? null);
         $decoded = is_array($decoded) ? $decoded : [];
 
         $personId = $decoded['c_personid'] ?? null;
-        $sequence = $decoded['c_sequence'] ?? null;
         $altNameChn = $decoded['c_alt_name_chn'] ?? null;
         $typeCode = $decoded['c_alt_name_type_code'] ?? null;
 
-        if ($personId === null || $sequence === null || $altNameChn === null || $typeCode === null) {
-            // 優先嘗試 query-string 格式（新格式）
+        // 從 resource_id 補齊缺少的欄位
+        if ($personId === null || $altNameChn === null || $typeCode === null) {
             $namedParts = CompositePrimaryKey::parseStoredResourceId(
                 $operation['resource_id'] ?? '',
                 'ALTNAME_DATA'
@@ -898,10 +868,6 @@ class OperationsController extends Controller {
                     $val = $namedParts['c_personid'];
                     $personId = ($val === 'NULL') ? null : (int) $val;
                 }
-                if ($sequence === null && isset($namedParts['c_sequence'])) {
-                    $val = $namedParts['c_sequence'];
-                    $sequence = ($val === 'NULL') ? null : (int) $val;
-                }
                 if ($altNameChn === null && isset($namedParts['c_alt_name_chn'])) {
                     $val = $namedParts['c_alt_name_chn'];
                     $altNameChn = ($val === 'NULL') ? null : $val;
@@ -910,38 +876,9 @@ class OperationsController extends Controller {
                     $val = $namedParts['c_alt_name_type_code'];
                     $typeCode = ($val === 'NULL') ? null : (int) $val;
                 }
-            } else {
-                // 回退到舊格式位置解析（4-key: personid-sequence-alt_name_chn-type_code）
-                $parts = $this->parseCompoundKey($operation['resource_id'] ?? null);
-                if ($personId === null && isset($parts[0]) && is_numeric($parts[0])) {
-                    $personId = (int) $parts[0];
-                }
-                if ($sequence === null && isset($parts[1]) && is_numeric($parts[1])) {
-                    $sequence = (int) $parts[1];
-                }
-                if ($altNameChn === null && isset($parts[2])) {
-                    $altNameChn = $parts[2];
-                }
-                if ($typeCode === null && isset($parts[3]) && is_numeric($parts[3])) {
-                    $typeCode = (int) $parts[3];
-                }
             }
         }
 
-        // NOTE (#834): 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
-        // c_sequence 非 PK。
-
-        // 4-key 查詢：所有欄位皆有值時（相容歷史 4-key resource_id）
-        if ($personId !== null && $sequence !== null && $altNameChn !== null && $typeCode !== null) {
-            return DB::table('ALTNAME_DATA')->where([
-                ['c_personid', '=', $personId],
-                ['c_sequence', '=', $sequence],
-                ['c_alt_name_chn', '=', $altNameChn],
-                ['c_alt_name_type_code', '=', $typeCode],
-            ])->first();
-        }
-
-        // Phase 1 相容 (#834)：c_sequence 未知時，以 DB 3-key 查詢
         if ($personId !== null && $altNameChn !== null && $typeCode !== null) {
             return DB::table('ALTNAME_DATA')->where([
                 ['c_personid', '=', $personId],
@@ -957,10 +894,8 @@ class OperationsController extends Controller {
         $map = [
             'BIOG_MAIN' => ['c_personid'],
             'BIOG_ADDR_DATA' => ['c_personid','c_addr_id','c_addr_type','c_sequence'],
-            // NOTE: 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
-            // c_sequence 非 PK 欄位。此處暫維持 4-key 以相容現有 resource_id 格式，
-            // 待 Phase 2 (#834) 統一切為 3-key。
-            'ALTNAME_DATA' => ['c_personid','c_sequence','c_alt_name_chn','c_alt_name_type_code'],
+            // (#834 Phase 2): 3-key，c_sequence 不參與定位
+            'ALTNAME_DATA' => ['c_personid','c_alt_name_chn','c_alt_name_type_code'],
             'BIOG_TEXT_DATA' => ['c_personid','c_textid','c_role_id'],
             'POSTED_TO_OFFICE_DATA' => ['c_office_id','c_posting_id'],
             'OFFICE_CODES' => ['c_office_id'],

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -2600,30 +2600,28 @@ class BiogMainRepository {
     /**
      * 依複合主鍵取得 ALTNAME_DATA 記錄
      *
-     * NOTE (#834): 資料庫 PK 為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)，
-     * c_sequence 非 PK。此方法暫維持 4-key 查詢以相容歷史格式，
-     * 待 Phase 2 統一切為 3-key。
+     * (#834 Phase 2): 使用 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code) 定位，
+     * c_sequence 不參與定位。接受字串或 3-key 關聯陣列。
+     *
+     * @param string|array $id 複合主鍵字串或 3-key 關聯陣列
      */
     public function altnameById($id) {
-        $addr_l = $this->parseAltnameId($id);
+        $pk = is_array($id) ? $id : $this->parseAltnameId($id);
 
-        $row = DB::table('ALTNAME_DATA')->where([
-            ['c_personid', '=', $addr_l[0]],
-            ['c_sequence', '=', $addr_l[1]],
-            ['c_alt_name_chn', '=', $addr_l[2]],
-            ['c_alt_name_type_code', '=', $addr_l[3]],
+        return DB::table('ALTNAME_DATA')->where([
+            ['c_personid', '=', $pk['c_personid']],
+            ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
+            ['c_alt_name_type_code', '=', $pk['c_alt_name_type_code']],
         ])->first();
-
-        return $row;
     }
 
     public function altnameStoreById(Request $request, $id) {
         $data = $request->all();
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
+        // (#834 Phase 2): 重複檢查使用 3-key，c_sequence 不參與定位
         $duplicate = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $data['c_personid']],
-            ['c_sequence', '=', $data['c_sequence']],
             ['c_alt_name_chn', '=', $data['c_alt_name_chn']],
             ['c_alt_name_type_code', '=', $data['c_alt_name_type_code']],
         ])->first();
@@ -2634,22 +2632,17 @@ class BiogMainRepository {
 
         return DB::transaction(function () use ($id, $data) {
             DB::table('ALTNAME_DATA')->insert($data);
-            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId([
+            $pk3 = [
                 'c_personid' => $data['c_personid'],
-                'c_sequence' => $data['c_sequence'],
                 'c_alt_name_chn' => $data['c_alt_name_chn'],
                 'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-            ]), $data);
+            ];
+            $operation = (new OperationRepository())->store(Auth::id(), $id, 1, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk3), $data);
 
             (new AuditLogService())->write(
                 'ALTNAME_DATA',
                 'INSERT',
-                [
-                    'c_personid' => $data['c_personid'],
-                    'c_sequence' => $data['c_sequence'],
-                    'c_alt_name_chn' => $data['c_alt_name_chn'],
-                    'c_alt_name_type_code' => $data['c_alt_name_type_code'],
-                ],
+                $pk3,
                 null,
                 $data,
                 'user',
@@ -2661,35 +2654,34 @@ class BiogMainRepository {
         });
     }
 
+    /**
+     * @param string|array $alt 複合主鍵字串或 3-key 關聯陣列
+     */
     public function altnameUpdateById(Request $request, $id, $alt) {
-        $addr_l = $this->parseAltnameId($alt);
+        $pk = is_array($alt) ? $alt : $this->parseAltnameId($alt);
         $data = $request->all();
         $comment = $data['__proposal_comment'] ?? null;
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = (new ToolsRepository())->timestamp($data);
 
-        return DB::transaction(function () use ($id, $addr_l, $data, $comment) {
-            $ori = DB::table('ALTNAME_DATA')->where([
-                ['c_personid', '=', $addr_l[0]],
-                ['c_sequence', '=', $addr_l[1]],
-                ['c_alt_name_chn', '=', $addr_l[2]],
-                ['c_alt_name_type_code', '=', $addr_l[3]],
-            ])->lockForUpdate()->first();
+        // (#834 Phase 2): WHERE 使用 3-key 定位
+        $where3key = [
+            ['c_personid', '=', $pk['c_personid']],
+            ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
+            ['c_alt_name_type_code', '=', $pk['c_alt_name_type_code']],
+        ];
+
+        return DB::transaction(function () use ($id, $where3key, $data, $comment) {
+            $ori = DB::table('ALTNAME_DATA')->where($where3key)->lockForUpdate()->first();
 
             if (!$ori) {
                 return null;
             }
 
-            DB::table('ALTNAME_DATA')->where([
-                ['c_personid', '=', $addr_l[0]],
-                ['c_sequence', '=', $addr_l[1]],
-                ['c_alt_name_chn', '=', $addr_l[2]],
-                ['c_alt_name_type_code', '=', $addr_l[3]],
-            ])->update($data);
+            DB::table('ALTNAME_DATA')->where($where3key)->update($data);
 
             $newPk = [
                 'c_personid' => $id,
-                'c_sequence' => $data['c_sequence'] ?? $ori->c_sequence,
                 'c_alt_name_chn' => $data['c_alt_name_chn'] ?? $ori->c_alt_name_chn,
                 'c_alt_name_type_code' => $data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code,
             ];
@@ -2716,41 +2708,41 @@ class BiogMainRepository {
         });
     }
 
+    /**
+     * @param string|array $id 複合主鍵字串或 3-key 關聯陣列
+     * @param int|string $c_personid 人物 ID
+     */
     public function altnameDeleteById($id, $c_personid) {
-        $addr_l = $this->parseAltnameId($id);
+        $pk = is_array($id) ? $id : $this->parseAltnameId($id);
 
-        return DB::transaction(function () use ($c_personid, $addr_l) {
-            $row = DB::table('ALTNAME_DATA')->where([
-                ['c_personid', '=', $addr_l[0]],
-                ['c_sequence', '=', $addr_l[1]],
-                ['c_alt_name_chn', '=', $addr_l[2]],
-                ['c_alt_name_type_code', '=', $addr_l[3]],
-            ])->lockForUpdate()->first();
+        // (#834 Phase 2): WHERE 使用 3-key 定位
+        $where3key = [
+            ['c_personid', '=', $pk['c_personid']],
+            ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
+            ['c_alt_name_type_code', '=', $pk['c_alt_name_type_code']],
+        ];
+
+        return DB::transaction(function () use ($c_personid, $where3key) {
+            $row = DB::table('ALTNAME_DATA')->where($where3key)->lockForUpdate()->first();
 
             if (!$row) {
                 return false;
             }
 
-            DB::table('ALTNAME_DATA')->where([
-                ['c_personid', '=', $addr_l[0]],
-                ['c_sequence', '=', $addr_l[1]],
-                ['c_alt_name_chn', '=', $addr_l[2]],
-                ['c_alt_name_type_code', '=', $addr_l[3]],
-            ])->delete();
+            DB::table('ALTNAME_DATA')->where($where3key)->delete();
 
-            $pk = [
+            $pk3 = [
                 'c_personid' => $row->c_personid,
-                'c_sequence' => $row->c_sequence,
                 'c_alt_name_chn' => $row->c_alt_name_chn,
                 'c_alt_name_type_code' => $row->c_alt_name_type_code,
             ];
 
-            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk), $row);
+            $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'ALTNAME_DATA', CompositePrimaryKey::buildStoredResourceId($pk3), $row);
 
             (new AuditLogService())->write(
                 'ALTNAME_DATA',
                 'DELETE',
-                $pk,
+                $pk3,
                 (new AuditLogService())->normalizeRow($row),
                 null,
                 'user',
@@ -2762,30 +2754,48 @@ class BiogMainRepository {
         });
     }
 
-    protected function parseAltnameId($alt) {
+    /**
+     * 解析 ALTNAME_DATA 複合主鍵字串為 3-key 關聯陣列
+     *
+     * (#834 Phase 2): 返回 3-key 關聯陣列，支援歷史 4-key 與新 3-key 格式。
+     *
+     * @param string $alt 複合主鍵字串
+     * @return array 3-key 關聯陣列 ['c_personid' => ..., 'c_alt_name_chn' => ..., 'c_alt_name_type_code' => ...]
+     */
+    public function parseAltnameId($alt) {
         if (strpos($alt, '_._') !== false) {
-            $addr_l = explode('_._', $alt);
+            $parts = explode('_._', $alt);
         } else {
-            $addr_l = explode("-", $alt);
-            foreach ($addr_l as $key => $value) {
-                $addr_l[$key] = $this->unionPKDef_decode($value);
+            $parts = explode("-", $alt);
+            foreach ($parts as $key => $value) {
+                $parts[$key] = $this->unionPKDef_decode($value);
             }
         }
 
-        if (count($addr_l) < 4) {
-            Log::error("ALTNAME_DATA ID 格式不正確: {$alt}", [
-                'parsed' => $addr_l,
-                'expected_count' => 4,
-                'actual_count' => count($addr_l),
-            ]);
-            abort(400, 'ALTNAME_DATA ID 格式不正確');
+        $count = count($parts);
+        if ($count === 4) {
+            // 歷史 4-key 格式：[c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code]
+            // 忽略 c_sequence (index 1)，返回 3-key
+            return [
+                'c_personid' => $parts[0],
+                'c_alt_name_chn' => $parts[2],
+                'c_alt_name_type_code' => $parts[3],
+            ];
+        } elseif ($count === 3) {
+            // 新 3-key 格式：[c_personid, c_alt_name_chn, c_alt_name_type_code]
+            return [
+                'c_personid' => $parts[0],
+                'c_alt_name_chn' => $parts[1],
+                'c_alt_name_type_code' => $parts[2],
+            ];
         }
 
-        if (isset($addr_l[1]) && $addr_l[1] === 'NULL') {
-            $addr_l[1] = null;
-        }
-
-        return $addr_l;
+        Log::error("ALTNAME_DATA ID 格式不正確: {$alt}", [
+            'parsed' => $parts,
+            'expected_count' => '3 or 4',
+            'actual_count' => $count,
+        ]);
+        abort(400, 'ALTNAME_DATA ID 格式不正確');
     }
 
     public function sourceById($id, $_id) {

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -25,14 +25,11 @@ class CompositePrimaryKey {
         'BIOG_MAIN' => [
             'c_personid',
         ],
-        // ⚠️ ALTNAME_DATA 定位 key 收斂計畫 (#834)
+        // ALTNAME_DATA 定位 key (#834 Phase 2)
         // 資料庫 PK 為 3-key: (c_personid, c_alt_name_chn, c_alt_name_type_code)
         // c_sequence 為一般排序欄位，不參與定位。
-        // 此處暫維持 4-key 以相容歷史 resource_id / URL 格式，
-        // 待 Phase 2 切為 3-key: ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code']
         'ALTNAME_DATA' => [
             'c_personid',
-            'c_sequence',       // 非 PK，Phase 2 將移除
             'c_alt_name_chn',
             'c_alt_name_type_code',
         ],
@@ -121,15 +118,14 @@ class CompositePrimaryKey {
     ];
 
     /**
-     * ALTNAME_DATA 實際資料庫主鍵（3-key）
+     * ALTNAME_DATA 歷史 4-key 格式（Phase 2 向後相容用）
      *
-     * 資料庫 PK 為 (c_personid, c_alt_name_chn, c_alt_name_type_code)，
-     * c_sequence 不參與定位。此常數用於 Phase 1 相容層：
-     * 當 resource_id 不含 c_sequence 時，以此 schema 進行解析。
+     * Phase 1 及之前的 resource_id 使用 4-key 格式（含 c_sequence），
+     * 此常數用於解析歷史 resource_id，解析後會自動 strip c_sequence 返回 3-key。
      *
      * @see https://github.com/cbdb-project/cbdb-online-main-server/issues/834
      */
-    private const ALTNAME_DB_PRIMARY_KEY = ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'];
+    private const ALTNAME_LEGACY_4KEY = ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'];
 
     /**
      * resource_id 的 schema 別名對應
@@ -425,14 +421,8 @@ class CompositePrimaryKey {
         if (str_contains($resourceId, '=') && !str_contains($resourceId, '_._')) {
             parse_str($resourceId, $parsed);
             if (!empty($parsed) && count(array_intersect($schema, array_keys($parsed))) === count($schema)) {
+                // 自動過濾多餘欄位（如歷史 4-key ALTNAME 的 c_sequence）
                 return array_intersect_key($parsed, array_flip($schema));
-            }
-            // ALTNAME_DATA Phase 1 相容 (#834)：接受不含 c_sequence 的 3-key query-string
-            if (strtoupper($effectiveTable) === 'ALTNAME_DATA' && !empty($parsed)) {
-                $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
-                if (count(array_intersect($dbPk, array_keys($parsed))) === count($dbPk)) {
-                    return array_intersect_key($parsed, array_flip($dbPk));
-                }
             }
         }
 
@@ -441,15 +431,18 @@ class CompositePrimaryKey {
         // 格式 1：_._  分隔符（CodesController）
         if (strpos($resourceId, '_._') !== false) {
             $parts = explode('_._', $resourceId);
+
+            // ALTNAME_DATA Phase 2 相容 (#834)：歷史 4-key _._  格式 → strip c_sequence 返回 3-key
+            // 必須在通用匹配前處理，否則 4 parts >= 3 expectedCount 會導致錯位
+            if (strtoupper($effectiveTable) === 'ALTNAME_DATA' && count($parts) === count(self::ALTNAME_LEGACY_4KEY)) {
+                $parsed4 = array_combine(self::ALTNAME_LEGACY_4KEY, $parts);
+                unset($parsed4['c_sequence']);
+
+                return $parsed4;
+            }
+
             if (count($parts) >= $expectedCount) {
                 return array_combine($schema, array_slice($parts, 0, $expectedCount));
-            }
-            // ALTNAME_DATA Phase 1 相容 (#834)：接受 3-key _._  格式
-            if (strtoupper($effectiveTable) === 'ALTNAME_DATA') {
-                $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
-                if (count($parts) === count($dbPk)) {
-                    return array_combine($dbPk, $parts);
-                }
             }
 
             return null;
@@ -492,15 +485,21 @@ class CompositePrimaryKey {
             return $result2;
         }
 
-        // ALTNAME_DATA Phase 1 相容 (#834)：以 DB 3-key 重試 dash 格式
+        // ALTNAME_DATA Phase 2 相容 (#834)：歷史 4-key dash 格式 → strip c_sequence 返回 3-key
         if (strtoupper($effectiveTable) === 'ALTNAME_DATA') {
-            $dbPk = self::ALTNAME_DB_PRIMARY_KEY;
-            $dbPkCount = count($dbPk);
-            if (count($parts) === $dbPkCount) {
-                return array_combine($dbPk, $parts);
+            $legacy4key = self::ALTNAME_LEGACY_4KEY;
+            $legacy4keyCount = count($legacy4key);
+            if (count($parts) === $legacy4keyCount) {
+                $parsed4 = array_combine($legacy4key, $parts);
+                unset($parsed4['c_sequence']);
+
+                return $parsed4;
             }
-            if (count($parts2) === $dbPkCount) {
-                return array_combine($dbPk, $parts2);
+            if (count($parts2) === $legacy4keyCount) {
+                $parsed4 = array_combine($legacy4key, $parts2);
+                unset($parsed4['c_sequence']);
+
+                return $parsed4;
             }
         }
 

--- a/resources/views/biogmains/altname/index.blade.php
+++ b/resources/views/biogmains/altname/index.blade.php
@@ -55,14 +55,6 @@ if ($altTypeLabel === '') {
     $altTypeLabel = $value->pivot->c_alt_name_type_code;
 }
 
-//20240508修正c_sequence的判斷，資料有NULL、0、1-7
-if($value->pivot->c_sequence === 0) {
-  $value->pivot->c_sequence = 0;
-} elseif($value->pivot->c_sequence == NULL) {
-  $value->pivot->c_sequence = 'NULL';
-} else {
-  $value->pivot->c_sequence = $value->pivot->c_sequence;
-}
 @endphp
                     <tr>
                         <td>{{ $key+1 }}</td>
@@ -73,7 +65,7 @@ if($value->pivot->c_sequence === 0) {
                             @if(Auth::user()->isActive())
                                 <td>
                                     <div class="btn-group">
-                                        <a type="button" class="btn btn-sm btn-info" href="{{ CompositePrimaryKey::buildUrl('basicinformation.altnames.edit.query', ['id' => $basicinformation->c_personid], ['c_personid' => $value->pivot->c_personid, 'c_sequence' => $value->pivot->c_sequence ?? 'NULL', 'c_alt_name_chn' => unionPKDef_decode($value->pivot->c_alt_name_chn), 'c_alt_name_type_code' => $value->pivot->c_alt_name_type_code]) }}">edit</a>
+                                        <a type="button" class="btn btn-sm btn-info" href="{{ CompositePrimaryKey::buildUrl('basicinformation.altnames.edit.query', ['id' => $basicinformation->c_personid], ['c_personid' => $value->pivot->c_personid, 'c_alt_name_chn' => unionPKDef_decode($value->pivot->c_alt_name_chn), 'c_alt_name_type_code' => $value->pivot->c_alt_name_type_code]) }}">edit</a>
                                         <a href=""
                                            onclick="
                                                    let msg = '您真的确定要删除吗？\n\n请确认！';
@@ -87,7 +79,7 @@ if($value->pivot->c_sequence === 0) {
                                            class="btn btn-sm btn-danger">delete</a>
 
                                     </div>
-                                    <form id="delete-form-{{ $value->pivot->c_personid.'-'.$value->pivot->c_alt_name_chn.'-'.$value->pivot->c_alt_name_type_code }}" action="{{ CompositePrimaryKey::buildUrl('basicinformation.altnames.destroy.query', ['id' => $basicinformation->c_personid], ['c_personid' => $value->pivot->c_personid, 'c_sequence' => $value->pivot->c_sequence ?? 'NULL', 'c_alt_name_chn' => unionPKDef_decode($value->pivot->c_alt_name_chn), 'c_alt_name_type_code' => $value->pivot->c_alt_name_type_code]) }}" method="POST" style="display: none;">
+                                    <form id="delete-form-{{ $value->pivot->c_personid.'-'.$value->pivot->c_alt_name_chn.'-'.$value->pivot->c_alt_name_type_code }}" action="{{ CompositePrimaryKey::buildUrl('basicinformation.altnames.destroy.query', ['id' => $basicinformation->c_personid], ['c_personid' => $value->pivot->c_personid, 'c_alt_name_chn' => unionPKDef_decode($value->pivot->c_alt_name_chn), 'c_alt_name_type_code' => $value->pivot->c_alt_name_type_code]) }}" method="POST" style="display: none;">
                                         {{ method_field('DELETE') }}
                                         {{ csrf_field() }}
                                     </form>

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -165,7 +165,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
             'table_name' => 'ALTNAME_DATA',
             'operation' => 'INSERT',
             'actor_id' => (string) $user->id,
-            'row_pk_text' => 'c_personid=1&c_sequence=1&c_alt_name_chn=%E6%96%B0%E5%A2%9E%E5%88%A5%E5%90%8D&c_alt_name_type_code=1',
+            'row_pk_text' => 'c_personid=1&c_alt_name_chn=%E6%96%B0%E5%A2%9E%E5%88%A5%E5%90%8D&c_alt_name_type_code=1',
         ]);
 
         $log = DB::table('audit_log')->first();
@@ -546,9 +546,9 @@ class BasicInformationAltnamesControllerTest extends TestCase {
             'c_source' => null,
         ]);
 
-        // 使用查詢參數模式（c_sequence=NULL）
+        // 使用查詢參數模式（舊 URL 含 c_sequence=NULL，controller 會忽略多餘參數）
         $response = $this->actingAs($user)
-            ->get('/basicinformation/1/altnames/edit?c_personid=1&c_sequence=NULL&c_alt_name_chn=別名測試&c_alt_name_type_code=1');
+            ->get('/basicinformation/1/altnames/edit?c_personid=1&c_alt_name_chn=別名測試&c_alt_name_type_code=1');
 
         $response->assertStatus(200);
         $response->assertViewHas('row');
@@ -594,9 +594,10 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $response->assertRedirect();
         $response->assertSessionHas('flash_notification');
 
-        // 驗證重定向 URL 包含 c_sequence=NULL
+        // (#834 Phase 2): 重定向 URL 使用 3-key，不含 c_sequence
         $redirectUrl = $response->headers->get('Location');
-        $this->assertStringContainsString('c_sequence=NULL', $redirectUrl);
+        $this->assertStringContainsString('c_personid=1', $redirectUrl);
+        $this->assertStringNotContainsString('c_sequence', $redirectUrl);
 
         // 跟隨重定向，確認編輯頁可正常載入（200）
         $followResponse = $this->actingAs($user)->get($redirectUrl);

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -232,7 +232,7 @@ class BasicInformationProposalTest extends TestCase {
         $this->assertSame('測試別名', $payload['c_alt_name_chn']);
         $this->assertSame('pending', $payload['__review_status']);
         $this->assertSame('新增測試別名', $payload['__proposal_meta']['comment']);
-        $this->assertSame(['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'], $payload['__key_columns']);
+        $this->assertSame(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'], $payload['__key_columns']);
     }
 
     #[Test]
@@ -325,20 +325,24 @@ class BasicInformationProposalTest extends TestCase {
         $user = $this->makeActiveUser();
         $this->actingAs($user);
 
-        // 先創建一個待審核的新增提案
+        // 先創建一個待審核的新增提案（query-string 格式）
         $operation = new Operation();
         $operation->user_id = $user->id;
         $operation->c_personid = 1;
         $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
         $operation->resource = 'ALTNAME_DATA';
-        $operation->resource_id = '1-1-衝突別名-1';
+        $operation->resource_id = \App\Support\CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => 1,
+            'c_alt_name_chn' => '衝突別名',
+            'c_alt_name_type_code' => 1,
+        ]);
         $operation->resource_data = json_encode([
             'c_personid' => 1,
             'c_sequence' => 1,
             'c_alt_name_chn' => '衝突別名',
             'c_alt_name_type_code' => 1,
             '__review_status' => 'pending',
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
         ], JSON_UNESCAPED_UNICODE);
         $operation->save();
 
@@ -378,7 +382,7 @@ class BasicInformationProposalTest extends TestCase {
         $response = $this->post(route('basicinformation.proposal.update', [
             'personid' => 1,
             'resource' => 'altnames',
-            'id' => '1-1-原始別名-1',
+            'id' => '1-原始別名-1',
         ]), [
             'c_sequence' => 1,
             'c_alt_name_chn' => '原始別名',
@@ -428,7 +432,7 @@ class BasicInformationProposalTest extends TestCase {
         $response = $this->post(route('basicinformation.proposal.update', [
             'personid' => 1,
             'resource' => 'altnames',
-            'id' => '1-1-無變更別名-1',
+            'id' => '1-無變更別名-1',
         ]), [
             'c_sequence' => 1,
             'c_alt_name_chn' => '無變更別名',
@@ -456,7 +460,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_source' => 100,
             'c_pages' => '第1頁',
             'c_notes' => '核准的別名',
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
             '__proposal_meta' => ['submitted_by' => 'tester', 'submitted_at' => Carbon::now()->format('Y-m-d H:i:s')],
         ];
@@ -523,7 +527,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_alt_name' => 'After',
             'c_alt_name_type_code' => 1,
             'c_notes' => '修改後筆記',
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ];
 
@@ -581,7 +585,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_sequence' => 1,
             'c_alt_name_chn' => '退回別名',
             'c_alt_name_type_code' => 1,
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ];
 
@@ -627,7 +631,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_sequence' => 1,
             'c_alt_name_chn' => '無權',
             'c_alt_name_type_code' => 1,
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ], JSON_UNESCAPED_UNICODE);
         $operation->save();
@@ -652,7 +656,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_sequence' => 1,
             'c_alt_name_chn' => '非提案',
             'c_alt_name_type_code' => 1,
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
         ], JSON_UNESCAPED_UNICODE);
         $operation->save();
 
@@ -710,7 +714,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_sequence' => 1,
             'c_alt_name_chn' => '已存在',
             'c_alt_name_type_code' => 1,
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ], JSON_UNESCAPED_UNICODE);
         $operation->save();
@@ -751,7 +755,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_alt_name_chn' => '缺少原始',
             'c_alt_name_type_code' => 1,
             'c_notes' => '新的備註',
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ], JSON_UNESCAPED_UNICODE);
         $operation->resource_original = json_encode([]);
@@ -794,7 +798,7 @@ class BasicInformationProposalTest extends TestCase {
             'c_sequence' => 1,
             'c_alt_name_chn' => '新主鍵值',
             'c_alt_name_type_code' => 1,
-            '__key_columns' => ['c_personid', 'c_sequence', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             '__review_status' => 'pending',
         ], JSON_UNESCAPED_UNICODE);
         $operation->resource_original = json_encode([
@@ -822,12 +826,12 @@ class BasicInformationProposalTest extends TestCase {
         $user = $this->makeActiveUser();
         $this->actingAs($user);
 
+        // (#834 Phase 2): 3-key 中缺少 c_alt_name_type_code
         $response = $this->post(route('basicinformation.proposal.store', [
             'personid' => 1,
             'resource' => 'altnames',
         ]), [
             'c_alt_name_chn' => '缺少主鍵欄位',
-            'c_alt_name_type_code' => 1,
             '__proposal_comment' => '主鍵缺失',
         ]);
 
@@ -846,7 +850,7 @@ class BasicInformationProposalTest extends TestCase {
         $response = $this->post(route('basicinformation.proposal.update', [
             'personid' => 1,
             'resource' => 'altnames',
-            'id' => '1-1-不存在-1',
+            'id' => '1-不存在-1',
         ]), [
             'c_sequence' => 1,
             'c_alt_name_chn' => '不存在',
@@ -898,6 +902,94 @@ class BasicInformationProposalTest extends TestCase {
 
         $operation = Operation::first();
         $this->assertNotNull($operation);
-        $this->assertSame('1-1-名minus字-1', $operation->resource_id);
+        // query-string 格式：連字符透過 URL 編碼處理，不再使用 bare minus
+        $expected = \App\Support\CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => 1,
+            'c_alt_name_chn' => '名-字',
+            'c_alt_name_type_code' => 1,
+        ]);
+        $this->assertSame($expected, $operation->resource_id);
+        // 確認 resource_id 中不含 bare 'minus' 編碼
+        $this->assertStringNotContainsString('minus', $operation->resource_id);
+    }
+
+    #[Test]
+    public function testConflictDetectionMatchesLegacyDashFormatPendingProposal() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 模擬歷史舊格式（dash + bare minus）的 pending 提案
+        $operation = new Operation();
+        $operation->user_id = $user->id;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        // 舊格式：dash 分隔 + bare minus 編碼
+        $operation->resource_id = '1-舊別名-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => 1,
+            '__review_status' => 'pending',
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        // 用新格式提交相同主鍵的新增提案，應偵測到衝突
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '嘗試與舊格式衝突',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已有其他新增提案', $flash[0]['message'] ?? '');
+    }
+
+    #[Test]
+    public function testConflictDetectionMatchesLegacyDashFormatWithHyphenInName() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        // 舊格式中含連字符的名字用 bare minus 編碼
+        $operation = new Operation();
+        $operation->user_id = $user->id;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ALTNAME_DATA';
+        // 舊格式：名-字 → 名minus字
+        $operation->resource_id = '1-名minus字-1';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '名-字',
+            'c_alt_name_type_code' => 1,
+            '__review_status' => 'pending',
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        // 用新格式提交相同主鍵，應偵測到衝突
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '名-字',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '嘗試與含連字符舊格式衝突',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已有其他新增提案', $flash[0]['message'] ?? '');
     }
 }

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -149,7 +149,7 @@ class BiogMainProposalTest extends TestCase {
             'c_personid' => $personId,
             'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
             'resource' => 'BIOG_MAIN',
-            'resource_id' => (string)$personId,
+            'resource_id' => \App\Support\CompositePrimaryKey::buildStoredResourceId(['c_personid' => $personId]),
         ]);
 
         $operation = Operation::where('resource', 'BIOG_MAIN')->first();

--- a/tests/Feature/FormUrlEncodingTest.php
+++ b/tests/Feature/FormUrlEncodingTest.php
@@ -585,10 +585,10 @@ class FormUrlEncodingTest extends TestCase {
 
         // 驗證 redirect URL 使用新的查詢參數模式
         $redirectUrl = $response->headers->get('Location');
-        // 新模式使用 ?c_personid=...&c_sequence=...&c_alt_name_chn=... 格式
+        // (#834 Phase 2): 3-key 格式 ?c_personid=...&c_alt_name_chn=...&c_alt_name_type_code=...
         $this->assertStringContainsString('c_personid=', $redirectUrl);
-        $this->assertStringContainsString('c_sequence=', $redirectUrl);
         $this->assertStringContainsString('c_alt_name_chn=', $redirectUrl);
+        $this->assertStringContainsString('c_alt_name_type_code=', $redirectUrl);
         // 特殊字符會被標準 URL 編碼（%2F = /, %3F = ?）
         $this->assertMatchesRegularExpression('/c_alt_name_chn=.*%2F.*%3F/', $redirectUrl);
     }

--- a/tests/Unit/AuditLogServiceTest.php
+++ b/tests/Unit/AuditLogServiceTest.php
@@ -48,8 +48,9 @@ class AuditLogServiceTest extends TestCase {
 
         $text = $this->service->buildRowPkText('ALTNAME_DATA', $rowPk);
 
+        // (#834 Phase 2): Schema 已切為 3-key，c_sequence 被過濾
         $this->assertSame(
-            'c_personid=123&c_sequence=1&c_alt_name_chn=A%20%26%20B&c_alt_name_type_code=10',
+            'c_personid=123&c_alt_name_chn=A%20%26%20B&c_alt_name_type_code=10',
             $text
         );
     }

--- a/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
+++ b/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
@@ -7,9 +7,10 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
- * ALTNAME_DATA 3-key 相容層測試 (#834 Phase 1)
+ * ALTNAME_DATA 3-key 相容層測試 (#834 Phase 2)
  *
- * 確保 parseStoredResourceId() 同時支援歷史 4-key 與未來 3-key 格式，
+ * Schema 已切為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)。
+ * 確保 parseStoredResourceId() 對歷史 4-key resource_id 自動 strip c_sequence 返回 3-key，
  * 涵蓋 query-string、_._、dash 三種分隔符。
  */
 class CompositePrimaryKeyAltnameCompatTest extends TestCase {
@@ -31,25 +32,30 @@ class CompositePrimaryKeyAltnameCompatTest extends TestCase {
 
     #[Test]
     public function test_parse_altname_4key_query_string_still_works(): void {
+        // 歷史 4-key query-string → array_intersect_key 自動過濾 c_sequence 返回 3-key
         $resourceId = 'c_personid=123&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
         $this->assertNotNull($result);
-        $this->assertCount(4, $result);
+        $this->assertCount(3, $result);
         $this->assertSame('123', $result['c_personid']);
-        $this->assertSame('1', $result['c_sequence']);
         $this->assertSame('張三', $result['c_alt_name_chn']);
         $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     #[Test]
     public function test_parse_altname_4key_query_string_with_null_sentinel(): void {
+        // 歷史 4-key query-string（含 NULL sentinel）→ c_sequence 被過濾
         $resourceId = 'c_personid=200&c_sequence=NULL&c_alt_name_chn=%E6%B8%AC%E8%A9%A6&c_alt_name_type_code=5';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
         $this->assertNotNull($result);
-        $this->assertCount(4, $result);
-        $this->assertSame('NULL', $result['c_sequence']);
+        $this->assertCount(3, $result);
+        $this->assertArrayNotHasKey('c_sequence', $result);
+        $this->assertSame('200', $result['c_personid']);
+        $this->assertSame('測試', $result['c_alt_name_chn']);
+        $this->assertSame('5', $result['c_alt_name_type_code']);
     }
 
     // -------------------------------------------------------
@@ -70,15 +76,16 @@ class CompositePrimaryKeyAltnameCompatTest extends TestCase {
 
     #[Test]
     public function test_parse_altname_4key_dot_format_still_works(): void {
+        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $resourceId = '123_._1_._張三_._10';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
         $this->assertNotNull($result);
-        $this->assertCount(4, $result);
+        $this->assertCount(3, $result);
         $this->assertSame('123', $result['c_personid']);
-        $this->assertSame('1', $result['c_sequence']);
         $this->assertSame('張三', $result['c_alt_name_chn']);
         $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     // -------------------------------------------------------
@@ -124,15 +131,16 @@ class CompositePrimaryKeyAltnameCompatTest extends TestCase {
 
     #[Test]
     public function test_parse_altname_4key_dash_format_still_works(): void {
+        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $resourceId = '123-1-張三-10';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
         $this->assertNotNull($result);
-        $this->assertCount(4, $result);
+        $this->assertCount(3, $result);
         $this->assertSame('123', $result['c_personid']);
-        $this->assertSame('1', $result['c_sequence']);
         $this->assertSame('張三', $result['c_alt_name_chn']);
         $this->assertSame('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     // -------------------------------------------------------

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -19,7 +19,6 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertEquals([
             'c_personid',
-            'c_sequence',
             'c_alt_name_chn',
             'c_alt_name_type_code',
         ], $schema);
@@ -55,20 +54,19 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertEquals([
             'c_personid' => 12345,
-            'c_sequence' => 1,
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => 10,
         ], $pk);
 
-        // 確認 other_field 被過濾掉
+        // 確認 c_sequence 和 other_field 被過濾掉（c_sequence 不在 3-key schema 中）
         $this->assertArrayNotHasKey('other_field', $pk);
+        $this->assertArrayNotHasKey('c_sequence', $pk);
     }
 
     /** @test */
     public function it_filters_out_null_but_preserves_empty_strings_from_request(): void {
         $request = new Request([
             'c_personid' => 12345,
-            'c_sequence' => '',
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => null,
         ]);
@@ -79,7 +77,6 @@ class CompositePrimaryKeyTest extends TestCase {
         // NULL 應該被過濾掉，但空字串應該保留（支援某些表的主鍵欄位可以為空）
         $this->assertEquals([
             'c_personid' => 12345,
-            'c_sequence' => '',
             'c_alt_name_chn' => '張三',
         ], $pk);
     }
@@ -246,7 +243,6 @@ class CompositePrimaryKeyTest extends TestCase {
     public function it_can_validate_complete_pk(): void {
         $pk = [
             'c_personid' => 12345,
-            'c_sequence' => 1,
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => 10,
         ];
@@ -256,21 +252,20 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_can_validate_pk_with_optional_fields(): void {
-        // c_sequence 是可選的
+        // BIOG_ADDR_DATA 的 c_sequence 是可選的
         $pk = [
             'c_personid' => 12345,
-            'c_alt_name_chn' => '張三',
-            'c_alt_name_type_code' => 10,
+            'c_addr_id' => 100,
+            'c_addr_type' => 2,
         ];
 
-        $this->assertTrue(CompositePrimaryKey::validate($pk, 'ALTNAME_DATA', ['c_sequence']));
+        $this->assertTrue(CompositePrimaryKey::validate($pk, 'BIOG_ADDR_DATA', ['c_sequence']));
     }
 
     /** @test */
     public function it_fails_validation_for_missing_required_field(): void {
         $pk = [
             'c_personid' => 12345,
-            'c_sequence' => 1,
             // 缺少 c_alt_name_chn 和 c_alt_name_type_code
         ];
 
@@ -298,20 +293,19 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertEquals([
             'c_personid' => 12345,
-            'c_sequence' => 1,
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => 10,
         ], $pk);
 
-        // 確認非主鍵欄位被過濾掉
+        // 確認非主鍵欄位被過濾掉（c_sequence 和 c_notes 不在 3-key schema 中）
         $this->assertArrayNotHasKey('c_notes', $pk);
+        $this->assertArrayNotHasKey('c_sequence', $pk);
     }
 
     /** @test */
     public function it_can_build_pk_from_record_array(): void {
         $record = [
             'c_personid' => 12345,
-            'c_sequence' => 1,
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => 10,
         ];
@@ -353,15 +347,14 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_can_parse_legacy_pk_format(): void {
-        // 測試舊格式解析（用於向後相容）
+        // 測試舊格式解析（Schema 已切為 3-key，parseLegacy 使用 3-key 格式）
         $decoded = CompositePrimaryKey::parseLegacy(
-            '12345-1-張三-10',
+            '12345-張三-10',
             'ALTNAME_DATA'
         );
 
         $this->assertEquals([
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => '10',
         ], $decoded);
@@ -369,15 +362,14 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_can_parse_legacy_pk_with_embedded_minus(): void {
-        // 測試欄位值中包含負號的情況
+        // 測試欄位值中包含負號的情況（Schema 已切為 3-key）
         $decoded = CompositePrimaryKey::parseLegacy(
-            '12345-1-張--三-10', // 張-三 在舊格式中被編碼為 張--三
+            '12345-張--三-10', // 張-三 在舊格式中被編碼為 張--三
             'ALTNAME_DATA'
         );
 
         $this->assertEquals([
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張-三',
             'c_alt_name_type_code' => '10',
         ], $decoded);
@@ -385,7 +377,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_returns_null_for_invalid_legacy_pk(): void {
-        // 測試欄位數量不足的情況
+        // ALTNAME_DATA 需要 3 個欄位，只提供 2 個
         $decoded = CompositePrimaryKey::parseLegacy(
             '12345-1',
             'ALTNAME_DATA'
@@ -413,6 +405,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_parses_resource_id_with_encoded_slash(): void {
+        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-張(slash)三-10',
             'ALTNAME_DATA'
@@ -420,7 +413,6 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertEquals([
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張/三',
             'c_alt_name_type_code' => '10',
         ], $result);
@@ -469,7 +461,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_parses_underscore_dot_separator_format(): void {
-        // CodesController 使用的 _._ 分隔符格式
+        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345_._1_._張三_._10',
             'ALTNAME_DATA'
@@ -477,7 +469,6 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertEquals([
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => '10',
         ], $result);
@@ -492,7 +483,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_returns_null_for_insufficient_parts(): void {
-        // ALTNAME_DATA 需要 4 個欄位，只提供 2 個
+        // ALTNAME_DATA 需要 3 個欄位，只提供 2 個
         $result = CompositePrimaryKey::parseStoredResourceId('12345-1', 'ALTNAME_DATA');
 
         $this->assertNull($result);
@@ -556,6 +547,7 @@ class CompositePrimaryKeyTest extends TestCase {
     /** @test */
     public function it_parses_old_format_with_double_dash(): void {
         // 舊格式：-- 代表欄位值中的 -
+        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-張--三-10',
             'ALTNAME_DATA'
@@ -563,6 +555,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
         $this->assertNotNull($result);
         $this->assertEquals('張-三', $result['c_alt_name_chn']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     // === buildStoredResourceId 測試 ===
@@ -603,11 +596,11 @@ class CompositePrimaryKeyTest extends TestCase {
         $this->assertStringContainsString('c_sequence=NULL', $result);
         $this->assertStringContainsString('c_personid=12345', $result);
 
-        // 來回測試：build → parse → 應還原 'NULL' 字串
+        // 來回測試：build → parse → Schema 已切為 3-key，c_sequence 被自動過濾
         $parsed = CompositePrimaryKey::parseStoredResourceId($result, 'ALTNAME_DATA');
         $this->assertNotNull($parsed);
-        $this->assertArrayHasKey('c_sequence', $parsed);
-        $this->assertSame('NULL', $parsed['c_sequence']);
+        $this->assertCount(3, $parsed);
+        $this->assertArrayNotHasKey('c_sequence', $parsed);
         $this->assertEquals('12345', $parsed['c_personid']);
         $this->assertEquals('張三', $parsed['c_alt_name_chn']);
         $this->assertEquals('10', $parsed['c_alt_name_type_code']);
@@ -661,9 +654,9 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_roundtrips_build_and_parse_for_altname(): void {
+        // Phase 2：3-key roundtrip（c_sequence 不參與定位）
         $pk = [
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張-三',
             'c_alt_name_type_code' => '10',
         ];
@@ -719,7 +712,6 @@ class CompositePrimaryKeyTest extends TestCase {
     public function it_roundtrips_build_and_parse_with_chinese_chars(): void {
         $pk = [
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '張三',
             'c_alt_name_type_code' => '10',
         ];
@@ -734,7 +726,6 @@ class CompositePrimaryKeyTest extends TestCase {
     public function it_roundtrips_build_and_parse_with_brackets(): void {
         $pk = [
             'c_personid' => '12345',
-            'c_sequence' => '1',
             'c_alt_name_chn' => '{張三}',
             'c_alt_name_type_code' => '10',
         ];
@@ -747,16 +738,17 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_parses_query_string_format_resource_id(): void {
-        // 直接測試 parseStoredResourceId 對 query-string 格式的偵測
+        // 歷史 4-key query-string → array_intersect_key 自動過濾 c_sequence 返回 3-key
         $resourceId = 'c_personid=12345&c_sequence=1&c_alt_name_chn=%E5%BC%B5%E4%B8%89&c_alt_name_type_code=10';
 
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
         $this->assertNotNull($result);
+        $this->assertCount(3, $result);
         $this->assertEquals('12345', $result['c_personid']);
-        $this->assertEquals('1', $result['c_sequence']);
         $this->assertEquals('張三', $result['c_alt_name_chn']);
         $this->assertEquals('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     /** @test */
@@ -775,33 +767,37 @@ class CompositePrimaryKeyTest extends TestCase {
     /** @test */
     public function it_still_parses_underscore_dot_format_with_equals(): void {
         // 確保含 = 但也含 _._ 的格式不會被誤判為 query-string
-        // （雖然現實中不太可能，但邊界情況要處理）
+        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345_._1_._a=b_._10',
             'ALTNAME_DATA'
         );
 
         $this->assertNotNull($result);
+        $this->assertCount(3, $result);
         $this->assertEquals('12345', $result['c_personid']);
         $this->assertEquals('a=b', $result['c_alt_name_chn']);
+        $this->assertEquals('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     /** @test */
     public function it_rejects_legacy_id_with_equals_via_schema_validation(): void {
         // 舊格式 resource_id 的欄位值恰好含有 '='（極端邊界情況）
         // parse_str('12345-1-a=b-10') 會產生 ['12345-1-a' => 'b-10']
-        // 因為 key 不在 ALTNAME_DATA schema 中，應回退到 dash 分隔符解析
+        // 因為 key 不在 ALTNAME_DATA schema 中，回退到 dash 分隔符解析
+        // 歷史 4-key dash → Phase 2 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-a=b-10',
             'ALTNAME_DATA'
         );
 
         $this->assertNotNull($result);
-        // 應走 dash 分隔符路徑，正確解析出 4 個欄位
+        $this->assertCount(3, $result);
         $this->assertEquals('12345', $result['c_personid']);
-        $this->assertEquals('1', $result['c_sequence']);
         $this->assertEquals('a=b', $result['c_alt_name_chn']);
         $this->assertEquals('10', $result['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $result);
     }
 
     /** @test */

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -106,8 +106,9 @@ class OperationsAltnameResolverTest extends TestCase {
 
     #[Test]
     public function test_build_key_conditions_normalizes_null_sentinel(): void {
-        // buildKeyConditions() 從 resource_id 的 query-string 中讀取 'NULL' 時，
-        // 應轉換為 PHP null（以便後續產生 WHERE IS NULL）
+        // (#834 Phase 2): resourceKeyColumns 已切為 3-key，
+        // 歷史 4-key resource_id 中的 c_sequence 被 parseStoredResourceId 過濾，
+        // buildKeyConditions 只返回 3 個 conditions
         Schema::create('operations', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id')->nullable();
@@ -135,17 +136,17 @@ class OperationsAltnameResolverTest extends TestCase {
         // $current 和 $fallback 都不含完整 key，迫使 buildKeyConditions 解析 resource_id
         $conditions = $controller->publicBuildKeyConditions($op, [], []);
 
-        $this->assertCount(4, $conditions); // ALTNAME_DATA key columns: c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code
+        $this->assertCount(3, $conditions); // ALTNAME_DATA 3-key: c_personid, c_alt_name_chn, c_alt_name_type_code
         $this->assertSame('123', $conditions['c_personid']);
-        $this->assertNull($conditions['c_sequence']); // 'NULL' 應轉為 PHP null
         $this->assertSame('張三', $conditions['c_alt_name_chn']);
         $this->assertSame('10', $conditions['c_alt_name_type_code']);
+        $this->assertArrayNotHasKey('c_sequence', $conditions);
 
         Schema::dropIfExists('operations');
     }
 
     // -------------------------------------------------------
-    // Phase 1 (#834)：3-key 相容層測試
+    // (#834): 3-key 查詢測試
     // -------------------------------------------------------
 
     #[Test]


### PR DESCRIPTION
## Summary

- **SCHEMAS['ALTNAME_DATA']** 從 4-key 切為 3-key `(c_personid, c_alt_name_chn, c_alt_name_type_code)`，c_sequence 不再參與定位
- 所有下游（Repository WHERE 條件、Controller URL/PK 處理、OperationsController 操作記錄與復原、Proposal key_columns、Blade 模板 URL）統一使用 3-key
- `parseStoredResourceId()` 保留歷史 4-key resource_id 的讀取相容（舊 4-key 自動過濾為 3-key）
- `BasicInformationProposalController::buildCompositeId()` 改用 `CompositePrimaryKey::buildStoredResourceId()` query-string 格式，消除舊 bare minus 編碼歧義
- `parseCompositeId()` 以 `parse_str` 結果回退判定格式，避免啟發式誤判
- `hasActiveProposalConflict()` 同時查詢新舊兩種 resource_id 格式，確保歷史 pending 提案仍可被偵測

## 受影響檔案

| 檔案 | 變更類型 |
|------|---------|
| `app/Support/CompositePrimaryKey.php` | Schema 定義 + 解析相容 |
| `app/Repositories/BiogMainRepository.php` | WHERE 條件 + resource_id |
| `app/Http/Controllers/BasicInformationAltnamesController.php` | URL/PK 處理 |
| `app/Http/Controllers/BasicInformationProposalController.php` | key_columns + buildCompositeId + 衝突偵測 |
| `app/Http/Controllers/OperationsController.php` | 還原/比對條件 |
| `resources/views/biogmains/altname/index.blade.php` | URL 參數 |
| 測試（7 個檔案） | 測試更新 |

## Test plan

- [x] 全部 584 tests pass
- [x] php-cs-fixer 0 files to fix
- [x] 驗證 ALTNAME 別名的 CRUD 流程（新增、編輯、刪除）
- [x] 驗證操作記錄頁面能正確顯示歷史 4-key 操作記錄

🤖 Generated with [Claude Code](https://claude.com/claude-code)