### PR TITLE
修正官名提案核准與復原失敗

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -701,7 +701,16 @@ class OperationsController extends Controller {
     protected function restoreUpdate(Operation $operation) {
         $table = $operation->resource;
         $current = $this->decodeJson($operation->resource_data);
-        $target = $this->getPreviousSnapshot($operation);
+
+        // 優先使用 resource_original（操作時保存的原始快照），因為它是最準確的「修改前」狀態。
+        // 當主鍵欄位（如 c_office_id）有變動時，用 resource_id 去搜尋前一筆操作的 resource_data
+        // 可能找到的是「更早之前同 resource_id」的操作（主鍵值相同但不是本次的直接前身），
+        // 導致復原到錯誤的狀態。
+        // getPreviousSnapshot 僅在 resource_original 為空時作為回退方案。
+        $target = $this->decodeJson($operation->resource_original);
+        if (empty($target)) {
+            $target = $this->getPreviousSnapshot($operation);
+        }
         if (empty($target)) {
             throw new \RuntimeException('找不到可恢復的資料內容');
         }
@@ -757,9 +766,12 @@ class OperationsController extends Controller {
     }
 
     protected function getPreviousSnapshot(Operation $operation) {
+        // 排除提案操作（op_type 8/9），因為提案的 resource_data 存的是「修改後的值」，
+        // 不是「修改前的快照」，用於復原會導致恢復到修改後的狀態（等於沒復原）。
         $previous = Operation::where('resource', $operation->resource)
             ->where('resource_id', $operation->resource_id)
             ->where('id', '<', $operation->id)
+            ->whereNotIn('op_type', [Operation::TYPE_PROPOSAL_CREATE, Operation::TYPE_PROPOSAL_UPDATE])
             ->orderBy('id', 'desc')
             ->first();
 

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -332,6 +332,21 @@ class OperationsProposalController extends Controller {
         array $auxiliaryPayload
     ): array {
         $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
+
+        // 更新提案：officeUpdateById() 需要表單隱藏欄位 _id, _postingid, _officeid 來定位原始記錄。
+        // 早期提案可能未將這些欄位存入 __proposal_aux，需從 $original 補齊。
+        if ((int) $operation->op_type !== Operation::TYPE_PROPOSAL_CREATE) {
+            if (!isset($auxiliaryPayload['_id'])) {
+                $auxiliaryPayload['_id'] = $personId;
+            }
+            if (!isset($auxiliaryPayload['_postingid'])) {
+                $auxiliaryPayload['_postingid'] = $original['c_posting_id'] ?? $data['c_posting_id'] ?? null;
+            }
+            if (!isset($auxiliaryPayload['_officeid'])) {
+                $auxiliaryPayload['_officeid'] = $original['c_office_id'] ?? null;
+            }
+        }
+
         $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
 
         if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -1837,4 +1837,111 @@ class BasicInformationProposalTest extends TestCase {
         $this->assertNotNull($officeRow);
         $this->assertEquals(300, $officeRow->c_office_id, '交易回滾後 c_office_id 應維持原值');
     }
+
+    #[Test]
+    public function testApproveOfficeUpdateProposalWithoutProposalAuxStillWorks() {
+        $this->createOfficeTables();
+        $this->app->instance(BiogMainRepository::class, new BiogMainRepository());
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        DB::table('POSTING_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 700,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 700,
+            'c_office_id' => 12356,
+            'c_sequence' => 0,
+            'c_source' => 32038,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '原始備註',
+            'c_created_by' => 'load',
+            'c_created_date' => '2013-09-23 00:00:00',
+        ]);
+
+        $originalRow = [
+            'c_personid' => 1,
+            'c_posting_id' => 700,
+            'c_office_id' => 12356,
+            'c_sequence' => 0,
+            'c_source' => 32038,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '原始備註',
+            'c_created_by' => 'load',
+            'c_created_date' => '2013-09-23 00:00:00',
+            'c_modified_by' => null,
+            'c_modified_date' => null,
+            'c_pages' => null,
+        ];
+
+        // 模擬早期提案：沒有 __proposal_aux（c_office_id 從 12356 改為 10539）
+        $operation = new Operation();
+        $operation->user_id = 100;
+        $operation->c_personid = 1;
+        $operation->op_type = Operation::TYPE_PROPOSAL_UPDATE;
+        $operation->resource = 'POSTED_TO_OFFICE_DATA';
+        $operation->resource_id = 'c_office_id=10539&c_posting_id=700';
+        $operation->resource_data = json_encode([
+            'c_personid' => 1,
+            'c_posting_id' => 700,
+            'c_office_id' => 10539,
+            'c_sequence' => 0,
+            'c_source' => 32038,
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_notes' => '修改後備註',
+            '__key_columns' => ['c_office_id', 'c_posting_id'],
+            '__review_status' => 'pending',
+            '__proposal_meta' => [
+                'action' => 'update',
+                'resource_type' => 'offices',
+                'table' => 'POSTED_TO_OFFICE_DATA',
+                'submitted_by' => 'Test User',
+                'submitted_at' => '2026-03-19 13:40:00',
+                'comment' => '測試無 __proposal_aux 的情況',
+            ],
+        ], JSON_UNESCAPED_UNICODE);
+        $operation->resource_original = json_encode($originalRow, JSON_UNESCAPED_UNICODE);
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => '同意',
+        ]);
+
+        $response->assertRedirect();
+
+        // 驗證無錯誤
+        $flash = session('flash_notification', collect())->toArray();
+        if (!empty($flash)) {
+            $this->assertStringNotContainsString('審核失敗', $flash[0]['message'] ?? '', '核准應該成功，實際錯誤：'.($flash[0]['message'] ?? ''));
+        }
+
+        // 驗證 c_office_id 已更新為 10539
+        $updatedRow = DB::table('POSTED_TO_OFFICE_DATA')
+            ->where('c_posting_id', 700)
+            ->first();
+
+        $this->assertNotNull($updatedRow, '更新後的記錄應存在');
+        $this->assertEquals(10539, $updatedRow->c_office_id, 'c_office_id 應更新為 10539');
+        $this->assertSame('修改後備註', $updatedRow->c_notes, 'c_notes 應更新');
+
+        // 驗證提案狀態已改為 approved
+        $operation->refresh();
+        $proposalData = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $proposalData['__review_status'] ?? null);
+    }
 }

--- a/tests/Feature/OperationsOfficeRestoreTest.php
+++ b/tests/Feature/OperationsOfficeRestoreTest.php
@@ -1,0 +1,407 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use App\Support\CompositePrimaryKey;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * POSTED_TO_OFFICE_DATA 操作復原整合測試
+ *
+ * 驗證：
+ * - 復原更新操作（op_type=3）能正確回復 DB 資料
+ * - getPreviousSnapshot 會跳過提案操作（op_type=8/9），避免「復原到修改後的值」
+ */
+class OperationsOfficeRestoreTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid')->default(0);
+            $table->smallInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id');
+            $table->longText('resource_data');
+            $table->longText('resource_original')->nullable();
+            $table->timestamps();
+            $table->smallInteger('crowdsourcing_status')->default(0);
+            $table->smallInteger('rate')->default(0);
+        });
+
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id');
+            $table->integer('c_office_id');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages')->nullable();
+            $table->string('c_notes')->nullable();
+            $table->integer('c_fy_intercalary')->default(0);
+            $table->integer('c_ly_intercalary')->default(0);
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+            $table->primary(['c_office_id', 'c_posting_id']);
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('POSTED_TO_OFFICE_DATA');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    protected function actingAsAdmin(): User {
+        $user = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    /**
+     * 當提案核准產生的 op_type=3 操作之前存在同 resource_id 的提案操作（op_type=9）時，
+     * 復原應跳過提案操作，使用 resource_original 恢復到修改前的值。
+     *
+     * 場景：提案把 c_office_id 從 100 改為 200，核准後產生 op_type=3 操作。
+     * 復原該操作應恢復 c_office_id=100，而非讀取提案的 resource_data（c_office_id=200）。
+     */
+    #[Test]
+    public function test_restore_office_update_skips_proposal_operation(): void {
+        $this->actingAsAdmin();
+
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => 200,
+            'c_posting_id' => 500,
+        ]);
+
+        // DB 中的現行資料（核准後狀態：c_office_id 已改為 200）
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 500,
+            'c_office_id' => 200,
+            'c_sequence' => 0,
+            'c_source' => 50,
+            'c_notes' => '修改後備註',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+            'c_modified_by' => 'Admin',
+            'c_modified_date' => '2026-03-19 13:40:55',
+        ]);
+
+        // 先建立提案操作（op_type=9）——resource_data 存的是修改後的值
+        $proposalOp = Operation::create([
+            'user_id' => 100,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 500,
+                'c_office_id' => 200,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '修改後備註',
+                '__key_columns' => ['c_office_id', 'c_posting_id'],
+                '__review_status' => 'approved',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 500,
+                'c_office_id' => 100,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '原始備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now()->subMinutes(2),
+            'updated_at' => Carbon::now()->subMinutes(2),
+        ]);
+
+        // 再建立核准後產生的實際更新操作（op_type=3）
+        $updateOp = Operation::create([
+            'user_id' => 1,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 500,
+                'c_office_id' => 200,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '修改後備註',
+                'c_modified_by' => 'Admin',
+                'c_modified_date' => '2026-03-19 13:40:55',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 500,
+                'c_office_id' => 100,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '原始備註',
+                'c_created_by' => 'seed',
+                'c_created_date' => '2025-01-01 00:00:00',
+                'c_modified_by' => null,
+                'c_modified_date' => null,
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now()->subMinute(),
+            'updated_at' => Carbon::now()->subMinute(),
+        ]);
+
+        // 執行復原
+        $response = $this->post("/operations/{$updateOp->id}/restore");
+        $response->assertRedirect();
+
+        // 驗證 flash 無錯誤
+        $flash = session('flash_notification', collect())->toArray();
+        if (!empty($flash)) {
+            $this->assertStringNotContainsString('恢復失敗', $flash[0]['message'] ?? '', '復原應成功，實際錯誤：'.($flash[0]['message'] ?? ''));
+        }
+
+        // 核心斷言：c_office_id 應恢復為 100（原始值），而非停留在 200（提案修改後的值）
+        $restoredRow = DB::table('POSTED_TO_OFFICE_DATA')
+            ->where('c_posting_id', 500)
+            ->first();
+
+        $this->assertNotNull($restoredRow, '復原後記錄應存在');
+        $this->assertEquals(100, $restoredRow->c_office_id, 'c_office_id 應恢復為原始值 100，而非提案的 200');
+        $this->assertSame('原始備註', $restoredRow->c_notes, 'c_notes 應恢復為原始值');
+    }
+
+    /**
+     * 當沒有提案操作介入時，復原仍能正常使用 resource_original。
+     */
+    #[Test]
+    public function test_restore_office_update_without_proposal_uses_resource_original(): void {
+        $this->actingAsAdmin();
+
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => 300,
+            'c_posting_id' => 600,
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 2,
+            'c_posting_id' => 600,
+            'c_office_id' => 300,
+            'c_sequence' => 1,
+            'c_source' => 0,
+            'c_notes' => '新備註',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 1,
+            'c_personid' => 2,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 2,
+                'c_posting_id' => 600,
+                'c_office_id' => 300,
+                'c_sequence' => 1,
+                'c_source' => 0,
+                'c_notes' => '新備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 2,
+                'c_posting_id' => 600,
+                'c_office_id' => 300,
+                'c_sequence' => 0,
+                'c_source' => 0,
+                'c_notes' => '舊備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $response = $this->post("/operations/{$operation->id}/restore");
+        $response->assertRedirect();
+
+        $restoredRow = DB::table('POSTED_TO_OFFICE_DATA')
+            ->where('c_posting_id', 600)
+            ->first();
+
+        $this->assertNotNull($restoredRow);
+        $this->assertEquals(0, $restoredRow->c_sequence, 'c_sequence 應恢復為原始值');
+        $this->assertSame('舊備註', $restoredRow->c_notes, 'c_notes 應恢復為原始值');
+    }
+
+    /**
+     * 當 c_office_id 經過來回改動（10539 → 12356 → 10539），同 resource_id 下有歷史操作時，
+     * 復原應使用 resource_original（c_office_id=12356），而非找到更早的同 resource_id 操作。
+     *
+     * 這模擬實際場景：同一個 resource_id 下有多筆歷史操作（來自 PK 來回變更），
+     * getPreviousSnapshot 會找到的是「更早之前」的操作（PK 值相同但不是本次的直接前身）。
+     */
+    #[Test]
+    public function test_restore_office_update_prefers_resource_original_over_stale_previous_operation(): void {
+        $this->actingAsAdmin();
+
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_office_id' => 10539,
+            'c_posting_id' => 700,
+        ]);
+
+        // DB 中的現行資料
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1,
+            'c_posting_id' => 700,
+            'c_office_id' => 10539,
+            'c_sequence' => 0,
+            'c_source' => 50,
+            'c_notes' => '第三次修改的備註',
+            'c_fy_intercalary' => 0,
+            'c_ly_intercalary' => 0,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2025-01-01 00:00:00',
+        ]);
+
+        // 更早的操作（同 resource_id），代表 c_office_id 還是 10539 時的修改
+        $earlierOp = Operation::create([
+            'user_id' => 1,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 10539,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '第一次修改的備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 10539,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '原始備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now()->subMinutes(5),
+            'updated_at' => Carbon::now()->subMinutes(5),
+        ]);
+
+        // 中間操作（不同 resource_id = 12356），代表 c_office_id 被改為 12356
+        // 這筆不會被 getPreviousSnapshot 找到（resource_id 不同）
+        Operation::create([
+            'user_id' => 1,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => CompositePrimaryKey::buildStoredResourceId([
+                'c_office_id' => 12356,
+                'c_posting_id' => 700,
+            ]),
+            'resource_data' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 12356,
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 10539,
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now()->subMinutes(3),
+            'updated_at' => Carbon::now()->subMinutes(3),
+        ]);
+
+        // 當前操作：把 c_office_id 從 12356 改回 10539
+        $currentOp = Operation::create([
+            'user_id' => 1,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 10539,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '第三次修改的備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 1,
+                'c_posting_id' => 700,
+                'c_office_id' => 12356,
+                'c_sequence' => 0,
+                'c_source' => 50,
+                'c_notes' => '第二次修改的備註',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now()->subMinute(),
+            'updated_at' => Carbon::now()->subMinute(),
+        ]);
+
+        // 執行復原
+        $response = $this->post("/operations/{$currentOp->id}/restore");
+        $response->assertRedirect();
+
+        $flash = session('flash_notification', collect())->toArray();
+        if (!empty($flash)) {
+            $this->assertStringNotContainsString('恢復失敗', $flash[0]['message'] ?? '', '復原應成功，實際錯誤：'.($flash[0]['message'] ?? ''));
+        }
+
+        // 核心斷言：應恢復到 resource_original 的值（c_office_id=12356），
+        // 而非 earlierOp 的 resource_data（c_office_id=10539）
+        $restoredRow = DB::table('POSTED_TO_OFFICE_DATA')
+            ->where('c_posting_id', 700)
+            ->first();
+
+        $this->assertNotNull($restoredRow, '復原後記錄應存在');
+        $this->assertEquals(12356, $restoredRow->c_office_id, 'c_office_id 應恢復為 resource_original 的 12356，而非歷史操作的 10539');
+        $this->assertSame('第二次修改的備註', $restoredRow->c_notes, 'c_notes 應恢復為 resource_original 的值');
+    }
+}


### PR DESCRIPTION
## Summary
- 修正 `applyOfficeProposal` 缺少表單隱藏欄位（`_id`, `_postingid`, `_officeid`），導致無 `__proposal_aux` 的提案核准時崩潰
- `restoreUpdate` 優先使用 `resource_original`，避免主鍵來回變動時復原到錯誤的歷史操作
- `getPreviousSnapshot` 排除提案操作（op_type 8/9），防止提案的「修改後值」被誤認為「修改前快照」

## 影響範圍
- `OperationsProposalController::applyOfficeProposal()` — 提案核准
- `OperationsController::restoreUpdate()` — 操作復原
- `OperationsController::getPreviousSnapshot()` — 前一筆快照查詢

## Test plan
- [x] `./vendor/bin/phpunit --filter BasicInformationProposalTest`（63 tests）
- [x] `./vendor/bin/phpunit --filter OperationsOfficeRestoreTest`（3 tests，新增）
- [x] `./vendor/bin/phpunit --filter OperationsAltnameRestoreTest`（6 tests，既有）
- [x] `./vendor/bin/phpunit --filter OperationsRestoreAuthorizeTest`（7 tests，既有）
- [x] 所有 regression test 已驗證：移除修復後測試失敗，加回後通過
- [x] 本地 dev server 實際操作驗證復原功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)