### PR TITLE
清理 ALTNAME_DATA 4-key 過渡期遺留程式碼 (#834 Phase 4)

### DIFF
--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -136,7 +136,6 @@ class BasicInformationAltnamesController extends Controller {
 
         flash('Store success @ '.Carbon::now(), 'success');
 
-        // (#834 Phase 2): 使用 3-key 重定向，c_sequence 不參與定位
         $newPk = [
             'c_personid' => $data['c_personid'],
             'c_alt_name_chn' => $data['c_alt_name_chn'],
@@ -242,7 +241,6 @@ class BasicInformationAltnamesController extends Controller {
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // (#834 Phase 2): 使用 3-key 關聯陣列
             $originalPk = $this->parseAltnameId($alt);
 
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
@@ -311,7 +309,7 @@ class BasicInformationAltnamesController extends Controller {
     /**
      * 解析別名複合主鍵 ID 為 3-key 關聯陣列
      *
-     * (#834 Phase 2): 委派給 Repository，支援歷史 4-key 與新 3-key 格式。
+     * 委派給 Repository，支援歷史 4-key 與新 3-key 格式。
      *
      * @param string $alt 複合主鍵 ID
      * @return array 3-key 關聯陣列 ['c_personid' => ..., 'c_alt_name_chn' => ..., 'c_alt_name_type_code' => ...]
@@ -336,7 +334,6 @@ class BasicInformationAltnamesController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function editQuery(Request $request, $id) {
-        // (#834 Phase 2): 從查詢參數提取 3-key
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $pk = CompositePrimaryKey::fromRequest($request, $schema);
 
@@ -433,7 +430,6 @@ class BasicInformationAltnamesController extends Controller {
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // (#834 Phase 2): 從 URL 查詢字串取得 3-key 原始 PK
             $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
             $originalPk = [];
             foreach ($schema as $field) {
@@ -454,7 +450,6 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // (#834 Phase 2): 從 URL 查詢字串提取 3-key 原始 PK
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $originalPk = [];
         foreach ($schema as $field) {
@@ -534,7 +529,6 @@ class BasicInformationAltnamesController extends Controller {
             return redirect()->back();
         }
 
-        // (#834 Phase 2): 從查詢參數提取 3-key
         $schema = CompositePrimaryKey::SCHEMAS['ALTNAME_DATA'];
         $pk = CompositePrimaryKey::fromRequest($request, $schema);
         CompositePrimaryKey::validateOrFail($pk, 'ALTNAME_DATA');

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -31,7 +31,6 @@ class BasicInformationProposalController extends Controller {
         ],
         'altnames' => [
             'table' => 'ALTNAME_DATA',
-            // (#834 Phase 2): 3-key，c_sequence 不參與定位
             'key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
             'controller' => 'BasicInformationAltnamesController',
             'route_prefix' => 'basicinformation.altnames',

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -157,8 +157,7 @@ class OperationsController extends Controller {
 
                             break;
                         case "ALTNAME_DATA":
-                            // (#834 Phase 2): 使用 CompositePrimaryKey 解析 resource_id（支援歷史 4-key 與新 3-key），
-                            // 返回 3-key 查詢
+                            // 使用 CompositePrimaryKey 解析 resource_id（支援歷史 4-key 與新 3-key），返回 3-key 查詢
                             $parsedAlt = CompositePrimaryKey::parseStoredResourceId($resource_id, 'ALTNAME_DATA');
                             if ($parsedAlt !== null) {
                                 $altQuery = DB::table('ALTNAME_DATA');
@@ -733,7 +732,7 @@ class OperationsController extends Controller {
             }
         }
 
-        // (#834 Phase 3): ALTNAME 跨格式回退
+        // ALTNAME 跨格式回退 (#834)
         // 同一 ALTNAME 行的操作可能以不同格式儲存 resource_id（4-key vs 3-key），
         // 精確匹配會遺漏。透過解析 resource_id 再逐一比對來搜尋前次操作。
         if ($previous === null && $operation->resource === 'ALTNAME_DATA') {
@@ -752,7 +751,7 @@ class OperationsController extends Controller {
     }
 
     /**
-     * (#834 Phase 3): 跨格式搜尋前一筆 ALTNAME 操作
+     * 跨格式搜尋前一筆 ALTNAME 操作 (#834)
      *
      * 先從當前操作的 resource_id 解析出 3-key 值，
      * 再比對歷史操作的 resource_id（解析後）是否指向同一行。
@@ -896,7 +895,7 @@ class OperationsController extends Controller {
     }
 
     /**
-     * (#834 Phase 2): 使用 3-key 查詢 ALTNAME_DATA 現行資料列
+     * 使用 3-key 查詢 ALTNAME_DATA 現行資料列
      */
     protected function fetchAltnameCurrentRow(array $operation) {
         $decoded = $this->decodeJson($operation['resource_data'] ?? null);
@@ -943,7 +942,7 @@ class OperationsController extends Controller {
         $map = [
             'BIOG_MAIN' => ['c_personid'],
             'BIOG_ADDR_DATA' => ['c_personid','c_addr_id','c_addr_type','c_sequence'],
-            // (#834 Phase 2): 3-key，c_sequence 不參與定位
+            // ALTNAME_DATA 使用 3-key，c_sequence 不參與定位 (#834)
             'ALTNAME_DATA' => ['c_personid','c_alt_name_chn','c_alt_name_type_code'],
             'BIOG_TEXT_DATA' => ['c_personid','c_textid','c_role_id'],
             'POSTED_TO_OFFICE_DATA' => ['c_office_id','c_posting_id'],
@@ -976,7 +975,7 @@ class OperationsController extends Controller {
         $previous = isset($result['previous']) ? (array) $result['previous'] : [];
         $personId = $this->resolvePersonId($originalOperation, $restored, $previous);
 
-        // (#834 Phase 3): 正規化 resource_id，確保新紀錄一律使用最新格式
+        // 正規化 resource_id，確保新紀錄一律使用最新格式
         $resourceId = $this->normalizeResourceId(
             $originalOperation->resource,
             $originalOperation->resource_id,
@@ -995,7 +994,7 @@ class OperationsController extends Controller {
     }
 
     /**
-     * (#834 Phase 3): 正規化 resource_id
+     * 正規化 resource_id
      *
      * 對於有 resourceKeyColumns 定義的資源，嘗試從 $data 提取 key 欄位
      * 並重建 query-string 格式 resource_id。確保新寫入的操作紀錄一律使用最新格式，

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -2661,7 +2661,7 @@ class BiogMainRepository {
     /**
      * 依複合主鍵取得 ALTNAME_DATA 記錄
      *
-     * (#834 Phase 2): 使用 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code) 定位，
+     * 使用 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code) 定位，
      * c_sequence 不參與定位。接受字串或 3-key 關聯陣列。
      *
      * @param string|array $id 複合主鍵字串或 3-key 關聯陣列
@@ -2680,7 +2680,7 @@ class BiogMainRepository {
         $data = $request->all();
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
         $data['c_personid'] = $id;
-        // (#834 Phase 2): 重複檢查使用 3-key，c_sequence 不參與定位
+        // 重複檢查使用 3-key，c_sequence 不參與定位
         $duplicate = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $data['c_personid']],
             ['c_alt_name_chn', '=', $data['c_alt_name_chn']],
@@ -2725,7 +2725,7 @@ class BiogMainRepository {
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         $data = (new ToolsRepository())->timestamp($data);
 
-        // (#834 Phase 2): WHERE 使用 3-key 定位
+        // WHERE 使用 3-key 定位
         $where3key = [
             ['c_personid', '=', $pk['c_personid']],
             ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
@@ -2776,7 +2776,7 @@ class BiogMainRepository {
     public function altnameDeleteById($id, $c_personid) {
         $pk = is_array($id) ? $id : $this->parseAltnameId($id);
 
-        // (#834 Phase 2): WHERE 使用 3-key 定位
+        // WHERE 使用 3-key 定位
         $where3key = [
             ['c_personid', '=', $pk['c_personid']],
             ['c_alt_name_chn', '=', $pk['c_alt_name_chn']],
@@ -2818,44 +2818,18 @@ class BiogMainRepository {
     /**
      * 解析 ALTNAME_DATA 複合主鍵字串為 3-key 關聯陣列
      *
-     * (#834 Phase 2): 返回 3-key 關聯陣列，支援歷史 4-key 與新 3-key 格式。
+     * 支援歷史 4-key 與新 3-key 格式，委派給 CompositePrimaryKey 統一處理。
      *
      * @param string $alt 複合主鍵字串
      * @return array 3-key 關聯陣列 ['c_personid' => ..., 'c_alt_name_chn' => ..., 'c_alt_name_type_code' => ...]
      */
     public function parseAltnameId($alt) {
-        if (strpos($alt, '_._') !== false) {
-            $parts = explode('_._', $alt);
-        } else {
-            $parts = explode("-", $alt);
-            foreach ($parts as $key => $value) {
-                $parts[$key] = $this->unionPKDef_decode($value);
-            }
+        $parsed = CompositePrimaryKey::parseStoredResourceId($alt, 'ALTNAME_DATA');
+        if ($parsed !== null) {
+            return $parsed;
         }
 
-        $count = count($parts);
-        if ($count === 4) {
-            // 歷史 4-key 格式：[c_personid, c_sequence, c_alt_name_chn, c_alt_name_type_code]
-            // 忽略 c_sequence (index 1)，返回 3-key
-            return [
-                'c_personid' => $parts[0],
-                'c_alt_name_chn' => $parts[2],
-                'c_alt_name_type_code' => $parts[3],
-            ];
-        } elseif ($count === 3) {
-            // 新 3-key 格式：[c_personid, c_alt_name_chn, c_alt_name_type_code]
-            return [
-                'c_personid' => $parts[0],
-                'c_alt_name_chn' => $parts[1],
-                'c_alt_name_type_code' => $parts[2],
-            ];
-        }
-
-        Log::error("ALTNAME_DATA ID 格式不正確: {$alt}", [
-            'parsed' => $parts,
-            'expected_count' => '3 or 4',
-            'actual_count' => $count,
-        ]);
+        Log::error("ALTNAME_DATA ID 格式不正確: {$alt}");
         abort(400, 'ALTNAME_DATA ID 格式不正確');
     }
 

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -25,7 +25,7 @@ class CompositePrimaryKey {
         'BIOG_MAIN' => [
             'c_personid',
         ],
-        // ALTNAME_DATA 定位 key (#834 Phase 2)
+        // ALTNAME_DATA 定位 key (#834)
         // 資料庫 PK 為 3-key: (c_personid, c_alt_name_chn, c_alt_name_type_code)
         // c_sequence 為一般排序欄位，不參與定位。
         'ALTNAME_DATA' => [
@@ -118,10 +118,11 @@ class CompositePrimaryKey {
     ];
 
     /**
-     * ALTNAME_DATA 歷史 4-key 格式（Phase 2 向後相容用）
+     * ALTNAME_DATA 歷史 4-key 格式
      *
-     * Phase 1 及之前的 resource_id 使用 4-key 格式（含 c_sequence），
-     * 此常數用於解析歷史 resource_id，解析後會自動 strip c_sequence 返回 3-key。
+     * 2025 年以前的 resource_id 使用 4-key 格式（含 c_sequence），
+     * 此常數用於解析歷史操作紀錄的 resource_id，
+     * 解析後會自動 strip c_sequence 返回當前 3-key 格式。
      *
      * @see https://github.com/cbdb-project/cbdb-online-main-server/issues/834
      */
@@ -432,7 +433,7 @@ class CompositePrimaryKey {
         if (strpos($resourceId, '_._') !== false) {
             $parts = explode('_._', $resourceId);
 
-            // ALTNAME_DATA Phase 2 相容 (#834)：歷史 4-key _._  格式 → strip c_sequence 返回 3-key
+            // #834: 歷史 4-key _._  格式 → strip c_sequence 返回 3-key
             // 必須在通用匹配前處理，否則 4 parts >= 3 expectedCount 會導致錯位
             if (strtoupper($effectiveTable) === 'ALTNAME_DATA' && count($parts) === count(self::ALTNAME_LEGACY_4KEY)) {
                 $parsed4 = array_combine(self::ALTNAME_LEGACY_4KEY, $parts);
@@ -485,7 +486,7 @@ class CompositePrimaryKey {
             return $result2;
         }
 
-        // ALTNAME_DATA Phase 2 相容 (#834)：歷史 4-key dash 格式 → strip c_sequence 返回 3-key
+        // #834: 歷史 4-key dash 格式 → strip c_sequence 返回 3-key
         if (strtoupper($effectiveTable) === 'ALTNAME_DATA') {
             $legacy4key = self::ALTNAME_LEGACY_4KEY;
             $legacy4keyCount = count($legacy4key);

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -594,7 +594,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $response->assertRedirect();
         $response->assertSessionHas('flash_notification');
 
-        // (#834 Phase 2): 重定向 URL 使用 3-key，不含 c_sequence
+        // 重定向 URL 使用 3-key，不含 c_sequence
         $redirectUrl = $response->headers->get('Location');
         $this->assertStringContainsString('c_personid=1', $redirectUrl);
         $this->assertStringNotContainsString('c_sequence', $redirectUrl);

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -826,7 +826,7 @@ class BasicInformationProposalTest extends TestCase {
         $user = $this->makeActiveUser();
         $this->actingAs($user);
 
-        // (#834 Phase 2): 3-key 中缺少 c_alt_name_type_code
+        // 3-key 中缺少 c_alt_name_type_code
         $response = $this->post(route('basicinformation.proposal.store', [
             'personid' => 1,
             'resource' => 'altnames',

--- a/tests/Feature/FormUrlEncodingTest.php
+++ b/tests/Feature/FormUrlEncodingTest.php
@@ -585,7 +585,7 @@ class FormUrlEncodingTest extends TestCase {
 
         // 驗證 redirect URL 使用新的查詢參數模式
         $redirectUrl = $response->headers->get('Location');
-        // (#834 Phase 2): 3-key 格式 ?c_personid=...&c_alt_name_chn=...&c_alt_name_type_code=...
+        // 3-key 格式 ?c_personid=...&c_alt_name_chn=...&c_alt_name_type_code=...
         $this->assertStringContainsString('c_personid=', $redirectUrl);
         $this->assertStringContainsString('c_alt_name_chn=', $redirectUrl);
         $this->assertStringContainsString('c_alt_name_type_code=', $redirectUrl);

--- a/tests/Feature/OperationsAltnameRestoreTest.php
+++ b/tests/Feature/OperationsAltnameRestoreTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
- * (#834 Phase 3): ALTNAME_DATA 操作復原整合測試
+ * ALTNAME_DATA 操作復原整合測試 (#834)
  *
  * 驗證：
  * - 復原更新操作（op_type=3）能正確回復 DB 資料

--- a/tests/Feature/OperationsIndexDiffTest.php
+++ b/tests/Feature/OperationsIndexDiffTest.php
@@ -170,7 +170,7 @@ BLADE
     }
 
     // -------------------------------------------------------
-    // Phase 1 (#834)：ALTNAME 3-key 舊格式分支差異比對測試
+    // ALTNAME 3-key 舊格式分支差異比對測試 (#834)
     // -------------------------------------------------------
 
     #[Test]
@@ -319,7 +319,7 @@ BLADE
 
     #[Test]
     public function test_operations_index_altname_4key_legacy_still_works(): void {
-        // 確認既有 4-key 舊格式不受 Phase 1 影響
+        // 確認既有 4-key 舊格式不受 3-key 遷移影響
         $this->actingAsAdmin();
         $this->createAltnameTable();
 

--- a/tests/Unit/AuditLogServiceTest.php
+++ b/tests/Unit/AuditLogServiceTest.php
@@ -48,7 +48,7 @@ class AuditLogServiceTest extends TestCase {
 
         $text = $this->service->buildRowPkText('ALTNAME_DATA', $rowPk);
 
-        // (#834 Phase 2): Schema 已切為 3-key，c_sequence 被過濾
+        // Schema 已切為 3-key，c_sequence 被過濾
         $this->assertSame(
             'c_personid=123&c_alt_name_chn=A%20%26%20B&c_alt_name_type_code=10',
             $text

--- a/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
+++ b/tests/Unit/CompositePrimaryKeyAltnameCompatTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
- * ALTNAME_DATA 3-key 相容層測試 (#834 Phase 2)
+ * ALTNAME_DATA 3-key 相容層測試 (#834)
  *
  * Schema 已切為 3-key (c_personid, c_alt_name_chn, c_alt_name_type_code)。
  * 確保 parseStoredResourceId() 對歷史 4-key resource_id 自動 strip c_sequence 返回 3-key，
@@ -76,7 +76,7 @@ class CompositePrimaryKeyAltnameCompatTest extends TestCase {
 
     #[Test]
     public function test_parse_altname_4key_dot_format_still_works(): void {
-        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key _._  格式 → 相容層自動 strip c_sequence 返回 3-key
         $resourceId = '123_._1_._張三_._10';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 
@@ -131,7 +131,7 @@ class CompositePrimaryKeyAltnameCompatTest extends TestCase {
 
     #[Test]
     public function test_parse_altname_4key_dash_format_still_works(): void {
-        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key dash 格式 → 相容層自動 strip c_sequence 返回 3-key
         $resourceId = '123-1-張三-10';
         $result = CompositePrimaryKey::parseStoredResourceId($resourceId, 'ALTNAME_DATA');
 

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -405,7 +405,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_parses_resource_id_with_encoded_slash(): void {
-        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key dash 格式 → 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-張(slash)三-10',
             'ALTNAME_DATA'
@@ -461,7 +461,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_parses_underscore_dot_separator_format(): void {
-        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key _._  格式 → 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345_._1_._張三_._10',
             'ALTNAME_DATA'
@@ -547,7 +547,7 @@ class CompositePrimaryKeyTest extends TestCase {
     /** @test */
     public function it_parses_old_format_with_double_dash(): void {
         // 舊格式：-- 代表欄位值中的 -
-        // 歷史 4-key dash 格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key dash 格式 → 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-張--三-10',
             'ALTNAME_DATA'
@@ -654,7 +654,7 @@ class CompositePrimaryKeyTest extends TestCase {
 
     /** @test */
     public function it_roundtrips_build_and_parse_for_altname(): void {
-        // Phase 2：3-key roundtrip（c_sequence 不參與定位）
+        // 3-key roundtrip（c_sequence 不參與定位）
         $pk = [
             'c_personid' => '12345',
             'c_alt_name_chn' => '張-三',
@@ -767,7 +767,7 @@ class CompositePrimaryKeyTest extends TestCase {
     /** @test */
     public function it_still_parses_underscore_dot_format_with_equals(): void {
         // 確保含 = 但也含 _._ 的格式不會被誤判為 query-string
-        // 歷史 4-key _._  格式 → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key _._  格式 → 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345_._1_._a=b_._10',
             'ALTNAME_DATA'
@@ -786,7 +786,7 @@ class CompositePrimaryKeyTest extends TestCase {
         // 舊格式 resource_id 的欄位值恰好含有 '='（極端邊界情況）
         // parse_str('12345-1-a=b-10') 會產生 ['12345-1-a' => 'b-10']
         // 因為 key 不在 ALTNAME_DATA schema 中，回退到 dash 分隔符解析
-        // 歷史 4-key dash → Phase 2 相容層自動 strip c_sequence 返回 3-key
+        // 歷史 4-key dash → 相容層自動 strip c_sequence 返回 3-key
         $result = CompositePrimaryKey::parseStoredResourceId(
             '12345-1-a=b-10',
             'ALTNAME_DATA'

--- a/tests/Unit/OperationsAltnameResolverTest.php
+++ b/tests/Unit/OperationsAltnameResolverTest.php
@@ -69,7 +69,7 @@ class OperationsAltnameResolverTest extends TestCase {
     public function test_fetch_altname_handles_null_sentinel_in_query_string_resource_id(): void {
         // 當 resource_data 缺少欄位，且 resource_id 用新格式包含 NULL sentinel 時，
         // c_sequence=NULL 經解析後為 PHP null。
-        // Phase 1 (#834)：c_sequence 為 null 時改走 3-key 查詢（DB PK），
+        // #834: c_sequence 為 null 時改走 3-key 查詢（DB PK），
         // 因此能正確定位到該筆資料（不論 c_sequence 實際值為何）。
         DB::table('ALTNAME_DATA')->insert([
             'c_personid' => 200,
@@ -96,7 +96,7 @@ class OperationsAltnameResolverTest extends TestCase {
 
         $row = $controller->resolveAltname($operationPayload);
 
-        // Phase 1：c_sequence 為 null → 3-key 回退查詢，以 DB PK 定位
+        // c_sequence 為 null → 3-key 回退查詢，以 DB PK 定位
         // (c_personid=200, c_alt_name_chn=測試, c_alt_name_type_code=5) 能唯一找到該列
         $this->assertNotNull($row);
         $this->assertEquals(200, $row->c_personid);
@@ -106,7 +106,7 @@ class OperationsAltnameResolverTest extends TestCase {
 
     #[Test]
     public function test_build_key_conditions_normalizes_null_sentinel(): void {
-        // (#834 Phase 2): resourceKeyColumns 已切為 3-key，
+        // resourceKeyColumns 已切為 3-key (#834)，
         // 歷史 4-key resource_id 中的 c_sequence 被 parseStoredResourceId 過濾，
         // buildKeyConditions 只返回 3 個 conditions
         Schema::create('operations', function (Blueprint $table) {


### PR DESCRIPTION
## Summary

- 整合 `BiogMainRepository::parseAltnameId()` 至 `CompositePrimaryKey::parseStoredResourceId()`，消除重複的 4-key/3-key 解析邏輯
- 移除 14 個檔案中約 43 處 `(#834 Phase N)` 過渡期註解，簡化為 `#834` 或移除自明註解
- `ALTNAME_LEGACY_4KEY` 常數與所有 4-key 解析分支維持不變（歷史操作紀錄永久相容）

## Test plan

- [x] 全套 594 tests 通過
- [x] php-cs-fixer 無格式修正
- [x] `grep -r "Phase [0-4]" --include="*.php" app/ tests/` 回傳 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)