### PR TITLE
修正 MCP read-only SQL 重複 LIMIT 導致呼叫失敗

### DIFF
--- a/app/Mcp/Tools/QueryReadOnlySqlTool.php
+++ b/app/Mcp/Tools/QueryReadOnlySqlTool.php
@@ -4,9 +4,11 @@ namespace App\Mcp\Tools;
 
 use App\Services\Mcp\ReadOnlyTableQueryService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use JsonException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Throwable;
 
 class QueryReadOnlySqlTool extends Tool {
     public string $name = 'query_read_only_sql';
@@ -24,13 +26,21 @@ class QueryReadOnlySqlTool extends Tool {
     public function handle(Request $request): Response {
         $service = app(ReadOnlyTableQueryService::class);
 
-        return Response::text(json_encode(
-            $service->queryReadOnlySql(
+        try {
+            $result = $service->queryReadOnlySql(
                 (string) $request->get('sql'),
                 (int) $request->get('limit', 20),
                 (int) $request->get('offset', 0)
-            ),
-            JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
-        ));
+            );
+
+            return Response::text(json_encode(
+                $result,
+                JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR
+            ));
+        } catch (JsonException $e) {
+            return Response::error('query_read_only_sql 返回结果无法编码为 JSON（可能包含无效字符）');
+        } catch (Throwable $e) {
+            return Response::error('query_read_only_sql 执行失败：' . $e->getMessage());
+        }
     }
 }

--- a/app/Services/Mcp/ReadOnlyTableQueryService.php
+++ b/app/Services/Mcp/ReadOnlyTableQueryService.php
@@ -304,10 +304,21 @@ class ReadOnlyTableQueryService {
 
     private function buildPaginatedSql(string $sql, int $limit, int $offset): string {
         if (preg_match('/^WITH\b/i', $sql)) {
+            if ($this->hasTrailingLimitOrOffset($sql)) {
+                return $sql;
+            }
+
             return $sql . " LIMIT {$limit} OFFSET {$offset}";
         }
 
         return "SELECT * FROM ({$sql}) AS subquery_wrapper LIMIT {$limit} OFFSET {$offset}";
+    }
+
+    private function hasTrailingLimitOrOffset(string $sql): bool {
+        return preg_match(
+            '/\bLIMIT\s+\d+(?:\s*,\s*\d+)?(?:\s+OFFSET\s+\d+)?\s*$/i',
+            $sql
+        ) === 1;
     }
 
     /**

--- a/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
+++ b/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
@@ -171,6 +171,22 @@ class ReadOnlyTableQueryServiceTest extends TestCase {
     }
 
     #[Test]
+    public function it_keeps_existing_limit_for_with_query(): void {
+        $result = $this->service->queryReadOnlySql(
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 1',
+            10,
+            0
+        );
+
+        $this->assertSame(
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 1',
+            $result['sql']
+        );
+        $this->assertSame(['DYNASTIES'], $result['tables']);
+        $this->assertSame(1, $result['returned_rows']);
+    }
+
+    #[Test]
     public function it_supports_multiple_ctes_without_treating_aliases_as_tables(): void {
         $result = $this->service->queryReadOnlySql(
             'WITH cte_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active"), cte_people AS (SELECT c_personid FROM BIOG_MAIN) SELECT cte_dynasties.c_dy FROM cte_dynasties JOIN cte_people ON 1 = 1 ORDER BY cte_dynasties.c_dy',


### PR DESCRIPTION
- 修正 WITH 查詢在已含 LIMIT/OFFSET 時不再重複追加分頁子句

- 強化 query_read_only_sql 工具錯誤處理，改回傳工具級錯誤避免 500 傳輸解碼異常

- 新增 WITH + LIMIT 回歸測試

- 測試：./vendor/bin/phpunit --filter ReadOnlyTableQueryServiceTest