### PR TITLE
為操作紀錄頁面新增修改人與修改類型篩選功能

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -56,6 +56,33 @@ class OperationsController extends Controller {
             }
         }
 
+        // 修改人篩選（支援 user_id 或 name 模糊匹配）
+        $editorFilter = trim($request->input('editor', ''));
+        if ($editorFilter !== '') {
+            $query->whereHas('user', function ($q) use ($editorFilter) {
+                if (ctype_digit($editorFilter)) {
+                    $q->where('id', (int) $editorFilter);
+                } else {
+                    $q->where('name', 'like', '%' . $editorFilter . '%');
+                }
+            });
+        }
+
+        // 修改類型篩選（多選 op_type，僅非 proposals 模式）
+        if (!$proposalsOnly) {
+            $rawOpTypes = $request->input('op_type', []);
+            if (!is_array($rawOpTypes)) {
+                $rawOpTypes = [$rawOpTypes];
+            }
+            $opTypeFilter = array_values(array_intersect(
+                array_filter(array_map('intval', $rawOpTypes)),
+                [1, 2, 3, 4, 8, 9]
+            ));
+            if (!empty($opTypeFilter)) {
+                $query->whereIn('op_type', $opTypeFilter);
+            }
+        }
+
         $lists = $query->orderBy('updated_at', 'desc')->paginate(20);
         $lists->appends($request->except('page'));
         //將物件轉為陣列進行陣列比對

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -7,38 +7,65 @@ use App\Support\CompositePrimaryKey;
 @include('biogmains.defense')
     <div class="card card-default">
         <div class="card-body">
-            @if(!empty($proposals_only))
-                @php
-                    $statusOptions = [
-                        'pending' => '待審核',
-                        'approved' => '已核准',
-                        'rejected' => '已退修',
-                        'cancelled' => '已撤回',
-                    ];
-                    $selectedStatuses = $status_filters ?? [];
-                @endphp
-                <form method="GET" action="{{ route('operations.index') }}" class="form-inline" style="margin-bottom: 15px;" id="proposal-status-filters">
+            <form method="GET" action="{{ route('operations.index') }}" class="form-inline" style="margin-bottom: 15px;" id="operations-filters">
+                @if(!empty($proposals_only))
                     <input type="hidden" name="proposals_only" value="1">
-                    @foreach($statusOptions as $value => $label)
-                        <label class="checkbox-inline" style="margin-right: 12px;">
-                            <input type="checkbox" name="status[]" value="{{ $value }}" {{ in_array($value, $selectedStatuses, true) ? 'checked' : '' }}>
-                            {{ $label }}
-                        </label>
-                    @endforeach
-                    <a href="{{ route('operations.index', ['proposals_only' => 1]) }}" class="btn btn-secondary btn-sm" style="margin-left: 8px;">清除篩選</a>
-                </form>
-                <script>
-                    document.addEventListener('DOMContentLoaded', function () {
-                        var form = document.getElementById('proposal-status-filters');
-                        if (!form) {
-                            return;
-                        }
-                        form.addEventListener('change', function () {
-                            form.submit();
-                        });
-                    });
-                </script>
-            @endif
+                @endif
+
+                {{-- 修改人篩選 --}}
+                <div class="form-group mr-3">
+                    <label class="mr-1">修改人：</label>
+                    <input type="text" name="editor" class="form-control form-control-sm"
+                           placeholder="名稱或 ID" value="{{ request('editor', '') }}" style="width: 150px;">
+                </div>
+
+                @if(!empty($proposals_only))
+                    {{-- 提案狀態篩選 --}}
+                    @php
+                        $statusOptions = [
+                            'pending' => '待審核',
+                            'approved' => '已核准',
+                            'rejected' => '已退修',
+                            'cancelled' => '已撤回',
+                        ];
+                        $selectedStatuses = $status_filters ?? [];
+                    @endphp
+                    <div class="form-group mr-3">
+                        <label class="mr-1">提案狀態：</label>
+                        @foreach($statusOptions as $value => $label)
+                            <label class="form-check-inline mr-2">
+                                <input type="checkbox" name="status[]" value="{{ $value }}" {{ in_array($value, $selectedStatuses, true) ? 'checked' : '' }}>
+                                {{ $label }}
+                            </label>
+                        @endforeach
+                    </div>
+                @else
+                    {{-- 修改類型篩選（僅一般模式） --}}
+                    @php
+                        $opTypeOptions = [
+                            1 => '新增',
+                            2 => '整體覆寫',
+                            3 => '修改',
+                            4 => '刪除',
+                        ];
+                        $selectedOpTypes = array_map('intval', (array) request('op_type', []));
+                    @endphp
+                    <div class="form-group mr-3">
+                        <label class="mr-1">修改類型：</label>
+                        @foreach($opTypeOptions as $val => $lbl)
+                            <label class="form-check-inline mr-2">
+                                <input type="checkbox" name="op_type[]" value="{{ $val }}"
+                                       {{ in_array($val, $selectedOpTypes, true) ? 'checked' : '' }}>
+                                {{ $lbl }}
+                            </label>
+                        @endforeach
+                    </div>
+                @endif
+
+                <button type="submit" class="btn btn-primary btn-sm mr-2">篩選</button>
+                <a href="{{ route('operations.index', !empty($proposals_only) ? ['proposals_only' => 1] : []) }}"
+                   class="btn btn-secondary btn-sm">清除篩選</a>
+            </form>
             <div class="table-responsive">
                 <table class="table table-bordered table-striped">
                 <thead>

--- a/tests/Feature/OperationsIndexFilterTest.php
+++ b/tests/Feature/OperationsIndexFilterTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class OperationsIndexFilterTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid')->nullable();
+            $table->tinyInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->tinyInteger('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('BIOG_MAIN', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('audit_log', function ($table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    private function makeUser(string $name, string $email, array $overrides = []): User {
+        return User::create(array_merge([
+            'name' => $name,
+            'email' => $email,
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ], $overrides));
+    }
+
+    private function makeOperation(User $user, int $opType, array $overrides = []): Operation {
+        return Operation::create(array_merge([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => $opType,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => '1',
+            'resource_data' => json_encode(['c_name_chn' => '測試'], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_name_chn' => '原始'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ], $overrides));
+    }
+
+    /** 取出 viewData('lists') 中所有 user_id */
+    private function listUserIds($response): array {
+        return $response->viewData('lists')->pluck('user_id')->all();
+    }
+
+    /** 取出 viewData('lists') 中所有 op_type */
+    private function listOpTypes($response): array {
+        return $response->viewData('lists')->pluck('op_type')->map(fn ($v) => (int) $v)->all();
+    }
+
+    // ── editor 篩選 ──
+
+    #[Test]
+    public function editor_numeric_input_filters_by_user_id(): void {
+        $alice = $this->makeUser('Alice', 'alice@example.com');
+        $bob = $this->makeUser('Bob', 'bob@example.com');
+
+        $this->makeOperation($alice, Operation::TYPE_CREATE);
+        $this->makeOperation($bob, Operation::TYPE_CREATE);
+
+        $response = $this->actingAs($alice)->get('/operations?editor=' . $bob->id);
+
+        $response->assertStatus(200);
+        $userIds = $this->listUserIds($response);
+        $this->assertSame([$bob->id], $userIds);
+    }
+
+    #[Test]
+    public function editor_text_input_filters_by_name_like(): void {
+        $alice = $this->makeUser('Alice Wang', 'alice@example.com');
+        $bob = $this->makeUser('Bob Chen', 'bob@example.com');
+
+        $this->makeOperation($alice, Operation::TYPE_CREATE);
+        $this->makeOperation($bob, Operation::TYPE_CREATE);
+
+        $response = $this->actingAs($alice)->get('/operations?editor=Wang');
+
+        $response->assertStatus(200);
+        $userIds = $this->listUserIds($response);
+        $this->assertSame([$alice->id], $userIds);
+    }
+
+    #[Test]
+    public function editor_empty_string_shows_all_results(): void {
+        $alice = $this->makeUser('Alice', 'alice@example.com');
+        $bob = $this->makeUser('Bob', 'bob@example.com');
+
+        $this->makeOperation($alice, Operation::TYPE_CREATE);
+        $this->makeOperation($bob, Operation::TYPE_UPDATE);
+
+        $response = $this->actingAs($alice)->get('/operations?editor=');
+
+        $response->assertStatus(200);
+        $userIds = $this->listUserIds($response);
+        $this->assertCount(2, $userIds);
+        $this->assertContains($alice->id, $userIds);
+        $this->assertContains($bob->id, $userIds);
+    }
+
+    // ── op_type 篩選 ──
+
+    #[Test]
+    public function op_type_filters_by_selected_types(): void {
+        $user = $this->makeUser('Admin', 'admin@example.com');
+
+        $this->makeOperation($user, Operation::TYPE_CREATE);
+        $this->makeOperation($user, Operation::TYPE_UPDATE);
+        $this->makeOperation($user, Operation::TYPE_DELETE);
+
+        // 只篩選「新增」和「刪除」
+        $response = $this->actingAs($user)->get('/operations?op_type[]=1&op_type[]=4');
+
+        $response->assertStatus(200);
+        $opTypes = $this->listOpTypes($response);
+        $this->assertCount(2, $opTypes);
+        $this->assertContains(Operation::TYPE_CREATE, $opTypes);
+        $this->assertContains(Operation::TYPE_DELETE, $opTypes);
+        $this->assertNotContains(Operation::TYPE_UPDATE, $opTypes);
+    }
+
+    #[Test]
+    public function op_type_rejects_invalid_values(): void {
+        $user = $this->makeUser('Admin', 'admin@example.com');
+
+        $this->makeOperation($user, Operation::TYPE_CREATE);
+        $this->makeOperation($user, Operation::TYPE_UPDATE);
+
+        // 傳入非法值 99，應被過濾掉，等同無篩選
+        $response = $this->actingAs($user)->get('/operations?op_type[]=99');
+
+        $response->assertStatus(200);
+        $opTypes = $this->listOpTypes($response);
+        $this->assertCount(2, $opTypes);
+    }
+
+    #[Test]
+    public function op_type_filter_ignored_in_proposals_mode(): void {
+        $user = $this->makeUser('Admin', 'admin@example.com');
+
+        $this->makeOperation($user, Operation::TYPE_PROPOSAL_CREATE, [
+            'resource_data' => json_encode([
+                'c_name_chn' => '提案',
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by' => 'Admin', 'submitted_at' => now()->format('Y-m-d H:i:s')],
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        // proposals 模式下傳入 op_type=1 應被忽略，提案仍然顯示
+        $response = $this->actingAs($user)->get('/operations?proposals_only=1&op_type[]=1');
+
+        $response->assertStatus(200);
+        $opTypes = $this->listOpTypes($response);
+        $this->assertCount(1, $opTypes);
+        $this->assertSame(Operation::TYPE_PROPOSAL_CREATE, $opTypes[0]);
+    }
+
+    // ── proposals 模式 status + editor 組合 ──
+
+    #[Test]
+    public function proposals_status_and_editor_filter_work_together(): void {
+        $alice = $this->makeUser('Alice', 'alice@example.com');
+        $bob = $this->makeUser('Bob', 'bob@example.com');
+
+        // Alice 的 pending 提案
+        $this->makeOperation($alice, Operation::TYPE_PROPOSAL_CREATE, [
+            'resource_data' => json_encode([
+                'c_name_chn' => 'Alice提案',
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by' => 'Alice', 'submitted_at' => now()->format('Y-m-d H:i:s')],
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        // Bob 的 pending 提案
+        $this->makeOperation($bob, Operation::TYPE_PROPOSAL_UPDATE, [
+            'resource_data' => json_encode([
+                'c_name_chn' => 'Bob提案',
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by' => 'Bob', 'submitted_at' => now()->format('Y-m-d H:i:s')],
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        // Alice 的 approved 提案
+        $this->makeOperation($alice, Operation::TYPE_PROPOSAL_CREATE, [
+            'resource_data' => json_encode([
+                'c_name_chn' => 'Alice已核准',
+                '__review_status' => 'approved',
+                '__proposal_meta' => ['submitted_by' => 'Alice', 'submitted_at' => now()->format('Y-m-d H:i:s')],
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        // 篩選 Alice 的 pending 提案
+        $response = $this->actingAs($alice)->get('/operations?proposals_only=1&status[]=pending&editor=Alice');
+
+        $response->assertStatus(200);
+
+        $lists = $response->viewData('lists');
+        $this->assertCount(1, $lists);
+        $this->assertSame($alice->id, $lists[0]->user_id);
+
+        $data = json_decode($lists[0]->resource_data, true);
+        $this->assertSame('pending', $data['__review_status']);
+    }
+}


### PR DESCRIPTION
## Summary
- 在 `/operations` 頁面新增「修改人」篩選（支援 user ID 精確匹配與名稱模糊匹配）和「修改類型」多選篩選
- 將提案模式的狀態篩選整合進統一表單，以明確提交按鈕取代舊的 auto-submit JavaScript
- 新增 7 個 Feature 測試覆蓋 editor 分流、op_type 白名單過濾、proposals 模式組合篩選

## Test plan
- [x] `./vendor/bin/phpunit --filter OperationsIndexFilterTest`（7 tests, 22 assertions 通過）
- [x] `./vendor/bin/phpunit`（603 tests, 2317 assertions 全部通過，無回歸）
- [x] `./vendor/bin/php-cs-fixer fix --dry-run`（無格式問題）
- [ ] 手動驗證 `/operations` 頁面篩選表單顯示與功能
- [ ] 手動驗證 `/operations?proposals_only=1` 提案狀態篩選正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)