### PR TITLE
修正任官地址部分異動時未變更地址時間戳被覆寫

### DIFF
--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -248,8 +248,6 @@ class OfficePostingRepository {
                 }
 
 
-                $this->updateAddr($addressesForInsert, $_id, $_postingid, $currentOfficeId, $c_created_by, $c_created_date);
-
                 $afterRows = DB::table('POSTED_TO_ADDR_DATA')
                     ->where('c_personid', $_id)
                     ->where('c_posting_id', $_postingid)
@@ -607,29 +605,6 @@ class OfficePostingRepository {
                     'c_created_date' => $c_created_date,
                 ]
             );
-        }
-    }
-
-    protected function updateAddr(array $c_addr, $_id, $_postingid, $_officeid, $c_created_by = '', $c_created_date = '') {
-        foreach ($c_addr as $item) {
-            $addr = '';
-            $addr = DB::table('POSTED_TO_ADDR_DATA')->where([
-                ['c_personid', '=', $_id],
-                ['c_posting_id', '=', $_postingid],
-                ['c_office_id', '=', $_officeid],
-                ['c_addr_id', '=', $item],
-            ])->get();
-
-            if (!empty($addr)) {
-                //有資料就更新
-                DB::table('POSTED_TO_ADDR_DATA')->where([
-                    ['c_personid', '=', $_id],
-                    ['c_posting_id', '=', $_postingid],
-                    ['c_office_id', '=', $_officeid],
-                    ['c_addr_id', '=', $item],
-                ])
-                    ->update(['c_modified_by' => $c_created_by, 'c_modified_date' => $c_created_date]);
-            }
         }
     }
 }

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -290,6 +290,91 @@ class OfficeAddressOperationLoggingTest extends TestCase {
     }
 
     #[Test]
+    public function testPartialAddressChangeDoesNotTouchUnchangedAddressTimestamp(): void {
+        DB::table('POSTING_DATA')->insert([
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-06-01 00:00:00',
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 920003,
+            'c_office_id' => 77773,
+            'c_posting_id' => 880003,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_office_id' => 77773,
+            'c_addr_id' => 25,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-06-01 00:00:00',
+            'c_modified_by' => 'Seeder',
+            'c_modified_date' => '2023-06-02 00:00:00',
+        ]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_office_id' => 77773,
+            'c_addr_id' => 26,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => '2023-06-01 00:00:00',
+            'c_modified_by' => 'Seeder',
+            'c_modified_date' => '2023-06-03 00:00:00',
+        ]);
+
+        Auth::guard()->setUser(new GenericUser(['id' => 4, 'name' => 'Updater C']));
+
+        $request = new Request([
+            '_id' => 920003,
+            '_postingid' => 880003,
+            '_officeid' => 77773,
+            'c_office_id' => 77773,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [25, 27],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 880003, 920003);
+
+        $unchangedAddress = DB::table('POSTED_TO_ADDR_DATA')->where([
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_office_id' => 77773,
+            'c_addr_id' => 25,
+        ])->first();
+
+        $newAddress = DB::table('POSTED_TO_ADDR_DATA')->where([
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_office_id' => 77773,
+            'c_addr_id' => 27,
+        ])->first();
+
+        $this->assertNotNull($unchangedAddress);
+        $this->assertSame('Seeder', $unchangedAddress->c_modified_by);
+        $this->assertSame('2023-06-02 00:00:00', $unchangedAddress->c_modified_date);
+
+        $this->assertNotNull($newAddress);
+        $this->assertSame('Updater C', $newAddress->c_modified_by);
+        $this->assertNotNull($newAddress->c_modified_date);
+
+        $this->assertDatabaseMissing('POSTED_TO_ADDR_DATA', [
+            'c_personid' => 920003,
+            'c_posting_id' => 880003,
+            'c_office_id' => 77773,
+            'c_addr_id' => 26,
+        ]);
+    }
+
+    #[Test]
     public function testAddressChangeOnlyTouchesTargetOffice(): void {
         DB::table('POSTED_TO_OFFICE_DATA')->insert([
             'c_personid' => 100000,


### PR DESCRIPTION
- 移除 officeUpdateById 中批次更新保留地址 modified 欄位的流程

- 刪除僅用於批次刷新地址時間戳的 updateAddr 方法

- 新增回歸測試，確保部分地址增刪時未變更地址的 modified_by/date 保持不變