### PR TITLE
修補 UNION 查詢白名單繞過漏洞

### DIFF
--- a/app/Services/SqlTableNameExtractor.php
+++ b/app/Services/SqlTableNameExtractor.php
@@ -128,6 +128,19 @@ class SqlTableNameExtractor {
             }
         }
 
+        if ($statement->union) {
+            foreach ($statement->union as $unionEntry) {
+                if (!is_array($unionEntry) || count($unionEntry) < 2) {
+                    continue;
+                }
+
+                $unionStatement = $unionEntry[1] ?? null;
+                if ($unionStatement instanceof SelectStatement) {
+                    $tables = array_merge($tables, $this->extractTablesFromSelectStatement($unionStatement, $cteAliases));
+                }
+            }
+        }
+
         return $tables;
     }
 

--- a/tests/Feature/QueryPlaygroundTest.php
+++ b/tests/Feature/QueryPlaygroundTest.php
@@ -146,6 +146,18 @@ class QueryPlaygroundTest extends TestCase {
     }
 
     #[Test]
+    public function it_blocks_non_whitelisted_tables_in_union_queries() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.run'), [
+            'sql' => 'SELECT * FROM ALLOWED1 UNION ALL SELECT * FROM users',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertStringContainsString('users', strtolower($response->json()['error'] ?? ''));
+    }
+
+    #[Test]
     public function it_blocks_multiple_statements() {
         $this->be($this->adminUser);
 

--- a/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
+++ b/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
@@ -147,6 +147,14 @@ class ReadOnlyTableQueryServiceTest extends TestCase {
     }
 
     #[Test]
+    public function it_rejects_non_allowlisted_table_in_union_read_only_sql(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not in allowlist');
+
+        $this->service->queryReadOnlySql('SELECT c_dy FROM DYNASTIES UNION ALL SELECT id FROM users');
+    }
+
+    #[Test]
     public function it_supports_with_query_in_read_only_sql(): void {
         $result = $this->service->queryReadOnlySql(
             'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy',

--- a/tests/Unit/Services/SqlTableNameExtractorTest.php
+++ b/tests/Unit/Services/SqlTableNameExtractorTest.php
@@ -53,4 +53,11 @@ class SqlTableNameExtractorTest extends TestCase {
 
         $this->assertSame(['DYNASTIES'], $tables);
     }
+
+    #[Test]
+    public function it_extracts_tables_from_union_queries(): void {
+        $tables = $this->extractor->extractTableNames('SELECT * FROM DYNASTIES UNION ALL SELECT * FROM BIOG_MAIN');
+
+        $this->assertEqualsCanonicalizing(['DYNASTIES', 'BIOG_MAIN'], $tables);
+    }
 }


### PR DESCRIPTION
- 在 SqlTableNameExtractor 補上 union 分支遞迴解析，確保 UNION/UNION ALL 的所有子查詢都會抽取表名
- 補充 MCP 與 Query Playground 回歸測試，驗證 union 含非 allowlist 表會被拒絕
- 補充 extractor 單元測試，驗證 union 可正確抽取多個基礎表