### PR TITLE
修正出處更新時表單值覆蓋原始主鍵導致 Undefined array key

### DIFF
--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -371,12 +371,25 @@ class BasicInformationSourcesController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串提取原始 PK（用於定位記錄）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body，
+        // 當使用者修改了 c_textid 或 c_pages 時，表單的新值會覆蓋原始 PK
         $schema = CompositePrimaryKey::SCHEMAS['BIOG_SOURCE_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $pk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $pk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位（c_pages 為可選）
         CompositePrimaryKey::validateOrFail($pk, 'BIOG_SOURCE_DATA', ['c_pages']);
+
+        // 檢查路徑人物 ID 與查詢主鍵是否一致
+        if ((string) ($pk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
 
         // 構建舊格式 ID（格式：c_personid-c_textid-c_pages）
         $c_pages = $pk['c_pages'] ?? '';
@@ -385,6 +398,10 @@ class BasicInformationSourcesController extends Controller {
 
         // 使用 Repository 更新
         $data = $this->biogMainRepository->sourceUpdateById($request, $id, $id_);
+
+        if (empty($data)) {
+            abort(404, 'BIOG_SOURCE_DATA 記錄不存在');
+        }
 
         flash('Update success @ '.Carbon::now(), 'success');
 

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -80,6 +80,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('BIOG_SOURCE_DATA');
+        Schema::dropIfExists('users');
         parent::tearDown();
     }
 
@@ -271,5 +272,143 @@ class BasicInformationSourcesControllerTest extends TestCase {
         $this->assertSame('to delete', $payload['c_notes']);
         $this->assertSame('Creator User', $payload['c_created_by']);
         $this->assertNotNull($payload['c_created_date']);
+    }
+
+    // ─── updateQuery controller-level feature tests ───
+
+    /**
+     * 建立 users 表供 HTTP feature test 使用
+     */
+    private function createUsersTable(): void {
+        if (!Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->string('email')->unique();
+                $table->string('password');
+                $table->string('confirmation_token')->nullable();
+                $table->smallInteger('is_active')->default(0);
+                $table->smallInteger('is_admin')->default(0);
+                $table->rememberToken();
+                $table->timestamps();
+            });
+        }
+    }
+
+    private function createWriterUser(): User {
+        $this->createUsersTable();
+
+        return User::create([
+            'name' => 'Writer User',
+            'email' => 'writer@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'token',
+            'is_active' => 1,
+            'is_admin' => User::ROLE_EXPERT,
+        ]);
+    }
+
+    private function seedSourceRow(int $personid, int $textid, string $pages, string $notes = ''): void {
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            'c_personid' => $personid,
+            'c_textid' => $textid,
+            'c_pages' => $pages,
+            'c_notes' => $notes,
+            'c_main_source' => 0,
+            'c_self_bio' => 0,
+            'c_created_by' => 'Seeder',
+            'c_created_date' => now(),
+        ]);
+    }
+
+    #[Test]
+    public function updateQuery_changing_c_pages_succeeds(): void {
+        $this->actingAs($this->createWriterUser());
+
+        $this->seedSourceRow(100, 200, 'old-page');
+
+        // 查詢參數帶原始 PK，表單 body 帶新的 c_pages
+        $response = $this->patch(
+            route('basicinformation.sources.update.query', ['id' => 100])
+            .'?'.http_build_query(['c_personid' => 100, 'c_textid' => 200, 'c_pages' => 'old-page']),
+            [
+                'c_textid' => 200,
+                'c_pages' => 'new-page',
+                'c_notes' => '',
+                'c_main_source' => 0,
+                'c_self_bio' => 0,
+                'action' => 'save',
+            ]
+        );
+
+        $response->assertRedirect();
+
+        // 舊記錄已被更新為新的 c_pages
+        $this->assertDatabaseMissing('BIOG_SOURCE_DATA', [
+            'c_personid' => 100,
+            'c_textid' => 200,
+            'c_pages' => 'old-page',
+        ]);
+        $this->assertDatabaseHas('BIOG_SOURCE_DATA', [
+            'c_personid' => 100,
+            'c_textid' => 200,
+            'c_pages' => 'new-page',
+        ]);
+    }
+
+    #[Test]
+    public function updateQuery_changing_c_textid_succeeds(): void {
+        $this->actingAs($this->createWriterUser());
+
+        $this->seedSourceRow(100, 300, 'page1');
+
+        // 查詢參數帶原始 c_textid=300，表單 body 帶新的 c_textid=400
+        $response = $this->patch(
+            route('basicinformation.sources.update.query', ['id' => 100])
+            .'?'.http_build_query(['c_personid' => 100, 'c_textid' => 300, 'c_pages' => 'page1']),
+            [
+                'c_textid' => 400,
+                'c_pages' => 'page1',
+                'c_notes' => '',
+                'c_main_source' => 0,
+                'c_self_bio' => 0,
+                'action' => 'save',
+            ]
+        );
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseMissing('BIOG_SOURCE_DATA', [
+            'c_personid' => 100,
+            'c_textid' => 300,
+        ]);
+        $this->assertDatabaseHas('BIOG_SOURCE_DATA', [
+            'c_personid' => 100,
+            'c_textid' => 400,
+            'c_pages' => 'page1',
+        ]);
+    }
+
+    #[Test]
+    public function updateQuery_personid_mismatch_returns_400(): void {
+        $this->actingAs($this->createWriterUser());
+
+        $this->seedSourceRow(100, 200, 'p1');
+
+        // 路徑 id=100，但查詢參數 c_personid=999
+        $response = $this->patch(
+            route('basicinformation.sources.update.query', ['id' => 100])
+            .'?'.http_build_query(['c_personid' => 999, 'c_textid' => 200, 'c_pages' => 'p1']),
+            [
+                'c_textid' => 200,
+                'c_pages' => 'p1',
+                'c_notes' => '',
+                'c_main_source' => 0,
+                'c_self_bio' => 0,
+                'action' => 'save',
+            ]
+        );
+
+        $response->assertStatus(400);
     }
 }


### PR DESCRIPTION
## Summary
- `updateQuery` 使用 `fromRequest()` 提取複合主鍵，但該方法會合併 URL 查詢參數與表單 body；當使用者修改 `c_textid` 或 `c_pages` 時，表單的新值覆蓋查詢字串中的舊值，導致用新值查舊記錄找不到，回傳空陣列後存取 `$data['c_textid']` 報錯
- 改用 `$request->query()` 提取原始 PK（與 proposal 分支及 EntriesController 一致）
- 新增 path/query `c_personid` 不一致時 abort 400（與 TextsController、AddressesController 一致）
- 新增 `sourceUpdateById` 回傳空陣列時 abort 404 的防護
- 補齊三個 controller-level feature test

## Test plan
- [x] `./vendor/bin/phpunit --filter BasicInformationSourcesControllerTest`（8 tests, 48 assertions）
- [x] 在測試環境手動修改出處的頁碼/出處欄位，確認可正常儲存

🤖 Generated with [Claude Code](https://claude.com/claude-code)