### PR TITLE
入仕清單頁新增「入仕年」欄位

### DIFF
--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -58,7 +58,28 @@ class BasicInformationEntriesController extends Controller {
             // 如果 byPersonId 失敗（例如在測試環境中表結構不完整），只使用 ID
         }
 
+        // 收集所有年號 ID，批量查詢年號名稱
+        $nianhaoMap = collect();
+
+        try {
+            if ($biogbasicinformation && $biogbasicinformation->entries->isNotEmpty()) {
+                $nianhaoIds = $biogbasicinformation->entries
+                    ->pluck('pivot.c_entry_nh_id')
+                    ->filter(fn ($v) => $v && $v != 0)
+                    ->unique()
+                    ->values();
+                if ($nianhaoIds->isNotEmpty()) {
+                    $nianhaoMap = DB::table('NIAN_HAO')
+                        ->whereIn('c_nianhao_id', $nianhaoIds)
+                        ->pluck('c_nianhao_chn', 'c_nianhao_id');
+                }
+            }
+        } catch (\Exception $e) {
+            // 測試環境或最小化 schema 可能缺少 NIAN_HAO 表，降級為不顯示年號
+        }
+
         return view('biogmains.entries.index', ['basicinformation' => $biogbasicinformation,
+            'nianhaoMap' => $nianhaoMap,
             'page_title' => '入仕', 'page_description' => '基本信息表 入仕', 'breadcrumb_home' => '人物基本資料',
             'breadcrumbs' => [
                 ['label' => '人物基本資料', 'url' => route('basicinformation.index')],

--- a/app/Models/BiogMain.php
+++ b/app/Models/BiogMain.php
@@ -104,7 +104,7 @@ class BiogMain extends Model {
     }
 
     public function entries() {
-        return $this->belongsToMany('App\Models\EntryCode', 'ENTRY_DATA', 'c_personid', 'c_entry_code')->withPivot('c_sequence', 'c_kin_code', 'c_kin_id', 'c_assoc_code', 'c_assoc_id', 'c_year', 'c_inst_code', 'c_inst_name_code')->orderBy('c_sequence');
+        return $this->belongsToMany('App\Models\EntryCode', 'ENTRY_DATA', 'c_personid', 'c_entry_code')->withPivot('c_sequence', 'c_kin_code', 'c_kin_id', 'c_assoc_code', 'c_assoc_id', 'c_year', 'c_inst_code', 'c_inst_name_code', 'c_entry_nh_id', 'c_entry_nh_year')->orderBy('c_sequence');
     }
 
     public function statuses() {

--- a/resources/views/biogmains/entries/index.blade.php
+++ b/resources/views/biogmains/entries/index.blade.php
@@ -25,6 +25,7 @@ use App\Support\CompositePrimaryKey;
                     <th>序號</th>
                     <th>sequence</th>
                     <th>入仕法</th>
+                    <th>入仕年</th>
                     @auth
                         @if(Auth::user()->isActive())
                             <th style="width: 120px">操作</th>
@@ -38,6 +39,13 @@ use App\Support\CompositePrimaryKey;
                         <td>{{ $key+1 }}</td>
                         <td>{{ $value->pivot->c_sequence }}</td>
                         <td>{{ $value->c_entry_desc_chn }}</td>
+                        <td>
+                            @if($value->pivot->c_year && $value->pivot->c_year != 0)
+                                {{ $value->pivot->c_year }}
+                            @elseif($value->pivot->c_entry_nh_id && $value->pivot->c_entry_nh_id != 0)
+                                {{ $nianhaoMap[$value->pivot->c_entry_nh_id] ?? '' }}{{ $value->pivot->c_entry_nh_year ? $value->pivot->c_entry_nh_year . '年' : '' }}
+                            @endif
+                        </td>
                         @auth
                             @if(Auth::user()->isActive())
                                 <td>

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -189,6 +189,8 @@ class BasicInformationPagesLoadTest extends TestCase {
             $table->integer('c_year')->nullable();
             $table->integer('c_inst_code')->nullable();
             $table->integer('c_inst_name_code')->nullable();
+            $table->smallInteger('c_entry_nh_id')->nullable();
+            $table->smallInteger('c_entry_nh_year')->nullable();
             $table->text('c_notes')->nullable();
             $table->timestamps();
             $table->primary(['c_personid', 'c_entry_code', 'c_sequence']);
@@ -421,6 +423,14 @@ class BasicInformationPagesLoadTest extends TestCase {
             'c_entry_code' => 1,
             'c_entry_desc_chn' => '进士',
         ]);
+        \DB::table('ENTRY_CODES')->insert([
+            'c_entry_code' => 2,
+            'c_entry_desc_chn' => '举人',
+        ]);
+        \DB::table('ENTRY_CODES')->insert([
+            'c_entry_code' => 3,
+            'c_entry_desc_chn' => '贡生',
+        ]);
 
         \DB::table('STATUS_CODES')->insert([
             'c_status_code' => 1,
@@ -514,11 +524,29 @@ class BasicInformationPagesLoadTest extends TestCase {
         ]);
 
         // 6. 入词数据 (entries)
+        // 6a. 有西元年的入仕
         \DB::table('ENTRY_DATA')->insert([
             'c_personid' => $this->testPersonId,
             'c_entry_code' => 1,
             'c_sequence' => 1,
+            'c_year' => 1351,
             'c_notes' => '测试入词',
+        ]);
+        // 6b. 無西元年，有年號 fallback
+        \DB::table('ENTRY_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_entry_code' => 2,
+            'c_sequence' => 2,
+            'c_year' => 0,
+            'c_entry_nh_id' => 1,
+            'c_entry_nh_year' => 3,
+        ]);
+        // 6c. 無西元年、無年號
+        \DB::table('ENTRY_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_entry_code' => 3,
+            'c_sequence' => 3,
+            'c_year' => 0,
         ]);
 
         // 7. 事件数据 (events)
@@ -676,6 +704,44 @@ class BasicInformationPagesLoadTest extends TestCase {
     public function test_basicinformation_entries_index_loads() {
         $response = $this->get("/basicinformation/{$this->testPersonId}/entries");
         $response->assertStatus(200);
+    }
+
+    /**
+     * 測試入仕年欄位：有西元年時直接顯示
+     */
+    #[Test]
+    public function test_entries_index_shows_calendar_year() {
+        $response = $this->get("/basicinformation/{$this->testPersonId}/entries");
+        $response->assertStatus(200);
+        $response->assertSee('1351');
+    }
+
+    /**
+     * 測試入仕年欄位：無西元年但有年號時顯示年號 fallback
+     */
+    #[Test]
+    public function test_entries_index_shows_nianhao_fallback() {
+        $response = $this->get("/basicinformation/{$this->testPersonId}/entries");
+        $response->assertStatus(200);
+        $response->assertSee('测试年号');
+        $response->assertSee('3年');
+    }
+
+    /**
+     * 測試入仕年欄位：無西元年也無年號時，入仕年 td 內容為空白
+     */
+    #[Test]
+    public function test_entries_index_no_year_shows_empty() {
+        $response = $this->get("/basicinformation/{$this->testPersonId}/entries");
+        $response->assertStatus(200);
+        $response->assertSee('贡生');
+        // 驗證「貢生」所在行的入仕年 td 為空白（入仕法 td 後緊接入仕年 td）
+        $html = $response->getContent();
+        $this->assertMatchesRegularExpression(
+            '/<td>\s*贡生\s*<\/td>\s*<td>\s*<\/td>/s',
+            $html,
+            '無年份的入仕記錄，入仕年欄位應為空'
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- 入仕清單表格新增「入仕年」欄位，優先顯示西元年（`c_year`），若為 0 或空則 fallback 顯示年號名稱＋年數（如「至正11年」）
- Controller 批量查詢 NIAN_HAO 取得年號名稱，加入 try-catch 容錯
- 測試覆蓋三種情境：西元年顯示、年號 fallback、無年份時欄位為空

## Test plan
- [x] `./vendor/bin/phpunit --filter "test_basicinformation_entries|test_entries_index"` 全部通過（4 tests, 8 assertions）
- [x] 在生產環境確認 `/basicinformation/541122/entries` 頁面正確顯示入仕年欄位

🤖 Generated with [Claude Code](https://claude.com/claude-code)