### PR TITLE
整合只讀 SQL 查詢驗證並統一表名解析邏輯

### DIFF
--- a/app/Http/Controllers/AdminExplainSqlController.php
+++ b/app/Http/Controllers/AdminExplainSqlController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\Mcp\ReadOnlyTableQueryService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 
 class AdminExplainSqlController extends Controller {
     protected function ensureAdmin() {
@@ -38,16 +40,13 @@ class AdminExplainSqlController extends Controller {
         $error = null;
         $results = null;
         $columns = [];
+        $service = app(ReadOnlyTableQueryService::class);
 
-        if (strpos($sql, ';') !== false) {
-            $error = '請勿在語句中包含分號。';
-        } else {
-            $firstToken = strtoupper(strtok(ltrim($sql), " \t\n\r"));
-            $allowed = ['SELECT', 'WITH'];
-
-            if (!in_array($firstToken, $allowed, true)) {
-                $error = '僅允許只讀查詢（SELECT / WITH）。';
-            }
+        try {
+            $inspection = $service->inspectReadOnlySql($sql);
+            $sql = $inspection['sql'];
+        } catch (InvalidArgumentException $e) {
+            $error = $e->getMessage();
         }
 
         if (!$error) {

--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -3,12 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Services\NaturalLanguageQueryService;
+use App\Services\SqlTableNameExtractor;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use PhpMyAdmin\SqlParser\Components\Expression;
-use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 
 class QueryPlaygroundController extends Controller {
     public function __construct() {
@@ -64,16 +62,6 @@ class QueryPlaygroundController extends Controller {
             ], 403);
         }
 
-        // Remove trailing semicolons to allow "SELECT ...;"
-        $sql = rtrim($sql, "; \t\n\r\0\x0B");
-
-        // Check for multiple statements (semicolon inside query)
-        if (strpos($sql, ';') !== false) {
-            return response()->json([
-               'error' => "Forbidden character detected: ';'. Multiple statements are not allowed.",
-            ], 403);
-        }
-
         $page = (int) $request->input('page', 1);
         $perPage = 20;
         $offset = ($page - 1) * $perPage;
@@ -93,7 +81,7 @@ class QueryPlaygroundController extends Controller {
         // Add internal allowed tables if not in codes.tables but deemed safe?
         // For now strict adherence to codes.tables as requested.
 
-        $tablesInQuery = $this->extractTableNames($sql);
+        $tablesInQuery = app(SqlTableNameExtractor::class)->extractTableNames($sql);
 
         if (empty($tablesInQuery)) {
             return response()->json([
@@ -153,109 +141,6 @@ class QueryPlaygroundController extends Controller {
                 'error' => 'Database Error: ' . $e->getMessage(),
             ], 500);
         }
-    }
-
-    /**
-     * Extract table names from SQL queries using AST parser.
-     * This correctly handles subqueries, quoted identifiers, and string literals.
-     */
-    protected function extractTableNames($sql) {
-        try {
-            // Parse the SQL using PhpMyAdmin SQL Parser
-            $parser = new Parser($sql);
-
-            $tables = [];
-
-            // Process all statements (usually just one SELECT)
-            foreach ($parser->statements as $statement) {
-                if ($statement instanceof SelectStatement) {
-                    $tables = array_merge($tables, $this->extractTablesFromSelectStatement($statement));
-                }
-            }
-
-            // Check for parser errors
-            if (!empty($parser->errors)) {
-                // If parser fails, return empty array to trigger the "could not detect" error
-                return [];
-            }
-
-            return array_unique($tables);
-        } catch (\Exception $e) {
-            // If parsing fails entirely, return empty array
-            return [];
-        }
-    }
-
-    /**
-     * Recursively extract table names from a SELECT statement and its subqueries.
-     */
-    protected function extractTablesFromSelectStatement(SelectStatement $statement) {
-        $tables = [];
-
-        // Extract from FROM clause
-        if ($statement->from) {
-            foreach ($statement->from as $fromClause) {
-                // Check if this is a subquery (indicated by subquery property or expr starting with '(')
-                if ($fromClause->subquery || (is_string($fromClause->expr) && strpos($fromClause->expr, '(') === 0)) {
-                    // Extract subquery content from parentheses
-                    $subqueryContent = $fromClause->expr;
-                    if (is_string($subqueryContent) && preg_match('/^\((.*)\)$/s', $subqueryContent, $matches)) {
-                        // Parse the subquery
-                        $subqueryParser = new Parser($matches[1]);
-                        foreach ($subqueryParser->statements as $subStatement) {
-                            if ($subStatement instanceof SelectStatement) {
-                                $tables = array_merge($tables, $this->extractTablesFromSelectStatement($subStatement));
-                            }
-                        }
-                    }
-                } elseif ($fromClause->table) {
-                    // Regular table reference
-                    $tableName = $fromClause->table;
-                    if (is_string($tableName)) {
-                        $tableName = trim($tableName, '`\'"');
-                        if (!empty($tableName)) {
-                            $tables[] = $tableName;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Extract from JOIN clauses
-        if ($statement->join) {
-            foreach ($statement->join as $joinClause) {
-                // JOIN clause expr is an Expression object
-                if ($joinClause->expr instanceof Expression) {
-                    $expression = $joinClause->expr;
-
-                    // Check if this is a subquery
-                    if ($expression->subquery || (is_string($expression->expr) && strpos($expression->expr, '(') === 0)) {
-                        // Extract subquery content from parentheses
-                        $subqueryContent = $expression->expr;
-                        if (is_string($subqueryContent) && preg_match('/^\((.*)\)$/s', $subqueryContent, $matches)) {
-                            // Parse the subquery
-                            $subqueryParser = new Parser($matches[1]);
-                            foreach ($subqueryParser->statements as $subStatement) {
-                                if ($subStatement instanceof SelectStatement) {
-                                    $tables = array_merge($tables, $this->extractTablesFromSelectStatement($subStatement));
-                                }
-                            }
-                        }
-                    } elseif ($expression->table) {
-                        // Regular table reference
-                        $tableName = $expression->table;
-                        if (is_string($tableName)) {
-                            $tableName = trim($tableName, '`\'"');
-                            if (!empty($tableName)) {
-                                $tables[] = $tableName;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return $tables;
     }
 
     /**

--- a/app/Mcp/Servers/CbdbReadOnlyServer.php
+++ b/app/Mcp/Servers/CbdbReadOnlyServer.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Servers;
 use App\Mcp\Tools\GetSampleDataTool;
 use App\Mcp\Tools\GetTableRowByIdTool;
 use App\Mcp\Tools\ListAllowedTablesTool;
+use App\Mcp\Tools\QueryReadOnlySqlTool;
 use App\Mcp\Tools\QueryTableSchemaTool;
 use App\Mcp\Tools\QueryTableTool;
 use Laravel\Mcp\Server;
@@ -22,5 +23,6 @@ class CbdbReadOnlyServer extends Server {
         GetTableRowByIdTool::class,
         GetSampleDataTool::class,
         QueryTableTool::class,
+        QueryReadOnlySqlTool::class,
     ];
 }

--- a/app/Mcp/Tools/QueryReadOnlySqlTool.php
+++ b/app/Mcp/Tools/QueryReadOnlySqlTool.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Services\Mcp\ReadOnlyTableQueryService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class QueryReadOnlySqlTool extends Tool {
+    public string $name = 'query_read_only_sql';
+
+    public string $description = 'Execute a read-only SQL query (SELECT/WITH only) against allowlisted tables.';
+
+    public function schema(JsonSchema $schema): array {
+        return [
+            'sql' => $schema->string()->description('Read-only SQL (SELECT/WITH only)')->required(),
+            'limit' => $schema->integer()->description('Max rows to return (1-100)')->default(20),
+            'offset' => $schema->integer()->description('Rows to skip')->default(0),
+        ];
+    }
+
+    public function handle(Request $request): Response {
+        $service = app(ReadOnlyTableQueryService::class);
+
+        return Response::text(json_encode(
+            $service->queryReadOnlySql(
+                (string) $request->get('sql'),
+                (int) $request->get('limit', 20),
+                (int) $request->get('offset', 0)
+            ),
+            JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
+        ));
+    }
+}

--- a/app/Services/Mcp/ReadOnlyTableQueryService.php
+++ b/app/Services/Mcp/ReadOnlyTableQueryService.php
@@ -2,12 +2,35 @@
 
 namespace App\Services\Mcp;
 
+use App\Services\SqlTableNameExtractor;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 
 class ReadOnlyTableQueryService {
     private const IDENTIFIER_PATTERN = '/^[A-Za-z0-9_]+$/';
+
+    /**
+     * Forbidden keywords for read-only SQL execution.
+     *
+     * @var string[]
+     */
+    private array $forbiddenKeywords = [
+        'UPDATE', 'DELETE', 'INSERT', 'ALTER', 'DROP', 'TRUNCATE',
+        'CREATE', 'GRANT', 'REVOKE', 'REPLACE', 'LOCK', 'UNLOCK',
+        'COMMIT', 'ROLLBACK', 'SAVEPOINT', 'SET', 'EXECUTE', 'CALL',
+        'SHOW', 'DESCRIBE', 'USE', 'EXPLAIN',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private array $forbiddenPatterns = [
+        '/\bINTO\s+OUTFILE\b/i',
+        '/\bINTO\s+DUMPFILE\b/i',
+        '/\bFOR\s+UPDATE\b/i',
+        '/\bLOCK\s+IN\s+SHARE\s+MODE\b/i',
+    ];
 
     /**
      * @return string[]
@@ -163,6 +186,51 @@ class ReadOnlyTableQueryService {
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function queryReadOnlySql(string $sql, int $limit = 20, int $offset = 0): array {
+        $inspection = $this->inspectReadOnlySql($sql);
+        $normalizedSql = $inspection['sql'];
+        $limit = $this->sanitizeLimit($limit);
+        $offset = $this->sanitizeOffset($offset);
+
+        $rows = DB::select($this->buildPaginatedSql($normalizedSql, $limit, $offset));
+        $normalizedRows = array_map(static fn ($row): array => (array) $row, $rows);
+
+        return [
+            'sql' => $normalizedSql,
+            'tables' => $inspection['tables'],
+            'limit' => $limit,
+            'offset' => $offset,
+            'returned_rows' => count($normalizedRows),
+            'rows' => $normalizedRows,
+        ];
+    }
+
+    /**
+     * @return array{sql:string,tables:string[]}
+     */
+    public function inspectReadOnlySql(string $sql): array {
+        $normalizedSql = $this->normalizeAndValidateReadOnlySql($sql);
+
+        $tablesInQuery = app(SqlTableNameExtractor::class)->extractTableNames($normalizedSql);
+        if ($tablesInQuery === []) {
+            throw new InvalidArgumentException('Could not detect any table names. Please ensure your query is standard SQL.');
+        }
+
+        $normalizedTables = [];
+        foreach ($tablesInQuery as $table) {
+            $normalizedTableName = $this->normalizeAllowedTableName($table);
+            $normalizedTables[$normalizedTableName] = $normalizedTableName;
+        }
+
+        return [
+            'sql' => $normalizedSql,
+            'tables' => array_values($normalizedTables),
+        ];
+    }
+
     private function sanitizeLimit(int $limit): int {
         $maxLimit = (int) config('mcp.cbdb.max_limit', 100);
         if ($limit < 1 || $limit > $maxLimit) {
@@ -178,6 +246,45 @@ class ReadOnlyTableQueryService {
         }
 
         return $offset;
+    }
+
+    private function normalizeAndValidateReadOnlySql(string $sql): string {
+        $normalizedSql = trim($sql);
+        $normalizedSql = rtrim($normalizedSql, "; \t\n\r\0\x0B");
+
+        if ($normalizedSql === '') {
+            throw new InvalidArgumentException('SQL must not be empty');
+        }
+
+        if (strpos($normalizedSql, ';') !== false) {
+            throw new InvalidArgumentException("Multiple SQL statements separated by ';' are not allowed. A single trailing ';' is permitted.");
+        }
+
+        if (!preg_match('/^(SELECT|WITH)\b/i', $normalizedSql)) {
+            throw new InvalidArgumentException('Only SELECT / WITH queries are allowed.');
+        }
+
+        foreach ($this->forbiddenKeywords as $keyword) {
+            if (preg_match('/\b' . preg_quote($keyword, '/') . '\b/i', $normalizedSql)) {
+                throw new InvalidArgumentException("Forbidden keyword detected: {$keyword}");
+            }
+        }
+
+        foreach ($this->forbiddenPatterns as $pattern) {
+            if (preg_match($pattern, $normalizedSql)) {
+                throw new InvalidArgumentException('SQL contains forbidden read-only side-effect clauses.');
+            }
+        }
+
+        return $normalizedSql;
+    }
+
+    private function buildPaginatedSql(string $sql, int $limit, int $offset): string {
+        if (preg_match('/^WITH\b/i', $sql)) {
+            return $sql . " LIMIT {$limit} OFFSET {$offset}";
+        }
+
+        return "SELECT * FROM ({$sql}) AS subquery_wrapper LIMIT {$limit} OFFSET {$offset}";
     }
 
     /**

--- a/app/Services/SqlTableNameExtractor.php
+++ b/app/Services/SqlTableNameExtractor.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use PhpMyAdmin\SqlParser\Components\Expression;
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statements\SelectStatement;
+use PhpMyAdmin\SqlParser\Statements\WithStatement;
+
+class SqlTableNameExtractor {
+    private const IDENTIFIER_PATTERN = '/^[A-Za-z0-9_]+$/';
+    private const EXPLAIN_DERIVED_PATTERN = '/^<[^>]+>$/';
+
+    /**
+     * @return string[]
+     */
+    public function extractTableNames(string $sql): array {
+        $tablesFromParser = $this->extractTableNamesFromParser($sql);
+        if ($tablesFromParser !== []) {
+            return $tablesFromParser;
+        }
+
+        $cteAliases = $this->extractCteAliasesFromSql($sql);
+
+        return $this->extractTableNamesFromExplain($sql, $cteAliases);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function extractTableNamesFromParser(string $sql): array {
+        try {
+            $parser = new Parser($sql);
+            if (!empty($parser->errors)) {
+                return [];
+            }
+
+            $tables = [];
+            $cteAliases = [];
+
+            foreach ($parser->statements as $statement) {
+                $tables = array_merge($tables, $this->extractTablesFromStatement($statement, $cteAliases));
+            }
+
+            return $this->normalizeAndFilterTables($tables, $cteAliases);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function extractTablesFromStatement(object $statement, array &$cteAliases): array {
+        if ($statement instanceof SelectStatement) {
+            return $this->extractTablesFromSelectStatement($statement, $cteAliases);
+        }
+
+        if ($statement instanceof WithStatement) {
+            return $this->extractTablesFromWithStatement($statement, $cteAliases);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function extractTablesFromWithStatement(WithStatement $statement, array &$cteAliases): array {
+        $tables = [];
+
+        foreach ($statement->withers as $key => $withClause) {
+            $alias = is_string($key) ? $key : (is_string($withClause->name ?? null) ? $withClause->name : '');
+            $alias = $this->normalizeTableName($alias);
+            if ($alias !== '') {
+                $cteAliases[strtoupper($alias)] = true;
+            }
+
+            $withStatementParser = $withClause->statement ?? null;
+            if ($withStatementParser instanceof Parser) {
+                foreach ($withStatementParser->statements as $withStatement) {
+                    $tables = array_merge($tables, $this->extractTablesFromStatement($withStatement, $cteAliases));
+                }
+            }
+        }
+
+        if ($statement->cteStatementParser instanceof Parser) {
+            foreach ($statement->cteStatementParser->statements as $cteStatement) {
+                $tables = array_merge($tables, $this->extractTablesFromStatement($cteStatement, $cteAliases));
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function extractTablesFromSelectStatement(SelectStatement $statement, array &$cteAliases): array {
+        $tables = [];
+
+        if ($statement->from) {
+            foreach ($statement->from as $fromClause) {
+                if ($fromClause->subquery || (is_string($fromClause->expr) && strpos($fromClause->expr, '(') === 0)) {
+                    $tables = array_merge($tables, $this->extractTablesFromSubquery((string) $fromClause->expr, $cteAliases));
+                } elseif ($fromClause->table) {
+                    $tables[] = (string) $fromClause->table;
+                }
+            }
+        }
+
+        if ($statement->join) {
+            foreach ($statement->join as $joinClause) {
+                if (!$joinClause->expr instanceof Expression) {
+                    continue;
+                }
+
+                $expression = $joinClause->expr;
+                if ($expression->subquery || (is_string($expression->expr) && strpos($expression->expr, '(') === 0)) {
+                    $tables = array_merge($tables, $this->extractTablesFromSubquery((string) $expression->expr, $cteAliases));
+                } elseif ($expression->table) {
+                    $tables[] = (string) $expression->table;
+                }
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function extractTablesFromSubquery(string $subqueryExpression, array &$cteAliases): array {
+        if (!preg_match('/^\((.*)\)$/s', $subqueryExpression, $matches)) {
+            return [];
+        }
+
+        try {
+            $subqueryParser = new Parser($matches[1]);
+            if (!empty($subqueryParser->errors)) {
+                return [];
+            }
+
+            $tables = [];
+            foreach ($subqueryParser->statements as $subStatement) {
+                $tables = array_merge($tables, $this->extractTablesFromStatement($subStatement, $cteAliases));
+            }
+
+            return $tables;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function extractTableNamesFromExplain(string $sql, array $cteAliases): array {
+        $driver = DB::connection()->getDriverName();
+
+        try {
+            if ($driver === 'sqlite') {
+                $planRows = DB::select('EXPLAIN QUERY PLAN ' . $sql);
+                $tables = [];
+
+                foreach ($planRows as $row) {
+                    $detail = (string) ($row->detail ?? '');
+                    if (preg_match_all('/\b(?:SCAN|SEARCH)\s+[`\"]?([A-Za-z0-9_]+)[`\"]?/i', $detail, $matches)) {
+                        foreach ($matches[1] as $table) {
+                            $tables[] = $table;
+                        }
+                    }
+                }
+
+                return $this->normalizeAndFilterTables($tables, $cteAliases);
+            }
+
+            $planRows = DB::select('EXPLAIN ' . $sql);
+            $tables = [];
+
+            foreach ($planRows as $row) {
+                $table = (string) ($row->table ?? '');
+                if ($table !== '') {
+                    $tables[] = $table;
+                }
+            }
+
+            return $this->normalizeAndFilterTables($tables, $cteAliases);
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function extractCteAliasesFromSql(string $sql): array {
+        $aliases = [];
+
+        if (preg_match_all('/\b([A-Za-z0-9_`"]+)\s+AS\s*\(/i', $sql, $matches)) {
+            foreach ($matches[1] as $match) {
+                $alias = $this->normalizeTableName((string) $match);
+                if ($alias !== '') {
+                    $aliases[strtoupper($alias)] = true;
+                }
+            }
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @param string[] $tables
+     * @param array<string, bool> $cteAliases
+     * @return string[]
+     */
+    private function normalizeAndFilterTables(array $tables, array $cteAliases): array {
+        $normalized = [];
+
+        foreach ($tables as $table) {
+            $tableName = $this->normalizeTableName((string) $table);
+            if ($tableName === '') {
+                continue;
+            }
+
+            if (preg_match(self::EXPLAIN_DERIVED_PATTERN, $tableName) === 1) {
+                continue;
+            }
+
+            if (isset($cteAliases[strtoupper($tableName)])) {
+                continue;
+            }
+
+            if (preg_match(self::IDENTIFIER_PATTERN, $tableName) !== 1) {
+                continue;
+            }
+
+            $normalized[strtoupper($tableName)] = $tableName;
+        }
+
+        return array_values($normalized);
+    }
+
+    private function normalizeTableName(string $tableName): string {
+        $tableName = trim($tableName);
+        if ($tableName === '') {
+            return '';
+        }
+
+        if (str_contains($tableName, '.')) {
+            $parts = explode('.', $tableName);
+            $tableName = (string) end($parts);
+        }
+
+        return trim($tableName, "`'\" \t\n\r\0\x0B");
+    }
+}

--- a/tests/Feature/AdminExplainSqlTest.php
+++ b/tests/Feature/AdminExplainSqlTest.php
@@ -16,6 +16,8 @@ class AdminExplainSqlTest extends TestCase {
 
         config()->set('database.default', 'sqlite');
         config()->set('database.connections.sqlite.database', ':memory:');
+        config()->set('mcp.cbdb.allowed_tables', ['sample']);
+        config()->set('mcp.cbdb.max_limit', 100);
 
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
@@ -102,5 +104,34 @@ class AdminExplainSqlTest extends TestCase {
         $response->assertStatus(200)
             ->assertSee('MySQL EXPLAIN')
             ->assertSee('本次查詢共');
+    }
+
+    #[Test]
+    public function test_explain_rejects_non_allowlisted_tables(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::statement('CREATE TABLE sample (id INTEGER)');
+        DB::statement('CREATE TABLE users2 (id INTEGER)');
+
+        $response = $this->post('/admin/explainsql', [
+            'sql' => 'SELECT * FROM users2',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertSeeText("Table 'users2' is not in allowlist");
+    }
+
+    #[Test]
+    public function test_explain_rejects_non_select_queries(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->post('/admin/explainsql', [
+            'sql' => 'DELETE FROM sample',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertSee('Only SELECT / WITH queries are allowed.');
     }
 }

--- a/tests/Feature/QueryPlaygroundTest.php
+++ b/tests/Feature/QueryPlaygroundTest.php
@@ -239,6 +239,17 @@ class QueryPlaygroundTest extends TestCase {
     }
 
     #[Test]
+    public function it_allows_with_queries_using_whitelisted_tables() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'WITH allowed_rows AS (SELECT * FROM ALLOWED1) SELECT * FROM allowed_rows',
+        ]);
+
+        $this->assertNotEquals(403, $response->status(), 'Should allow WITH query that only uses whitelisted tables');
+    }
+
+    #[Test]
     public function it_handles_real_world_example_from_issue() {
         $this->be($this->adminUser);
 

--- a/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
+++ b/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
@@ -124,4 +124,65 @@ class ReadOnlyTableQueryServiceTest extends TestCase {
         $this->assertSame('sqlite', $result['table_info']['driver']);
         $this->assertNotEmpty($result['columns']);
     }
+
+    #[Test]
+    public function it_executes_read_only_sql_for_allowlisted_tables(): void {
+        $result = $this->service->queryReadOnlySql(
+            "SELECT c_dy, c_dynasty_chn FROM DYNASTIES WHERE status = 'active' ORDER BY c_dy",
+            10,
+            0
+        );
+
+        $this->assertSame(['DYNASTIES'], $result['tables']);
+        $this->assertSame(2, $result['returned_rows']);
+        $this->assertContains('Tang', array_column($result['rows'], 'c_dy'));
+    }
+
+    #[Test]
+    public function it_rejects_non_allowlisted_table_in_read_only_sql(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not in allowlist');
+
+        $this->service->queryReadOnlySql('SELECT * FROM users');
+    }
+
+    #[Test]
+    public function it_supports_with_query_in_read_only_sql(): void {
+        $result = $this->service->queryReadOnlySql(
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy',
+            10,
+            0
+        );
+
+        $this->assertSame(['DYNASTIES'], $result['tables']);
+        $this->assertSame(2, $result['returned_rows']);
+    }
+
+    #[Test]
+    public function it_supports_multiple_ctes_without_treating_aliases_as_tables(): void {
+        $result = $this->service->queryReadOnlySql(
+            'WITH cte_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active"), cte_people AS (SELECT c_personid FROM BIOG_MAIN) SELECT cte_dynasties.c_dy FROM cte_dynasties JOIN cte_people ON 1 = 1 ORDER BY cte_dynasties.c_dy',
+            10,
+            0
+        );
+
+        $this->assertEqualsCanonicalizing(['DYNASTIES', 'BIOG_MAIN'], $result['tables']);
+        $this->assertSame(2, $result['returned_rows']);
+    }
+
+    #[Test]
+    public function it_rejects_into_outfile_clause_in_read_only_sql(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('forbidden read-only side-effect clauses');
+
+        $this->service->queryReadOnlySql('SELECT c_dy INTO OUTFILE "x" FROM DYNASTIES');
+    }
+
+    #[Test]
+    public function it_rejects_non_select_read_only_sql(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only SELECT / WITH queries are allowed');
+
+        $this->service->queryReadOnlySql('DELETE FROM DYNASTIES');
+    }
 }

--- a/tests/Unit/Services/SqlTableNameExtractorTest.php
+++ b/tests/Unit/Services/SqlTableNameExtractorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\SqlTableNameExtractor;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SqlTableNameExtractorTest extends TestCase {
+    protected SqlTableNameExtractor $extractor;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        DB::statement('PRAGMA foreign_keys = OFF');
+        DB::statement('DROP TABLE IF EXISTS DYNASTIES');
+        DB::statement('DROP TABLE IF EXISTS BIOG_MAIN');
+        DB::statement('CREATE TABLE DYNASTIES (c_dy TEXT PRIMARY KEY, status TEXT)');
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY)');
+
+        $this->extractor = new SqlTableNameExtractor();
+    }
+
+    #[Test]
+    public function it_extracts_tables_from_simple_select(): void {
+        $tables = $this->extractor->extractTableNames('SELECT c_dy FROM DYNASTIES');
+
+        $this->assertSame(['DYNASTIES'], $tables);
+    }
+
+    #[Test]
+    public function it_extracts_base_tables_from_with_query(): void {
+        $tables = $this->extractor->extractTableNames(
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties'
+        );
+
+        $this->assertSame(['DYNASTIES'], $tables);
+    }
+
+    #[Test]
+    public function it_extracts_base_tables_from_multiple_ctes(): void {
+        $tables = $this->extractor->extractTableNames(
+            'WITH cte_dynasties AS (SELECT c_dy FROM DYNASTIES), cte_people AS (SELECT c_personid FROM BIOG_MAIN) SELECT cte_dynasties.c_dy FROM cte_dynasties JOIN cte_people ON 1 = 1'
+        );
+
+        $this->assertEqualsCanonicalizing(['DYNASTIES', 'BIOG_MAIN'], $tables);
+    }
+
+    #[Test]
+    public function it_normalizes_schema_qualified_table_names(): void {
+        $tables = $this->extractor->extractTableNames('SELECT * FROM main.DYNASTIES');
+
+        $this->assertSame(['DYNASTIES'], $tables);
+    }
+}


### PR DESCRIPTION
- 新增 query_read_only_sql MCP 工具，提供 SELECT/WITH 查詢能力，並支援 limit/offset 分頁輸出。

- 在 ReadOnlyTableQueryService 強化只讀 SQL 安全檢查：
  * 僅允許 SELECT/WITH，禁止多語句與副作用子句（如 INTO OUTFILE / FOR UPDATE）。
  * 新增 inspectReadOnlySql() 供多入口共用，避免 Controller 與 Service 驗證邏輯分岔。

- 抽出 SqlTableNameExtractor 共用服務：
  * 以 AST 解析為主，支援 WITH、子查詢、JOIN、巢狀查詢。
  * 過濾 CTE alias 與 EXPLAIN 衍生表名，避免誤判為實際資料表。
  * 正規化 schema-qualified 名稱後再做 allowlist 比對。

- 將 QueryPlaygroundController 與 AdminExplainSqlController 改為共用同一套只讀 SQL 與表名驗證。

- 補強測試涵蓋：
  * MCP 只讀 SQL：WITH、多 CTE、非 allowlist、非 SELECT/WITH、副作用子句拒絕。
  * 共用表名解析服務：基本查詢、WITH、多 CTE、schema.table 正規化。
  * Query Playground 與 Admin EXPLAIN 的白名單與拒絕情境。

- 驗證：
  * ./vendor/bin/phpunit tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
  * ./vendor/bin/phpunit tests/Unit/Services/SqlTableNameExtractorTest.php
  * ./vendor/bin/phpunit tests/Feature/QueryPlaygroundTest.php
  * ./vendor/bin/phpunit tests/Feature/AdminExplainSqlTest.php
  * ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff