### PR TITLE
修正 WITH 查詢既有 LIMIT 繞過 MCP 分頁上限

### DIFF
--- a/app/Services/Mcp/ReadOnlyTableQueryService.php
+++ b/app/Services/Mcp/ReadOnlyTableQueryService.php
@@ -304,8 +304,9 @@ class ReadOnlyTableQueryService {
 
     private function buildPaginatedSql(string $sql, int $limit, int $offset): string {
         if (preg_match('/^WITH\b/i', $sql)) {
-            if ($this->hasTrailingLimitOrOffset($sql)) {
-                return $sql;
+            $paginatedSql = $this->replaceTrailingLimitOrOffset($sql, $limit, $offset);
+            if ($paginatedSql !== null) {
+                return $paginatedSql;
             }
 
             return $sql . " LIMIT {$limit} OFFSET {$offset}";
@@ -314,11 +315,28 @@ class ReadOnlyTableQueryService {
         return "SELECT * FROM ({$sql}) AS subquery_wrapper LIMIT {$limit} OFFSET {$offset}";
     }
 
-    private function hasTrailingLimitOrOffset(string $sql): bool {
-        return preg_match(
-            '/\bLIMIT\s+\d+(?:\s*,\s*\d+)?(?:\s+OFFSET\s+\d+)?\s*$/i',
-            $sql
-        ) === 1;
+    private function replaceTrailingLimitOrOffset(string $sql, int $limit, int $offset): ?string {
+        $pattern = '/\bLIMIT\s+(?:(\d+)\s*,\s*(\d+)|(\d+)(?:\s+OFFSET\s+(\d+))?)\s*$/i';
+        if (preg_match($pattern, $sql, $matches) !== 1) {
+            return null;
+        }
+
+        $existingOffset = 0;
+        $existingLimit = 0;
+
+        if (isset($matches[1], $matches[2]) && $matches[1] !== '' && $matches[2] !== '') {
+            $existingOffset = (int) $matches[1];
+            $existingLimit = (int) $matches[2];
+        } elseif (isset($matches[3]) && $matches[3] !== '') {
+            $existingLimit = (int) $matches[3];
+            $existingOffset = isset($matches[4]) && $matches[4] !== '' ? (int) $matches[4] : 0;
+        }
+
+        $effectiveLimit = min($existingLimit, $limit);
+        $effectiveOffset = $existingOffset + $offset;
+        $replacement = "LIMIT {$effectiveLimit} OFFSET {$effectiveOffset}";
+
+        return preg_replace($pattern, $replacement, $sql, 1);
     }
 
     /**

--- a/app/Services/Mcp/ReadOnlyTableQueryService.php
+++ b/app/Services/Mcp/ReadOnlyTableQueryService.php
@@ -332,7 +332,8 @@ class ReadOnlyTableQueryService {
             $existingOffset = isset($matches[4]) && $matches[4] !== '' ? (int) $matches[4] : 0;
         }
 
-        $effectiveLimit = min($existingLimit, $limit);
+        $remainingRows = max(0, $existingLimit - $offset);
+        $effectiveLimit = min($limit, $remainingRows);
         $effectiveOffset = $existingOffset + $offset;
         $replacement = "LIMIT {$effectiveLimit} OFFSET {$effectiveOffset}";
 

--- a/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
+++ b/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
@@ -171,19 +171,27 @@ class ReadOnlyTableQueryServiceTest extends TestCase {
     }
 
     #[Test]
-    public function it_keeps_existing_limit_for_with_query(): void {
+    public function it_enforces_service_limit_for_with_query_that_has_existing_limit(): void {
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 'A0', 'c_dynasty_chn' => '甲', 'status' => 'active'],
+            ['c_dy' => 'A1', 'c_dynasty_chn' => '乙', 'status' => 'active'],
+            ['c_dy' => 'A2', 'c_dynasty_chn' => '丙', 'status' => 'active'],
+            ['c_dy' => 'A3', 'c_dynasty_chn' => '丁', 'status' => 'active'],
+            ['c_dy' => 'A4', 'c_dynasty_chn' => '戊', 'status' => 'active'],
+        ]);
+
         $result = $this->service->queryReadOnlySql(
-            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 1',
-            10,
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 100000',
+            2,
             0
         );
 
         $this->assertSame(
-            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 1',
+            'WITH active_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active") SELECT c_dy FROM active_dynasties ORDER BY c_dy LIMIT 100000',
             $result['sql']
         );
         $this->assertSame(['DYNASTIES'], $result['tables']);
-        $this->assertSame(1, $result['returned_rows']);
+        $this->assertSame(2, $result['returned_rows']);
     }
 
     #[Test]

--- a/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
+++ b/tests/Unit/Mcp/ReadOnlyTableQueryServiceTest.php
@@ -195,6 +195,29 @@ class ReadOnlyTableQueryServiceTest extends TestCase {
     }
 
     #[Test]
+    public function it_limits_remaining_rows_when_merging_existing_limit_and_offset(): void {
+        $rows = [];
+        for ($i = 0; $i < 20; $i++) {
+            $rows[] = [
+                'c_dy' => sprintf('Z%02d', $i),
+                'c_dynasty_chn' => '測試',
+                'status' => 'active',
+            ];
+        }
+        DB::table('DYNASTIES')->insert($rows);
+
+        $result = $this->service->queryReadOnlySql(
+            'WITH z_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE c_dy LIKE "Z%") SELECT c_dy FROM z_dynasties ORDER BY c_dy LIMIT 5 OFFSET 10',
+            5,
+            3
+        );
+
+        $this->assertSame(2, $result['returned_rows']);
+        $this->assertSame('Z13', $result['rows'][0]['c_dy']);
+        $this->assertSame('Z14', $result['rows'][1]['c_dy']);
+    }
+
+    #[Test]
     public function it_supports_multiple_ctes_without_treating_aliases_as_tables(): void {
         $result = $this->service->queryReadOnlySql(
             'WITH cte_dynasties AS (SELECT c_dy FROM DYNASTIES WHERE status = "active"), cte_people AS (SELECT c_personid FROM BIOG_MAIN) SELECT cte_dynasties.c_dy FROM cte_dynasties JOIN cte_people ON 1 = 1 ORDER BY cte_dynasties.c_dy',


### PR DESCRIPTION
- 針對 WITH 查詢尾端 LIMIT/OFFSET 進行重寫，不再直接放行原 SQL
- 既有 LIMIT 時套用 min(existingLimit, serviceLimit) 並合併 offset
- 新增回歸測試覆蓋 LIMIT 100000 仍受服務端上限約束
