### PR TITLE
統一 auto_pinyin 與 API 拼音轉換邏輯

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -10,7 +10,6 @@ use App\Models\EntryCode;
 use App\Models\EventCode;
 use App\Models\KinshipCode;
 use App\Models\OfficeCode;
-use App\Models\Pinyin;
 use App\Models\SocialInst;
 use App\Models\SocialInstAddr;
 use App\Models\SocialInstCode;
@@ -19,6 +18,7 @@ use App\Models\TextCode;
 use App\Repositories\AddrCodeRepository;
 use App\Repositories\AltCodeRepository;
 use App\Repositories\BiogAddrCodeRepository;
+use App\Repositories\BiogMainRepository;
 use App\Repositories\ChoronymRepository;
 use App\Repositories\DynastyRepository;
 use App\Repositories\EthnicityRepository;
@@ -552,18 +552,42 @@ class ApiController extends Controller {
     }
 
     public function searchPinyin(Request $request) {
-        $word = $request->q;
+        $word = trim((string) $request->q);
         if (!empty($word)) {
-            $pinyin = DB::table('pinyin')->select('lastname_pinyin')->where('lastname_chn', 'like', $word)->first();
-            if (!empty($pinyin->lastname_pinyin)) {
-                $res = $pinyin->lastname_pinyin;
+            // 特例 1：例如「（李白妻）」→「(Wife of Li Bai)」
+            if (preg_match('/^\s*[（(]\s*(.+?)\s*妻\s*[）)]\s*$/u', $word, $matches) === 1) {
+                $wifeOf = $this->buildPinyinWord($matches[1] ?? '');
+                $res = '(Wife of '.trim($wifeOf).')';
+                // 特例 2：例如「宗氏（李白妻）」→「Zong Shi (Wife of Li Bai)」
+            } elseif (preg_match('/^(.*?)[（(]\s*(.+?)\s*妻\s*[）)]\s*$/u', $word, $matches) === 1) {
+                $prefix = $this->buildPinyinWord($matches[1] ?? '');
+                $wifeOf = $this->buildPinyinWord($matches[2] ?? '');
+                $res = trim($prefix).' (Wife of '.trim($wifeOf).')';
             } else {
-                $res = ucfirst(Pinyin::getPinyin($word)) ?? '';
+                $res = $this->buildPinyinWord($word);
             }
+
+            // 全角括號轉半角，並確保括號前與文字之間有一個空格
+            $res = str_replace(['（', '）'], ['(', ')'], $res);
+            $res = preg_replace('/\s*\(/u', ' (', $res);
+            $res = preg_replace('/^\s+\(/u', '(', $res);
+            $res = trim($res);
 
             return $res;
         } else {
             return '';
         }
+    }
+
+    private function buildPinyinWord(string $word): string {
+        $word = trim($word);
+        if ($word === '') {
+            return '';
+        }
+
+        $repository = new BiogMainRepository();
+        $result = $repository->auto_pinyin(['c_name_chn' => $word]);
+
+        return trim((string) ($result['c_name'] ?? ''));
     }
 }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -3089,14 +3089,35 @@ class BiogMainRepository {
     //20230628觸發「自動生成」功能
     public function auto_pinyin($data) {
         $c_surname_chn = $c_surname = $c_mingzi_chn = $c_mingzi = $c_name = '';
-        $name = $data['c_name_chn'];
+        $name = trim((string) ($data['c_name_chn'] ?? ''));
+        if ($name === '') {
+            $data['c_surname_chn'] = '';
+            $data['c_surname'] = '';
+            $data['c_mingzi_chn'] = '';
+            $data['c_mingzi'] = '';
+            $data['c_name'] = '';
+
+            return $data;
+        }
+
         $len = mb_strlen($name, 'utf-8');
+        $prefixes = [];
         for ($i = $len; $i >= 1; $i--) {
-            $str = mb_substr($name, 0, $i, 'utf-8');
-            $pinyin = DB::table('pinyin')->select('lastname_pinyin')->where('lastname_chn', 'like', $str)->first();
-            if (!empty($pinyin->lastname_pinyin) && $len - $i <= 2) { //[名]的字長必須是小於等於二
-                $c_surname_chn = $str;
-                $c_surname = $pinyin->lastname_pinyin;
+            $prefixes[] = mb_substr($name, 0, $i, 'utf-8');
+        }
+
+        $surnameRows = DB::table('pinyin')
+            ->select('lastname_chn', 'lastname_pinyin')
+            ->whereIn('lastname_chn', $prefixes)
+            ->get()
+            ->keyBy('lastname_chn');
+
+        // 以最長前綴優先，盡量命中已知姓氏（包含複姓）
+        foreach ($prefixes as $prefix) {
+            $row = $surnameRows->get($prefix);
+            if (!empty($row?->lastname_pinyin)) {
+                $c_surname_chn = $prefix;
+                $c_surname = (string) $row->lastname_pinyin;
 
                 break;
             }

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -3100,10 +3100,11 @@ class BiogMainRepository {
             return $data;
         }
 
-        $len = mb_strlen($name, 'utf-8');
+        $normalizedNameForLookup = VariantCharNormalizer::normalize($name);
+        $len = mb_strlen($normalizedNameForLookup, 'utf-8');
         $prefixes = [];
         for ($i = $len; $i >= 1; $i--) {
-            $prefixes[] = mb_substr($name, 0, $i, 'utf-8');
+            $prefixes[] = mb_substr($normalizedNameForLookup, 0, $i, 'utf-8');
         }
 
         $surnameRows = DB::table('pinyin')
@@ -3125,11 +3126,12 @@ class BiogMainRepository {
 
         if ($c_surname_chn != '') {
             $surnameLength = mb_strlen($c_surname_chn, 'utf-8');
+            $c_surname_chn = mb_substr($name, 0, $surnameLength, 'utf-8');
             $c_mingzi_chn = mb_substr($name, $surnameLength, null, 'utf-8');
             // 標準化異體字（僅用於拼音轉換，不修改原始名字）
             $normalizedMingzi = VariantCharNormalizer::normalize($c_mingzi_chn);
             $c_mingzi = ucfirst(Pinyin::getPinyin($normalizedMingzi)) ?? '';
-            $c_name = $c_surname.' '.$c_mingzi;
+            $c_name = trim($c_surname.' '.$c_mingzi);
             $data['c_surname_chn'] = $c_surname_chn;
             $data['c_surname'] = $c_surname;
             $data['c_mingzi_chn'] = $c_mingzi_chn;

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -3124,7 +3124,8 @@ class BiogMainRepository {
         }
 
         if ($c_surname_chn != '') {
-            $c_mingzi_chn = str_replace($c_surname_chn, '', $name);
+            $surnameLength = mb_strlen($c_surname_chn, 'utf-8');
+            $c_mingzi_chn = mb_substr($name, $surnameLength, null, 'utf-8');
             // 標準化異體字（僅用於拼音轉換，不修改原始名字）
             $normalizedMingzi = VariantCharNormalizer::normalize($c_mingzi_chn);
             $c_mingzi = ucfirst(Pinyin::getPinyin($normalizedMingzi)) ?? '';

--- a/config/codes.php
+++ b/config/codes.php
@@ -61,6 +61,7 @@ return [
         'OFFICE_CODE_TYPE_REL' => '官職代碼與類型關聯表',
         'OFFICE_TYPE_TREE' => '官職類型層級樹',
         'PARENTAL_STATUS_CODES' => '父母狀況代碼表',
+        'pinyin' => '姓氏拼音對照表',
         'POSSESSION_ACT_CODES' => '財產行為代碼表',
         'POSSESSION_ADDR' => '財產地址資料表',
         'POSSESSION_DATA' => '財產資料表',

--- a/tests/Feature/ApiSearchPinyinTest.php
+++ b/tests/Feature/ApiSearchPinyinTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ApiSearchPinyinTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('pinyin');
+        Schema::create('pinyin', function (Blueprint $table) {
+            $table->string('lastname_chn')->primary();
+            $table->string('lastname_pinyin')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('pinyin');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function search_pinyin_converts_fullwidth_parentheses_and_keeps_space_before_parenthesis(): void {
+        $response = $this->get('/api/select/search/pinyin?q=宗氏（李白妻）');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertStringContainsString('(Wife of', $content);
+        $this->assertStringNotContainsString('（', $content);
+        $this->assertStringNotContainsString('）', $content);
+        $this->assertStringContainsString(' (', $content);
+    }
+
+    #[Test]
+    public function search_pinyin_converts_wife_pattern_to_wife_of_english_phrase(): void {
+        $response = $this->get('/api/select/search/pinyin?q=（李白妻）');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+        $this->assertStringStartsWith('(Wife of ', $content);
+        $this->assertStringEndsWith(')', $content);
+        $this->assertStringNotContainsString('妻', $content);
+    }
+
+    #[Test]
+    public function search_pinyin_matches_known_surname_using_same_logic_as_auto_pinyin(): void {
+        DB::table('pinyin')->insert([
+            'lastname_chn' => '王',
+            'lastname_pinyin' => 'Wang',
+        ]);
+
+        $response = $this->get('/api/select/search/pinyin?q=王安石傳');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+        $this->assertStringStartsWith('Wang ', $content);
+    }
+}

--- a/tests/Unit/AutoPinyinTest.php
+++ b/tests/Unit/AutoPinyinTest.php
@@ -41,6 +41,7 @@ class AutoPinyinTest extends TestCase {
         DB::table('pinyin')->insert([
             ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
             ['lastname_chn' => '歐陽', 'lastname_pinyin' => 'Ouyang'],
+            ['lastname_chn' => '林', 'lastname_pinyin' => 'Lin'],
         ]);
 
         $this->repository = new BiogMainRepository();
@@ -103,5 +104,15 @@ class AutoPinyinTest extends TestCase {
         $this->assertSame('Wang', $result['c_surname']);
         $this->assertSame('安石傳', $result['c_mingzi_chn']);
         $this->assertSame('Wang ' . $result['c_mingzi'], $result['c_name']);
+    }
+
+    #[Test]
+    public function testRepeatedCharacterNameKeepsGivenNameAfterSurnameSplit(): void {
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '林林']);
+
+        $this->assertSame('林', $result['c_surname_chn']);
+        $this->assertSame('Lin', $result['c_surname']);
+        $this->assertSame('林', $result['c_mingzi_chn']);
+        $this->assertSame('Lin Lin', $result['c_name']);
     }
 }

--- a/tests/Unit/AutoPinyinTest.php
+++ b/tests/Unit/AutoPinyinTest.php
@@ -42,6 +42,7 @@ class AutoPinyinTest extends TestCase {
             ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
             ['lastname_chn' => '歐陽', 'lastname_pinyin' => 'Ouyang'],
             ['lastname_chn' => '林', 'lastname_pinyin' => 'Lin'],
+            ['lastname_chn' => '於', 'lastname_pinyin' => 'Yu'],
         ]);
 
         $this->repository = new BiogMainRepository();
@@ -94,6 +95,7 @@ class AutoPinyinTest extends TestCase {
         $this->assertSame('王', $result['c_surname_chn']);
         $this->assertSame('Wang', $result['c_surname']);
         $this->assertSame('', $result['c_mingzi_chn']);
+        $this->assertSame('Wang', $result['c_name']);
     }
 
     #[Test]
@@ -114,5 +116,15 @@ class AutoPinyinTest extends TestCase {
         $this->assertSame('Lin', $result['c_surname']);
         $this->assertSame('林', $result['c_mingzi_chn']);
         $this->assertSame('Lin Lin', $result['c_name']);
+    }
+
+    #[Test]
+    public function testVariantSurnameCanMatchNormalizedKnownSurname(): void {
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '于慎行']);
+
+        $this->assertSame('于', $result['c_surname_chn']);
+        $this->assertSame('Yu', $result['c_surname']);
+        $this->assertSame('慎行', $result['c_mingzi_chn']);
+        $this->assertStringStartsWith('Yu ', $result['c_name']);
     }
 }

--- a/tests/Unit/AutoPinyinTest.php
+++ b/tests/Unit/AutoPinyinTest.php
@@ -94,4 +94,14 @@ class AutoPinyinTest extends TestCase {
         $this->assertSame('Wang', $result['c_surname']);
         $this->assertSame('', $result['c_mingzi_chn']);
     }
+
+    #[Test]
+    public function testKnownSurnameStillMatchesWhenGivenNameLongerThanTwoChars(): void {
+        $result = $this->repository->auto_pinyin(['c_name_chn' => '王安石傳']);
+
+        $this->assertSame('王', $result['c_surname_chn']);
+        $this->assertSame('Wang', $result['c_surname']);
+        $this->assertSame('安石傳', $result['c_mingzi_chn']);
+        $this->assertSame('Wang ' . $result['c_mingzi'], $result['c_name']);
+    }
 }


### PR DESCRIPTION
- BiogMainRepository::auto_pinyin 改為最長已知姓氏前綴匹配，移除名長度限制並補空值防護。
- ApiController::searchPinyin 透過 repository 共用同一套轉換邏輯，避免 API 與按鈕行為分歧。
- 補齊單元與功能測試，涵蓋已知姓氏匹配與括號/妻稱轉換場景。

測試：./vendor/bin/phpunit tests/Unit/AutoPinyinTest.php tests/Feature/ApiSearchPinyinTest.php

https://github.com/cbdb-project/cbdb-online-main-server/issues/829