### PR TITLE
改善操作列表多人顯示並防止親屬更新覆寫建檔欄位

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -70,7 +70,12 @@ class OperationsController extends Controller {
             $arr1 = $dataRows[$x]['resource_data'];
             $arr2 = $dataRows[$x]['resource_original'];
             $operationId = (string) ($dataRows[$x]['id'] ?? '');
-            $lists[$x]->setAttribute('audit_logs', $auditLogsByOperation[$operationId] ?? []);
+            $auditLogsForOperation = $auditLogsByOperation[$operationId] ?? [];
+            $lists[$x]->setAttribute('audit_logs', $auditLogsForOperation);
+            $lists[$x]->setAttribute(
+                'affected_person_ids',
+                $this->extractAffectedPersonIds($dataRows[$x], $auditLogsForOperation)
+            );
             //20191225實時比對的程式判斷
             if (!empty($c_personid = $dataRows[$x]['c_personid']) && $dataRows[$x]['resource'] == "BIOG_MAIN") {
                 $arr3 = BiogMain::find($c_personid)->toArray();
@@ -596,6 +601,7 @@ class OperationsController extends Controller {
                 $lists[$x]->setAttribute('resource_diff', null);
             }
         }
+        $this->attachAffectedPeople($lists);
         //echo "<pre><code>";
         //print_r($lists[0]['resource_original']); //成功
         //echo "</code></pre>";
@@ -1108,11 +1114,116 @@ class OperationsController extends Controller {
                 'table_name' => (string) $log->table_name,
                 'operation' => (string) $log->operation,
                 'row_pk_text' => (string) $log->row_pk_text,
+                'row_pk' => $rowPk,
+                'old_data' => $oldData,
+                'new_data' => $newData,
                 'diff' => $this->buildAuditDiff($oldData, $newData, $currentData),
             ];
         }
 
         return $grouped;
+    }
+
+    protected function extractAffectedPersonIds(array $operationRow, array $auditLogs): array {
+        $personIds = [];
+        $pushId = static function ($value) use (&$personIds): void {
+            if ($value === null || $value === '' || !is_numeric($value)) {
+                return;
+            }
+
+            $id = (int) $value;
+            if ($id <= 0) {
+                return;
+            }
+
+            $personIds[] = $id;
+        };
+
+        $pushId($operationRow['c_personid'] ?? null);
+
+        foreach ($auditLogs as $audit) {
+            if (!is_array($audit)) {
+                continue;
+            }
+
+            $tableName = strtoupper(trim((string) ($audit['table_name'] ?? '')));
+            $rowPk = is_array($audit['row_pk'] ?? null) ? $audit['row_pk'] : [];
+            $oldData = is_array($audit['old_data'] ?? null) ? $audit['old_data'] : [];
+            $newData = is_array($audit['new_data'] ?? null) ? $audit['new_data'] : [];
+
+            $pushId($rowPk['c_personid'] ?? null);
+            $pushId($oldData['c_personid'] ?? null);
+            $pushId($newData['c_personid'] ?? null);
+
+            if (in_array($tableName, ['KIN_DATA', 'ASSOC_DATA'], true)) {
+                $pushId($rowPk['c_kin_id'] ?? null);
+                $pushId($oldData['c_kin_id'] ?? null);
+                $pushId($newData['c_kin_id'] ?? null);
+            }
+        }
+
+        $personIds = array_values(array_unique($personIds));
+        sort($personIds);
+
+        return $personIds;
+    }
+
+    protected function attachAffectedPeople($lists): void {
+        $allPersonIds = [];
+        foreach ($lists as $item) {
+            $ids = $item->affected_person_ids ?? [];
+            if (is_array($ids)) {
+                foreach ($ids as $id) {
+                    if (is_numeric($id) && (int) $id > 0) {
+                        $allPersonIds[] = (int) $id;
+                    }
+                }
+            }
+        }
+        $allPersonIds = array_values(array_unique($allPersonIds));
+
+        $peopleMap = [];
+        if (!empty($allPersonIds) && Schema::hasTable('BIOG_MAIN')) {
+            $peopleMap = DB::table('BIOG_MAIN')
+                ->whereIn('c_personid', $allPersonIds)
+                ->get(['c_personid', 'c_name_chn', 'c_name'])
+                ->keyBy('c_personid');
+        }
+
+        foreach ($lists as $item) {
+            $ids = $item->affected_person_ids ?? [];
+            if (!is_array($ids) || empty($ids)) {
+                $item->setAttribute('affected_people', []);
+
+                continue;
+            }
+
+            $primaryId = is_numeric($item->c_personid ?? null) ? (int) $item->c_personid : null;
+            $people = [];
+            foreach ($ids as $id) {
+                if (!is_numeric($id) || (int) $id <= 0) {
+                    continue;
+                }
+                $personId = (int) $id;
+                $person = $peopleMap[$personId] ?? null;
+                $people[] = [
+                    'id' => $personId,
+                    'name_chn' => $person->c_name_chn ?? '',
+                    'name' => $person->c_name ?? '',
+                    'is_primary' => $primaryId !== null && $personId === $primaryId,
+                ];
+            }
+
+            usort($people, function ($a, $b) {
+                if (($a['is_primary'] ?? false) !== ($b['is_primary'] ?? false)) {
+                    return ($a['is_primary'] ?? false) ? -1 : 1;
+                }
+
+                return ($a['id'] ?? 0) <=> ($b['id'] ?? 0);
+            });
+
+            $item->setAttribute('affected_people', $people);
+        }
     }
 
     protected function decodeJsonNullable($payload): ?array {

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -1186,7 +1186,7 @@ class BiogMainRepository {
         $c_autogen_notes = $row->c_autogen_notes;
         $old_kin_id = $row->c_kin_id;
         $old_kin_code = $row->c_kin_code;
-        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'c_kinship_pair']);
+        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'c_kinship_pair', 'c_created_by', 'c_created_date']);
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -71,6 +71,28 @@ if (str_contains($rawResourceId ?? '', '=') && !str_contains($rawResourceId ?? '
 }
 $item->resource_data = unionPKDef($item->resource_data);
 @endphp
+                        @php
+                            $affectedPeople = is_array($item->affected_people ?? null) ? $item->affected_people : [];
+                            if (empty($affectedPeople)) {
+                                if (!empty($item->biogmain) && (int) ($item->c_personid ?? 0) !== 0) {
+                                    $affectedPeople[] = [
+                                        'id' => (int) $item->c_personid,
+                                        'name_chn' => $item->biogmain->c_name_chn ?? '',
+                                        'name' => $item->biogmain->c_name ?? '',
+                                        'is_primary' => true,
+                                    ];
+                                } else {
+                                    $affectedPeople[] = [
+                                        'id' => null,
+                                        'name_chn' => '',
+                                        'name' => '',
+                                        'is_primary' => false,
+                                    ];
+                                }
+                            }
+                            $personRowspan = count($affectedPeople);
+                            $firstPerson = $affectedPeople[0];
+                        @endphp
                         <tr>
                             <td>
                             @php
@@ -103,10 +125,17 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $originalResourceId], false);
                                 }
                             @endphp
-                            @if(!$hasPersonLink)
+                            @if(empty($firstPerson['id']))
                                 <span class="text-muted">(本修改不涉及人物)</span>
                             @else
-                                <a href="{{ $personLink }}">{{ $item->biogmain->c_name_chn.' '.$item->biogmain->c_name }}</a>
+                                <a href="/basicinformation/{{ $firstPerson['id'] }}/edit">
+                                    {{ trim(($firstPerson['name_chn'] ?? '').' '.($firstPerson['name'] ?? '')) !== '' ? trim(($firstPerson['name_chn'] ?? '').' '.($firstPerson['name'] ?? '')) : $firstPerson['id'] }}
+                                </a>
+                                @if($personRowspan > 1)
+                                    <span class="badge badge-secondary" style="margin-left:4px;">
+                                        {{ !empty($firstPerson['is_primary']) ? '主操作' : '連動' }}
+                                    </span>
+                                @endif
                             @endif
                             </td>
                             @php
@@ -123,7 +152,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     ? implode(' / ', $auditTableNames)
                                     : (string) $item->resource;
                             @endphp
-                            <td>
+                            <td rowspan="{{ $personRowspan }}">
                                 {{ $resourceDisplay }}
                             </td>
                             @php
@@ -199,7 +228,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @php
                                     $canCompare = ($hasAuditLogs || $hasDiffContent) && (int)$item->op_type !== 4;
                                 @endphp
-                            <td>
+                            <td rowspan="{{ $personRowspan }}">
                                 @if($isProposal)
                                     <div class="proposal-status" style="margin-bottom:6px;">
                                         @if($reviewStatus === 'approved')
@@ -368,14 +397,14 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     </div>
                                 @endif
                             </td>
-                            <td>
+                            <td rowspan="{{ $personRowspan }}">
                                 @if($resourceLink)
                                     <a href="{{ $resourceLink }}">{{ $item->resource_id }}</a>
                                 @else
                                     {{ $item->resource_id }}
                                 @endif
                             </td>
-                            <td>
+                            <td rowspan="{{ $personRowspan }}">
                                 @php
                                     $opTypeLabels = [
                                         1 => '1-新增',
@@ -388,7 +417,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @endphp
                                 {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
                             </td>
-                            <td>{{ $item->user->name }}</td>
+                            <td rowspan="{{ $personRowspan }}">{{ $item->user->name }}</td>
                             @php
                                 $updatedUtc = '';
                                 $updatedDisplay = '';
@@ -407,10 +436,31 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     }
                                 }
                             @endphp
-                            <td class="js-utc-datetime" data-utc="{{ $updatedUtc }}">
+                            <td rowspan="{{ $personRowspan }}" class="js-utc-datetime" data-utc="{{ $updatedUtc }}">
                                 {{ $updatedDisplay }}
                             </td>
                         </tr>
+                        @if($personRowspan > 1)
+                            @for($personIdx = 1; $personIdx < $personRowspan; $personIdx++)
+                                @php
+                                    $relatedPerson = $affectedPeople[$personIdx];
+                                @endphp
+                                <tr>
+                                    <td>
+                                        @if(empty($relatedPerson['id']))
+                                            <span class="text-muted">(本修改不涉及人物)</span>
+                                        @else
+                                            <a href="/basicinformation/{{ $relatedPerson['id'] }}/edit">
+                                                {{ trim(($relatedPerson['name_chn'] ?? '').' '.($relatedPerson['name'] ?? '')) !== '' ? trim(($relatedPerson['name_chn'] ?? '').' '.($relatedPerson['name'] ?? '')) : $relatedPerson['id'] }}
+                                            </a>
+                                            <span class="badge badge-secondary" style="margin-left:4px;">
+                                                {{ !empty($relatedPerson['is_primary']) ? '主操作' : '連動' }}
+                                            </span>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endfor
+                        @endif
                     @endforeach
                 </tbody>
 

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -276,4 +276,78 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertSee('POSTED_TO_OFFICE_DATA');
         $response->assertSee('POSTED_TO_ADDR_DATA');
     }
+
+    #[Test]
+    public function test_operations_index_renders_composite_rows_for_multi_person_operation(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'multi-person@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 101, 'c_name_chn' => '甲', 'c_name' => 'Jia'],
+            ['c_personid' => 202, 'c_name_chn' => '乙', 'c_name' => 'Yi'],
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_office_id' => 10,
+            'c_posting_id' => 1,
+            'c_personid' => 101,
+            'c_fy_intercalary' => 0,
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 101,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => 'c_office_id=10&c_posting_id=1',
+            'resource_data' => json_encode(['c_office_id' => 10, 'c_posting_id' => 1, 'c_fy_intercalary' => 1], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_office_id' => 10, 'c_posting_id' => 1, 'c_fy_intercalary' => 0], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $now = now()->format('Y-m-d H:i:s');
+        \Illuminate\Support\Facades\DB::table('audit_log')->insert([
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=101&c_kin_id=202&c_kin_code=1',
+                'old_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 2], JSON_UNESCAPED_UNICODE),
+            ],
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=202&c_kin_id=101&c_kin_code=3',
+                'old_data' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 4], JSON_UNESCAPED_UNICODE),
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('/basicinformation/101/edit', false);
+        $response->assertSee('/basicinformation/202/edit', false);
+        $response->assertSee('rowspan="2"', false);
+        $response->assertSee('主操作');
+        $response->assertSee('連動');
+    }
 }

--- a/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
+++ b/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
@@ -1048,6 +1048,71 @@ class UnidirectionalRelationshipRepairControllerTest extends TestCase {
     }
 
     #[Test]
+    public function kinship_update_does_not_override_created_fields_even_if_request_contains_them() {
+        $person1 = $this->createTestPerson();
+        $person2 = $this->createTestPerson();
+
+        DB::table('KINSHIP_CODES')->where('c_kincode', 2)->update([
+            'c_kin_pair1' => 303,
+        ]);
+
+        DB::table('KIN_DATA')->insert([
+            'c_personid' => $person1->c_personid,
+            'c_kin_id' => $person2->c_personid,
+            'c_kin_code' => 2,
+            'c_source' => 100,
+            'c_autogen_notes' => 'created-field-lock-test',
+            'c_created_by' => 'Original Creator',
+            'c_created_date' => '2024-01-01 08:00:00',
+        ]);
+        DB::table('KIN_DATA')->insert([
+            'c_personid' => $person2->c_personid,
+            'c_kin_id' => $person1->c_personid,
+            'c_kin_code' => 303,
+            'c_source' => 100,
+            'c_autogen_notes' => 'created-field-lock-test',
+            'c_created_by' => 'Original Creator Mirror',
+            'c_created_date' => '2024-01-02 08:00:00',
+        ]);
+
+        $this->actingAs($this->adminUser);
+
+        $repository = app(\App\Repositories\BiogMainRepository::class);
+        $request = new \Illuminate\Http\Request([
+            'c_personid' => $person1->c_personid,
+            'c_kin_id' => $person2->c_personid,
+            'c_kin_code' => 3,
+            'c_kinship_pair' => 301,
+            'c_source' => 100,
+            'c_autogen_notes' => 'created-field-lock-test',
+            // 模擬異常請求：即使傳入空值，也不應覆寫 created 欄位
+            'c_created_by' => '',
+            'c_created_date' => '',
+        ]);
+
+        $repository->kinshipUpdateById($request, $person1->c_personid, "{$person1->c_personid}-{$person2->c_personid}-2");
+
+        $updatedPrimary = DB::table('KIN_DATA')->where([
+            'c_personid' => $person1->c_personid,
+            'c_kin_id' => $person2->c_personid,
+            'c_kin_code' => 3,
+        ])->first();
+        $updatedMirror = DB::table('KIN_DATA')->where([
+            'c_personid' => $person2->c_personid,
+            'c_kin_id' => $person1->c_personid,
+            'c_kin_code' => 301,
+        ])->first();
+
+        $this->assertNotNull($updatedPrimary);
+        $this->assertSame('Original Creator', $updatedPrimary->c_created_by);
+        $this->assertSame('2024-01-01 08:00:00', $updatedPrimary->c_created_date);
+
+        $this->assertNotNull($updatedMirror);
+        $this->assertSame('Original Creator Mirror', $updatedMirror->c_created_by);
+        $this->assertSame('2024-01-02 08:00:00', $updatedMirror->c_created_date);
+    }
+
+    #[Test]
     public function kinship_delete_writes_audit_log_for_mirrored_row() {
         $person1 = $this->createTestPerson();
         $person2 = $this->createTestPerson();


### PR DESCRIPTION
- 以 audit_log 聚合 operation 涉及人物，operations 列表改為多人複合列顯示

- 多人情境以 rowspan 合併共用欄位，人物列標示主操作與連動

- 修正 kinshipUpdateById 更新時忽略 c_created_by/c_created_date

- 新增對應功能測試，涵蓋多人複合列與建檔欄位保護