### PR TITLE
修正地址與著述主鍵欄位無法更新及社會關係排序問題

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -543,7 +543,13 @@ class BasicInformationAddressesController extends Controller {
         }
 
         $legacyId = $originalPk['c_personid']."-".$originalPk['c_addr_id']."-".$originalPk['c_addr_type']."-".$originalPk['c_sequence'];
-        $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
+        try {
+            $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
+        } catch (\InvalidArgumentException $e) {
+            flash($e->getMessage(), 'error');
+
+            return redirect()->back()->withInput();
+        }
         if ($newPk === null) {
             abort(404, 'BIOG_ADDR_DATA 記錄不存在');
         }

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -543,6 +543,7 @@ class BasicInformationAddressesController extends Controller {
         }
 
         $legacyId = $originalPk['c_personid']."-".$originalPk['c_addr_id']."-".$originalPk['c_addr_type']."-".$originalPk['c_sequence'];
+
         try {
             $newPk = $this->biogMainRepository->addrUpdateById($request, $id, $legacyId);
         } catch (\InvalidArgumentException $e) {

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -253,7 +253,13 @@ class BasicInformationTextsController extends Controller {
         }
 
         // 使用 Repository 進行更新（內含事務與審計）
-        $newPk = $this->biogMainRepository->textUpdateById($request, $id, $id_);
+        try {
+            $newPk = $this->biogMainRepository->textUpdateById($request, $id, $id_);
+        } catch (\InvalidArgumentException $e) {
+            flash($e->getMessage(), 'error');
+
+            return redirect()->back()->withInput();
+        }
         if (!$newPk) {
             abort(404, 'BIOG_TEXT_DATA 記錄不存在');
         }
@@ -397,7 +403,13 @@ class BasicInformationTextsController extends Controller {
 
         $c_role_id = $originalPk['c_role_id'] ?? 0;
         $legacyId = $originalPk['c_personid']."-".$originalPk['c_textid']."-".$c_role_id;
-        $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);
+        try {
+            $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);
+        } catch (\InvalidArgumentException $e) {
+            flash($e->getMessage(), 'error');
+
+            return redirect()->back()->withInput();
+        }
         if ($newPk === null) {
             abort(404, 'BIOG_TEXT_DATA 記錄不存在');
         }

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -403,6 +403,7 @@ class BasicInformationTextsController extends Controller {
 
         $c_role_id = $originalPk['c_role_id'] ?? 0;
         $legacyId = $originalPk['c_personid']."-".$originalPk['c_textid']."-".$c_role_id;
+
         try {
             $newPk = $this->biogMainRepository->textUpdateById($request, $id, $legacyId);
         } catch (\InvalidArgumentException $e) {

--- a/app/Models/BiogMain.php
+++ b/app/Models/BiogMain.php
@@ -125,11 +125,12 @@ class BiogMain extends Model {
 
     public function assoc() {
         return $this->belongsToMany('App\Models\AssocCode', 'ASSOC_DATA', 'c_personid', 'c_assoc_code')
-            ->withPivot('c_personid', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year');
+            ->withPivot('c_personid', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year')
+            ->orderByPivot('c_sequence');
     }
 
     public function assoc_name() {
-        return $this->belongsToMany('App\Models\BiogMain', 'ASSOC_DATA', 'c_personid', 'c_assoc_id')->select(['c_name', 'c_name_chn' ,'c_sequence']);
+        return $this->belongsToMany('App\Models\BiogMain', 'ASSOC_DATA', 'c_personid', 'c_assoc_id')->select(['c_name', 'c_name_chn' ,'c_sequence'])->orderByPivot('c_sequence');
     }
 
     public function possession() {

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -708,7 +708,7 @@ class BiogMainRepository {
         $temp_l = explode("-", $id_);
         $data = $request->all();
         $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_textid', 'c_role_id']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid']);
         $data = (new ToolsRepository())->timestamp($data);
 
         return DB::transaction(function () use ($id, $temp_l, $data, $comment) {
@@ -720,6 +720,26 @@ class BiogMainRepository {
 
             if (!$ori) {
                 return null;
+            }
+
+            // 若主鍵欄位有變動，檢查新主鍵是否與既有記錄衝突
+            $newTextid = $data['c_textid'] ?? $ori->c_textid;
+            $newRoleId = $data['c_role_id'] ?? $ori->c_role_id;
+            $pkChanged = (string) $newTextid !== (string) $ori->c_textid
+                      || (string) $newRoleId !== (string) $ori->c_role_id;
+
+            if ($pkChanged) {
+                $conflict = DB::table('BIOG_TEXT_DATA')->where([
+                    ['c_personid', '=', $temp_l[0]],
+                    ['c_textid', '=', $newTextid],
+                    ['c_role_id', '=', $newRoleId],
+                ])->exists();
+
+                if ($conflict) {
+                    throw new \InvalidArgumentException(
+                        '目標著述代碼與著述角色的組合已存在，請使用不同的值。'
+                    );
+                }
             }
 
             DB::table('BIOG_TEXT_DATA')->where([
@@ -2824,7 +2844,7 @@ class BiogMainRepository {
         $addr_l = $this->parseAddrId($addr);
         $data = $request->all();
         $comment = $data['__proposal_comment'] ?? null;
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_addr_id', 'c_addr_type', 'c_sequence']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_personid', 'c_addr_id']);
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
         $data = (new ToolsRepository())->timestamp($data);
@@ -2839,6 +2859,27 @@ class BiogMainRepository {
 
             if (!$ori) {
                 return null;
+            }
+
+            // 若主鍵欄位有變動，檢查新主鍵是否與既有記錄衝突
+            $newAddrType = $data['c_addr_type'] ?? $ori->c_addr_type;
+            $newSequence = $data['c_sequence'] ?? $ori->c_sequence;
+            $pkChanged = (string) $newAddrType !== (string) $ori->c_addr_type
+                      || (string) $newSequence !== (string) $ori->c_sequence;
+
+            if ($pkChanged) {
+                $conflict = DB::table('BIOG_ADDR_DATA')->where([
+                    ['c_personid', '=', $addr_l[0]],
+                    ['c_addr_id', '=', $addr_l[1]],
+                    ['c_addr_type', '=', $newAddrType],
+                    ['c_sequence', '=', $newSequence],
+                ])->exists();
+
+                if ($conflict) {
+                    throw new \InvalidArgumentException(
+                        '目標地址類別與遷徙次序的組合已存在，請使用不同的值。'
+                    );
+                }
             }
 
             DB::table('BIOG_ADDR_DATA')->where([

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -174,6 +174,7 @@ class BasicInformationPagesLoadTest extends TestCase {
             $table->integer('c_assoc_kin_id')->default(0);
             $table->string('c_text_title', 255)->nullable();
             $table->integer('c_assoc_first_year')->default(-9999);
+            $table->integer('c_sequence')->default(0);
             $table->timestamps();
         });
 


### PR DESCRIPTION
## Summary
- 修正 `BIOG_ADDR_DATA` 的 `c_addr_type`（地址類別）和 `c_sequence`（遷徙次序）編輯後顯示成功但實際未寫入的問題，原因是 `Arr::except()` 誤將這兩個複合主鍵欄位從更新資料中排除
- 修正 `BIOG_TEXT_DATA` 的 `c_textid`（著述代碼）和 `c_role_id`（著述角色）存在同樣的主鍵欄位無法更新問題
- 修正社會關係列表頁未按 `c_sequence` 排序，導致顯示順序與錄入次序不一致
- 為主鍵欄位變更加入衝突檢查，避免更新為重複主鍵時產生 500 錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)