### PR TITLE
移除「生成拼音」按鈕旁的空白 label 避免誤觸

### DIFF
--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -75,12 +75,8 @@
                 </div>
                 @if(!$readonly)
                     <div class="form-group row">
-                        <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
-                        <div class="col-sm-4">
+                        <div class="col-sm-4 offset-sm-2">
                             <button type="button" id="button_ajax_load" class="btn btn-info">生成拼音</button>
-                        </div>
-                        <label for="button_ajax_load" class="col-sm-2 col-form-label"></label>
-                        <div class="col-sm-4">
                         </div>
                     </div>
                 @endif


### PR DESCRIPTION
## Summary
- 修正基本資訊編輯頁「生成拼音」按鈕左側存在空白 `<label for="button_ajax_load">`，點擊空白區域會因 HTML 標準行為激活按鈕功能的問題
- 移除兩個空白 label 與多餘的空 div，改用 Bootstrap `offset-sm-2` 維持按鈕水平對齊位置

Closes #837

## Test plan
- [x] 進入人物基本資訊編輯頁，確認「生成拼音」按鈕位置與先前一致
- [x] 確認按鈕左側空白區域不再可點擊觸發拼音生成
- [x] 點擊按鈕本身仍能正常生成拼音

🤖 Generated with [Claude Code](https://claude.com/claude-code)