### PR TITLE
修正人物基本資料翻頁時查詢參數為 null 導致 TypeError

### DIFF
--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -82,7 +82,7 @@ class BasicInformationController extends Controller {
      */
     public function index(Request $request) {
         // 获取查询参数
-        $q = $request->input('q', '');
+        $q = $request->input('q', '') ?? '';
         $num = $request->input('num', 20);
         $cDy = $request->input('c_dy');
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -343,7 +343,7 @@ class BiogMainRepository {
      */
     public static function namesByQuery(Request $request, $num = 20) {
         //20220303增加addslashes()防禦查詢參數
-        $request->q = addslashes($request->q);
+        $request->q = addslashes($request->q ?? '');
         if ($temp = $request->num) {
             $num = addslashes($temp);
         }

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -601,6 +601,24 @@ class BasicInformationPagesLoadTest extends TestCase {
     }
 
     /**
+     * 回歸測試：翻頁時 q 為空字串（ConvertEmptyStringsToNull 會轉為 null）不應 500
+     */
+    #[Test]
+    public function test_basicinformation_index_with_empty_query_and_pagination() {
+        $response = $this->get('/basicinformation?q=&page=2');
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 回歸測試：不帶 q 參數直接翻頁不應 500
+     */
+    #[Test]
+    public function test_basicinformation_index_without_query_param_and_pagination() {
+        $response = $this->get('/basicinformation?page=2');
+        $response->assertStatus(200);
+    }
+
+    /**
      * 测试创建页面：/basicinformation/create
      */
     #[Test]


### PR DESCRIPTION
## Summary
- 修正 `/basicinformation?q=&page=2` 翻頁時因 `ConvertEmptyStringsToNull` middleware 將 `q=` 轉為 `null`，導致 `dynastyFacetsByQuery()` 和 `addslashes()` 在 PHP 8.4 拋出 TypeError
- 在 Controller 和 Repository 加上 null coalescing 保護
- 補齊 q 為空值與缺省時翻頁的回歸測試

## Test plan
- [x] `./vendor/bin/phpunit --filter BasicInformationPagesLoadTest` 全部通過（24 tests）
- [x] 既有失敗（`CodesControllerTest`）確認為 develop 上已存在的問題，與本次改動無關

🤖 Generated with [Claude Code](https://claude.com/claude-code)