### PR TITLE
收斂更新路徑並補齊審計測試

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -531,6 +531,10 @@ class BasicInformationAddressesController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'BIOG_ADDR_DATA');
 
+        if ((string) ($pk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
+
         $legacyId = $pk['c_personid']."-".$pk['c_addr_id']."-".$pk['c_addr_type']."-".$pk['c_sequence'];
         $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
         if ($newPk === null) {

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -7,13 +7,9 @@ use App\Models\AddrCode;
 use App\Models\AddressCode;
 use App\Models\TextCode;
 use App\Repositories\BiogMainRepository;
-use App\Repositories\OperationRepository;
-use App\Repositories\ToolsRepository;
-use App\Services\AuditLogService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -22,17 +18,13 @@ class BasicInformationAddressesController extends Controller {
      * @var BiogMainRepository
      */
     protected $biogMainRepository;
-    protected $operationRepository;
-    protected $toolsRepository;
 
     /**
      * TextsController constructor.
      * @param BiogMainRepository $biogMainRepository
      */
-    public function __construct(BiogMainRepository $biogMainRepository, OperationRepository $operationRepository, ToolsRepository $toolsRepository) {
+    public function __construct(BiogMainRepository $biogMainRepository) {
         $this->biogMainRepository = $biogMainRepository;
-        $this->operationRepository = $operationRepository;
-        $this->toolsRepository = $toolsRepository;
         $this->middleware('auth')->except(['index', 'show', 'edit', 'editQuery']);
     }
 
@@ -539,56 +531,11 @@ class BasicInformationAddressesController extends Controller {
         // 驗證必填欄位
         CompositePrimaryKey::validateOrFail($pk, 'BIOG_ADDR_DATA');
 
-        // 準備更新資料
-        $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
-        $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
-        $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence']);
-        $data = $this->toolsRepository->timestamp($data);
-
-        // 構建查詢條件
-        $conditions = [
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_addr_id', '=', $pk['c_addr_id']],
-            ['c_addr_type', '=', $pk['c_addr_type']],
-            ['c_sequence', '=', $pk['c_sequence']],
-        ];
-
-        // 取得原始資料
-        $ori = DB::table('BIOG_ADDR_DATA')->where($conditions)->first();
-        if (!$ori) {
+        $legacyId = $pk['c_personid']."-".$pk['c_addr_id']."-".$pk['c_addr_type']."-".$pk['c_sequence'];
+        $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
+        if ($newPk === null) {
             abort(404, 'BIOG_ADDR_DATA 記錄不存在');
         }
-
-        // 更新資料
-        DB::table('BIOG_ADDR_DATA')->where($conditions)->update($data);
-
-        // 記錄操作
-        $newPk = [
-            'c_personid' => $pk['c_personid'],
-            'c_addr_id' => $data['c_addr_id'] ?? $pk['c_addr_id'],
-            'c_addr_type' => $data['c_addr_type'] ?? $pk['c_addr_type'],
-            'c_sequence' => $data['c_sequence'] ?? $pk['c_sequence'],
-        ];
-
-        // 準備存入 operations 的數據，加入註解
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
-        (new AuditLogService())->write(
-            'BIOG_ADDR_DATA',
-            'UPDATE',
-            $newPk,
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
 
         flash('Update success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -3,15 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Repositories\BiogMainRepository;
-use App\Repositories\OperationRepository;
-use App\Repositories\ToolsRepository;
-use App\Services\AuditLogService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 
 class BasicInformationTextsController extends Controller {
     /**
@@ -19,18 +14,14 @@ class BasicInformationTextsController extends Controller {
      */
     protected $biogMainRepository;
     protected $table_name;
-    protected $operationRepository;
-    protected $toolsRepository;
 
     /**
      * TextsController constructor.
      * @param BiogMainRepository $biogMainRepository
      */
-    public function __construct(BiogMainRepository $biogMainRepository, OperationRepository $operationRepository, ToolsRepository $toolsRepository) {
+    public function __construct(BiogMainRepository $biogMainRepository) {
         $this->biogMainRepository = $biogMainRepository;
         $this->table_name = 'BIOG_TEXT_DATA';
-        $this->operationRepository = $operationRepository;
-        $this->toolsRepository = $toolsRepository;
         $this->middleware('auth')->except(['index', 'show', 'edit', 'editQuery']);
     }
 
@@ -393,53 +384,12 @@ class BasicInformationTextsController extends Controller {
         // 驗證必填欄位（c_role_id 為可選，預設為 0）
         CompositePrimaryKey::validateOrFail($pk, 'TEXT_DATA', ['c_role_id']);
 
-        // 準備更新資料
-        $data = $request->all();
-        $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_textid', 'c_role_id']);
-        $data = $this->toolsRepository->timestamp($data);
-
-        // 構建查詢條件（使用 BIOG_TEXT_DATA 表）
         $c_role_id = $pk['c_role_id'] ?? 0;
-        $conditions = [
-            ['c_personid', '=', $pk['c_personid']],
-            ['c_textid', '=', $pk['c_textid']],
-            ['c_role_id', '=', $c_role_id],
-        ];
-
-        // 取得原始資料
-        $ori = DB::table($this->table_name)->where($conditions)->first();
-        if (!$ori) {
+        $legacyId = $pk['c_personid']."-".$pk['c_textid']."-".$c_role_id;
+        $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);
+        if ($newPk === null) {
             abort(404, 'BIOG_TEXT_DATA 記錄不存在');
         }
-
-        // 更新資料
-        DB::table($this->table_name)->where($conditions)->update($data);
-
-        // 記錄操作
-        $newPk = [
-            'c_personid' => $pk['c_personid'],
-            'c_textid' => $data['c_textid'] ?? $pk['c_textid'],
-            'c_role_id' => $data['c_role_id'] ?? $c_role_id,
-        ];
-
-        // 準備要存入 operations 表的數據，加入註解
-        $operationData = $data;
-        if ($comment) {
-            $operationData['__note'] = $comment;
-        }
-
-        $operation = $this->operationRepository->store(Auth::id(), $id, 3, $this->table_name, CompositePrimaryKey::buildStoredResourceId($newPk), $operationData, $ori);
-        (new AuditLogService())->write(
-            $this->table_name,
-            'UPDATE',
-            $newPk,
-            (new AuditLogService())->normalizeRow($ori),
-            array_merge((new AuditLogService())->normalizeRow($ori), $data),
-            'user',
-            (string) Auth::id(),
-            $operation ? (string) $operation->id : null
-        );
 
         flash('Update success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -384,6 +384,10 @@ class BasicInformationTextsController extends Controller {
         // 驗證必填欄位（c_role_id 為可選，預設為 0）
         CompositePrimaryKey::validateOrFail($pk, 'TEXT_DATA', ['c_role_id']);
 
+        if ((string) ($pk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
+
         $c_role_id = $pk['c_role_id'] ?? 0;
         $legacyId = $pk['c_personid']."-".$pk['c_textid']."-".$c_role_id;
         $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -573,7 +573,7 @@ class BiogMainRepository {
         $temp_l = explode("-", $id_);
         $data = $request->all();
         $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_textid', 'c_role_id']);
         $data = (new ToolsRepository())->timestamp($data);
 
         return DB::transaction(function () use ($id, $temp_l, $data, $comment) {
@@ -2549,7 +2549,7 @@ class BiogMainRepository {
         $addr_l = $this->parseAddrId($addr);
         $data = $request->all();
         $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
         $data = (new ToolsRepository())->timestamp($data);

--- a/docs/AUDIT_LOG_PROPOSAL.md
+++ b/docs/AUDIT_LOG_PROPOSAL.md
@@ -57,8 +57,8 @@ This proposal only targets `/basicinformation` and its 12 subpages. No other mod
 - [~] Integrate `BIOG_MAIN` writes (currently split across `BiogMainRepository` and controller/API paths)
 - [x] Integrate `POSTED_TO_OFFICE_DATA` / `POSTED_TO_ADDR_DATA` writes
 - [x] Integrate remaining `/basicinformation` tables
-- [~] Ensure transactional writes for audit + data changes (partially done; several controller paths still write without single transaction boundary)
-- [~] Add SQLite migration/test coverage in tests (multiple feature tests now create `audit_log`; assertion coverage for audit behavior is still incomplete)
+- [~] Ensure transactional writes for audit + data changes (partially done; major CRUD 已收斂到 repository transaction，仍有少量舊流程待收斂)
+- [~] Add SQLite migration/test coverage in tests (多數核心路徑已有 payload 斷言；仍需補齊剩餘 legacy 入口)
 
 ### Progress Update (2026-02-16)
 - BasicInformation 核心寫入路徑（`BIOG_MAIN`、`ALTNAME_DATA`、`BIOG_ADDR_DATA`、`BIOG_TEXT_DATA`、`ENTRY_DATA`）已統一改為 Repository 層處理，並在主要 CRUD 路徑寫入 `audit_log`。
@@ -80,14 +80,24 @@ This proposal only targets `/basicinformation` and its 12 subpages. No other mod
   - `tests/Feature/BasicInformationAltnamesControllerTest.php`（新增 `NULL sequence` 提案更新場景）
   - `tests/Feature/BasicInformationTextsControllerTest.php`（新增刪除不存在資料回傳 `404`）
 
+### Progress Update (2026-02-18)
+- `BasicInformationTextsController::updateQuery()`、`BasicInformationAddressesController::updateQuery()` 已改為統一委派 repository（`textUpdateById` / `addrUpdateById`），避免 controller 直接執行 `data -> operations -> audit` 的非交易寫入路徑。
+- `BiogMainRepository::textUpdateById()`、`addrUpdateById()` 已補上主鍵欄位過濾，保持原先查詢參數模式下「不可直接更新主鍵」的行為邊界。
+- `ASSOC_DATA` 鏡像路徑（新增/更新/刪除）已補齊 audit，且正向與鏡像記錄共用同一 `operation_id`。
+- 測試補強（SQLite）：
+  - `tests/Feature/BasicInformationAddressesControllerTest.php`（新增 `updateQuery` 審計 payload + `operation_id` 關聯斷言）
+  - `tests/Feature/BasicInformationTextsControllerTest.php`（新增 `updateQuery` 審計 payload + `operation_id` 關聯斷言）
+  - `tests/Feature/OfficeAddressOperationLoggingTest.php`（新增 `POSTED_TO_ADDR_DATA` 一對多變更 `INSERT/DELETE` 共用 `operation_id` 與 old/new payload 斷言）
+  - `tests/Feature/UnidirectionalRelationshipRepairControllerTest.php`（`KIN_DATA` / `ASSOC_DATA` 鏡像 audit 覆蓋）
+
 ## Known Issues (Current Branch)
-- **Transaction consistency gaps**:
-  - Multiple controller write paths still execute `data write -> operations write -> audit_log write` without wrapping all steps in one DB transaction.
-  - A partial failure can leave data/operations/audit out of sync.
+- **Transaction consistency gaps (remaining legacy paths)**:
+  - `BasicInformationController::Duplicate_Collateral_Info()` 仍是 controller 內大型批次寫入邏輯，雖在 transaction 內，但未完全收斂到 repository/service 層，後續維護與測試成本偏高。
+  - 少量非 `/basicinformation` 模組仍有 controller-centric 寫入路徑，未納入本 proposal 的第一階段收斂範圍。
 - **Test coverage gaps**:
-  - Several feature tests were updated to create `audit_log` schema only, but do not yet assert audit payload correctness (row count, operation type, PK serialization, before/after snapshot).
+  - 主要高風險表已有 payload 斷言，但仍有部分 legacy 入口僅驗證「有寫入」而未完整斷言 `row_pk_text` 與 old/new JSON 結構。
 - **Progress semantics caveat**:
-  - "Integrated" currently means "hooks added on major CRUD paths", not "fully transactional and fully asserted across all legacy entry points".
+  - "Integrated" 目前可視為「核心 CRUD 與高風險鏡像路徑已接入並有審計斷言」，但尚未達成所有歷史入口完全一致。
 
 ## Planned Touchpoints
 - `app/Services/AuditLogService.php`
@@ -195,5 +205,5 @@ If history lookup becomes too slow or volume grows:
 - Consider partitioning in MariaDB for very large volumes.
 
 ## Version
-- Version: 0.5
-- Date: 2026-02-17
+- Version: 0.6
+- Date: 2026-02-18

--- a/tests/Feature/BasicInformationAddressesControllerTest.php
+++ b/tests/Feature/BasicInformationAddressesControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BasicInformationAddressesControllerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('BIOG_ADDR_DATA');
+        Schema::create('BIOG_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_addr_id');
+            $table->integer('c_addr_type');
+            $table->integer('c_sequence');
+            $table->integer('c_fy_intercalary')->default(0);
+            $table->integer('c_ly_intercalary')->default(0);
+            $table->string('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->timestamp('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->timestamp('c_modified_date')->nullable();
+        });
+
+        Schema::dropIfExists('operations');
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid');
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id');
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at');
+            $table->string('table_name');
+            $table->string('operation');
+            $table->string('actor_type');
+            $table->string('actor_id');
+            $table->string('operation_id');
+            $table->json('row_pk');
+            $table->string('row_pk_text');
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('BIOG_ADDR_DATA');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function testUpdateQueryWritesAuditPayloadWithOperationId(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'addr-update@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_ADDR_DATA')->insert([
+            'c_personid' => 1,
+            'c_addr_id' => 10,
+            'c_addr_type' => 2,
+            'c_sequence' => 1,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_notes' => 'old-note',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            '/basicinformation/1/addresses/update?c_personid=1&c_addr_id=10&c_addr_type=2&c_sequence=1',
+            [
+                'c_personid' => 1,
+                'c_addr_id' => 10,
+                'c_addr_type' => 2,
+                'c_sequence' => 1,
+                'c_fy_intercalary' => 0,
+                'c_ly_intercalary' => 1,
+                'c_notes' => 'new-note',
+                '__proposal_comment' => 'update-addr',
+            ]
+        );
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('BIOG_ADDR_DATA', [
+            'c_personid' => 1,
+            'c_addr_id' => 10,
+            'c_addr_type' => 2,
+            'c_sequence' => 1,
+            'c_notes' => 'new-note',
+            'c_ly_intercalary' => 1,
+        ]);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $this->assertNotNull($operation);
+        $this->assertSame(3, (int) $operation->op_type);
+        $this->assertSame('BIOG_ADDR_DATA', $operation->resource);
+
+        $log = DB::table('audit_log')->where('table_name', 'BIOG_ADDR_DATA')->where('operation', 'UPDATE')->first();
+        $this->assertNotNull($log);
+        $this->assertSame((string) $operation->id, $log->operation_id);
+        $this->assertSame('c_personid=1&c_addr_id=10&c_addr_type=2&c_sequence=1', $log->row_pk_text);
+
+        $oldData = json_decode($log->old_data, true);
+        $newData = json_decode($log->new_data, true);
+        $this->assertSame('old-note', $oldData['c_notes']);
+        $this->assertSame('new-note', $newData['c_notes']);
+        $this->assertSame(0, $oldData['c_ly_intercalary']);
+        $this->assertSame(1, $newData['c_ly_intercalary']);
+    }
+}

--- a/tests/Feature/BasicInformationAddressesControllerTest.php
+++ b/tests/Feature/BasicInformationAddressesControllerTest.php
@@ -152,4 +152,44 @@ class BasicInformationAddressesControllerTest extends TestCase {
         $this->assertSame(0, $oldData['c_ly_intercalary']);
         $this->assertSame(1, $newData['c_ly_intercalary']);
     }
+
+    #[Test]
+    public function testUpdateQueryReturns400WhenPathPersonIdMismatchesQueryPk(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'addr-update-mismatch@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_ADDR_DATA')->insert([
+            'c_personid' => 2,
+            'c_addr_id' => 10,
+            'c_addr_type' => 2,
+            'c_sequence' => 1,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_notes' => 'old-note',
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            '/basicinformation/1/addresses/update?c_personid=2&c_addr_id=10&c_addr_type=2&c_sequence=1',
+            [
+                'c_notes' => 'new-note',
+            ]
+        );
+
+        $response->assertStatus(400);
+
+        $this->assertDatabaseHas('BIOG_ADDR_DATA', [
+            'c_personid' => 2,
+            'c_addr_id' => 10,
+            'c_addr_type' => 2,
+            'c_sequence' => 1,
+            'c_notes' => 'old-note',
+        ]);
+        $this->assertDatabaseCount('operations', 0);
+        $this->assertDatabaseCount('audit_log', 0);
+    }
 }

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -189,6 +189,42 @@ class BasicInformationTextsControllerTest extends TestCase {
     }
 
     #[Test]
+    public function testUpdateQueryReturns400WhenPathPersonIdMismatchesQueryPk(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'texts-update-mismatch@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_TEXT_DATA')->insert([
+            'c_personid' => 2,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 9,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            '/basicinformation/1/texts/update?c_personid=2&c_textid=100&c_role_id=0',
+            [
+                'c_source' => 200,
+            ]
+        );
+
+        $response->assertStatus(400);
+
+        $this->assertDatabaseHas('BIOG_TEXT_DATA', [
+            'c_personid' => 2,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 9,
+        ]);
+        $this->assertDatabaseCount('operations', 0);
+        $this->assertDatabaseCount('audit_log', 0);
+    }
+
+    #[Test]
     public function testStoreDuplicateTextShowsErrorAndDoesNotInsertAgain(): void {
         $user = User::create([
             'name' => 'Test User',

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -136,6 +136,59 @@ class BasicInformationTextsControllerTest extends TestCase {
     }
 
     #[Test]
+    public function testUpdateQueryWritesAuditPayloadWithOperationId(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'texts-update@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_TEXT_DATA')->insert([
+            'c_personid' => 1,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 9,
+        ]);
+
+        $response = $this->actingAs($user)->put(
+            '/basicinformation/1/texts/update?c_personid=1&c_textid=100&c_role_id=0',
+            [
+                'c_personid' => 1,
+                'c_textid' => 100,
+                'c_role_id' => 0,
+                'c_source' => 200,
+                '__proposal_comment' => 'update-source',
+            ]
+        );
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('BIOG_TEXT_DATA', [
+            'c_personid' => 1,
+            'c_textid' => 100,
+            'c_role_id' => 0,
+            'c_source' => 200,
+        ]);
+
+        $operation = DB::table('operations')->orderByDesc('id')->first();
+        $this->assertNotNull($operation);
+        $this->assertSame(3, (int) $operation->op_type);
+        $this->assertSame('BIOG_TEXT_DATA', $operation->resource);
+
+        $log = DB::table('audit_log')->where('table_name', 'BIOG_TEXT_DATA')->where('operation', 'UPDATE')->first();
+        $this->assertNotNull($log);
+        $this->assertSame((string) $operation->id, $log->operation_id);
+        $this->assertSame('c_personid=1&c_textid=100&c_role_id=0', $log->row_pk_text);
+
+        $oldData = json_decode($log->old_data, true);
+        $newData = json_decode($log->new_data, true);
+        $this->assertSame(9, $oldData['c_source']);
+        $this->assertSame(200, $newData['c_source']);
+    }
+
+    #[Test]
     public function testStoreDuplicateTextShowsErrorAndDoesNotInsertAgain(): void {
         $user = User::create([
             'name' => 'Test User',

--- a/tests/Feature/OfficeAddressOperationLoggingTest.php
+++ b/tests/Feature/OfficeAddressOperationLoggingTest.php
@@ -510,4 +510,68 @@ class OfficeAddressOperationLoggingTest extends TestCase {
             'c_addr_id' => 500,
         ]);
     }
+
+    #[Test]
+    public function testAddressChangeAuditPayloadUsesSharedOperationId(): void {
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 300000,
+            'c_office_id' => 82001,
+            'c_posting_id' => 777001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 300000,
+            'c_posting_id' => 777001,
+            'c_office_id' => 82001,
+            'c_addr_id' => 600,
+        ]);
+
+        $request = new Request([
+            '_id' => 300000,
+            '_postingid' => 777001,
+            '_officeid' => 82001,
+            'c_office_id' => 82001,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_source' => 0,
+            'c_addr' => [601],
+        ]);
+
+        $repository = new BiogMainRepository();
+        $repository->officeUpdateById($request, 777001, 300000);
+
+        $operation = DB::table('operations')
+            ->where('resource', 'POSTED_TO_ADDR_DATA')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($operation);
+
+        $logs = DB::table('audit_log')
+            ->where('table_name', 'POSTED_TO_ADDR_DATA')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertSame(2, $logs->count());
+        $this->assertSame(1, $logs->pluck('operation_id')->unique()->count());
+        $this->assertSame((string) $operation->id, $logs->first()->operation_id);
+
+        $deleteLog = $logs->firstWhere('operation', 'DELETE');
+        $insertLog = $logs->firstWhere('operation', 'INSERT');
+
+        $this->assertNotNull($deleteLog);
+        $this->assertNotNull($insertLog);
+        $this->assertSame('c_addr_id=600&c_office_id=82001&c_posting_id=777001', $deleteLog->row_pk_text);
+        $this->assertSame('c_addr_id=601&c_office_id=82001&c_posting_id=777001', $insertLog->row_pk_text);
+
+        $this->assertNull($insertLog->old_data);
+        $this->assertNull($deleteLog->new_data);
+
+        $insertNewData = json_decode($insertLog->new_data, true);
+        $deleteOldData = json_decode($deleteLog->old_data, true);
+        $this->assertSame(601, $insertNewData['c_addr_id']);
+        $this->assertSame(600, $deleteOldData['c_addr_id']);
+    }
 }


### PR DESCRIPTION
- 將 texts/addresses 的 updateQuery 改為委派 repository 交易流程
- 在 BiogMainRepository 的 text/addr 更新補上主鍵欄位過濾，避免主鍵被請求覆寫
- 補強審計 payload 測試：texts、addresses、office address 一對多 operation_id 聚合
- 更新 docs/AUDIT_LOG_PROPOSAL.md 進度、已知問題與版本為 0.6

測試：
- ./vendor/bin/phpunit tests/Feature/BasicInformationTextsControllerTest.php
- ./vendor/bin/phpunit tests/Feature/BasicInformationAddressesControllerTest.php
- ./vendor/bin/phpunit tests/Feature/OfficeAddressOperationLoggingTest.php
- ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --using-cache=no app/Http/Controllers/BasicInformationTextsController.php app/Http/Controllers/BasicInformationAddressesController.php app/Repositories/BiogMainRepository.php tests/Feature/BasicInformationTextsControllerTest.php tests/Feature/BasicInformationAddressesControllerTest.php tests/Feature/OfficeAddressOperationLoggingTest.php