### PR TITLE
調整操作記錄列表的資源導覽與顯示

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -54,6 +54,11 @@ class OperationsController extends Controller {
                     }
                 });
             }
+        } else {
+            $query->whereNotIn('op_type', [
+                Operation::TYPE_PROPOSAL_CREATE,
+                Operation::TYPE_PROPOSAL_UPDATE,
+            ]);
         }
 
         // 修改人篩選（支援 user_id 或 name 模糊匹配）
@@ -1225,6 +1230,7 @@ class OperationsController extends Controller {
             }
 
             $primaryId = is_numeric($item->c_personid ?? null) ? (int) $item->c_personid : null;
+            $resourceTargets = $this->resolveAffectedPeopleResourceTargets($item);
             $people = [];
             foreach ($ids as $id) {
                 if (!is_numeric($id) || (int) $id <= 0) {
@@ -1237,6 +1243,8 @@ class OperationsController extends Controller {
                     'name_chn' => $person->c_name_chn ?? '',
                     'name' => $person->c_name ?? '',
                     'is_primary' => $primaryId !== null && $personId === $primaryId,
+                    'resource_id' => $resourceTargets[$personId]['resource_id'] ?? null,
+                    'resource_link' => $resourceTargets[$personId]['resource_link'] ?? null,
                 ];
             }
 
@@ -1250,6 +1258,61 @@ class OperationsController extends Controller {
 
             $item->setAttribute('affected_people', $people);
         }
+    }
+
+    protected function resolveAffectedPeopleResourceTargets($item): array {
+        $resource = strtoupper((string) ($item->resource ?? ''));
+        if (!in_array($resource, ['KIN_DATA', 'ASSOC_DATA'], true)) {
+            return [];
+        }
+
+        $targets = [];
+        $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
+        foreach ($auditLogs as $audit) {
+            if (!is_array($audit)) {
+                continue;
+            }
+
+            $tableName = strtoupper(trim((string) ($audit['table_name'] ?? '')));
+            if ($tableName !== $resource) {
+                continue;
+            }
+
+            $rowPk = is_array($audit['row_pk'] ?? null) ? $audit['row_pk'] : [];
+            $personId = $rowPk['c_personid'] ?? null;
+            if (!is_numeric($personId) || (int) $personId <= 0) {
+                continue;
+            }
+            $personId = (int) $personId;
+
+            $personResourceId = trim((string) ($audit['row_pk_text'] ?? ''));
+            if ($personResourceId === '' && !empty($rowPk)) {
+                $personResourceId = CompositePrimaryKey::buildStoredResourceId($rowPk);
+            }
+
+            if ($personResourceId === '') {
+                continue;
+            }
+
+            $targets[$personId] = [
+                'resource_id' => $personResourceId,
+                'resource_link' => CompositePrimaryKey::buildResourceEditUrl($resource, $personResourceId, $personId),
+            ];
+        }
+
+        $primaryId = $item->c_personid ?? null;
+        $primaryResourceId = trim((string) ($item->resource_id ?? ''));
+        if (is_numeric($primaryId) && (int) $primaryId > 0 && $primaryResourceId !== '') {
+            $primaryId = (int) $primaryId;
+            if (!isset($targets[$primaryId])) {
+                $targets[$primaryId] = [
+                    'resource_id' => $primaryResourceId,
+                    'resource_link' => CompositePrimaryKey::buildResourceEditUrl($resource, $primaryResourceId, $primaryId),
+                ];
+            }
+        }
+
+        return $targets;
     }
 
     protected function decodeJsonNullable($payload): ?array {

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -1266,6 +1266,7 @@ class OperationsController extends Controller {
             return [];
         }
 
+        $allowEditLink = (int) ($item->op_type ?? 0) !== Operation::TYPE_DELETE;
         $targets = [];
         $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
         foreach ($auditLogs as $audit) {
@@ -1296,7 +1297,9 @@ class OperationsController extends Controller {
 
             $targets[$personId] = [
                 'resource_id' => $personResourceId,
-                'resource_link' => CompositePrimaryKey::buildResourceEditUrl($resource, $personResourceId, $personId),
+                'resource_link' => $allowEditLink
+                    ? CompositePrimaryKey::buildResourceEditUrl($resource, $personResourceId, $personId)
+                    : null,
             ];
         }
 
@@ -1307,7 +1310,9 @@ class OperationsController extends Controller {
             if (!isset($targets[$primaryId])) {
                 $targets[$primaryId] = [
                     'resource_id' => $primaryResourceId,
-                    'resource_link' => CompositePrimaryKey::buildResourceEditUrl($resource, $primaryResourceId, $primaryId),
+                    'resource_link' => $allowEditLink
+                        ? CompositePrimaryKey::buildResourceEditUrl($resource, $primaryResourceId, $primaryId)
+                        : null,
                 ];
             }
         }

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -3,6 +3,33 @@ use App\Support\CompositePrimaryKey;
 @endphp
 @extends('layouts.dashboard-v3')
 
+@section('css')
+<style>
+    .operations-action-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+    }
+
+    .operations-action-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        border-radius: 999px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        padding: 0.3rem 0.8rem;
+        box-shadow: none;
+    }
+
+    .operations-action-form {
+        margin: 0;
+    }
+</style>
+@endsection
+
 @section('content')
 @include('biogmains.defense')
     <div class="card card-default">
@@ -72,9 +99,9 @@ use App\Support\CompositePrimaryKey;
                 <tr>
                     <th>人物</th>
                     <th>修改資源</th>
+                    <th>資源定位</th>
                     <th>修改值</th>
-                    <th>資源 TTS</th>
-                    <th>修改類型</th>
+                    <th>操作類型</th>
                     <th>修改人</th>
                     <th>修改時間</th>
                 </tr>
@@ -84,18 +111,27 @@ use App\Support\CompositePrimaryKey;
                         $codeTableKeys = array_keys(config('codes.tables', []));
                         $codeTables = array_map('strtoupper', $codeTableKeys);
                     @endphp
-                    @foreach($lists as $item)
+@foreach($lists as $item)
 @php
 $rawResourceId = $item->resource_id;
-// 用於顯示：偵測格式後轉換（處理 Blade 模板衝突）
-if (str_contains($rawResourceId ?? '', '=') && !str_contains($rawResourceId ?? '', '_._')) {
-    // 新格式（query-string）：解碼後以 - 分隔顯示值
-    parse_str($rawResourceId, $parsedQs);
-    $displayValues = implode('-', array_values($parsedQs));
-    $item->resource_id = str_replace(['{{', '}}'], ['{ {', '} }'], $displayValues);
-} else {
-    $item->resource_id = unionPKDef($item->resource_id);
-}
+$formatResourceDescription = static function ($resourceName, $resourceId) {
+    if (!is_string($resourceId) || trim($resourceId) === '') {
+        return '';
+    }
+
+    $parsedResourceId = CompositePrimaryKey::parseStoredResourceId($resourceId, (string) $resourceName);
+    if (is_array($parsedResourceId) && !empty($parsedResourceId)) {
+        $parts = [];
+        foreach ($parsedResourceId as $column => $value) {
+            $parts[] = $column . '：' . (($value === 'NULL' || $value === null) ? '(null)' : (string) $value);
+        }
+
+        return implode("\n", $parts);
+    }
+
+    return unionPKDef_decode_for_convert(unionPKDef($resourceId));
+};
+$resourceDescription = $formatResourceDescription($item->resource, (string) $rawResourceId);
 $item->resource_data = unionPKDef($item->resource_data);
 @endphp
                         @php
@@ -137,7 +173,6 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         $resourceSpecificLink = CompositePrimaryKey::buildResourceEditUrl($a, $rawResourceId, $id);
                                     }
                                 }
-                                $item->resource_id = unionPKDef_decode_for_convert($item->resource_id);
                                 $item->resource_data = unionPKDef_decode_for_convert($item->resource_data);
                                 $hasPersonLink = $personLink && !empty($item->biogmain);
                                 $isCodeResource = in_array(strtoupper($item->resource), $codeTables, true);
@@ -151,6 +186,7 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 elseif ($isCodeResource && $item->op_type != 4) {
                                     $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $originalResourceId], false);
                                 }
+                                $showPerPersonResourceButtons = in_array(strtoupper($item->resource), ['KIN_DATA', 'ASSOC_DATA'], true) && $personRowspan > 1;
                             @endphp
                             @if(empty($firstPerson['id']))
                                 <span class="text-muted">(本修改不涉及人物)</span>
@@ -222,6 +258,20 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     </button>
                                 @endif
                             </td>
+                            @if($showPerPersonResourceButtons)
+                                <td>
+                                    @if(!empty($firstPerson['resource_link']))
+                                        <a href="{{ $firstPerson['resource_link'] }}" class="btn btn-outline-primary btn-sm">查閱</a>
+                                    @else
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled>無資源頁面</button>
+                                    @endif
+                                    @if(!empty($firstPerson['resource_id']))
+                                        <div class="small text-muted mt-1" style="word-break: break-all;">
+                                            {!! nl2br(e($formatResourceDescription($item->resource, (string) $firstPerson['resource_id']))) !!}
+                                        </div>
+                                    @endif
+                                </td>
+                            @endif
                             @php
                                 $diffSource = $item->resource_diff ?? $item->resource_original;
                                 $hasAuditLogs = !empty($auditLogs);
@@ -316,8 +366,22 @@ $item->resource_data = unionPKDef($item->resource_data);
                             @endphp
                                 @php
                                     $canCompare = ($hasAuditLogs || $hasDiffContent) && (int)$item->op_type !== 4;
-                                @endphp
-                            <td rowspan="{{ $personRowspan }}">
+                            @endphp
+                            @if(!$showPerPersonResourceButtons)
+                                <td rowspan="{{ $personRowspan }}">
+                                    @if($resourceLink)
+                                        <a href="{{ $resourceLink }}" class="btn btn-outline-primary btn-sm">查閱</a>
+                                    @else
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled>無資源頁面</button>
+                                    @endif
+                                    @if($resourceDescription !== '')
+                                        <div class="small text-muted mt-1" style="word-break: break-all;">
+                                            {!! nl2br(e($resourceDescription)) !!}
+                                        </div>
+                                    @endif
+                                </td>
+                            @endif
+                            <td rowspan="{{ $personRowspan }}" style="max-width: 28rem; white-space: normal; word-break: break-word; overflow-wrap: anywhere;">
                                 @if($isProposal)
                                     <div class="proposal-status" style="margin-bottom:6px;">
                                         @if($reviewStatus === 'approved')
@@ -366,11 +430,22 @@ $item->resource_data = unionPKDef($item->resource_data);
                                         @endif
                                     </div>
                                 @endif
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal{{ $item->id }}">內容快照</button>
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#myModal-mapping{{ $item->id }}"
-                                    {{ $canCompare ? '' : 'disabled' }}>
-                                    比較
-                                </button>
+                                <div class="operations-action-list">
+                                    <button type="button"
+                                            class="btn btn-outline-primary btn-sm operations-action-btn"
+                                            data-toggle="modal"
+                                            data-target="#myModal{{ $item->id }}">
+                                        <span>內容快照</span>
+                                    </button>
+                                    <button type="button"
+                                            class="btn btn-outline-info btn-sm operations-action-btn"
+                                            data-toggle="modal"
+                                            data-target="#myModal-mapping{{ $item->id }}"
+                                            {{ $canCompare ? '' : 'disabled' }}>
+                                        <i class="fas fa-code-compare" aria-hidden="true"></i>
+                                        <span>比較</span>
+                                    </button>
+                                </div>
                                 <div id="myModal{{ $item->id }}" class="modal fade" role="dialog" tabindex="-1">
                                   <div class="modal-dialog">
                                     <div class="modal-content">
@@ -446,42 +521,47 @@ $item->resource_data = unionPKDef($item->resource_data);
                                     </div>
                                 @endif
                                 @if(Auth::check() && Auth::user()->isAdmin() && in_array((int)$item->op_type, [3,4]) && $item->resource !== 'POSTED_TO_ADDR_DATA' && $canCompare)
-                                    <form method="post" action="{{ route('operations.restore', $item->id) }}" style="display:inline;">
+                                    <form method="post" action="{{ route('operations.restore', $item->id) }}" class="operations-action-form">
                                         {{ csrf_field() }}
-                                        <button type="submit" class="btn btn-warning"
+                                        <button type="submit" class="btn btn-outline-warning btn-sm operations-action-btn"
                                             onclick="return confirm('將以你的名義對該資源進行一次修改，恢復至本次改動之前，是否繼續？');">
+                                            <i class="fas fa-history" aria-hidden="true"></i>
                                             復原
                                         </button>
                                     </form>
                                 @endif
                                 @if($canEditProposal)
-                                    <div class="proposal-actions" style="margin-top:8px;">
+                                    <div class="operations-action-list">
                                         <a href="{{ route('codes.proposals.edit', ['table_name' => $item->resource, 'operation' => $item->id]) }}"
-                                           class="btn btn-secondary btn-sm">
+                                           class="btn btn-outline-secondary btn-sm operations-action-btn">
+                                            <i class="far fa-pen-to-square" aria-hidden="true"></i>
                                             修改提案
                                         </a>
                                         <form method="post"
                                               action="{{ route('codes.proposals.cancel', ['table_name' => $item->resource, 'operation' => $item->id]) }}"
-                                              style="display:inline;">
+                                              class="operations-action-form">
                                             {{ csrf_field() }}
                                             {{ method_field('DELETE') }}
-                                            <button type="submit" class="btn btn-warning btn-sm"
+                                            <button type="submit" class="btn btn-outline-warning btn-sm operations-action-btn"
                                                     onclick="return confirm('確定要撤回此提案？');">
+                                                <i class="fas fa-ban" aria-hidden="true"></i>
                                                 撤回提案
                                             </button>
                                         </form>
                                     </div>
                                 @endif
                                 @if($isProposal && Auth::check() && Auth::user()->canManageUsers() && $reviewStatus === 'pending')
-                                    <div class="proposal-actions" style="margin-top:8px;">
-                                        <form method="post" action="{{ route('operations.proposals.approve', $item->id) }}" style="display:inline;">
+                                    <div class="operations-action-list">
+                                        <form method="post" action="{{ route('operations.proposals.approve', $item->id) }}" class="operations-action-form">
                                             {{ csrf_field() }}
                                             <input type="hidden" name="review_comment" value="">
-                                            <button type="submit" class="btn btn-success btn-sm" onclick="return confirm('確定核准此提案並寫入資料表？');">
+                                            <button type="submit" class="btn btn-outline-success btn-sm operations-action-btn" onclick="return confirm('確定核准此提案並寫入資料表？');">
+                                                <i class="fas fa-check" aria-hidden="true"></i>
                                                 核准
                                             </button>
                                         </form>
-                                        <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#proposal-reject-{{ $item->id }}">
+                                        <button type="button" class="btn btn-outline-danger btn-sm operations-action-btn" data-toggle="modal" data-target="#proposal-reject-{{ $item->id }}">
+                                            <i class="fas fa-reply" aria-hidden="true"></i>
                                             退修
                                         </button>
                                     </div>
@@ -511,13 +591,6 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @endif
                             </td>
                             <td rowspan="{{ $personRowspan }}">
-                                @if($resourceLink)
-                                    <a href="{{ $resourceLink }}">{{ $item->resource_id }}</a>
-                                @else
-                                    {{ $item->resource_id }}
-                                @endif
-                            </td>
-                            <td rowspan="{{ $personRowspan }}">
                                 @php
                                     $opTypeLabels = [
                                         1 => '1-新增',
@@ -530,7 +603,13 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 @endphp
                                 {{ $opTypeLabels[$item->op_type] ?? $item->op_type }}
                             </td>
-                            <td rowspan="{{ $personRowspan }}">{{ $item->user->name }}</td>
+                            <td rowspan="{{ $personRowspan }}">
+                                @if(Auth::check())
+                                    {{ $item->user->name ?? ('User ' . $item->user_id) }}
+                                @else
+                                    {{ 'User ' . $item->user_id }}
+                                @endif
+                            </td>
                             @php
                                 $updatedUtc = '';
                                 $updatedDisplay = '';
@@ -571,6 +650,20 @@ $item->resource_data = unionPKDef($item->resource_data);
                                             </span>
                                         @endif
                                     </td>
+                                    @if($showPerPersonResourceButtons)
+                                        <td>
+                                            @if(!empty($relatedPerson['resource_link']))
+                                                <a href="{{ $relatedPerson['resource_link'] }}" class="btn btn-outline-primary btn-sm">查閱</a>
+                                            @else
+                                                <button type="button" class="btn btn-outline-secondary btn-sm" disabled>無資源頁面</button>
+                                            @endif
+                                            @if(!empty($relatedPerson['resource_id']))
+                                                <div class="small text-muted mt-1" style="word-break: break-all;">
+                                                    {!! nl2br(e($formatResourceDescription($item->resource, (string) $relatedPerson['resource_id']))) !!}
+                                                </div>
+                                            @endif
+                                        </td>
+                                    @endif
                                 </tr>
                             @endfor
                         @endif

--- a/tests/Feature/OperationsIndexFilterTest.php
+++ b/tests/Feature/OperationsIndexFilterTest.php
@@ -206,6 +206,29 @@ class OperationsIndexFilterTest extends TestCase {
         $this->assertSame(Operation::TYPE_PROPOSAL_CREATE, $opTypes[0]);
     }
 
+    #[Test]
+    public function default_operations_index_hides_proposals(): void {
+        $user = $this->makeUser('Admin', 'admin@example.com');
+
+        $this->makeOperation($user, Operation::TYPE_CREATE, [
+            'resource_data' => json_encode(['c_name_chn' => '一般操作'], JSON_UNESCAPED_UNICODE),
+        ]);
+        $this->makeOperation($user, Operation::TYPE_PROPOSAL_CREATE, [
+            'resource_data' => json_encode([
+                'c_name_chn' => '提案操作',
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by' => 'Admin', 'submitted_at' => now()->format('Y-m-d H:i:s')],
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $opTypes = $this->listOpTypes($response);
+        $this->assertCount(1, $opTypes);
+        $this->assertSame(Operation::TYPE_CREATE, $opTypes[0]);
+    }
+
     // ── proposals 模式 status + editor 組合 ──
 
     #[Test]

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -59,6 +59,24 @@ class OperationsIndexLinksTest extends TestCase {
             $table->integer('c_fy_intercalary')->nullable();
         });
 
+        Schema::create('KIN_DATA', function ($table) {
+            $table->integer('c_personid');
+            $table->integer('c_kin_id');
+            $table->integer('c_kin_code');
+        });
+
+        Schema::create('ASSOC_DATA', function ($table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code');
+            $table->integer('c_assoc_id');
+            $table->integer('c_kin_code');
+            $table->integer('c_kin_id');
+            $table->integer('c_assoc_kin_code');
+            $table->integer('c_assoc_kin_id');
+            $table->string('c_text_title')->nullable();
+            $table->integer('c_assoc_first_year')->nullable();
+        });
+
         Schema::create('audit_log', function ($table) {
             $table->bigIncrements('id');
             $table->dateTime('occurred_at');
@@ -106,6 +124,9 @@ class OperationsIndexLinksTest extends TestCase {
 
         // 验证页面包含正确的链接
         $response->assertSee('/codes/TEXT_CODES/68942/edit', false);
+        $response->assertSee('查閱');
+        $response->assertDontSee('>68942</a>', false);
+        $response->assertSee('overflow-wrap: anywhere;', false);
         $response->assertSee('(本修改不涉及人物)');
     }
 
@@ -204,8 +225,38 @@ class OperationsIndexLinksTest extends TestCase {
 
         // 验证删除操作不生成編輯链接
         $response->assertDontSee('/codes/TEXT_CODES/68942/edit', false);
+        $response->assertSee('無資源頁面');
         // 但应该显示 resource_id
         $response->assertSee('68942');
+    }
+
+    #[Test]
+    public function test_operations_index_hides_editor_full_name_for_guests(): void {
+        $user = User::create([
+            'name' => 'Hidden Editor',
+            'email' => 'guest-hidden@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'guest-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'TEXT_CODES',
+            'resource_id' => '68942',
+            'resource_data' => json_encode(['c_textid' => 68942, 'c_text_name' => 'Guest Visible']),
+            'resource_original' => json_encode(['c_textid' => 68942, 'c_text_name' => 'Old Text']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $response = $this->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('User ' . $user->id);
+        $response->assertDontSee('Hidden Editor');
     }
 
     #[Test]
@@ -349,5 +400,208 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertSee('rowspan="2"', false);
         $response->assertSee('主操作');
         $response->assertSee('連動');
+    }
+
+    #[Test]
+    public function test_operations_index_renders_person_specific_resource_links_for_kin_data(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'kin-links@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 101, 'c_name_chn' => '甲', 'c_name' => 'Jia'],
+            ['c_personid' => 202, 'c_name_chn' => '乙', 'c_name' => 'Yi'],
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('KIN_DATA')->insert([
+            ['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1],
+            ['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3],
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 101,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'KIN_DATA',
+            'resource_id' => 'c_personid=101&c_kin_id=202&c_kin_code=1',
+            'resource_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 2], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $now = now()->format('Y-m-d H:i:s');
+        \Illuminate\Support\Facades\DB::table('audit_log')->insert([
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=101&c_kin_id=202&c_kin_code=1',
+                'old_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 2], JSON_UNESCAPED_UNICODE),
+            ],
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=202&c_kin_id=101&c_kin_code=3',
+                'old_data' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 4], JSON_UNESCAPED_UNICODE),
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('/basicinformation/101/kinship/edit?c_personid=101&amp;c_kin_id=202&amp;c_kin_code=1', false);
+        $response->assertSee('/basicinformation/202/kinship/edit?c_personid=202&amp;c_kin_id=101&amp;c_kin_code=3', false);
+        $response->assertSee('c_personid：101<br', false);
+        $response->assertSee('c_personid：101');
+        $response->assertSee('c_kin_code：3');
+    }
+
+    #[Test]
+    public function test_operations_index_renders_person_specific_resource_links_for_assoc_data(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'assoc-links@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 101, 'c_name_chn' => '甲', 'c_name' => 'Jia'],
+            ['c_personid' => 202, 'c_name_chn' => '乙', 'c_name' => 'Yi'],
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('ASSOC_DATA')->insert([
+            [
+                'c_personid' => 101,
+                'c_assoc_code' => 301,
+                'c_assoc_id' => 202,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => '測試文獻',
+                'c_assoc_first_year' => 1100,
+            ],
+            [
+                'c_personid' => 202,
+                'c_assoc_code' => 302,
+                'c_assoc_id' => 101,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => '測試文獻',
+                'c_assoc_first_year' => 1100,
+            ],
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 101,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => 'c_personid=101&c_assoc_code=301&c_assoc_id=202&c_kin_code=0&c_kin_id=0&c_assoc_kin_code=0&c_assoc_kin_id=0&c_text_title=%E6%B8%AC%E8%A9%A6%E6%96%87%E7%8D%BB&c_assoc_first_year=1100',
+            'resource_data' => json_encode([
+                'c_personid' => 101,
+                'c_assoc_code' => 301,
+                'c_assoc_id' => 202,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => '測試文獻',
+                'c_assoc_first_year' => 1101,
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 101,
+                'c_assoc_code' => 301,
+                'c_assoc_id' => 202,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => '測試文獻',
+                'c_assoc_first_year' => 1100,
+            ], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $now = now()->format('Y-m-d H:i:s');
+        \Illuminate\Support\Facades\DB::table('audit_log')->insert([
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'ASSOC_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode([
+                    'c_personid' => 101,
+                    'c_assoc_code' => 301,
+                    'c_assoc_id' => 202,
+                    'c_kin_code' => 0,
+                    'c_kin_id' => 0,
+                    'c_assoc_kin_code' => 0,
+                    'c_assoc_kin_id' => 0,
+                    'c_text_title' => '測試文獻',
+                    'c_assoc_first_year' => 1100,
+                ], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=101&c_assoc_code=301&c_assoc_id=202&c_kin_code=0&c_kin_id=0&c_assoc_kin_code=0&c_assoc_kin_id=0&c_text_title=%E6%B8%AC%E8%A9%A6%E6%96%87%E7%8D%BB&c_assoc_first_year=1100',
+                'old_data' => json_encode(['c_assoc_first_year' => 1100], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_assoc_first_year' => 1101], JSON_UNESCAPED_UNICODE),
+            ],
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'ASSOC_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode([
+                    'c_personid' => 202,
+                    'c_assoc_code' => 302,
+                    'c_assoc_id' => 101,
+                    'c_kin_code' => 0,
+                    'c_kin_id' => 0,
+                    'c_assoc_kin_code' => 0,
+                    'c_assoc_kin_id' => 0,
+                    'c_text_title' => '測試文獻',
+                    'c_assoc_first_year' => 1100,
+                ], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=202&c_assoc_code=302&c_assoc_id=101&c_kin_code=0&c_kin_id=0&c_assoc_kin_code=0&c_assoc_kin_id=0&c_text_title=%E6%B8%AC%E8%A9%A6%E6%96%87%E7%8D%BB&c_assoc_first_year=1100',
+                'old_data' => json_encode(['c_assoc_first_year' => 1100], JSON_UNESCAPED_UNICODE),
+                'new_data' => json_encode(['c_assoc_first_year' => 1101], JSON_UNESCAPED_UNICODE),
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('/basicinformation/101/assoc/edit?c_personid=101&amp;c_assoc_code=301&amp;c_assoc_id=202', false);
+        $response->assertSee('/basicinformation/202/assoc/edit?c_personid=202&amp;c_assoc_code=302&amp;c_assoc_id=101', false);
+        $response->assertSee('c_assoc_code：301');
+        $response->assertSee('c_assoc_code：302');
     }
 }

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -604,4 +604,69 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertSee('c_assoc_code：301');
         $response->assertSee('c_assoc_code：302');
     }
+
+    #[Test]
+    public function test_operations_index_does_not_render_person_specific_resource_links_for_deleted_kin_data(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'deleted-kin-links@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        \Illuminate\Support\Facades\DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 101, 'c_name_chn' => '甲', 'c_name' => 'Jia'],
+            ['c_personid' => 202, 'c_name_chn' => '乙', 'c_name' => 'Yi'],
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 101,
+            'op_type' => Operation::TYPE_DELETE,
+            'resource' => 'KIN_DATA',
+            'resource_id' => 'c_personid=101&c_kin_id=202&c_kin_code=1',
+            'resource_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+            'resource_original' => null,
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $now = now()->format('Y-m-d H:i:s');
+        \Illuminate\Support\Facades\DB::table('audit_log')->insert([
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'DELETE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=101&c_kin_id=202&c_kin_code=1',
+                'old_data' => json_encode(['c_personid' => 101, 'c_kin_id' => 202, 'c_kin_code' => 1], JSON_UNESCAPED_UNICODE),
+                'new_data' => null,
+            ],
+            [
+                'occurred_at' => $now,
+                'created_at' => $now,
+                'table_name' => 'KIN_DATA',
+                'operation' => 'DELETE',
+                'actor_type' => 'user',
+                'actor_id' => (string) $user->id,
+                'operation_id' => (string) $operation->id,
+                'row_pk' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'row_pk_text' => 'c_personid=202&c_kin_id=101&c_kin_code=3',
+                'old_data' => json_encode(['c_personid' => 202, 'c_kin_id' => 101, 'c_kin_code' => 3], JSON_UNESCAPED_UNICODE),
+                'new_data' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('/basicinformation/101/kinship/edit?c_personid=101&amp;c_kin_id=202&amp;c_kin_code=1', false);
+        $response->assertDontSee('/basicinformation/202/kinship/edit?c_personid=202&amp;c_kin_id=101&amp;c_kin_code=3', false);
+        $response->assertSee('無資源頁面');
+    }
 }


### PR DESCRIPTION
- 隱藏預設列表中的提案，僅在 proposals_only 模式顯示
- 將資源入口改為查閱按鈕，並改善資源定位文字格式
- 針對 KIN_DATA 與 ASSOC_DATA 顯示人物各自的資源按鈕
- 調整修改值操作按鈕樣式與多行內容顯示
- 補充 OperationsIndexFilterTest 與 OperationsIndexLinksTest 驗證