### PR TITLE
改善 list_allowed_tables 參數設計並補齊 MCP schema 檢查

### DIFF
--- a/app/Mcp/Tools/ListAllowedTablesTool.php
+++ b/app/Mcp/Tools/ListAllowedTablesTool.php
@@ -14,12 +14,22 @@ class ListAllowedTablesTool extends Tool {
     public string $description = 'List all allowlisted tables that MCP can query.';
 
     public function schema(JsonSchema $schema): array {
-        return [];
+        return [
+            'keyword' => $schema->string()
+                ->description('Optional keyword filter for table names (case-insensitive).'),
+        ];
     }
 
     public function handle(Request $request): Response {
         $service = app(ReadOnlyTableQueryService::class);
         $tables = $service->listAllowedTables();
+        $keyword = trim((string) $request->get('keyword', ''));
+
+        if ($keyword !== '') {
+            $tables = array_values(array_filter($tables, static function ($table) use ($keyword) {
+                return stripos((string) $table, $keyword) !== false;
+            }));
+        }
 
         return Response::text(json_encode([
             'allowed_tables' => $tables,

--- a/tests/Unit/Mcp/ListAllowedTablesToolTest.php
+++ b/tests/Unit/Mcp/ListAllowedTablesToolTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit\Mcp;
+
+use App\Mcp\Tools\ListAllowedTablesTool;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ListAllowedTablesToolTest extends TestCase {
+    #[Test]
+    public function it_exposes_object_input_schema_for_function_calling_compatibility(): void {
+        $tool = new ListAllowedTablesTool();
+        $toolArray = $tool->toArray();
+
+        $this->assertIsArray($toolArray['inputSchema'] ?? null);
+        $this->assertSame('object', $toolArray['inputSchema']['type'] ?? null);
+        $this->assertIsArray($toolArray['inputSchema']['properties'] ?? null);
+        $this->assertArrayHasKey('keyword', $toolArray['inputSchema']['properties'] ?? []);
+        $this->assertSame('string', $toolArray['inputSchema']['properties']['keyword']['type'] ?? null);
+    }
+}

--- a/tests/Unit/Mcp/McpToolSchemaCompatibilityTest.php
+++ b/tests/Unit/Mcp/McpToolSchemaCompatibilityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Mcp;
+
+use App\Mcp\Servers\CbdbReadOnlyServer;
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Server\Tool;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Tests\TestCase;
+
+class McpToolSchemaCompatibilityTest extends TestCase {
+    /**
+     * @return array<int, class-string<Tool>>
+     */
+    private function getServerToolClasses(): array {
+        $ref = new ReflectionClass(CbdbReadOnlyServer::class);
+        /** @var array<int, class-string<Tool>> $tools */
+        $tools = $ref->getDefaultProperties()['tools'] ?? [];
+
+        return $tools;
+    }
+
+    #[Test]
+    public function all_cbdb_mcp_tools_use_object_input_schema(): void {
+        foreach ($this->getServerToolClasses() as $toolClass) {
+            $tool = app($toolClass);
+            $toolArray = $tool->toArray();
+
+            $this->assertSame('object', Arr::get($toolArray, 'inputSchema.type'), "{$toolClass} inputSchema.type should be object");
+
+            $this->assertTrue(
+                is_array(Arr::get($toolArray, 'inputSchema.properties')) || is_object(Arr::get($toolArray, 'inputSchema.properties')),
+                "{$toolClass} inputSchema.properties should be array|object for function-calling compatibility"
+            );
+        }
+    }
+}


### PR DESCRIPTION
- 將 list_allowed_tables 的占位參數改為可用的 keyword 過濾參數，避免不必要的 '_' 欄位。
- 在工具實作加入關鍵字過濾邏輯，保留既有無參數行為相容性。
- 新增 McpToolSchemaCompatibilityTest，檢查 CBDB MCP 全部 tools 的 inputSchema 皆為 object，避免再出現 [] 型別不相容。
- 更新 ListAllowedTablesToolTest 以驗證 keyword 參數 schema。