### PR TITLE
在每日 SQLite 導出前重建索引年份與索引地址

### DIFF
--- a/scripts/export-daily-sqlite.sh
+++ b/scripts/export-daily-sqlite.sh
@@ -134,6 +134,15 @@ echo "表格數量: ${#TABLES[@]}"
 echo "================================================"
 echo ""
 
+# 導出前先重建索引欄位（寫回來源資料庫）
+echo "預處理：重建 BIOG_MAIN 索引年份..."
+php artisan cbdb:rebuild-index-year --no-interaction
+echo ""
+
+echo "預處理：重建 BIOG_MAIN 索引地址..."
+php artisan cbdb:rebuild-index-address --no-interaction
+echo ""
+
 # 計數器
 TOTAL=${#TABLES[@]}
 CURRENT=0


### PR DESCRIPTION
於 export-daily-sqlite 腳本加入 cbdb:rebuild-index-year 與 cbdb:rebuild-index-address。

確保導出的 BIOG_MAIN 包含最新 index year 與 index address 欄位值。