### PR TITLE
將 index address 重建改為分批暫存回寫

### DIFF
--- a/app/Console/Commands/RebuildIndexAddress.php
+++ b/app/Console/Commands/RebuildIndexAddress.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema;
 use Throwable;
 
 class RebuildIndexAddress extends Command {
-    protected $signature = 'cbdb:rebuild-index-address {--show-sql : 輸出每一步實際執行的 SQL}';
+    protected $signature = 'cbdb:rebuild-index-address {--show-sql : 輸出每一步實際執行的 SQL} {--batch-size=500 : 依 c_personid 區間分批處理筆數}';
 
     protected $description = '全量重建 BIOG_MAIN 的 index address 欄位（MySQL/MariaDB）';
 
@@ -44,8 +44,9 @@ class RebuildIndexAddress extends Command {
 
         $startedAt = microtime(true);
         $showSql = (bool) $this->option('show-sql');
+        $batchSize = max(1, (int) $this->option('batch-size'));
         $this->info('開始全量重建 BIOG_MAIN index address...');
-        $this->line('策略：逐條規則各自提交（避免單一大 transaction 鎖表）、按 c_index_addr_rank(<100) 循環、Max(c_sequence) 子查詢聚合、首命中優先');
+        $this->line(sprintf('策略：先計算到暫存表，再分批 SWAP 回 BIOG_MAIN（batch-size=%d），避免長時間鎖主表', $batchSize));
         if ($showSql) {
             $this->line('模式：已開啟 SQL 輸出（每條規則執行前顯示 SQL）');
         }
@@ -56,6 +57,7 @@ class RebuildIndexAddress extends Command {
                     $this->line($message);
                 })
                 ->setShowSql($showSql)
+                ->setBatchSize($batchSize)
                 ->rebuild();
 
             $elapsed = microtime(true) - $startedAt;
@@ -94,9 +96,12 @@ class RebuildIndexAddress extends Command {
      */
     protected function renderStats(array $stats, float $elapsed): void {
         $this->line(sprintf('地址類型數（rank<100）：%d', (int) ($stats['addr_type_count'] ?? 0)));
-        $this->line(sprintf('RESET 更新筆數：%d', (int) ($stats['reset'] ?? 0)));
+        $this->line(sprintf('分批大小 / 批次數：%d / %d', (int) ($stats['batch_size'] ?? 0), (int) ($stats['batch_count'] ?? 0)));
+        $this->line(sprintf('暫存表命中筆數：%d', (int) ($stats['staged_count'] ?? 0)));
+        $this->line(sprintf('需清空舊值筆數（無候選）：%d', (int) ($stats['clear_count'] ?? 0)));
+        $this->line(sprintf('SWAP 實際更新筆數：%d', (int) ($stats['swap_updated'] ?? 0)));
 
-        $this->line('每種地址類型更新統計：');
+        $this->line('每種地址類型命中統計：');
         foreach (($stats['per_type_updates'] ?? []) as $row) {
             $this->line(sprintf(
                 '  c_addr_type=%d (rank=%d): %d',
@@ -107,7 +112,7 @@ class RebuildIndexAddress extends Command {
         }
 
         $this->line(sprintf('最終 c_index_addr_id 非空筆數：%d', (int) ($stats['filled_count'] ?? 0)));
-        $this->line(sprintf('總更新筆數（含 reset 與各類型更新次數累計）：%d', (int) ($stats['total_updates'] ?? 0)));
+        $this->line(sprintf('總更新筆數（最終寫回 BIOG_MAIN）：%d', (int) ($stats['total_updates'] ?? 0)));
         $this->line(sprintf('耗時：%.2f 秒', $elapsed));
     }
 }

--- a/app/Services/IndexAddressRebuildService.php
+++ b/app/Services/IndexAddressRebuildService.php
@@ -10,6 +10,7 @@ class IndexAddressRebuildService {
      */
     protected $logger;
     protected bool $showSql = false;
+    protected int $batchSize = 500;
 
     public function setLogger(?callable $logger): self {
         $this->logger = $logger;
@@ -19,6 +20,12 @@ class IndexAddressRebuildService {
 
     public function setShowSql(bool $showSql): self {
         $this->showSql = $showSql;
+
+        return $this;
+    }
+
+    public function setBatchSize(int $batchSize): self {
+        $this->batchSize = max(1, $batchSize);
 
         return $this;
     }
@@ -43,6 +50,11 @@ class IndexAddressRebuildService {
             'reset' => 0,
             'per_type_updates' => [],
             'total_updates' => 0,
+            'staged_count' => 0,
+            'swap_updated' => 0,
+            'clear_count' => 0,
+            'batch_size' => $this->batchSize,
+            'batch_count' => 0,
         ];
 
         foreach ($addrTypes as $row) {
@@ -53,35 +65,231 @@ class IndexAddressRebuildService {
         }
 
         $this->log(sprintf('載入地址類型優先級：%d 個（c_index_addr_rank < 100）', $stats['addr_type_count']));
+        $batchRanges = $this->buildBatchRanges($this->batchSize);
+        $stats['batch_count'] = count($batchRanges);
+        if ($stats['batch_count'] > 0) {
+            $this->log(sprintf('分批設定：batch_size=%d，批次數=%d（依 c_personid 區間）', $this->batchSize, $stats['batch_count']));
+        } else {
+            $this->log('BIOG_MAIN 無資料，略過重建。');
+            $stats['filled_count'] = 0;
 
-        $stats['reset'] = $this->applyRule(
-            'RESET',
-            "UPDATE BIOG_MAIN
-             SET c_index_addr_id = NULL,
-                 c_index_addr_type_code = NULL"
-        );
-        $stats['total_updates'] += $stats['reset'];
-
-        foreach ($stats['addr_types'] as $item) {
-            $addrType = (int) $item['c_addr_type'];
-            $rank = (int) $item['rank'];
-
-            $count = $this->applyRule(
-                sprintf('AddrType %d (rank %d)', $addrType, $rank),
-                $this->sqlFillByAddrType($addrType)
-            );
-
-            $stats['per_type_updates'][] = [
-                'c_addr_type' => $addrType,
-                'rank' => $rank,
-                'updated' => $count,
-            ];
-            $stats['total_updates'] += $count;
+            return $stats;
         }
 
-        $filledCount = DB::table('BIOG_MAIN')->whereNotNull('c_index_addr_id')->count();
-        $stats['filled_count'] = $filledCount;
-        $this->log(sprintf('重建後 c_index_addr_id 非空筆數：%d', $filledCount));
+        $this->dropTempTables();
+
+        try {
+            $this->runStatement(
+                '建立暫存表（每人每地址類型最新記錄）',
+                "CREATE TEMPORARY TABLE tmp_biog_addr_latest (
+                    c_personid INT NOT NULL,
+                    c_addr_type SMALLINT NOT NULL,
+                    c_addr_id INT NOT NULL,
+                    PRIMARY KEY (c_personid, c_addr_type)
+                ) ENGINE=InnoDB"
+            );
+
+            $latestTotal = 0;
+            foreach ($batchRanges as $index => [$startId, $endId]) {
+                $count = $this->applyRuleWithBindings(
+                    sprintf('填充 tmp_biog_addr_latest（batch %d/%d: %d-%d）', $index + 1, $stats['batch_count'], $startId, $endId),
+                    "INSERT INTO tmp_biog_addr_latest (c_personid, c_addr_type, c_addr_id)
+                     SELECT picked.c_personid,
+                            picked.c_addr_type,
+                            MAX(picked.c_addr_id) AS c_addr_id
+                     FROM BIOG_ADDR_DATA picked
+                     JOIN (
+                         SELECT c_personid,
+                                c_addr_type,
+                                MAX(c_sequence) AS c_sequence
+                         FROM BIOG_ADDR_DATA
+                         WHERE c_personid BETWEEN ? AND ?
+                         GROUP BY c_personid, c_addr_type
+                     ) latest
+                       ON latest.c_personid = picked.c_personid
+                      AND latest.c_addr_type = picked.c_addr_type
+                      AND latest.c_sequence = picked.c_sequence
+                     WHERE picked.c_personid BETWEEN ? AND ?
+                     GROUP BY picked.c_personid, picked.c_addr_type",
+                    [$startId, $endId, $startId, $endId]
+                );
+                $latestTotal += $count;
+            }
+            $this->log(sprintf('填充 tmp_biog_addr_latest（累計） -> %d', $latestTotal));
+
+            $this->runStatement(
+                '建立暫存表（每人最終 index address）',
+                "CREATE TEMPORARY TABLE tmp_biog_index_addr_stage (
+                    c_personid INT NOT NULL,
+                    c_index_addr_id INT NULL,
+                    c_index_addr_type_code SMALLINT NULL,
+                    PRIMARY KEY (c_personid)
+                ) ENGINE=InnoDB"
+            );
+
+            // MySQL/MariaDB 對同一 TEMPORARY TABLE 在單一查詢中多次引用有限制，
+            // 透過建立鏡像表避免「Can't reopen table」。
+            $this->runStatement(
+                '建立鏡像暫存表（避免 latest 多重引用限制）',
+                "CREATE TEMPORARY TABLE tmp_biog_addr_latest_ref (
+                    c_personid INT NOT NULL,
+                    c_addr_type SMALLINT NOT NULL,
+                    c_addr_id INT NOT NULL,
+                    PRIMARY KEY (c_personid, c_addr_type)
+                ) ENGINE=InnoDB"
+            );
+
+            $this->applyRule(
+                '填充 tmp_biog_addr_latest_ref',
+                "INSERT INTO tmp_biog_addr_latest_ref (c_personid, c_addr_type, c_addr_id)
+                 SELECT c_personid, c_addr_type, c_addr_id
+                 FROM tmp_biog_addr_latest"
+            );
+
+            $this->runStatement(
+                '建立批次暫存表（best_rank）',
+                "CREATE TEMPORARY TABLE tmp_biog_best_rank_batch (
+                    c_personid INT NOT NULL,
+                    best_rank INT NOT NULL,
+                    PRIMARY KEY (c_personid)
+                ) ENGINE=InnoDB"
+            );
+
+            $this->runStatement(
+                '建立批次暫存表（best_type）',
+                "CREATE TEMPORARY TABLE tmp_biog_best_type_batch (
+                    c_personid INT NOT NULL,
+                    c_index_addr_rank INT NOT NULL,
+                    best_addr_type SMALLINT NOT NULL,
+                    PRIMARY KEY (c_personid, c_index_addr_rank)
+                ) ENGINE=InnoDB"
+            );
+
+            $stagedTotal = 0;
+            foreach ($batchRanges as $index => [$startId, $endId]) {
+                $this->runStatement(
+                    sprintf('清空 tmp_biog_best_rank_batch（batch %d/%d）', $index + 1, $stats['batch_count']),
+                    'TRUNCATE TABLE tmp_biog_best_rank_batch'
+                );
+                $this->applyRuleWithBindings(
+                    sprintf('填充 tmp_biog_best_rank_batch（batch %d/%d: %d-%d）', $index + 1, $stats['batch_count'], $startId, $endId),
+                    "INSERT INTO tmp_biog_best_rank_batch (c_personid, best_rank)
+                     SELECT latest_ref.c_personid AS c_personid,
+                            MIN(code_ref.c_index_addr_rank) AS best_rank
+                     FROM tmp_biog_addr_latest_ref latest_ref
+                     JOIN BIOG_ADDR_CODES code_ref
+                       ON code_ref.c_addr_type = latest_ref.c_addr_type
+                     WHERE latest_ref.c_personid BETWEEN ? AND ?
+                       AND code_ref.c_index_addr_rank IS NOT NULL
+                       AND code_ref.c_index_addr_rank < 100
+                     GROUP BY latest_ref.c_personid",
+                    [$startId, $endId]
+                );
+
+                $this->runStatement(
+                    sprintf('清空 tmp_biog_best_type_batch（batch %d/%d）', $index + 1, $stats['batch_count']),
+                    'TRUNCATE TABLE tmp_biog_best_type_batch'
+                );
+                $this->applyRuleWithBindings(
+                    sprintf('填充 tmp_biog_best_type_batch（batch %d/%d: %d-%d）', $index + 1, $stats['batch_count'], $startId, $endId),
+                    "INSERT INTO tmp_biog_best_type_batch (c_personid, c_index_addr_rank, best_addr_type)
+                     SELECT latest_ref.c_personid AS c_personid,
+                            code_ref.c_index_addr_rank AS c_index_addr_rank,
+                            MIN(latest_ref.c_addr_type) AS best_addr_type
+                     FROM tmp_biog_addr_latest_ref latest_ref
+                     JOIN BIOG_ADDR_CODES code_ref
+                       ON code_ref.c_addr_type = latest_ref.c_addr_type
+                     WHERE latest_ref.c_personid BETWEEN ? AND ?
+                       AND code_ref.c_index_addr_rank IS NOT NULL
+                       AND code_ref.c_index_addr_rank < 100
+                     GROUP BY latest_ref.c_personid, code_ref.c_index_addr_rank",
+                    [$startId, $endId]
+                );
+
+                $count = $this->applyRuleWithBindings(
+                    sprintf('填充 tmp_biog_index_addr_stage（batch %d/%d: %d-%d）', $index + 1, $stats['batch_count'], $startId, $endId),
+                    "INSERT INTO tmp_biog_index_addr_stage (c_personid, c_index_addr_id, c_index_addr_type_code)
+                     SELECT cand.c_personid,
+                            cand.c_addr_id,
+                            cand.c_addr_type
+                     FROM (
+                         SELECT latest.c_personid AS c_personid,
+                                latest.c_addr_id AS c_addr_id,
+                                latest.c_addr_type AS c_addr_type,
+                                current_code.c_index_addr_rank AS c_index_addr_rank
+                         FROM tmp_biog_addr_latest latest
+                         JOIN BIOG_ADDR_CODES current_code
+                           ON current_code.c_addr_type = latest.c_addr_type
+                         WHERE latest.c_personid BETWEEN ? AND ?
+                           AND current_code.c_index_addr_rank IS NOT NULL
+                           AND current_code.c_index_addr_rank < 100
+                     ) cand
+                     JOIN tmp_biog_best_rank_batch best_rank_pick
+                       ON best_rank_pick.c_personid = cand.c_personid
+                      AND best_rank_pick.best_rank = cand.c_index_addr_rank
+                     JOIN tmp_biog_best_type_batch best_type_pick
+                       ON best_type_pick.c_personid = cand.c_personid
+                      AND best_type_pick.c_index_addr_rank = cand.c_index_addr_rank
+                      AND best_type_pick.best_addr_type = cand.c_addr_type",
+                    [$startId, $endId]
+                );
+                $stagedTotal += $count;
+            }
+            $stats['staged_count'] = $stagedTotal;
+            $this->log(sprintf('填充 tmp_biog_index_addr_stage（累計） -> %d', $stagedTotal));
+
+            foreach ($stats['addr_types'] as $item) {
+                $addrType = (int) $item['c_addr_type'];
+                $rank = (int) $item['rank'];
+                $selected = (int) DB::table('tmp_biog_index_addr_stage')
+                    ->where('c_index_addr_type_code', $addrType)
+                    ->count();
+
+                $stats['per_type_updates'][] = [
+                    'c_addr_type' => $addrType,
+                    'rank' => $rank,
+                    'updated' => $selected,
+                ];
+            }
+
+            $stats['clear_count'] = (int) DB::table('BIOG_MAIN as bm')
+                ->leftJoin('tmp_biog_index_addr_stage as stage', 'stage.c_personid', '=', 'bm.c_personid')
+                ->whereNull('stage.c_personid')
+                ->where(function ($query) {
+                    $query->whereNotNull('bm.c_index_addr_id')
+                        ->orWhereNotNull('bm.c_index_addr_type_code');
+                })
+                ->count();
+            $stats['reset'] = $stats['clear_count'];
+
+            $swapTotal = 0;
+            foreach ($batchRanges as $index => [$startId, $endId]) {
+                $count = $this->applyRuleWithBindings(
+                    sprintf('SWAP（batch %d/%d: %d-%d）', $index + 1, $stats['batch_count'], $startId, $endId),
+                    "UPDATE BIOG_MAIN bm
+                     LEFT JOIN tmp_biog_index_addr_stage stage
+                       ON stage.c_personid = bm.c_personid
+                     SET bm.c_index_addr_id = stage.c_index_addr_id,
+                         bm.c_index_addr_type_code = stage.c_index_addr_type_code
+                     WHERE bm.c_personid BETWEEN ? AND ?
+                       AND (
+                            COALESCE(bm.c_index_addr_id, -1) <> COALESCE(stage.c_index_addr_id, -1)
+                            OR COALESCE(bm.c_index_addr_type_code, -1) <> COALESCE(stage.c_index_addr_type_code, -1)
+                       )",
+                    [$startId, $endId]
+                );
+                $swapTotal += $count;
+            }
+            $stats['swap_updated'] = $swapTotal;
+            $this->log(sprintf('SWAP（累計） -> %d', $swapTotal));
+            $stats['total_updates'] = $stats['swap_updated'];
+
+            $filledCount = DB::table('BIOG_MAIN')->whereNotNull('c_index_addr_id')->count();
+            $stats['filled_count'] = $filledCount;
+            $this->log(sprintf('重建後 c_index_addr_id 非空筆數：%d', $filledCount));
+        } finally {
+            $this->dropTempTables();
+        }
 
         return $stats;
     }
@@ -93,41 +301,63 @@ class IndexAddressRebuildService {
     }
 
     protected function applyRule(string $label, string $sql): int {
+        return $this->applyRuleWithBindings($label, $sql, []);
+    }
+
+    /**
+     * @param array<int, mixed> $bindings
+     */
+    protected function applyRuleWithBindings(string $label, string $sql, array $bindings): int {
         if ($this->showSql) {
             $this->log(sprintf('SQL [%s]:', $label));
             $this->log($sql);
         }
 
-        $count = DB::affectingStatement($sql);
+        $count = DB::affectingStatement($sql, $bindings);
         $this->log(sprintf('%s -> %d', $label, $count));
 
         return $count;
     }
 
-    protected function sqlFillByAddrType(int $addrType): string {
-        return "UPDATE BIOG_MAIN bm
-                JOIN (
-                    SELECT picked.c_personid,
-                           picked.c_addr_type,
-                           MAX(picked.c_addr_id) AS c_addr_id
-                    FROM BIOG_ADDR_DATA picked
-                    JOIN (
-                        SELECT c_personid,
-                               c_addr_type,
-                               MAX(c_sequence) AS c_sequence
-                        FROM BIOG_ADDR_DATA
-                        WHERE c_addr_type = {$addrType}
-                        GROUP BY c_personid, c_addr_type
-                    ) latest
-                      ON latest.c_personid = picked.c_personid
-                     AND latest.c_addr_type = picked.c_addr_type
-                     AND latest.c_sequence = picked.c_sequence
-                    WHERE picked.c_addr_type = $addrType
-                    GROUP BY picked.c_personid, picked.c_addr_type
-                ) addr_pick
-                  ON addr_pick.c_personid = bm.c_personid
-                SET bm.c_index_addr_id = addr_pick.c_addr_id,
-                    bm.c_index_addr_type_code = addr_pick.c_addr_type
-                WHERE bm.c_index_addr_id IS NULL";
+    protected function runStatement(string $label, string $sql): void {
+        if ($this->showSql) {
+            $this->log(sprintf('SQL [%s]:', $label));
+            $this->log($sql);
+        }
+
+        DB::statement($sql);
+        $this->log($label.' -> OK');
+    }
+
+    protected function dropTempTables(): void {
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_biog_best_type_batch');
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_biog_best_rank_batch');
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_biog_index_addr_stage');
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_biog_addr_latest_ref');
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS tmp_biog_addr_latest');
+    }
+
+    /**
+     * @return array<int, array{0:int,1:int}>
+     */
+    protected function buildBatchRanges(int $batchSize): array {
+        $row = DB::table('BIOG_MAIN')
+            ->selectRaw('MIN(c_personid) AS min_id, MAX(c_personid) AS max_id')
+            ->first();
+
+        if (!$row || $row->min_id === null || $row->max_id === null) {
+            return [];
+        }
+
+        $minId = (int) $row->min_id;
+        $maxId = (int) $row->max_id;
+        $ranges = [];
+
+        for ($start = $minId; $start <= $maxId; $start += $batchSize) {
+            $end = min($start + $batchSize - 1, $maxId);
+            $ranges[] = [$start, $end];
+        }
+
+        return $ranges;
     }
 }


### PR DESCRIPTION
- 改為先寫入暫存表，再分批回寫 BIOG_MAIN，避免先 RESET 導致中斷後全表為 NULL
- 三個重步驟（latest、stage、swap）皆依 c_personid 區間分批執行
- 新增 --batch-size 參數並將預設值設為 500，輸出分批統計
- 測試：./vendor/bin/phpunit（641 tests 通過）