### PR TITLE
修正切換搜尋關鍵字時朝代篩選殘留導致查無結果

### DIFF
--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -86,14 +86,24 @@ class BasicInformationController extends Controller {
         $num = $request->input('num', 20);
         $cDy = $request->input('c_dy');
 
-        // 使用 Repository 查询数据
-        $names = $this->biogMainRepository->namesByQuery($request, $num);
-
         // 如果有搜尋關鍵字，統計朝代分佈（用於篩選下拉選單）
         $dynastyFacets = [];
         if ($q !== '') {
             $dynastyFacets = BiogMainRepository::dynastyFacetsByQuery($q);
         }
+
+        // 驗證 c_dy 是否在當前查詢的朝代分佈中；若不存在則 redirect 到不帶 c_dy 的乾淨 URL
+        if ($cDy !== null && $cDy !== '' && !empty($dynastyFacets)) {
+            $validDynasties = collect($dynastyFacets)->pluck('c_dy')->map(fn ($v) => (string) $v)->toArray();
+            if (!in_array((string) $cDy, $validDynasties, true)) {
+                $params = $request->only(['q', 'num']);
+
+                return redirect()->route('basicinformation.index', array_filter($params, fn ($v) => $v !== null && $v !== ''));
+            }
+        }
+
+        // 使用 Repository 查询数据
+        $names = $this->biogMainRepository->namesByQuery($request, $num);
 
         return view('biogmains.basicinformation.index', [
             'page_title' => '人物基本資料',


### PR DESCRIPTION
## Summary

- 修正人物基本資料搜尋頁在切換關鍵字時，舊的朝代篩選值（`c_dy`）殘留在 URL 中，導致新查詢被錯誤篩選為零筆結果
- 將朝代分佈統計移至查詢之前執行，驗證 `c_dy` 是否存在於當前關鍵字的朝代 facets 中
- 若 `c_dy` 無效則 redirect 到不帶該參數的乾淨 URL，確保網址列與實際篩選狀態一致

## 重現步驟

1. 搜尋「費」→ 選擇朝代「明」（c_dy=15）
2. 改搜「紀昀」→ URL 仍帶 c_dy=15，但紀昀為清朝人，結果為零
3. 下拉選單顯示「全部朝代」（因 facets 無明朝），使用者誤以為無篩選

## Test plan

- [x] `./vendor/bin/phpunit --filter BasicInformation`（71 tests passed）
- [x] `php-cs-fixer` 格式檢查通過
- [x] 手動測試：搜尋「費」→ 選明朝 → 改搜「紀昀」→ 應自動 redirect 到無 c_dy 的 URL 並顯示結果

🤖 Generated with [Claude Code](https://claude.com/claude-code)