### PR TITLE
修正任官「另存新檔」未提交表單修改內容

### DIFF
--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -267,6 +267,11 @@ class BasicInformationOfficesController extends Controller {
             return redirect()->back();
         }
 
+        // 另存新檔：以表單目前的資料建立新記錄
+        if ($request->input('action') === 'saveas') {
+            return $this->storeSaveAs($request, $id);
+        }
+
         //return $request;
         //修改結束
         try {
@@ -371,6 +376,33 @@ class BasicInformationOfficesController extends Controller {
             'office' => $_id,
     ]);
     */
+    }
+
+    /**
+     * 以表單目前的資料另存為新記錄（由 update 方法的 action=saveas 觸發）。
+     */
+    private function storeSaveAs(Request $request, $id) {
+        // 移除編輯表單的隱藏欄位，這些不是資料庫欄位
+        $request->request->remove('_method');
+        $request->request->remove('_id');
+        $request->request->remove('_postingid');
+        $request->request->remove('_officeid');
+
+        $_id = $this->biogMainRepository->officeStoreById($request, $id);
+        flash('另存新檔成功 @ '.Carbon::now(), 'success');
+
+        $newPk = CompositePrimaryKey::parseStoredResourceId($_id, 'POSTED_TO_OFFICE_DATA');
+        if ($newPk === null) {
+            \Log::error('officeStoreById（另存）返回的 resource_id 無法解析', ['resource_id' => $_id]);
+
+            return redirect(route('basicinformation.offices.index', $id, false));
+        }
+
+        return redirect(CompositePrimaryKey::buildUrl(
+            'basicinformation.offices.edit.query',
+            ['id' => $id],
+            $newPk
+        ));
     }
 
     /**
@@ -522,6 +554,11 @@ class BasicInformationOfficesController extends Controller {
             flash('該用戶沒有權限，請聯絡管理員 @ '.Carbon::now(), 'error');
 
             return redirect()->back();
+        }
+
+        // 另存新檔：以表單目前的資料建立新記錄
+        if ($action === 'saveas') {
+            return $this->storeSaveAs($request, $id);
         }
 
         // 從 URL 查詢字串取得原始 PK（而非表單提交的新值）

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -279,7 +279,9 @@
                         <i class="fa fa-save"></i> 直接儲存
                     </button>
                     @if($isEdit)
-                        <a href="../../../../basicinformation/{{ $row->c_personid }}/offices/{{ $row->c_office_id.'-'.$row->c_posting_id }}/saveas" class="btn btn-success" style="margin-left:40px;">save as</a>
+                        <button type="submit" name="action" value="saveas" class="btn btn-success" style="margin-left:40px;">
+                            <i class="fa fa-copy"></i> 另存新檔
+                        </button>
                     @endif
                 @endif
 


### PR DESCRIPTION
## Summary

- 修正任官表單的「save as」按鈕為超連結，點擊時不提交表單資料，導致修改內容丟失、僅複製資料庫舊記錄的問題
- 將 `<a>` 改為 `<button type="submit" name="action" value="saveas">`，使表單資料隨提交一併送出
- 在 `update` / `updateQuery` 中偵測 `action=saveas`，改走 `officeStoreById` 新增邏輯

Closes #908

## Test plan

- [x] 42 個 Office 相關測試全數通過
- [x] 手動測試：開啟任官編輯表單 → 修改欄位 → 點擊「另存新檔」→ 確認新記錄包含修改後的內容

🤖 Generated with [Claude Code](https://claude.com/claude-code)