### PR TITLE
修正社會關係等模組編輯/更新時主鍵解析失敗

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -512,14 +512,21 @@ class BasicInformationAddressesController extends Controller {
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['BIOG_ADDR_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         if ($action === 'proposal') {
             // 使用新的查詢參數模式，直接傳遞主鍵陣列
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
-                ->proposalUpdateWithPk($request, $id, 'addresses', $pk);
+                ->proposalUpdateWithPk($request, $id, 'addresses', $originalPk);
         }
 
         if (!Auth::user()->canWriteDirectly()) {
@@ -529,13 +536,13 @@ class BasicInformationAddressesController extends Controller {
         }
 
         // 驗證必填欄位
-        CompositePrimaryKey::validateOrFail($pk, 'BIOG_ADDR_DATA');
+        CompositePrimaryKey::validateOrFail($originalPk, 'BIOG_ADDR_DATA');
 
-        if ((string) ($pk['c_personid'] ?? '') !== (string) $id) {
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
             abort(400, '路徑人物 ID 與查詢主鍵不一致');
         }
 
-        $legacyId = $pk['c_personid']."-".$pk['c_addr_id']."-".$pk['c_addr_type']."-".$pk['c_sequence'];
+        $legacyId = $originalPk['c_personid']."-".$originalPk['c_addr_id']."-".$originalPk['c_addr_type']."-".$originalPk['c_sequence'];
         $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
         if ($newPk === null) {
             abort(404, 'BIOG_ADDR_DATA 記錄不存在');

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -343,22 +343,8 @@ class BasicInformationAssocController extends Controller {
             }
         }
 
-        // 構建舊格式 ID（用於 Repository）
-        // 格式：c_personid-c_assoc_code-c_assoc_id-c_kin_code-c_kin_id-c_assoc_kin_code-c_assoc_kin_id-c_text_title-c_assoc_first_year
-        // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $assocFirstYear = $pk['c_assoc_first_year'] ?? '-9999';
-        $assocFirstYearEncoded = str_replace('-', '(minus)', $assocFirstYear);
-        $id_ = $pk['c_personid']."-".
-               ($pk['c_assoc_code'] ?? '0')."-".
-               ($pk['c_assoc_id'] ?? '0')."-".
-               ($pk['c_kin_code'] ?? '0')."-".
-               ($pk['c_kin_id'] ?? '0')."-".
-               ($pk['c_assoc_kin_code'] ?? '0')."-".
-               ($pk['c_assoc_kin_id'] ?? '0')."-".
-               ($pk['c_text_title'] ?? '')."-".
-               $assocFirstYearEncoded;
-
-        $res = $this->biogMainRepository->assocById($id_);
+        // 直接使用 PK 陣列查詢，避免舊格式編碼/解碼的解析問題
+        $res = $this->biogMainRepository->assocByPk($pk);
 
         // 處理 personLabel
         $personLabel = $id;
@@ -463,45 +449,41 @@ class BasicInformationAssocController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 與 proposal 分支寫法一致，避免表單 body 中的新 PK 值覆蓋原始值
         $schema = CompositePrimaryKey::SCHEMAS['ASSOC_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位（ASSOC_DATA 有較多可選欄位）
         $optional = ['c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'];
-        CompositePrimaryKey::validateOrFail($pk, 'ASSOC_DATA', $optional);
+        CompositePrimaryKey::validateOrFail($originalPk, 'ASSOC_DATA', $optional);
 
-        // 構建舊格式 ID
-        // 格式：c_personid-c_assoc_code-c_assoc_id-c_kin_code-c_kin_id-c_assoc_kin_code-c_assoc_kin_id-c_text_title-c_assoc_first_year
-        // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $assocFirstYear = $pk['c_assoc_first_year'] ?? '-9999';
-        $assocFirstYearEncoded = str_replace('-', '(minus)', $assocFirstYear);
-        $id_ = $pk['c_personid']."-".
-               ($pk['c_assoc_code'] ?? '0')."-".
-               ($pk['c_assoc_id'] ?? '0')."-".
-               ($pk['c_kin_code'] ?? '0')."-".
-               ($pk['c_kin_id'] ?? '0')."-".
-               ($pk['c_assoc_kin_code'] ?? '0')."-".
-               ($pk['c_assoc_kin_id'] ?? '0')."-".
-               ($pk['c_text_title'] ?? '')."-".
-               $assocFirstYearEncoded;
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
 
-        // 使用 Repository 更新
-        $data = $this->biogMainRepository->assocUpdateById($request, $id_, $id);
+        // 使用原始 PK 查找舊記錄並更新
+        $data = $this->biogMainRepository->assocUpdateByPk($request, $originalPk, $id);
 
         flash('Update success @ '.Carbon::now(), 'success');
 
-        // 重定向到新的查詢參數格式
+        // 重定向到新的查詢參數格式（使用更新後的值）
         $newPk = [
             'c_personid' => $id,
-            'c_assoc_code' => $data['c_assoc_code'] ?? $pk['c_assoc_code'],
-            'c_assoc_id' => $data['c_assoc_id'] ?? $pk['c_assoc_id'],
-            'c_kin_code' => $data['c_kin_code'] ?? $pk['c_kin_code'] ?? '0',
-            'c_kin_id' => $data['c_kin_id'] ?? $pk['c_kin_id'] ?? '0',
-            'c_assoc_kin_code' => $data['c_assoc_kin_code'] ?? $pk['c_assoc_kin_code'] ?? '0',
-            'c_assoc_kin_id' => $data['c_assoc_kin_id'] ?? $pk['c_assoc_kin_id'] ?? '0',
-            'c_text_title' => $data['c_text_title'] ?? $pk['c_text_title'] ?? '',
-            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? $pk['c_assoc_first_year'] ?? '',
+            'c_assoc_code' => $data['c_assoc_code'] ?? $originalPk['c_assoc_code'],
+            'c_assoc_id' => $data['c_assoc_id'] ?? $originalPk['c_assoc_id'],
+            'c_kin_code' => $data['c_kin_code'] ?? $originalPk['c_kin_code'] ?? '0',
+            'c_kin_id' => $data['c_kin_id'] ?? $originalPk['c_kin_id'] ?? '0',
+            'c_assoc_kin_code' => $data['c_assoc_kin_code'] ?? $originalPk['c_assoc_kin_code'] ?? '0',
+            'c_assoc_kin_id' => $data['c_assoc_kin_id'] ?? $originalPk['c_assoc_kin_id'] ?? '0',
+            'c_text_title' => $data['c_text_title'] ?? $originalPk['c_text_title'] ?? '',
+            'c_assoc_first_year' => $data['c_assoc_first_year'] ?? $originalPk['c_assoc_first_year'] ?? '',
         ];
 
         return redirect(CompositePrimaryKey::buildUrl(
@@ -538,22 +520,8 @@ class BasicInformationAssocController extends Controller {
         $optional = ['c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'];
         CompositePrimaryKey::validateOrFail($pk, 'ASSOC_DATA', $optional);
 
-        // 構建舊格式 ID
-        // 格式：c_personid-c_assoc_code-c_assoc_id-c_kin_code-c_kin_id-c_assoc_kin_code-c_assoc_kin_id-c_text_title-c_assoc_first_year
-        // 注意：c_assoc_first_year 可能包含負號（如 -9999），需要編碼為 (minus) 避免解析錯誤
-        $assocFirstYear = $pk['c_assoc_first_year'] ?? '-9999';
-        $assocFirstYearEncoded = str_replace('-', '(minus)', $assocFirstYear);
-        $id_ = $pk['c_personid']."-".
-               ($pk['c_assoc_code'] ?? '0')."-".
-               ($pk['c_assoc_id'] ?? '0')."-".
-               ($pk['c_kin_code'] ?? '0')."-".
-               ($pk['c_kin_id'] ?? '0')."-".
-               ($pk['c_assoc_kin_code'] ?? '0')."-".
-               ($pk['c_assoc_kin_id'] ?? '0')."-".
-               ($pk['c_text_title'] ?? '')."-".
-               $assocFirstYearEncoded;
-
-        $this->biogMainRepository->assocDeleteById($id_, $id);
+        // 直接使用 PK 陣列查詢，避免舊格式編碼/解碼的解析問題
+        $this->biogMainRepository->assocDeleteByPk($pk, $id);
 
         flash('Delete success @ '.Carbon::now(), 'success');
 

--- a/app/Http/Controllers/BasicInformationEventsController.php
+++ b/app/Http/Controllers/BasicInformationEventsController.php
@@ -351,15 +351,26 @@ class BasicInformationEventsController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['EVENTS_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位
-        CompositePrimaryKey::validateOrFail($pk, 'EVENTS_DATA');
+        CompositePrimaryKey::validateOrFail($originalPk, 'EVENTS_DATA');
+
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
 
         // 構建 ID（格式：c_sequence-c_event_code）
-        $id_ = $pk['c_sequence'] . '-' . $pk['c_event_code'];
+        $id_ = $originalPk['c_sequence'] . '-' . $originalPk['c_event_code'];
 
         // 使用 Repository 更新
         $result = $this->biogMainRepository->eventUpdateById($request, $id, $id_);

--- a/app/Http/Controllers/BasicInformationKinshipController.php
+++ b/app/Http/Controllers/BasicInformationKinshipController.php
@@ -361,15 +361,26 @@ class BasicInformationKinshipController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['KIN_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位
-        CompositePrimaryKey::validateOrFail($pk, 'KIN_DATA');
+        CompositePrimaryKey::validateOrFail($originalPk, 'KIN_DATA');
+
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
 
         // 構建舊格式 ID（格式：c_personid-c_kin_id-c_kin_code）
-        $id_ = $pk['c_personid'].'-'.$pk['c_kin_id'].'-'.$pk['c_kin_code'];
+        $id_ = $originalPk['c_personid'].'-'.$originalPk['c_kin_id'].'-'.$originalPk['c_kin_code'];
 
         // 使用 Repository 更新
         $data = $this->biogMainRepository->kinshipUpdateById($request, $id, $id_);

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -524,15 +524,22 @@ class BasicInformationOfficesController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['POSTED_TO_OFFICE_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位
-        CompositePrimaryKey::validateOrFail($pk, 'POSTED_TO_OFFICE_DATA');
+        CompositePrimaryKey::validateOrFail($originalPk, 'POSTED_TO_OFFICE_DATA');
 
         // 構建舊格式 ID（格式：c_office_id-c_posting_id）
-        $id_ = $pk['c_office_id'].'-'.$pk['c_posting_id'];
+        $id_ = $originalPk['c_office_id'].'-'.$originalPk['c_posting_id'];
 
         try {
             $result = $this->biogMainRepository->officeUpdateById($request, $id_, $id);

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -392,15 +392,26 @@ class BasicInformationStatusesController extends Controller {
             return redirect()->back();
         }
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['STATUS_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         // 驗證必填欄位
-        CompositePrimaryKey::validateOrFail($pk, 'STATUS_DATA');
+        CompositePrimaryKey::validateOrFail($originalPk, 'STATUS_DATA');
+
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
+            abort(400, '路徑人物 ID 與查詢主鍵不一致');
+        }
 
         // 構建舊格式 ID（格式：c_personid-c_sequence-c_status_code）
-        $id_ = $pk['c_personid'].'-'.$pk['c_sequence'].'-'.$pk['c_status_code'];
+        $id_ = $originalPk['c_personid'].'-'.$originalPk['c_sequence'].'-'.$originalPk['c_status_code'];
 
         // 使用 Repository 更新
         $data = $this->biogMainRepository->statuseUpdateById($request, $id_, $id);

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -366,13 +366,20 @@ class BasicInformationTextsController extends Controller {
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
-        // 從查詢參數提取複合主鍵
+        // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）
+        // 注意：不能用 fromRequest()，因為它會合併查詢參數和表單 body
         $schema = CompositePrimaryKey::SCHEMAS['TEXT_DATA'];
-        $pk = CompositePrimaryKey::fromRequest($request, $schema);
+        $originalPk = [];
+        foreach ($schema as $field) {
+            $value = $request->query($field);
+            if ($value !== null) {
+                $originalPk[$field] = $value;
+            }
+        }
 
         if ($action === 'proposal') {
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
-                ->proposalUpdateWithPk($request, $id, 'texts', $pk);
+                ->proposalUpdateWithPk($request, $id, 'texts', $originalPk);
         }
 
         if (!Auth::user()->canWriteDirectly()) {
@@ -382,14 +389,14 @@ class BasicInformationTextsController extends Controller {
         }
 
         // 驗證必填欄位（c_role_id 為可選，預設為 0）
-        CompositePrimaryKey::validateOrFail($pk, 'TEXT_DATA', ['c_role_id']);
+        CompositePrimaryKey::validateOrFail($originalPk, 'TEXT_DATA', ['c_role_id']);
 
-        if ((string) ($pk['c_personid'] ?? '') !== (string) $id) {
+        if ((string) ($originalPk['c_personid'] ?? '') !== (string) $id) {
             abort(400, '路徑人物 ID 與查詢主鍵不一致');
         }
 
-        $c_role_id = $pk['c_role_id'] ?? 0;
-        $legacyId = $pk['c_personid']."-".$pk['c_textid']."-".$c_role_id;
+        $c_role_id = $originalPk['c_role_id'] ?? 0;
+        $legacyId = $originalPk['c_personid']."-".$originalPk['c_textid']."-".$c_role_id;
         $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);
         if ($newPk === null) {
             abort(404, 'BIOG_TEXT_DATA 記錄不存在');

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -1994,6 +1994,80 @@ class BiogMainRepository {
                 $c_text_title = $temp_l[7] ?? '';
             }
         }
+        if (!$row) {
+            abort(404, '找不到指定的社會關係記錄');
+        }
+
+        return $this->assocBuildResult($row);
+    }
+
+    /**
+     * 使用複合主鍵陣列直接查詢社會關係記錄
+     *
+     * 避免舊格式 ID 字串的編碼/解碼，直接以 PK 欄位值查詢資料庫。
+     *
+     * @param array $pk 複合主鍵欄位陣列
+     * @return array 包含 row 與相關顯示資料的陣列
+     */
+    public function assocByPk(array $pk) {
+        $where = [];
+        $fields = ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'];
+        foreach ($fields as $field) {
+            if (isset($pk[$field]) && $pk[$field] !== '') {
+                $where[] = [$field, '=', $pk[$field]];
+            } else {
+                // 對於未提供的可選欄位使用預設值
+                $defaults = [
+                    'c_kin_code' => '0', 'c_kin_id' => '0',
+                    'c_assoc_kin_code' => '0', 'c_assoc_kin_id' => '0',
+                    'c_text_title' => '', 'c_assoc_first_year' => '-9999',
+                ];
+                if (isset($defaults[$field])) {
+                    $where[] = [$field, '=', $defaults[$field]];
+                }
+            }
+        }
+
+        $row = DB::table('ASSOC_DATA')->where($where)->first();
+
+        if (!$row) {
+            abort(404, '找不到指定的社會關係記錄');
+        }
+
+        return $this->assocBuildResult($row);
+    }
+
+    /**
+     * 從 PK 陣列建立 ASSOC_DATA 的 WHERE 條件
+     *
+     * @param array $pk 複合主鍵欄位陣列
+     * @return array WHERE 條件陣列
+     */
+    private function buildAssocWhereFromPk(array $pk): array {
+        $fields = ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'];
+        $defaults = [
+            'c_kin_code' => '0', 'c_kin_id' => '0',
+            'c_assoc_kin_code' => '0', 'c_assoc_kin_id' => '0',
+            'c_text_title' => '', 'c_assoc_first_year' => '-9999',
+        ];
+        $where = [];
+        foreach ($fields as $field) {
+            $value = $pk[$field] ?? ($defaults[$field] ?? null);
+            if ($value !== null) {
+                $where[] = [$field, '=', $value];
+            }
+        }
+
+        return $where;
+    }
+
+    /**
+     * 從 ASSOC_DATA 記錄建立編輯頁面所需的結果陣列
+     *
+     * @param object $row ASSOC_DATA 記錄
+     * @return array 包含 row 與相關顯示資料的陣列
+     */
+    private function assocBuildResult($row) {
         $text_str = null;
         if ($row->c_source || $row->c_source === 0) {
             $text_ = TextCode::find($row->c_source);
@@ -2128,6 +2202,25 @@ class BiogMainRepository {
             'tertiary_personid' => $tertiary_personid, 'assoc_claimer_id' => $assoc_claimer_id, 'addr_id' => $addr_id, 'inst_code' => $inst_code, 'kinship_pair' => $kinship_pair, 'assoc_kinship_pair' => $assoc_kinship_pair];
     }
 
+    /**
+     * 使用複合主鍵陣列更新社會關係記錄
+     *
+     * @param Request $request HTTP 請求
+     * @param array $pk 複合主鍵欄位陣列
+     * @param int|string $c_personid 人物 ID
+     * @return array 更新後的資料
+     */
+    public function assocUpdateByPk(Request $request, array $pk, $c_personid) {
+        $whereConditions = $this->buildAssocWhereFromPk($pk);
+        $row = DB::table('ASSOC_DATA')->where($whereConditions)->first();
+
+        if (!$row) {
+            abort(404, '找不到指定的社會關係記錄');
+        }
+
+        return $this->assocPerformUpdate($request, $whereConditions, $row, $c_personid);
+    }
+
     public function assocUpdateById(Request $request, $id, $c_personid) {
         $auditLog = new AuditLogService();
         //20200709聯合主鍵保留字弱點防禦函式
@@ -2209,6 +2302,33 @@ class BiogMainRepository {
             return [];
         }
 
+        $whereConditions = [
+            ['c_personid', '=', $temp_l[0]],
+            ['c_assoc_code', '=', $temp_l[1]],
+            ['c_assoc_id', '=', $temp_l[2]],
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $c_text_title],
+            ['c_assoc_first_year', '=', $c_assoc_first_year],
+        ];
+
+        return $this->assocPerformUpdate($request, $whereConditions, $row, $c_personid);
+    }
+
+    /**
+     * 執行社會關係更新的共用邏輯
+     *
+     * @param Request $request HTTP 請求
+     * @param array $whereConditions WHERE 條件陣列
+     * @param object $row 原始記錄
+     * @param int|string $c_personid 人物 ID
+     * @return array 更新後的資料
+     */
+    private function assocPerformUpdate(Request $request, array $whereConditions, $row, $c_personid) {
+        $auditLog = new AuditLogService();
+
         $data = $request->all();
         $data = $this->formatSelect($data);
         $assoc_pair = $data['c_assocship_pair'];
@@ -2229,19 +2349,8 @@ class BiogMainRepository {
 
         $ori_data = $data;
 
-        DB::transaction(function () use (&$ori_data, $c_personid, $temp_l, $c_text_title, $c_assoc_first_year, $row, $data, $kin_pair, $assoc_kin_pair, $assoc_pair, $assoc_id, $old_assoc_id, $old_c_text_title, $old_c_assoc_first_year, $old_c_assocship_pair1, $old_c_assocship_pair2, $auditLog) {
-            DB::table('ASSOC_DATA')->where([
-                ['c_personid', '=', $temp_l[0]],
-                ['c_assoc_code', '=', $temp_l[1]],
-                ['c_assoc_id', '=', $temp_l[2]],
-                //20191028進行聯合主鍵的擴充修改
-                ['c_kin_code', '=', $temp_l[3]],
-                ['c_kin_id', '=', $temp_l[4]],
-                ['c_assoc_kin_code', '=', $temp_l[5]],
-                ['c_assoc_kin_id', '=', $temp_l[6]],
-                ['c_text_title', '=', $c_text_title],
-                ['c_assoc_first_year', '=', $c_assoc_first_year],
-            ])->update($data);
+        DB::transaction(function () use (&$ori_data, $c_personid, $whereConditions, $row, $data, $kin_pair, $assoc_kin_pair, $assoc_pair, $assoc_id, $old_assoc_id, $old_c_text_title, $old_c_assoc_first_year, $old_c_assocship_pair1, $old_c_assocship_pair2, $auditLog) {
+            DB::table('ASSOC_DATA')->where($whereConditions)->update($data);
 
             // 修正：operation record ID 包含第 9 個欄位 c_assoc_first_year
             $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 3, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
@@ -2415,6 +2524,23 @@ class BiogMainRepository {
         return $ori_Data;
     }
 
+    /**
+     * 使用複合主鍵陣列刪除社會關係記錄
+     *
+     * @param array $pk 複合主鍵欄位陣列
+     * @param int|string $c_personid 人物 ID
+     */
+    public function assocDeleteByPk(array $pk, $c_personid) {
+        $whereConditions = $this->buildAssocWhereFromPk($pk);
+        $row = DB::table('ASSOC_DATA')->where($whereConditions)->first();
+
+        if (!$row) {
+            abort(404, '找不到指定的社會關係記錄');
+        }
+
+        $this->assocPerformDelete($whereConditions, $row, $c_personid);
+    }
+
     public function assocDeleteById($id, $c_personid) {
         $auditLog = new AuditLogService();
         //20200709聯合主鍵保留字弱點防禦函式
@@ -2496,7 +2622,32 @@ class BiogMainRepository {
             return;
         }
 
-        DB::transaction(function () use ($id, $c_personid, $temp_l, $c_text_title, $c_assoc_first_year, $row, $auditLog) {
+        $whereConditions = [
+            ['c_personid', '=', $temp_l[0]],
+            ['c_assoc_code', '=', $temp_l[1]],
+            ['c_assoc_id', '=', $temp_l[2]],
+            ['c_kin_code', '=', $temp_l[3]],
+            ['c_kin_id', '=', $temp_l[4]],
+            ['c_assoc_kin_code', '=', $temp_l[5]],
+            ['c_assoc_kin_id', '=', $temp_l[6]],
+            ['c_text_title', '=', $c_text_title],
+            ['c_assoc_first_year', '=', $c_assoc_first_year],
+        ];
+
+        $this->assocPerformDelete($whereConditions, $row, $c_personid);
+    }
+
+    /**
+     * 執行社會關係刪除的共用邏輯
+     *
+     * @param array $whereConditions WHERE 條件陣列
+     * @param object $row 原始記錄
+     * @param int|string $c_personid 人物 ID
+     */
+    private function assocPerformDelete(array $whereConditions, $row, $c_personid) {
+        $auditLog = new AuditLogService();
+
+        DB::transaction(function () use ($c_personid, $whereConditions, $row, $auditLog) {
             // 修正：查找配對記錄時使用多層次策略
             // 1. 如果 c_kin_id 和 c_assoc_kin_id 都是 0，反向記錄也應該是 0（對稱情況）
             // 2. 否則使用 paired c_assoc_code 來精確匹配
@@ -2543,17 +2694,7 @@ class BiogMainRepository {
                 }
             }
 
-            DB::table('ASSOC_DATA')->where([
-                ['c_personid', '=', $temp_l[0]],
-                ['c_assoc_code', '=', $temp_l[1]],
-                ['c_assoc_id', '=', $temp_l[2]],
-                ['c_kin_code', '=', $temp_l[3]],
-                ['c_kin_id', '=', $temp_l[4]],
-                ['c_assoc_kin_code', '=', $temp_l[5]],
-                ['c_assoc_kin_id', '=', $temp_l[6]],
-                ['c_text_title', '=', $c_text_title],
-                ['c_assoc_first_year', '=', $c_assoc_first_year],
-            ])->delete();
+            DB::table('ASSOC_DATA')->where($whereConditions)->delete();
 
             $assocResourceId = CompositePrimaryKey::buildStoredResourceId([
                 'c_personid' => $row->c_personid,
@@ -2623,10 +2764,9 @@ class BiogMainRepository {
             } elseif ($reverseDeleteSkipReason !== null) {
                 Log::info('[ASSOC_DATA] 跳過反向記錄刪除', [
                     'reason' => $reverseDeleteSkipReason,
-                    'forward_id' => $id,
-                    'c_personid' => $temp_l[0] ?? null,
-                    'c_assoc_id' => $temp_l[2] ?? null,
-                    'c_assoc_code' => $temp_l[1] ?? null,
+                    'c_personid' => $row->c_personid,
+                    'c_assoc_id' => $row->c_assoc_id,
+                    'c_assoc_code' => $row->c_assoc_code,
                     'c_kin_id' => $row->c_kin_id,
                     'c_assoc_kin_id' => $row->c_assoc_kin_id,
                 ]);


### PR DESCRIPTION
## Summary

- 社會關係編輯頁面因舊格式 ID 編碼/解碼不匹配導致 `$row` 為 null 崩潰（`Attempt to read property 'c_source' on null`），新增 `assocByPk` / `assocUpdateByPk` / `assocDeleteByPk` 直接以 PK 陣列查詢，繞過舊格式解析
- 7 個 Controller 的 `updateQuery` 直接更新分支將 `CompositePrimaryKey::fromRequest()` 改為 `$request->query()` 讀取原始 PK，修正使用者修改可編輯主鍵欄位時表單 body 覆蓋 URL 中舊主鍵值導致找不到原記錄的問題
- 4 個 Controller（Assoc、Kinship、Statuses、Events）補上 route `{id}` 與 query `c_personid` 一致性校驗，防止構造不一致 URL 造成跨人物資料歸屬錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)