### PR TITLE
擴充姓名稱謂拼音特例

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -554,18 +554,7 @@ class ApiController extends Controller {
     public function searchPinyin(Request $request) {
         $word = trim((string) $request->q);
         if (!empty($word)) {
-            // 特例 1：例如「（李白妻）」→「(Wife of Li Bai)」
-            if (preg_match('/^\s*[（(]\s*(.+?)\s*妻\s*[）)]\s*$/u', $word, $matches) === 1) {
-                $wifeOf = $this->buildPinyinWord($matches[1] ?? '');
-                $res = '(Wife of '.trim($wifeOf).')';
-                // 特例 2：例如「宗氏（李白妻）」→「Zong Shi (Wife of Li Bai)」
-            } elseif (preg_match('/^(.*?)[（(]\s*(.+?)\s*妻\s*[）)]\s*$/u', $word, $matches) === 1) {
-                $prefix = $this->buildPinyinWord($matches[1] ?? '');
-                $wifeOf = $this->buildPinyinWord($matches[2] ?? '');
-                $res = trim($prefix).' (Wife of '.trim($wifeOf).')';
-            } else {
-                $res = $this->buildPinyinWord($word);
-            }
+            $res = $this->buildRelationshipPinyin($word) ?? $this->buildPinyinWord($word);
 
             // 全角括號轉半角，並確保括號前與文字之間有一個空格
             $res = str_replace(['（', '）'], ['(', ')'], $res);
@@ -589,5 +578,41 @@ class ApiController extends Controller {
         $result = $repository->auto_pinyin(['c_name_chn' => $word]);
 
         return trim((string) ($result['c_name'] ?? ''));
+    }
+
+    private function buildRelationshipPinyin(string $word): ?string {
+        $titlesPattern = implode('|', array_map('preg_quote', array_keys($this->relationshipPhrases())));
+
+        // 特例 1：例如「（李白妻）」→「(Wife of Li Bai)」
+        if (preg_match('/^\s*[（(]\s*(.+?)\s*('.$titlesPattern.')\s*[）)]\s*$/u', $word, $matches) === 1) {
+            $target = $this->buildPinyinWord($matches[1] ?? '');
+            $phrase = $this->relationshipPhrases()[$matches[2]] ?? null;
+
+            return $phrase ? '('.$phrase.' '.trim($target).')' : null;
+        }
+
+        // 特例 2：例如「宗氏（李白妻）」→「Zong Shi (Wife of Li Bai)」
+        if (preg_match('/^(.*?)[（(]\s*(.+?)\s*('.$titlesPattern.')\s*[）)]\s*$/u', $word, $matches) === 1) {
+            $prefix = $this->buildPinyinWord($matches[1] ?? '');
+            $target = $this->buildPinyinWord($matches[2] ?? '');
+            $phrase = $this->relationshipPhrases()[$matches[3]] ?? null;
+
+            return $phrase ? trim($prefix).' ('.$phrase.' '.trim($target).')' : null;
+        }
+
+        return null;
+    }
+
+    private function relationshipPhrases(): array {
+        return [
+            '妻' => 'Wife of',
+            '母' => 'Mother of',
+            '女' => 'Daughter of',
+            '妾' => 'Concubine of',
+            '媳' => 'Daughter-in-law of',
+            '妹' => 'Younger Sister of',
+            '姐' => 'Elder Sister of',
+            '姊' => 'Elder Sister of',
+        ];
     }
 }

--- a/tests/Feature/ApiSearchPinyinTest.php
+++ b/tests/Feature/ApiSearchPinyinTest.php
@@ -46,6 +46,11 @@ class ApiSearchPinyinTest extends TestCase {
 
     #[Test]
     public function search_pinyin_converts_wife_pattern_to_wife_of_english_phrase(): void {
+        DB::table('pinyin')->insert([
+            'lastname_chn' => '李',
+            'lastname_pinyin' => 'Li',
+        ]);
+
         $response = $this->get('/api/select/search/pinyin?q=（李白妻）');
 
         $response->assertOk();
@@ -67,5 +72,47 @@ class ApiSearchPinyinTest extends TestCase {
         $response->assertOk();
         $content = trim($response->getContent());
         $this->assertStringStartsWith('Wang ', $content);
+    }
+
+    #[Test]
+    public function search_pinyin_converts_supported_relationship_patterns_to_english_phrases(): void {
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '李', 'lastname_pinyin' => 'Li'],
+            ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
+        ]);
+
+        $cases = [
+            '（李白母）' => 'Mother of Li Bai',
+            '（王安石女）' => 'Daughter of Wang Anshi',
+            '（李白妾）' => 'Concubine of Li Bai',
+            '（王安石媳）' => 'Daughter-in-law of Wang Anshi',
+            '（李白妹）' => 'Younger Sister of Li Bai',
+            '（王安石姐）' => 'Elder Sister of Wang Anshi',
+            '（李白姊）' => 'Elder Sister of Li Bai',
+        ];
+
+        foreach ($cases as $query => $expectedPhrase) {
+            $response = $this->get('/api/select/search/pinyin?q='.urlencode($query));
+
+            $response->assertOk();
+            $content = trim($response->getContent());
+
+            $this->assertSame('('.$expectedPhrase.')', $content);
+        }
+    }
+
+    #[Test]
+    public function search_pinyin_converts_prefixed_relationship_patterns_to_english_phrases(): void {
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '宗', 'lastname_pinyin' => 'Zong'],
+            ['lastname_chn' => '李', 'lastname_pinyin' => 'Li'],
+        ]);
+
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('宗氏（李白母）'));
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertSame('Zong Shi (Mother of Li Bai)', $content);
     }
 }


### PR DESCRIPTION
- 讓 searchPinyin 支援 母、女、妾、媳、妹、姐、姊 的稱謂轉寫
- 保留既有 妻 的特例邏輯並抽成共用映射
- 補上 API 拼音查詢的關係稱謂測試