### PR TITLE
修正年號轉換後「直接存儲」按鈕未啟用

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -603,8 +603,8 @@ function initEraConversion() {
             // 直接使用年號 ID 進行轉換（使用 code 而非字串）
             convertNianhaoIdToYear(nianhaoId, nhYear).then(result => {
                 if (result.success) {
-                    // 填充公元年份
-                    $yearInput.val(result.year);
+                    // 填充公元年份並觸發 change 事件，以通知表單髒值檢測
+                    $yearInput.val(result.year).trigger('change');
 
                     // 顯示成功提示
                     showConversionSuccess($btn, `公元 ${result.year} 年`, '將年號轉換為公元年份');
@@ -674,10 +674,10 @@ async function fillEraFields(eraResult, gregorianYear, $container, nhCodeName, n
             $nhSelect.val(nianhaoId).trigger('change');
         }
 
-        // 填充年號年數輸入框
+        // 填充年號年數輸入框並觸發 change 事件，以通知表單髒值檢測
         const $nhYearInput = $container.find(`input[name="${nhYearName}"]`);
         if ($nhYearInput.length) {
-            $nhYearInput.val(yearNum);
+            $nhYearInput.val(yearNum).trigger('change');
         }
 
         // 顯示成功提示


### PR DESCRIPTION
## Summary
- 年號轉換按鈕以程式碼設定欄位值（`.val()`）後未觸發 `change` 事件，導致表單髒值檢測（`evaluateFormDirty`）無法偵測到變更，「直接存儲」按鈕維持灰色不可點擊
- 在反向轉換（年號→公元）與正向轉換的年數欄位補上 `.trigger('change')`
- 同時修復基本資料編輯頁與任官編輯頁（兩者共用 `app.js` 轉換邏輯與 `evaluateFormDirty` 機制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)