### PR TITLE
修正社會機構操作紀錄查閱按鈕無法定位記錄

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
+++ b/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
@@ -119,7 +119,7 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
                     '',
                     1,
                     'SOCIAL_INSTITUTION_ADDR',
-                    $instCode . '-' . $row['addr_id'],
+                    $instCode . '_._' . $row['addr_id'],
                     $addrPayload
                 );
 

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -228,6 +228,8 @@ class CodesController extends Controller {
         'CBDB__NAME_FTS' => ['id'],
         'CBDB__TRAD_SIMP_MAP' => ['trad_char'],
         'POSSESSION_DATA' => ['c_possession_record_id'],
+        'SOCIAL_INSTITUTION_CODES' => ['c_inst_code'],
+        'SOCIAL_INSTITUTION_ADDR' => ['c_inst_code', 'c_inst_addr_id'],
         'TEXT_CODES' => ['c_textid'],
     ];
     /**
@@ -395,8 +397,22 @@ class CodesController extends Controller {
                 }
                 $data = $query->first();
 
+                // 舊版操作紀錄可能以 '-' 分隔複合鍵（如 "4005-7531"），
+                // 若以標準 '_._' 分隔找不到，嘗試用 '-' 重新解析
+                if (!$data && count($keyColumns) > 1
+                    && !str_contains($id, '_._') && str_contains($id, '-')) {
+                    $fallbackConditions = $this->buildConditionsFromId($keyColumns, str_replace('-', '_._', $id));
+                    if (count($fallbackConditions) > count($conditions)) {
+                        $fallbackQuery = DB::table($table);
+                        foreach ($fallbackConditions as $col => $val) {
+                            $fallbackQuery->where($col, $val);
+                        }
+                        $data = $fallbackQuery->first();
+                    }
+                }
+
                 if (!$data) {
-                    flash('找不到該資料表', 'warning');
+                    flash('找不到該筆資料', 'warning');
 
                     return redirect()->back();
                 }


### PR DESCRIPTION
## Summary
- SOCIAL_INSTITUTION_CODES 與 SOCIAL_INSTITUTION_ADDR 的操作紀錄「查閱」按鈕點擊後提示「找不到該資料表」
- 根因：CodesController 主鍵偵測 fallback 取到錯誤欄位，且批次匯入的 resource_id 使用 `-` 分隔符與 codes 模組的 `_._` 不一致
- 新增主鍵覆蓋、edit 方法加入舊格式 fallback、批次匯入改用 `_._` 分隔符

## Test plan
- [x] `./vendor/bin/phpunit`（691 tests passed）
- [x] 在操作紀錄頁面點擊 SOCIAL_INSTITUTION_CODES 的查閱按鈕，確認可正確跳轉至編輯頁
- [x] 在操作紀錄頁面點擊 SOCIAL_INSTITUTION_ADDR 的查閱按鈕，確認可正確跳轉至編輯頁
- [x] 確認其他代碼表的查閱按鈕不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)