### PR TITLE
移除 BIOG_MAIN.c_self_bio 欄位

### DIFF
--- a/database/migrations/2026_03_13_000000_drop_c_self_bio_from_biog_main.php
+++ b/database/migrations/2026_03_13_000000_drop_c_self_bio_from_biog_main.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+require_once __DIR__.'/helpers.php';
+
+return new class () extends Migration {
+    public function up(): void {
+        Schema::table('BIOG_MAIN', function (Blueprint $table) {
+            $table->dropColumn('c_self_bio');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('BIOG_MAIN', function (Blueprint $table) {
+            $table->smallInteger('c_self_bio')->nullable()->default(null);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- 新增 migration 移除 `BIOG_MAIN` 表的 `c_self_bio` 欄位（smallint, nullable）
- `down()` 方法可還原該欄位

🤖 Generated with [Claude Code](https://claude.com/claude-code)