### PR TITLE
提案審核流程多項改進，與「直接修改」行為一致

### DIFF
--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -11,11 +11,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class BasicInformationProposalController extends Controller {
     protected $biogMainRepository;
     protected $operationRepository;
+    protected array $tableColumnCache = [];
 
     /**
      * 資源配置數組
@@ -140,7 +142,8 @@ class BasicInformationProposalController extends Controller {
         $optionalKeyColumns = $config['optional_key_columns'] ?? [];
 
         // 提取表單數據
-        $payload = $this->extractFormData($request);
+        $formData = $this->extractFormData($request);
+        [$payload, $auxiliaryPayload] = $this->splitFormDataByTable($table, $formData);
         $payload['c_personid'] = $personid;
         $payload = $this->assignSingleNumericPrimaryKeyIfNeeded($table, $keyColumns, $payload);
 
@@ -178,7 +181,8 @@ class BasicInformationProposalController extends Controller {
             $personid,
             $payload,
             [],
-            $meta
+            $meta,
+            $auxiliaryPayload
         );
 
         if ($operation) {
@@ -251,7 +255,8 @@ class BasicInformationProposalController extends Controller {
         }
 
         // 提取表單數據
-        $payload = $this->extractFormData($request);
+        $formData = $this->extractFormData($request);
+        [$payload, $auxiliaryPayload] = $this->splitFormDataByTable($table, $formData);
         $payload['c_personid'] = $personid;
 
         // 檢查是否有實際修改
@@ -273,7 +278,8 @@ class BasicInformationProposalController extends Controller {
             $personid,
             $payload,
             $originalRow,
-            $meta
+            $meta,
+            $auxiliaryPayload
         );
 
         if ($operation) {
@@ -346,11 +352,15 @@ class BasicInformationProposalController extends Controller {
         $personId,
         $data,
         $original,
-        $meta
+        $meta,
+        array $auxiliaryPayload = []
     ) {
         $resourceId = $this->buildCompositeId($keyColumns, $data);
 
         $resourceData = $data;
+        if ($auxiliaryPayload !== []) {
+            $resourceData['__proposal_aux'] = $auxiliaryPayload;
+        }
         $resourceData['__proposal_meta'] = $meta;
         $resourceData['__review_status'] = 'pending';
         $resourceData['__key_columns'] = $keyColumns;
@@ -447,6 +457,40 @@ class BasicInformationProposalController extends Controller {
      */
     protected function extractFormData(Request $request) {
         return Arr::except($request->all(), ['_token', '_method', 'action', '__proposal_comment']);
+    }
+
+    protected function splitFormDataByTable(string $table, array $payload): array {
+        if (!Schema::hasTable($table)) {
+            return [$payload, []];
+        }
+
+        $columns = array_flip($this->getTableColumns($table));
+        $data = [];
+        $auxiliary = [];
+
+        foreach ($payload as $key => $value) {
+            if (!is_string($key)) {
+                $data[$key] = $value;
+
+                continue;
+            }
+
+            if (isset($columns[$key])) {
+                $data[$key] = $value;
+            } else {
+                $auxiliary[$key] = $value;
+            }
+        }
+
+        return [$data, $auxiliary];
+    }
+
+    protected function getTableColumns(string $table): array {
+        if (!array_key_exists($table, $this->tableColumnCache)) {
+            $this->tableColumnCache[$table] = Schema::getColumnListing($table);
+        }
+
+        return $this->tableColumnCache[$table];
     }
 
     /**

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -261,7 +261,7 @@ class BasicInformationProposalController extends Controller {
 
         // 檢查是否有實際修改
         $diff = $this->operationRepository->getArrDiff($payload, $originalRow, $originalRow);
-        if ($diff === null) {
+        if ($diff === null && !$this->hasAuxiliaryChanges($table, $conditions, $originalRow, $auxiliaryPayload)) {
             flash('提案失敗：未偵測到任何修改內容。', 'warning');
 
             return redirect()->back()->withInput();
@@ -483,6 +483,108 @@ class BasicInformationProposalController extends Controller {
         }
 
         return [$data, $auxiliary];
+    }
+
+    protected function hasAuxiliaryChanges(string $table, array $conditions, array $originalRow, array $auxiliaryPayload): bool {
+        if ($auxiliaryPayload === []) {
+            return false;
+        }
+
+        return match ($table) {
+            'POSTED_TO_OFFICE_DATA' => $this->hasOfficeAddressChanges($conditions, $originalRow, $auxiliaryPayload),
+            'EVENTS_DATA' => $this->hasEventAddressChanges($conditions, $originalRow, $auxiliaryPayload),
+            'KIN_DATA' => $this->hasKinshipPairChanges($originalRow, $auxiliaryPayload),
+            'ASSOC_DATA' => $this->hasAssocPairChanges($originalRow, $auxiliaryPayload),
+            default => false,
+        };
+    }
+
+    protected function hasOfficeAddressChanges(array $conditions, array $originalRow, array $auxiliaryPayload): bool {
+        $incomingAddr = array_key_exists('c_addr', $auxiliaryPayload)
+            ? (array) $auxiliaryPayload['c_addr']
+            : (($auxiliaryPayload['c_addr_cleared'] ?? '0') === '1' ? [] : null);
+
+        if ($incomingAddr === null) {
+            return false;
+        }
+
+        $currentAddr = DB::table('POSTED_TO_ADDR_DATA')
+            ->where('c_personid', $originalRow['c_personid'] ?? $conditions['c_personid'] ?? null)
+            ->where('c_posting_id', $originalRow['c_posting_id'] ?? $conditions['c_posting_id'] ?? null)
+            ->pluck('c_addr_id')
+            ->all();
+
+        return $this->normalizeSelectionList($incomingAddr) !== $this->normalizeSelectionList($currentAddr);
+    }
+
+    protected function hasEventAddressChanges(array $conditions, array $originalRow, array $auxiliaryPayload): bool {
+        if (!array_key_exists('c_addr_id', $auxiliaryPayload)) {
+            return false;
+        }
+
+        $incomingAddr = (array) $auxiliaryPayload['c_addr_id'];
+        $currentAddr = DB::table('EVENTS_ADDR')
+            ->where('c_personid', $originalRow['c_personid'] ?? $conditions['c_personid'] ?? null)
+            ->where('c_sequence', $originalRow['c_sequence'] ?? $conditions['c_sequence'] ?? null)
+            ->where('c_event_code', $originalRow['c_event_code'] ?? $conditions['c_event_code'] ?? null)
+            ->pluck('c_addr_id')
+            ->all();
+
+        return $this->normalizeSelectionList($incomingAddr) !== $this->normalizeSelectionList($currentAddr);
+    }
+
+    protected function hasKinshipPairChanges(array $originalRow, array $auxiliaryPayload): bool {
+        if (!array_key_exists('c_kinship_pair', $auxiliaryPayload)) {
+            return false;
+        }
+
+        $currentPair = DB::table('KIN_DATA')
+            ->where('c_personid', $originalRow['c_kin_id'] ?? null)
+            ->where('c_kin_id', $originalRow['c_personid'] ?? null)
+            ->where('c_autogen_notes', $originalRow['c_autogen_notes'] ?? null)
+            ->value('c_kin_code');
+
+        return (int) ($auxiliaryPayload['c_kinship_pair'] ?? 0) !== (int) ($currentPair ?? 0);
+    }
+
+    protected function hasAssocPairChanges(array $originalRow, array $auxiliaryPayload): bool {
+        $pairKeys = ['c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair'];
+        if (array_intersect($pairKeys, array_keys($auxiliaryPayload)) === []) {
+            return false;
+        }
+
+        $mirrorRow = DB::table('ASSOC_DATA')
+            ->where('c_personid', $originalRow['c_assoc_id'] ?? null)
+            ->where('c_assoc_id', $originalRow['c_personid'] ?? null)
+            ->where('c_text_title', $originalRow['c_text_title'] ?? '')
+            ->where('c_assoc_first_year', $originalRow['c_assoc_first_year'] ?? '-9999')
+            ->first();
+
+        $current = [
+            'c_assocship_pair' => (int) ($mirrorRow->c_assoc_code ?? 0),
+            'c_kinship_pair' => (int) ($mirrorRow->c_kin_code ?? 0),
+            'c_assoc_kinship_pair' => (int) ($mirrorRow->c_assoc_kin_code ?? 0),
+        ];
+
+        foreach ($pairKeys as $key) {
+            if (array_key_exists($key, $auxiliaryPayload) && (int) $auxiliaryPayload[$key] !== $current[$key]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function normalizeSelectionList(array $values): array {
+        $normalized = array_map(static function ($value) {
+            $value = (int) $value;
+
+            return $value === -999 ? 0 : $value;
+        }, $values);
+
+        sort($normalized);
+
+        return array_values(array_unique($normalized));
     }
 
     protected function getTableColumns(string $table): array {

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Operation;
+use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\NameSearchIndexService;
+use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -16,6 +18,8 @@ use Illuminate\Support\Facades\Schema;
 class OperationsProposalController extends Controller {
     protected $operationRepository;
     protected $nameSearchIndexService;
+    protected $biogMainRepository;
+    protected array $tableColumnCache = [];
 
     /**
      * 表名到模型類的映射
@@ -29,9 +33,14 @@ class OperationsProposalController extends Controller {
         // 注意：ALTNAME_DATA 使用復合主鍵，不使用 Eloquent，改為手動調用索引服務
     ];
 
-    public function __construct(OperationRepository $operationRepository, NameSearchIndexService $nameSearchIndexService) {
+    public function __construct(
+        OperationRepository $operationRepository,
+        NameSearchIndexService $nameSearchIndexService,
+        BiogMainRepository $biogMainRepository
+    ) {
         $this->operationRepository = $operationRepository;
         $this->nameSearchIndexService = $nameSearchIndexService;
+        $this->biogMainRepository = $biogMainRepository;
     }
 
     public function approve(Request $request, Operation $operation) {
@@ -49,19 +58,25 @@ class OperationsProposalController extends Controller {
             return redirect()->back();
         }
 
-        $data = $this->sanitizePayload($payload);
+        $data = $this->sanitizePayload($payload, $table);
+        $auxiliaryPayload = $this->extractAuxiliaryPayload($payload, $table);
         $comment = trim((string) $request->input('review_comment', ''));
 
         try {
-            DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original, $operation, $comment) {
-                if ($opType === Operation::TYPE_PROPOSAL_CREATE) {
-                    $appliedRow = $this->applyCreateProposal($table, $data, $keyColumns);
-                } else {
-                    $appliedRow = $this->applyUpdateProposal($table, $data, $keyColumns, $original);
-                }
+            DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original, $operation, $comment, $auxiliaryPayload) {
+                [$appliedRow, $usedDirectWorkflow] = $this->applyProposal(
+                    $operation,
+                    $table,
+                    $data,
+                    $keyColumns,
+                    $original,
+                    $auxiliaryPayload
+                );
 
-                $this->logFinalOperation($operation, $appliedRow, $original, $opType);
-                $this->writeAuditLogForApproval($operation, $appliedRow, $original, $opType);
+                if (!$usedDirectWorkflow) {
+                    $this->logFinalOperation($operation, $appliedRow, $original, $opType);
+                    $this->writeAuditLogForApproval($operation, $appliedRow, $original, $opType);
+                }
                 $this->updateProposalStatus(
                     $operation,
                     'approved',
@@ -116,16 +131,322 @@ class OperationsProposalController extends Controller {
         return is_array($original) ? $original : [];
     }
 
-    protected function sanitizePayload(array $payload): array {
+    protected function sanitizePayload(array $payload, ?string $table = null): array {
         $sanitized = [];
+        $columns = $this->getTableColumnMap($table);
+
         foreach ($payload as $key => $value) {
             if (is_string($key) && strpos($key, '__') === 0) {
+                continue;
+            }
+            if ($columns !== null && is_string($key) && !isset($columns[$key])) {
                 continue;
             }
             $sanitized[$key] = $value;
         }
 
         return $sanitized;
+    }
+
+    protected function extractAuxiliaryPayload(array $payload, string $table): array {
+        $auxiliary = [];
+        $storedAuxiliary = $payload['__proposal_aux'] ?? null;
+        if (is_array($storedAuxiliary)) {
+            $auxiliary = $storedAuxiliary;
+        }
+
+        $columns = $this->getTableColumnMap($table);
+        if ($columns === null) {
+            return $auxiliary;
+        }
+
+        foreach ($payload as $key => $value) {
+            if (!is_string($key) || strpos($key, '__') === 0) {
+                continue;
+            }
+            if (!isset($columns[$key])) {
+                $auxiliary[$key] = $value;
+            }
+        }
+
+        return $auxiliary;
+    }
+
+    protected function getTableColumnMap(?string $table): ?array {
+        if ($table === null || $table === '' || !Schema::hasTable($table)) {
+            return null;
+        }
+
+        if (!array_key_exists($table, $this->tableColumnCache)) {
+            $this->tableColumnCache[$table] = array_flip(Schema::getColumnListing($table));
+        }
+
+        return $this->tableColumnCache[$table];
+    }
+
+    protected function applyProposal(
+        Operation $operation,
+        string $table,
+        array $data,
+        array $keyColumns,
+        array $original,
+        array $auxiliaryPayload
+    ): array {
+        if ($table === 'KIN_DATA') {
+            return [$this->applyKinshipProposal($operation, $data, $original, $auxiliaryPayload), true];
+        }
+
+        if ($table === 'ASSOC_DATA') {
+            return [$this->applyAssocProposal($operation, $data, $original, $auxiliaryPayload), true];
+        }
+
+        if ($table === 'POSTED_TO_OFFICE_DATA') {
+            return [$this->applyOfficeProposal($operation, $data, $original, $auxiliaryPayload), true];
+        }
+
+        if ($table === 'EVENTS_DATA') {
+            return [$this->applyEventProposal($operation, $data, $original, $auxiliaryPayload), true];
+        }
+
+        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
+            return [$this->applyCreateProposal($table, $data, $keyColumns), false];
+        }
+
+        return [$this->applyUpdateProposal($table, $data, $keyColumns, $original), false];
+    }
+
+    protected function applyKinshipProposal(
+        Operation $operation,
+        array $data,
+        array $original,
+        array $auxiliaryPayload
+    ): array {
+        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
+        $requestPayload = array_merge($data, $auxiliaryPayload);
+        $request = Request::create('/', 'POST', $requestPayload);
+
+        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
+            return $this->biogMainRepository->kinshipStoreById($request, $personId);
+        }
+
+        if (empty($original)) {
+            throw new \RuntimeException('缺少原始資料，無法更新。');
+        }
+
+        $result = $this->biogMainRepository->kinshipUpdateById(
+            $request,
+            $personId,
+            $this->buildLegacyKinshipId($original)
+        );
+
+        $mirrorStatus = (int) ($result['err'] ?? 1);
+        unset($result['err']);
+
+        if ($mirrorStatus === 0) {
+            throw new \RuntimeException('對應的親屬資料更新失敗，請從對應的親屬人物修改。');
+        }
+
+        if ($mirrorStatus > 1) {
+            throw new \RuntimeException('對應的親屬資料有多筆重複，請從對應的親屬人物修改。');
+        }
+
+        return $result;
+    }
+
+    protected function applyAssocProposal(
+        Operation $operation,
+        array $data,
+        array $original,
+        array $auxiliaryPayload
+    ): array {
+        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
+        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
+
+        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
+            $result = $this->biogMainRepository->assocStoreById($request, $personId);
+
+            return $this->fetchAppliedRow('ASSOC_DATA', [
+                'c_personid' => $result['c_personid'] ?? $personId,
+                'c_assoc_code' => $result['c_assoc_code'] ?? null,
+                'c_assoc_id' => $result['c_assoc_id'] ?? null,
+                'c_kin_code' => $result['c_kin_code'] ?? null,
+                'c_kin_id' => $result['c_kin_id'] ?? null,
+                'c_assoc_kin_code' => $result['c_assoc_kin_code'] ?? null,
+                'c_assoc_kin_id' => $result['c_assoc_kin_id'] ?? null,
+                'c_text_title' => $result['c_text_title'] ?? '',
+                'c_assoc_first_year' => $result['c_assoc_first_year'] ?? '-9999',
+            ]) ?? $result;
+        }
+
+        if (empty($original)) {
+            throw new \RuntimeException('缺少原始資料，無法更新。');
+        }
+
+        $result = $this->biogMainRepository->assocUpdateById(
+            $request,
+            $this->buildLegacyAssocId($original),
+            $personId
+        );
+
+        if ($result === []) {
+            throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
+        }
+
+        return $this->fetchAppliedRow('ASSOC_DATA', [
+            'c_personid' => $personId,
+            'c_assoc_code' => $result['c_assoc_code'] ?? $original['c_assoc_code'] ?? null,
+            'c_assoc_id' => $result['c_assoc_id'] ?? $original['c_assoc_id'] ?? null,
+            'c_kin_code' => $result['c_kin_code'] ?? $original['c_kin_code'] ?? null,
+            'c_kin_id' => $result['c_kin_id'] ?? $original['c_kin_id'] ?? null,
+            'c_assoc_kin_code' => $result['c_assoc_kin_code'] ?? $original['c_assoc_kin_code'] ?? null,
+            'c_assoc_kin_id' => $result['c_assoc_kin_id'] ?? $original['c_assoc_kin_id'] ?? null,
+            'c_text_title' => $result['c_text_title'] ?? $original['c_text_title'] ?? '',
+            'c_assoc_first_year' => $result['c_assoc_first_year'] ?? $original['c_assoc_first_year'] ?? '-9999',
+        ]) ?? array_merge($original, $result);
+    }
+
+    protected function applyOfficeProposal(
+        Operation $operation,
+        array $data,
+        array $original,
+        array $auxiliaryPayload
+    ): array {
+        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
+        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
+
+        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
+            $resourceId = $this->biogMainRepository->officeStoreById($request, $personId);
+        } else {
+            if (empty($original)) {
+                throw new \RuntimeException('缺少原始資料，無法更新。');
+            }
+
+            $result = $this->biogMainRepository->officeUpdateById(
+                $request,
+                $this->buildLegacyOfficeId($original),
+                $personId
+            );
+            $resourceId = is_array($result) ? ($result['id'] ?? null) : $result;
+        }
+
+        if (!is_string($resourceId) || $resourceId === '') {
+            throw new \RuntimeException('官名提案套用後無法取得主鍵。');
+        }
+
+        $pk = CompositePrimaryKey::parseStoredResourceId($resourceId, 'POSTED_TO_OFFICE_DATA');
+        if ($pk === null) {
+            throw new \RuntimeException('官名提案套用後無法解析主鍵。');
+        }
+
+        $row = $this->fetchAppliedRow('POSTED_TO_OFFICE_DATA', $pk);
+        if ($row === null) {
+            throw new \RuntimeException('官名提案套用後讀取資料失敗。');
+        }
+
+        return $row;
+    }
+
+    protected function applyEventProposal(
+        Operation $operation,
+        array $data,
+        array $original,
+        array $auxiliaryPayload
+    ): array {
+        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
+        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
+
+        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
+            $result = $this->biogMainRepository->eventStoreById($request, $personId);
+        } else {
+            if (empty($original)) {
+                throw new \RuntimeException('缺少原始資料，無法更新。');
+            }
+
+            $result = $this->biogMainRepository->eventUpdateById(
+                $request,
+                $personId,
+                $this->buildLegacyEventId($original)
+            );
+        }
+
+        return $this->fetchAppliedRow('EVENTS_DATA', [
+            'c_personid' => $personId,
+            'c_sequence' => $result['c_sequence'] ?? $original['c_sequence'] ?? null,
+            'c_event_code' => $result['c_event_code'] ?? $original['c_event_code'] ?? null,
+        ]) ?? array_merge($original, $result);
+    }
+
+    protected function buildLegacyKinshipId(array $original): string {
+        foreach (['c_personid', 'c_kin_id', 'c_kin_code'] as $column) {
+            if (!array_key_exists($column, $original)) {
+                throw new \RuntimeException("缺少 {$column}，無法更新親屬提案。");
+            }
+        }
+
+        return implode('-', [
+            $original['c_personid'],
+            $original['c_kin_id'],
+            $original['c_kin_code'],
+        ]);
+    }
+
+    protected function buildLegacyAssocId(array $original): string {
+        $required = ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id'];
+        foreach ($required as $column) {
+            if (!array_key_exists($column, $original)) {
+                throw new \RuntimeException("缺少 {$column}，無法更新社會關係提案。");
+            }
+        }
+
+        $assocFirstYear = (string) ($original['c_assoc_first_year'] ?? '-9999');
+
+        return implode('-', [
+            $original['c_personid'],
+            $original['c_assoc_code'],
+            $original['c_assoc_id'],
+            $original['c_kin_code'],
+            $original['c_kin_id'],
+            $original['c_assoc_kin_code'],
+            $original['c_assoc_kin_id'],
+            $this->biogMainRepository->unionPKDef($original['c_text_title'] ?? ''),
+            str_replace('-', '(minus)', $assocFirstYear),
+        ]);
+    }
+
+    protected function buildLegacyOfficeId(array $original): string {
+        foreach (['c_office_id', 'c_posting_id'] as $column) {
+            if (!array_key_exists($column, $original)) {
+                throw new \RuntimeException("缺少 {$column}，無法更新官名提案。");
+            }
+        }
+
+        return $original['c_office_id'].'-'.$original['c_posting_id'];
+    }
+
+    protected function buildLegacyEventId(array $original): string {
+        foreach (['c_sequence', 'c_event_code'] as $column) {
+            if (!array_key_exists($column, $original)) {
+                throw new \RuntimeException("缺少 {$column}，無法更新事件提案。");
+            }
+        }
+
+        return $original['c_sequence'].'-'.$original['c_event_code'];
+    }
+
+    protected function fetchAppliedRow(string $table, array $conditions): ?array {
+        $conditions = array_filter($conditions, static fn ($value) => $value !== null);
+        if ($conditions === []) {
+            return null;
+        }
+
+        $query = DB::table($table);
+        foreach ($conditions as $column => $value) {
+            $query->where($column, $value);
+        }
+
+        $row = $query->first();
+
+        return $row ? $this->convertRowToArray($row) : null;
     }
 
     protected function applyCreateProposal(string $table, array $data, array $keyColumns): array {
@@ -205,21 +526,14 @@ class OperationsProposalController extends Controller {
             throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
         }
 
-        foreach ($keyColumns as $column) {
-            if (!array_key_exists($column, $original)) {
-                continue;
-            }
-            if (array_key_exists($column, $data) && !$this->keyValuesMatch($data[$column], $original[$column])) {
-                throw new \RuntimeException('提案不可修改主鍵欄位。');
-            }
-        }
-
-        $updatePayload = array_diff_key($data, array_flip($keyColumns));
+        $updatePayload = $this->buildUpdatePayload($data, $keyColumns, $original);
         if (!empty($updatePayload)) {
             DB::table($table)->where($conditions)->update($updatePayload);
         }
 
-        $row = DB::table($table)->where($conditions)->first();
+        $readKeyRow = $this->resolveReadbackKeyRow($keyColumns, $original, $updatePayload);
+        $readConditions = $this->buildKeyConditions($keyColumns, $readKeyRow);
+        $row = DB::table($table)->where($readConditions)->first();
         if (!$row) {
             throw new \RuntimeException('更新後讀取資料失敗。');
         }
@@ -230,6 +544,34 @@ class OperationsProposalController extends Controller {
         }
 
         return $this->convertRowToArray($row);
+    }
+
+    protected function buildUpdatePayload(array $data, array $keyColumns, array $original): array {
+        $updatePayload = array_diff_key($data, array_flip($keyColumns));
+
+        foreach ($keyColumns as $column) {
+            if (!array_key_exists($column, $original) || !array_key_exists($column, $data)) {
+                continue;
+            }
+
+            if (!$this->keyValuesMatch($data[$column], $original[$column])) {
+                $updatePayload[$column] = $data[$column];
+            }
+        }
+
+        return $updatePayload;
+    }
+
+    protected function resolveReadbackKeyRow(array $keyColumns, array $original, array $updatePayload): array {
+        $row = $original;
+
+        foreach ($keyColumns as $column) {
+            if (array_key_exists($column, $updatePayload)) {
+                $row[$column] = $updatePayload[$column];
+            }
+        }
+
+        return $row;
     }
 
     protected function keyValuesMatch($left, $right): bool {

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -91,6 +91,22 @@ class BasicInformationProposalTest extends TestCase {
             $table->timestamps();
         });
 
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('occurred_at')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->string('table_name');
+            $table->string('operation');
+            $table->string('actor_type')->nullable();
+            $table->string('actor_id')->nullable();
+            $table->string('operation_id')->nullable();
+            $table->longText('row_pk')->nullable();
+            $table->string('row_pk_text')->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+
         Schema::dropIfExists('ALTNAME_DATA');
         Schema::create('ALTNAME_DATA', function (Blueprint $table) {
             $table->integer('c_personid');
@@ -119,8 +135,17 @@ class BasicInformationProposalTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('EVENTS_ADDR');
+        Schema::dropIfExists('EVENTS_DATA');
+        Schema::dropIfExists('POSTED_TO_ADDR_DATA');
+        Schema::dropIfExists('POSTED_TO_OFFICE_DATA');
+        Schema::dropIfExists('POSTING_DATA');
+        Schema::dropIfExists('ASSOC_DATA');
+        Schema::dropIfExists('KIN_DATA');
+        Schema::dropIfExists('KINSHIP_CODES');
         Schema::dropIfExists('POSSESSION_DATA');
         Schema::dropIfExists('ALTNAME_DATA');
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('users');
         parent::tearDown();
@@ -157,6 +182,123 @@ class BasicInformationProposalTest extends TestCase {
         ]);
 
         return $user;
+    }
+
+    protected function createKinshipTables(): void {
+        Schema::dropIfExists('KIN_DATA');
+        Schema::dropIfExists('KINSHIP_CODES');
+
+        Schema::create('KINSHIP_CODES', function (Blueprint $table) {
+            $table->integer('c_kincode')->primary();
+            $table->integer('c_kin_pair1')->nullable();
+            $table->integer('c_kin_pair2')->nullable();
+        });
+
+        Schema::create('KIN_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_kin_id');
+            $table->integer('c_kin_code');
+            $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->text('c_notes')->nullable();
+            $table->text('c_autogen_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+    }
+
+    protected function createAssocTables(): void {
+        Schema::dropIfExists('ASSOC_DATA');
+
+        Schema::create('ASSOC_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code');
+            $table->integer('c_assoc_id');
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_assoc_kin_code')->default(0);
+            $table->integer('c_assoc_kin_id')->default(0);
+            $table->string('c_text_title')->default('');
+            $table->string('c_assoc_first_year')->default('-9999');
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+    }
+
+    protected function createOfficeTables(): void {
+        Schema::dropIfExists('POSTED_TO_ADDR_DATA');
+        Schema::dropIfExists('POSTED_TO_OFFICE_DATA');
+        Schema::dropIfExists('POSTING_DATA');
+
+        Schema::create('POSTING_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id');
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id');
+            $table->integer('c_office_id');
+            $table->integer('c_sequence')->default(1);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages')->nullable();
+            $table->integer('c_fy_intercalary')->default(0);
+            $table->integer('c_ly_intercalary')->default(0);
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+
+        Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id');
+            $table->integer('c_office_id');
+            $table->integer('c_addr_id');
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+    }
+
+    protected function createEventTables(): void {
+        Schema::dropIfExists('EVENTS_ADDR');
+        Schema::dropIfExists('EVENTS_DATA');
+
+        Schema::create('EVENTS_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence');
+            $table->integer('c_event_code');
+            $table->integer('c_source')->default(0);
+            $table->integer('c_intercalary')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+
+        Schema::create('EVENTS_ADDR', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence');
+            $table->integer('c_event_code');
+            $table->integer('c_addr_id');
+        });
     }
 
     #[Test]
@@ -447,6 +589,52 @@ class BasicInformationProposalTest extends TestCase {
     }
 
     #[Test]
+    public function testKinshipProposalUpdateStoresAuxiliaryFieldsInProposalMeta() {
+        $this->createKinshipTables();
+
+        DB::table('KIN_DATA')->insert([
+            'c_personid' => 1,
+            'c_kin_id' => 2,
+            'c_kin_code' => 111,
+            'c_source' => 100,
+            'c_pages' => '原頁碼',
+            'c_notes' => '原註記',
+            'c_autogen_notes' => 'mirror-note',
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'kinship',
+            'id' => '1-2-111',
+        ]), [
+            'c_kin_id' => 2,
+            'c_kin_code' => 75,
+            'c_source' => 65006,
+            'c_pages' => 'lgid=192832',
+            'c_notes' => '更新後註記',
+            'c_autogen_notes' => 'mirror-note',
+            'c_kinship_pair' => 176,
+            '__proposal_comment' => '修改親屬',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'KIN_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame(75, $payload['c_kin_code']);
+        $this->assertArrayNotHasKey('c_kinship_pair', $payload);
+        $this->assertSame(176, $payload['__proposal_aux']['c_kinship_pair'] ?? null);
+    }
+
+    #[Test]
     public function testApproveCreateProposalInsertsRow() {
         $admin = $this->makeAdmin();
         $this->actingAs($admin);
@@ -572,6 +760,294 @@ class BasicInformationProposalTest extends TestCase {
             'resource' => 'ALTNAME_DATA',
             'op_type' => Operation::TYPE_UPDATE,
             'c_personid' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function testApproveKinshipUpdateProposalUsesDirectWorkflowAndUpdatesMirrorRow() {
+        $this->createKinshipTables();
+        $this->app->instance(BiogMainRepository::class, new BiogMainRepository());
+
+        DB::table('KINSHIP_CODES')->insert([
+            'c_kincode' => 111,
+            'c_kin_pair1' => 301,
+            'c_kin_pair2' => null,
+        ]);
+
+        DB::table('KIN_DATA')->insert([
+            'c_personid' => 1,
+            'c_kin_id' => 2,
+            'c_kin_code' => 111,
+            'c_source' => 100,
+            'c_pages' => '原頁碼',
+            'c_notes' => '原註記',
+            'c_autogen_notes' => 'mirror-note',
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        DB::table('KIN_DATA')->insert([
+            'c_personid' => 2,
+            'c_kin_id' => 1,
+            'c_kin_code' => 301,
+            'c_source' => 100,
+            'c_pages' => '原頁碼',
+            'c_notes' => '原註記',
+            'c_autogen_notes' => 'mirror-note',
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_UPDATE;
+        $operation->resource = 'KIN_DATA';
+        $operation->resource_id = '1-2-111';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_kin_id' => 2,
+            'c_kin_code' => 75,
+            'c_source' => 65006,
+            'c_pages' => 'lgid=192832',
+            'c_notes' => null,
+            'c_autogen_notes' => 'mirror-note',
+            'c_kinship_pair' => 176,
+            '__key_columns' => ['c_personid', 'c_kin_id', 'c_kin_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode([
+            'c_personid' => 1,
+            'c_kin_id' => 2,
+            'c_kin_code' => 111,
+            'c_source' => 100,
+            'c_pages' => '原頁碼',
+            'c_notes' => '原註記',
+            'c_autogen_notes' => 'mirror-note',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '同意修改親屬',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('已核准', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('KIN_DATA', [
+            'c_personid' => 1,
+            'c_kin_id' => 2,
+            'c_kin_code' => 75,
+            'c_source' => 65006,
+            'c_pages' => 'lgid=192832',
+        ]);
+
+        $this->assertDatabaseHas('KIN_DATA', [
+            'c_personid' => 2,
+            'c_kin_id' => 1,
+            'c_kin_code' => 176,
+            'c_source' => 65006,
+            'c_pages' => 'lgid=192832',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+        $this->assertSame('同意修改親屬', $payload['__review_comment']);
+
+        $this->assertDatabaseHas('operations', [
+            'resource' => 'KIN_DATA',
+            'op_type' => Operation::TYPE_UPDATE,
+            'c_personid' => 1,
+        ]);
+    }
+
+    #[Test]
+    public function testApproveAssocCreateProposalUsesDirectWorkflowAndCreatesMirrorRow() {
+        $this->createAssocTables();
+        $this->app->instance(BiogMainRepository::class, new BiogMainRepository());
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'ASSOC_DATA';
+        $operation->resource_id = 'pending-assoc';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_assoc_code' => 10,
+            'c_assoc_id' => 2,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => '',
+            'c_assoc_first_year' => '-9999',
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '社會關係提案',
+            'c_assocship_pair' => 20,
+            'c_kinship_pair' => 301,
+            'c_assoc_kinship_pair' => 302,
+            '__key_columns' => ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '同意建立社會關係',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('ASSOC_DATA', [
+            'c_personid' => 1,
+            'c_assoc_code' => 10,
+            'c_assoc_id' => 2,
+            'c_notes' => '社會關係提案',
+        ]);
+
+        $this->assertDatabaseHas('ASSOC_DATA', [
+            'c_personid' => 2,
+            'c_assoc_code' => 20,
+            'c_assoc_id' => 1,
+            'c_kin_code' => 301,
+            'c_assoc_kin_code' => 302,
+        ]);
+    }
+
+    #[Test]
+    public function testApproveOfficeCreateProposalUsesDirectWorkflowAndCreatesAddressRows() {
+        $this->createOfficeTables();
+        $this->app->instance(BiogMainRepository::class, new BiogMainRepository());
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        DB::table('POSTING_DATA')->insert([
+            'c_personid' => 99,
+            'c_posting_id' => 7,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'POSTED_TO_OFFICE_DATA';
+        $operation->resource_id = 'pending-office';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_office_id' => 888,
+            'c_sequence' => 1,
+            'c_source' => 123,
+            'c_pages' => 'p.1',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '官名提案',
+            'c_addr' => [10, 11],
+            '__key_columns' => ['c_office_id', 'c_posting_id'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '同意建立官名',
+        ]);
+
+        $response->assertRedirect();
+
+        $officeRow = DB::table('POSTED_TO_OFFICE_DATA')
+            ->where('c_personid', 1)
+            ->where('c_office_id', 888)
+            ->first();
+
+        $this->assertNotNull($officeRow);
+        $this->assertSame('官名提案', $officeRow->c_notes);
+
+        $this->assertDatabaseHas('POSTING_DATA', [
+            'c_personid' => 1,
+            'c_posting_id' => $officeRow->c_posting_id,
+        ]);
+
+        $this->assertDatabaseHas('POSTED_TO_ADDR_DATA', [
+            'c_personid' => 1,
+            'c_posting_id' => $officeRow->c_posting_id,
+            'c_office_id' => 888,
+            'c_addr_id' => 10,
+        ]);
+
+        $this->assertDatabaseHas('POSTED_TO_ADDR_DATA', [
+            'c_personid' => 1,
+            'c_posting_id' => $officeRow->c_posting_id,
+            'c_office_id' => 888,
+            'c_addr_id' => 11,
+        ]);
+    }
+
+    #[Test]
+    public function testApproveEventCreateProposalUsesDirectWorkflowAndCreatesEventAddrRows() {
+        $this->createEventTables();
+        $this->app->instance(BiogMainRepository::class, new BiogMainRepository());
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_CREATE;
+        $operation->resource = 'EVENTS_DATA';
+        $operation->resource_id = 'pending-event';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_source' => 123,
+            'c_intercalary' => 0,
+            'c_notes' => '事件提案',
+            'c_addr_id' => [20, 21],
+            '__key_columns' => ['c_personid', 'c_sequence', 'c_event_code'],
+            '__review_status' => 'pending',
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '同意建立事件',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('EVENTS_DATA', [
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_notes' => '事件提案',
+        ]);
+
+        $this->assertDatabaseHas('EVENTS_ADDR', [
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_addr_id' => 20,
+        ]);
+
+        $this->assertDatabaseHas('EVENTS_ADDR', [
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_addr_id' => 21,
         ]);
     }
 
@@ -776,7 +1252,7 @@ class BasicInformationProposalTest extends TestCase {
     }
 
     #[Test]
-    public function testApproveUpdateRejectsPrimaryKeyChange() {
+    public function testApproveUpdateAllowsPrimaryKeyChange() {
         DB::table('ALTNAME_DATA')->insert([
             'c_personid' => 1,
             'c_sequence' => 1,
@@ -813,11 +1289,16 @@ class BasicInformationProposalTest extends TestCase {
         $response->assertRedirect();
         $flash = session('flash_notification', collect())->toArray();
         $this->assertNotEmpty($flash);
-        $this->assertStringContainsString('提案不可修改主鍵欄位', $flash[0]['message'] ?? '');
+        $this->assertStringContainsString('提案已核准並套用至資料表', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '不可改主鍵',
+        ]);
 
         $this->assertDatabaseHas('ALTNAME_DATA', [
             'c_personid' => 1,
-            'c_alt_name_chn' => '不可改主鍵',
+            'c_alt_name_chn' => '新主鍵值',
         ]);
     }
 

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -635,6 +635,114 @@ class BasicInformationProposalTest extends TestCase {
     }
 
     #[Test]
+    public function testOfficeProposalUpdateAllowsAddressOnlyChanges() {
+        $this->createOfficeTables();
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 8,
+            'c_office_id' => 888,
+            'c_sequence' => 1,
+            'c_source' => 123,
+            'c_pages' => 'p.1',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '原官名',
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 8,
+            'c_office_id' => 888,
+            'c_addr_id' => 10,
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'offices',
+            'id' => '888-8',
+        ]), [
+            'c_office_id' => 888,
+            'c_posting_id' => 8,
+            'c_sequence' => 1,
+            'c_source' => 123,
+            'c_pages' => 'p.1',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '原官名',
+            'c_addr' => [11],
+            '__proposal_comment' => '只改地址',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'POSTED_TO_OFFICE_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame([11], $payload['__proposal_aux']['c_addr'] ?? null);
+    }
+
+    #[Test]
+    public function testEventProposalUpdateAllowsAddressOnlyChanges() {
+        $this->createEventTables();
+
+        DB::table('EVENTS_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_source' => 123,
+            'c_intercalary' => 0,
+            'c_notes' => '原事件',
+        ]);
+
+        DB::table('EVENTS_ADDR')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_addr_id' => 20,
+        ]);
+
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'events',
+            'id' => '1-5-99',
+        ]), [
+            'c_sequence' => 5,
+            'c_event_code' => 99,
+            'c_source' => 123,
+            'c_intercalary' => 0,
+            'c_notes' => '原事件',
+            'c_addr_id' => [21],
+            '__proposal_comment' => '只改事件地址',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'EVENTS_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame([21], $payload['__proposal_aux']['c_addr_id'] ?? null);
+    }
+
+    #[Test]
     public function testApproveCreateProposalInsertsRow() {
         $admin = $this->makeAdmin();
         $this->actingAs($admin);

--- a/tests/Feature/OperationsProposalControllerTest.php
+++ b/tests/Feature/OperationsProposalControllerTest.php
@@ -243,6 +243,105 @@ class OperationsProposalControllerTest extends TestCase {
     }
 
     #[Test]
+    public function testApproveUpdateProposalAllowsCompositePrimaryKeyChange(): void {
+        DB::table('TEST_CODES')->insert([
+            'code_id' => 'UP',
+            'code_sub' => '02',
+            'description' => 'Before',
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $resourceData = [
+            'code_id' => 'UP',
+            'code_sub' => '03',
+            'description' => 'After PK changed',
+            '__key_columns' => ['code_id', 'code_sub'],
+            '__review_status' => 'pending',
+        ];
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource_id' => 'UP_._02',
+            'resource_data' => $resourceData,
+            'resource_original' => [
+                'code_id' => 'UP',
+                'code_sub' => '02',
+                'description' => 'Before',
+            ],
+        ]);
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '允許修改主鍵欄位',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseMissing('TEST_CODES', [
+            'code_id' => 'UP',
+            'code_sub' => '02',
+        ]);
+        $this->assertDatabaseHas('TEST_CODES', [
+            'code_id' => 'UP',
+            'code_sub' => '03',
+            'description' => 'After PK changed',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
+    public function testApproveUpdateProposalReadbackUsesUnchangedOriginalKeyRepresentation(): void {
+        DB::table('TEST_CODES')->insert([
+            'code_id' => 'UP',
+            'code_sub' => '02',
+            'description' => 'Before',
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $resourceData = [
+            'code_id' => 'UP',
+            'code_sub' => '2',
+            'description' => 'After normalize-equal key',
+            '__key_columns' => ['code_id', 'code_sub'],
+            '__review_status' => 'pending',
+        ];
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource_id' => 'UP_._02',
+            'resource_data' => $resourceData,
+            'resource_original' => [
+                'code_id' => 'UP',
+                'code_sub' => '02',
+                'description' => 'Before',
+            ],
+        ]);
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertNotEmpty($flash);
+        $this->assertStringContainsString('提案已核准並套用至資料表', $flash[0]['message'] ?? '');
+
+        $this->assertDatabaseHas('TEST_CODES', [
+            'code_id' => 'UP',
+            'code_sub' => '02',
+            'description' => 'After normalize-equal key',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
     public function testRejectProposalUpdatesStatus() {
         $admin = $this->makeAdmin();
         $this->actingAs($admin);


### PR DESCRIPTION
主要修正「提案審核」與「直接修改」行為不一致的問題，特別是複合主鍵更新、親屬/社會關係鏡像資料、官名地址子表與事件地址子表等帶副作用的資源。調整後，提案一旦被批准，落庫結果會盡量沿用既有 repository 的直接寫入流程，而不是再走一套獨立的 generic insert/update 邏輯。

# 變更重點

1. 允許提案審核更新複合主鍵欄位
2. 修正提案更新後的讀回鍵值比對條件，避免更新後找錯資料列
3. 將 KIN_DATA 提案審核改為沿用 kinshipStoreById() / kinshipUpdateById()
4. 將 ASSOC_DATA、POSTED_TO_OFFICE_DATA、EVENTS_DATA 提案審核改為沿用既有 repository 寫入流程
5. 提案 payload 分離正式資料欄位與表單輔助欄位，避免像 c_kinship_pair 這種非資料表欄位被誤寫入 SQL
6. 補上舊提案批准情境的回歸測試，確認批准結果與直接修改一致

# 解決的具體問題

- 提案審核時可正確處理複合主鍵欄位變更
- 更新後能依新鍵值正確讀回資料列
- 舊的 KIN_DATA 提案即使 payload 含有頂層 c_kinship_pair，也能正常批准
- KIN_DATA / ASSOC_DATA 的鏡像資料會與主記錄同步
- POSTED_TO_OFFICE_DATA 的批准會同步維護 POSTING_DATA、POSTED_TO_ADDR_DATA
- EVENTS_DATA 的批准會同步維護 EVENTS_ADDR

# 涉及資源

- KIN_DATA
- ASSOC_DATA
- POSTED_TO_OFFICE_DATA
- EVENTS_DATA

# 主要檔案

- OperationsProposalController.php
- BasicInformationProposalController.php
- BasicInformationProposalTest.php
- OperationsProposalControllerTest.php

已驗證：
 - ./vendor/bin/phpunit tests/Feature/BasicInformationProposalTest.php