### PR TITLE
修正基本資料編輯頁 indexYear 未定義導致年號轉換失敗

### DIFF
--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -467,7 +467,7 @@
             window.initLunarValidation();
         }
 
-        function indexYear() {
+        window.indexYear = function() {
             let birth = $('input[name=c_birthyear]').val();
             let death = $('input[name=c_deathyear]').val();
             if(birth && death){
@@ -477,8 +477,7 @@
                 let indexyear = deathage > 60 ? parseInt(birth) + 60 : death;
                 $('input[name=c_index_year]').val(indexyear);
             }
-            // let index =
-        }
+        };
     });
     </script>
 <!-- Javascript -->


### PR DESCRIPTION
## Summary
- 將 `indexYear()` 從 `onViteReady` 閉包內的區域函式改為 `window.indexYear`，使 inline `onchange` 屬性能在全域作用域正確呼叫
- 修復點擊「年號轉西元年」按鈕後填入年份觸發 `onchange` 時報 `indexYear is not defined` 的問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)