### PR TITLE
新增社會關係與社會區分 AI 智能識別代碼功能

### DIFF
--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -38,6 +38,11 @@ class AiFillLogController extends Controller {
             $query->where('ai_fill_logs.user_id', $request->input('user_id'));
         }
 
+        // 類別篩選
+        if ($request->filled('category')) {
+            $query->where('ai_fill_logs.category', $request->input('category'));
+        }
+
         $query->orderBy('ai_fill_logs.created_at', 'desc');
 
         $logs = $query->paginate(20)->withQueryString();
@@ -48,8 +53,11 @@ class AiFillLogController extends Controller {
             if ($log->ai_matched && $log->user_submitted) {
                 $aiMatched = json_decode($log->ai_matched, true);
                 $userSubmitted = json_decode($log->user_submitted, true);
+                $logCat = $log->category ?? 'posting';
                 if (is_array($aiMatched) && is_array($userSubmitted)) {
-                    $log->comparison_rows = $this->buildComparisonRows($aiMatched, $userSubmitted);
+                    $log->comparison_rows = ($logCat === 'assoc' || $logCat === 'status')
+                        ? $this->buildCodeComparisonRows($aiMatched, $userSubmitted, $logCat)
+                        : $this->buildComparisonRows($aiMatched, $userSubmitted);
                 }
             }
         }
@@ -74,6 +82,7 @@ class AiFillLogController extends Controller {
             'filters' => [
                 'search' => $request->input('search'),
                 'user_id' => $request->input('user_id'),
+                'category' => $request->input('category'),
             ],
         ]);
     }
@@ -281,5 +290,67 @@ class AiFillLogController extends Controller {
         }
 
         return $str;
+    }
+
+    /**
+     * 建構代碼查詢（assoc/status）的 AI 匹配結果與用戶提交數據的比較列表
+     *
+     * 每個 AI 候選代碼獨立一行，用戶選中的標綠。
+     */
+    private function buildCodeComparisonRows(array $aiMatched, array $userSubmitted, string $category): array {
+        if ($category === 'assoc') {
+            $codeField = 'c_assoc_code';
+            $codeTable = 'ASSOC_CODES';
+            $codePk = 'c_assoc_code';
+            $codeDescChn = 'c_assoc_desc_chn';
+            $codeDescEn = 'c_assoc_desc';
+        } else {
+            $codeField = 'c_status_code';
+            $codeTable = 'STATUS_CODES';
+            $codePk = 'c_status_code';
+            $codeDescChn = 'c_status_desc_chn';
+            $codeDescEn = 'c_status_desc';
+        }
+
+        $userCodeValue = (string) ($userSubmitted[$codeField] ?? '');
+
+        $rows = [];
+
+        // 每個 AI 候選代碼獨立一行
+        $matchedCodes = $aiMatched['matched_codes'] ?? [];
+        foreach ($matchedCodes as $i => $code) {
+            $codeId = (string) $code['code_id'];
+            $isSelected = ($codeId === $userCodeValue);
+            $aiText = $codeId . ' ' . ($code['desc_chn'] ?? '') . ' (' . ($code['desc_en'] ?? '') . ')';
+            $reason = $code['reason'] ?? '';
+            if ($reason !== '') {
+                $aiText .= ' — ' . $reason;
+            }
+
+            $rows[] = [
+                'field' => $i === 0 ? 'AI 候選代碼' : '',
+                'field_key' => $codeField . '_' . $i,
+                'ai_value' => $aiText,
+                'ai_type' => $code['relevance'] === '高' ? 'matched' : 'suggested',
+                'user_value' => $isSelected ? '✔ 已選用' : '',
+                'matches' => $isSelected,
+            ];
+        }
+
+        // 若用戶選了一個不在 AI 候選中的代碼
+        $aiCodeIds = array_map(fn ($c) => (string) $c['code_id'], $matchedCodes);
+        if ($userCodeValue !== '' && $userCodeValue !== '0' && !in_array($userCodeValue, $aiCodeIds, true)) {
+            $codeText = DB::table($codeTable)->where($codePk, $userCodeValue)->value($codeDescChn);
+            $rows[] = [
+                'field' => '',
+                'field_key' => $codeField . '_user',
+                'ai_value' => '',
+                'ai_type' => 'empty',
+                'user_value' => $userCodeValue . ($codeText ? ' (' . $codeText . ')' : '') . ' — 手動選擇（非 AI 候選）',
+                'matches' => false,
+            ];
+        }
+
+        return $rows;
     }
 }

--- a/app/Http/Controllers/AiPostingAutofillController.php
+++ b/app/Http/Controllers/AiPostingAutofillController.php
@@ -67,6 +67,7 @@ class AiPostingAutofillController extends Controller {
             $logId = DB::table('ai_fill_logs')->insertGetId([
                 'user_id' => Auth::id(),
                 'c_personid' => $personId,
+                'category' => 'posting',
                 'route_name' => $request->input('route_name') ?? '',
                 'route_url' => $request->input('route_url') ?? '',
                 'source_text' => $sourceText,

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -181,8 +181,15 @@ class BasicInformationAssocController extends Controller {
         }
         //return $request;
         //修改結束
+        $aiFillLogId = $request->input('ai_fill_log_id');
+        $request->request->remove('ai_fill_log_id');
+
         $data = $this->biogMainRepository->assocStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
+
+        if ($aiFillLogId) {
+            $this->updateAiFillLog($aiFillLogId, $request);
+        }
 
         // 使用新的查詢參數模式重定向
         $newPk = [
@@ -468,10 +475,17 @@ class BasicInformationAssocController extends Controller {
             abort(400, '路徑人物 ID 與查詢主鍵不一致');
         }
 
+        $aiFillLogId = $request->input('ai_fill_log_id');
+        $request->request->remove('ai_fill_log_id');
+
         // 使用原始 PK 查找舊記錄並更新
         $data = $this->biogMainRepository->assocUpdateByPk($request, $originalPk, $id);
 
         flash('Update success @ '.Carbon::now(), 'success');
+
+        if ($aiFillLogId) {
+            $this->updateAiFillLog($aiFillLogId, $request);
+        }
 
         // 重定向到新的查詢參數格式（使用更新後的值）
         $newPk = [
@@ -526,5 +540,36 @@ class BasicInformationAssocController extends Controller {
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.assoc.index', ['basicinformation' => $id]);
+    }
+
+    /**
+     * 更新 AI 填充日誌，記錄用戶實際提交的數據
+     */
+    private function updateAiFillLog(int $logId, Request $request): void {
+        try {
+            $relevantFields = [
+                'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id',
+                'c_assoc_kin_code', 'c_assoc_kin_id', 'c_sequence',
+                'c_assoc_first_year', 'c_assoc_last_year',
+                'c_source', 'c_pages', 'c_notes',
+                'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair',
+            ];
+            $submittedData = $request->only($relevantFields);
+
+            $personId = $request->input('c_personid') ?? $request->route('id');
+
+            DB::table('ai_fill_logs')
+                ->where('id', $logId)
+                ->where('user_id', Auth::id())
+                ->where('category', 'assoc')
+                ->where('c_personid', $personId)
+                ->update([
+                    'user_submitted' => json_encode($submittedData, JSON_UNESCAPED_UNICODE),
+                    'submitted_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        } catch (\Exception $e) {
+            \Log::warning('[AI Fill Log] 更新用戶提交數據失敗: ' . $e->getMessage());
+        }
     }
 }

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -666,9 +666,13 @@ class BasicInformationOfficesController extends Controller {
             ];
             $submittedData = $request->only($relevantFields);
 
+            $personId = $request->input('c_personid') ?? $request->route('id') ?? $request->input('_id');
+
             DB::table('ai_fill_logs')
                 ->where('id', $logId)
                 ->where('user_id', Auth::id())
+                ->where('category', 'posting')
+                ->where('c_personid', $personId)
                 ->update([
                     'user_submitted' => json_encode($submittedData, JSON_UNESCAPED_UNICODE),
                     'submitted_at' => now(),

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -136,8 +136,15 @@ class BasicInformationStatusesController extends Controller {
 
             return redirect()->back();
         }
+        $aiFillLogId = $request->input('ai_fill_log_id');
+        $request->request->remove('ai_fill_log_id');
+
         $data = $this->biogMainRepository->statuseStoreById($request, $id);
         flash('Store success @ '.Carbon::now(), 'success');
+
+        if ($aiFillLogId) {
+            $this->updateAiFillLog($aiFillLogId, $request);
+        }
 
         // 使用新的查詢參數模式重定向
         $newPk = [
@@ -413,10 +420,17 @@ class BasicInformationStatusesController extends Controller {
         // 構建舊格式 ID（格式：c_personid-c_sequence-c_status_code）
         $id_ = $originalPk['c_personid'].'-'.$originalPk['c_sequence'].'-'.$originalPk['c_status_code'];
 
+        $aiFillLogId = $request->input('ai_fill_log_id');
+        $request->request->remove('ai_fill_log_id');
+
         // 使用 Repository 更新
         $data = $this->biogMainRepository->statuseUpdateById($request, $id_, $id);
 
         flash('Update success @ '.Carbon::now(), 'success');
+
+        if ($aiFillLogId) {
+            $this->updateAiFillLog($aiFillLogId, $request);
+        }
 
         // 重定向到新的查詢參數格式
         $newPk = [
@@ -466,5 +480,35 @@ class BasicInformationStatusesController extends Controller {
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route('basicinformation.statuses.index', ['basicinformation' => $id]);
+    }
+
+    /**
+     * 更新 AI 填充日誌，記錄用戶實際提交的數據
+     */
+    private function updateAiFillLog(int $logId, Request $request): void {
+        try {
+            $relevantFields = [
+                'c_status_code', 'c_sequence', 'c_supplement',
+                'c_firstyear', 'c_fy_nh_code', 'c_fy_nh_year', 'c_fy_range',
+                'c_lastyear', 'c_ly_nh_code', 'c_ly_nh_year', 'c_ly_range',
+                'c_source', 'c_pages', 'c_notes',
+            ];
+            $submittedData = $request->only($relevantFields);
+
+            $personId = $request->input('c_personid') ?? $request->route('id');
+
+            DB::table('ai_fill_logs')
+                ->where('id', $logId)
+                ->where('user_id', Auth::id())
+                ->where('category', 'status')
+                ->where('c_personid', $personId)
+                ->update([
+                    'user_submitted' => json_encode($submittedData, JSON_UNESCAPED_UNICODE),
+                    'submitted_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        } catch (\Exception $e) {
+            \Log::warning('[AI Fill Log] 更新用戶提交數據失敗: ' . $e->getMessage());
+        }
     }
 }

--- a/app/Http/Controllers/CodeLookupController.php
+++ b/app/Http/Controllers/CodeLookupController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\CodeLookupService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class CodeLookupController extends Controller {
+    public function __construct() {
+        $this->middleware('auth');
+    }
+
+    /**
+     * AI 語義識別代碼 API
+     */
+    public function suggest(Request $request, CodeLookupService $service) {
+        if (!Auth::user()->isActive()) {
+            return response()->json([
+                'success' => false,
+                'error' => '您的帳號尚未啟用',
+            ], 403);
+        }
+
+        $request->validate([
+            'query' => 'required|string|max:500',
+            'table' => 'required|in:ASSOC_CODES,STATUS_CODES',
+            'person_id' => 'nullable|integer',
+            'route_name' => 'nullable|string|max:255',
+            'route_url' => 'nullable|string|max:500',
+        ]);
+
+        $query = trim($request->input('query'));
+        $table = $request->input('table');
+        $personId = $request->input('person_id', 0);
+        $category = $table === 'ASSOC_CODES' ? 'assoc' : 'status';
+
+        $startTime = microtime(true);
+        $result = $service->lookup($query, $table);
+        $executionTimeMs = (int) round((microtime(true) - $startTime) * 1000);
+
+        // 寫入 AI 填充日誌
+        $logId = $this->saveLog($request, $personId, $query, $result, $executionTimeMs, $category);
+
+        $result['ai_fill_log_id'] = $logId;
+
+        return response()->json($result, $result['success'] ? 200 : 400);
+    }
+
+    /**
+     * 儲存 AI 填充日誌記錄
+     */
+    private function saveLog(Request $request, int $personId, string $sourceText, array $result, int $executionTimeMs, string $category): ?int {
+        try {
+            $logId = DB::table('ai_fill_logs')->insertGetId([
+                'user_id' => Auth::id(),
+                'c_personid' => $personId,
+                'category' => $category,
+                'route_name' => $request->input('route_name') ?? '',
+                'route_url' => $request->input('route_url') ?? '',
+                'source_text' => $sourceText,
+                'ai_raw' => isset($result['data'])
+                    ? json_encode($result['data'], JSON_UNESCAPED_UNICODE)
+                    : null,
+                'ai_matched' => $result['success'] && isset($result['data'])
+                    ? json_encode($result['data'], JSON_UNESCAPED_UNICODE)
+                    : null,
+                'success' => $result['success'],
+                'error_message' => $result['error'] ?? null,
+                'execution_time_ms' => $executionTimeMs,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            return $logId;
+        } catch (\Exception $e) {
+            \Log::warning('[AI Fill Log] 日誌寫入失敗: ' . $e->getMessage());
+
+            return null;
+        }
+    }
+}

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -1341,7 +1341,7 @@ class BiogMainRepository {
         $c_autogen_notes = $row->c_autogen_notes;
         $old_kin_id = $row->c_kin_id;
         $old_kin_code = $row->c_kin_code;
-        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'c_kinship_pair', 'c_created_by', 'c_created_date']);
+        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'c_kinship_pair', 'c_created_by', 'c_created_date', 'ai_fill_log_id']);
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
@@ -2364,7 +2364,7 @@ class BiogMainRepository {
         $old_c_assocship_pair1 = $old_c_assocship_pair['c_assoc_pair'] ?? null;
         $old_c_assocship_pair2 = $old_c_assocship_pair['c_assoc_pair2'] ?? null;
 
-        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
+        $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair', 'ai_fill_log_id']);
         $data = (new ToolsRepository())->timestamp($data);
 
         $ori_data = $data;
@@ -2462,7 +2462,7 @@ class BiogMainRepository {
         $kin_pair = $data['c_kinship_pair'];
         $assoc_kin_pair = $data['c_assoc_kinship_pair'];
         $data['c_personid'] = $id;
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair', 'ai_fill_log_id']);
 
         #20250417「社會關係始年」缺省值製作，若「社會關係始年」為空，則自動填充為-9999。
         if ($data['c_assoc_first_year'] == '') {  #這個判斷式只會將「社會關係始年」為空白時，填充為-9999，如果使用者填寫0，會維持0的值而不更動。

--- a/app/Repositories/EventStatusRepository.php
+++ b/app/Repositories/EventStatusRepository.php
@@ -52,7 +52,7 @@ class EventStatusRepository {
             ['c_status_code', '=', $temp_l[2]],
         ])->first();
         $data = $request->all();
-        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment']);
+        $data = Arr::except($data, ['_token', '_method', 'action', '__proposal_comment', 'ai_fill_log_id']);
         $data['c_status_code'] = $data['c_status_code'] == -999 ? '0' : $data['c_status_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
         $data = (new ToolsRepository())->timestamp($data);
@@ -86,7 +86,7 @@ class EventStatusRepository {
 
     public function statuseStoreById(Request $request, $id) {
         $data = $request->all();
-        $data = Arr::except($data, ['_token', 'action', '__proposal_comment']);
+        $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'ai_fill_log_id']);
         $data['c_personid'] = $id;
         $data['c_status_code'] = $data['c_status_code'] == -999 ? '0' : $data['c_status_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];

--- a/app/Services/CodeLookupService.php
+++ b/app/Services/CodeLookupService.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class CodeLookupService {
+    protected string $apiKey;
+    protected string $apiEndpoint;
+    protected string $model;
+
+    public function __construct() {
+        $this->apiKey = config('services.gemini.api_key', '');
+        $this->apiEndpoint = config('services.gemini.api_endpoint');
+        $this->model = config('services.gemini.model', 'gemini-2.0-flash');
+    }
+
+    /**
+     * 語義查詢代碼表，回傳結構化候選結果
+     *
+     * @return array{success: bool, data?: array, error?: string}
+     */
+    public function lookup(string $query, string $table): array {
+        $codes = $this->loadCodes($table);
+
+        if (empty($codes)) {
+            return [
+                'success' => false,
+                'error' => '代碼表中沒有任何記錄。',
+            ];
+        }
+
+        $systemPrompt = $this->buildSystemPrompt($table, $codes);
+
+        $messages = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            ['role' => 'user', 'content' => $query],
+        ];
+
+        $result = $this->callLLM($messages);
+
+        if (!$result['success']) {
+            return [
+                'success' => false,
+                'error' => '呼叫 AI 服務失敗：' . $result['error'],
+            ];
+        }
+
+        $content = $result['data']['choices'][0]['message']['content'] ?? null;
+
+        if ($content === null) {
+            return [
+                'success' => false,
+                'error' => 'AI 未回傳有效結果。',
+            ];
+        }
+
+        $parsed = json_decode($content, true);
+
+        if (!is_array($parsed)) {
+            return [
+                'success' => false,
+                'error' => 'AI 回傳格式不正確。',
+            ];
+        }
+
+        // 過濾 AI 幻覺：移除不存在於真實代碼表中的 code_id
+        if (!empty($parsed['matched_codes'])) {
+            $beforeCount = count($parsed['matched_codes']);
+            $parsed['matched_codes'] = $this->filterValidCodes($parsed['matched_codes'], $table);
+            $filtered = $beforeCount - count($parsed['matched_codes']);
+            if ($filtered > 0) {
+                $parsed['filtered_hallucinations'] = $filtered;
+                Log::info('CodeLookup 過濾了 ' . $filtered . ' 個不存在的 code_id');
+            }
+        }
+
+        // 為 assoc 類型補充成對關係資訊
+        if ($table === 'ASSOC_CODES' && !empty($parsed['matched_codes'])) {
+            $parsed['matched_codes'] = $this->enrichWithPairInfo($parsed['matched_codes']);
+        }
+
+        return [
+            'success' => true,
+            'data' => $parsed,
+        ];
+    }
+
+    protected function loadCodes(string $table): array {
+        if ($table === 'ASSOC_CODES') {
+            return DB::table('ASSOC_CODES')
+                ->select(['c_assoc_code', 'c_assoc_desc', 'c_assoc_desc_chn'])
+                ->orderBy('c_assoc_code')
+                ->get()
+                ->map(fn ($row) => [
+                    'id' => $row->c_assoc_code,
+                    'desc_en' => $row->c_assoc_desc,
+                    'desc_chn' => $row->c_assoc_desc_chn,
+                ])
+                ->toArray();
+        }
+
+        return DB::table('STATUS_CODES')
+            ->select(['c_status_code', 'c_status_desc', 'c_status_desc_chn'])
+            ->orderBy('c_status_code')
+            ->get()
+            ->map(fn ($row) => [
+                'id' => $row->c_status_code,
+                'desc_en' => $row->c_status_desc,
+                'desc_chn' => $row->c_status_desc_chn,
+            ])
+            ->toArray();
+    }
+
+    /**
+     * 過濾掉 AI 幻覺的 code_id（不存在於真實代碼表中的）
+     */
+    protected function filterValidCodes(array $matchedCodes, string $table): array {
+        $codeIds = array_column($matchedCodes, 'code_id');
+
+        if (empty($codeIds)) {
+            return $matchedCodes;
+        }
+
+        $pkCol = $table === 'ASSOC_CODES' ? 'c_assoc_code' : 'c_status_code';
+
+        $validIds = DB::table($table)
+            ->whereIn($pkCol, $codeIds)
+            ->pluck($pkCol)
+            ->map(fn ($v) => (int) $v)
+            ->toArray();
+
+        return array_values(array_filter($matchedCodes, fn ($code) => in_array((int) $code['code_id'], $validIds, true)));
+    }
+
+    /**
+     * 為匹配的 ASSOC_CODES 補充成對關係資訊
+     */
+    protected function enrichWithPairInfo(array $matchedCodes): array {
+        $codeIds = array_column($matchedCodes, 'code_id');
+
+        if (empty($codeIds)) {
+            return $matchedCodes;
+        }
+
+        $pairData = DB::table('ASSOC_CODES')
+            ->whereIn('c_assoc_code', $codeIds)
+            ->select(['c_assoc_code', 'c_assoc_pair', 'c_assoc_pair2'])
+            ->get()
+            ->keyBy('c_assoc_code');
+
+        foreach ($matchedCodes as &$code) {
+            $id = $code['code_id'];
+            $row = $pairData[$id] ?? null;
+
+            if (!$row) {
+                continue;
+            }
+
+            $pairIds = array_filter([
+                $row->c_assoc_pair ?? null,
+                $row->c_assoc_pair2 ?? null,
+            ], fn ($v) => $v !== null && $v != 0);
+
+            if (!empty($pairIds)) {
+                $pairs = DB::table('ASSOC_CODES')
+                    ->whereIn('c_assoc_code', $pairIds)
+                    ->select(['c_assoc_code', 'c_assoc_desc', 'c_assoc_desc_chn'])
+                    ->get()
+                    ->map(fn ($p) => [
+                        'code_id' => $p->c_assoc_code,
+                        'desc_en' => $p->c_assoc_desc,
+                        'desc_chn' => $p->c_assoc_desc_chn,
+                    ])
+                    ->toArray();
+
+                $code['paired_codes'] = $pairs;
+            }
+        }
+
+        return $matchedCodes;
+    }
+
+    protected function buildSystemPrompt(string $table, array $codes): string {
+        $tableName = $table === 'ASSOC_CODES' ? '社會關係代碼表（ASSOC_CODES）' : '社會區分類別代碼表（STATUS_CODES）';
+        $codeList = $this->formatCodeList($codes);
+
+        return <<<PROMPT
+你是 CBDB（中國歷代人物傳記資料庫）的代碼查詢助手。
+
+你的任務：根據使用者輸入的短句或描述，從{$tableName}中找出語義上相關的代碼。
+
+## 重要規則
+1. **語義匹配**：不只是字面匹配，要理解語義。例如使用者說「土匪」，你需要考慮「rebel（叛臣）」等語義相近的代碼。
+2. **全面掃描**：掃過整張表的所有代碼，不要遺漏。
+3. **候選排序**：按相關度由高到低排列。
+4. **使用繁體中文**回覆（summary 和 reason 欄位）。
+5. matched_codes 最多回傳 10 個最相關的候選。
+
+## 回應格式
+必須回傳以下 JSON 格式：
+{
+  "matched_codes": [
+    {
+      "code_id": 數字,
+      "desc_en": "英文描述",
+      "desc_chn": "中文描述",
+      "relevance": "高/中/低",
+      "reason": "為何匹配的簡短說明"
+    }
+  ],
+  "not_found": ["使用者提到但表中無對應的概念1", "概念2"],
+  "summary": "總結性說明，幫助使用者理解匹配情況與代碼表的涵蓋範圍"
+}
+
+若沒有找到任何匹配，matched_codes 為空陣列。
+
+## 代碼表完整內容
+{$codeList}
+PROMPT;
+    }
+
+    protected function formatCodeList(array $codes): string {
+        $lines = [];
+        foreach ($codes as $code) {
+            $id = $code['id'];
+            $en = $code['desc_en'] ?? '';
+            $chn = $code['desc_chn'] ?? '';
+            $lines[] = "{$id} — {$en}（{$chn}）";
+        }
+
+        return implode("\n", $lines);
+    }
+
+    protected function callLLM(array $messages): array {
+        try {
+            $maxCompletionTokens = (int) config('services.gemini.max_completion_tokens', 8192);
+            if ($maxCompletionTokens < 256) {
+                $maxCompletionTokens = 256;
+            }
+
+            $requestData = [
+                'model' => $this->model,
+                'messages' => $messages,
+                'temperature' => 0.2,
+                'top_p' => 0.95,
+                'max_completion_tokens' => $maxCompletionTokens,
+                'response_format' => [
+                    'type' => 'json_schema',
+                    'json_schema' => [
+                        'name' => 'code_lookup_response',
+                        'strict' => true,
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'matched_codes' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'code_id' => ['type' => 'integer'],
+                                            'desc_en' => ['type' => 'string'],
+                                            'desc_chn' => ['type' => 'string'],
+                                            'relevance' => ['type' => 'string'],
+                                            'reason' => ['type' => 'string'],
+                                        ],
+                                        'required' => ['code_id', 'desc_en', 'desc_chn', 'relevance', 'reason'],
+                                        'additionalProperties' => false,
+                                    ],
+                                ],
+                                'not_found' => [
+                                    'type' => 'array',
+                                    'items' => ['type' => 'string'],
+                                ],
+                                'summary' => ['type' => 'string'],
+                            ],
+                            'required' => ['matched_codes', 'not_found', 'summary'],
+                            'additionalProperties' => false,
+                        ],
+                    ],
+                ],
+            ];
+
+            $maxAttempts = 3;
+            $retryDelayMs = 800;
+            $response = null;
+            $lastException = null;
+
+            for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+                try {
+                    $response = Http::connectTimeout(10)
+                        ->timeout(60)
+                        ->withHeaders([
+                            'Content-Type' => 'application/json',
+                            'Authorization' => 'Bearer ' . $this->apiKey,
+                        ])
+                        ->post($this->apiEndpoint, $requestData);
+
+                    $lastException = null;
+
+                    if ($response->successful()) {
+                        break;
+                    }
+
+                    if ($attempt < $maxAttempts && $response->status() >= 500) {
+                        usleep($retryDelayMs * 1000);
+
+                        continue;
+                    }
+
+                    break;
+                } catch (\Throwable $exception) {
+                    $lastException = $exception;
+
+                    if ($attempt < $maxAttempts) {
+                        usleep($retryDelayMs * 1000);
+
+                        continue;
+                    }
+
+                    throw $exception;
+                }
+            }
+
+            if ($lastException !== null && $response === null) {
+                throw $lastException;
+            }
+
+            if (!$response->successful()) {
+                $body = $response->json();
+                $errorMessage = $body['error']['message'] ?? $response->body();
+                Log::error('CodeLookup LLM API 呼叫失敗', [
+                    'status' => $response->status(),
+                    'error' => $errorMessage,
+                ]);
+
+                return [
+                    'success' => false,
+                    'data' => null,
+                    'error' => $errorMessage,
+                ];
+            }
+
+            return [
+                'success' => true,
+                'data' => $response->json(),
+                'error' => null,
+            ];
+        } catch (\Exception $e) {
+            Log::error('CodeLookup 呼叫 LLM 時發生異常', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return [
+                'success' => false,
+                'data' => null,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+}

--- a/database/migrations/2026_03_24_000000_add_category_to_ai_fill_logs.php
+++ b/database/migrations/2026_03_24_000000_add_category_to_ai_fill_logs.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void {
+        Schema::table('ai_fill_logs', function (Blueprint $table) {
+            $table->string('category', 20)->default('posting')->after('c_personid');
+            $table->index('category');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('ai_fill_logs', function (Blueprint $table) {
+            $table->dropIndex(['category']);
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/resources/views/admin/ai_fill_logs/index.blade.php
+++ b/resources/views/admin/ai_fill_logs/index.blade.php
@@ -33,14 +33,25 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="col-md-3">
+                        <div class="col-md-2">
+                            <div class="form-group">
+                                <label for="category">類別</label>
+                                <select class="form-control" id="category" name="category">
+                                    <option value="">全部類別</option>
+                                    <option value="posting" {{ ($filters['category'] ?? '') === 'posting' ? 'selected' : '' }}>任官</option>
+                                    <option value="assoc" {{ ($filters['category'] ?? '') === 'assoc' ? 'selected' : '' }}>社會關係</option>
+                                    <option value="status" {{ ($filters['category'] ?? '') === 'status' ? 'selected' : '' }}>社會區分</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-1">
                             <div class="form-group">
                                 <label>&nbsp;</label>
                                 <div>
                                     <button type="submit" class="btn btn-primary">
                                         <i class="fas fa-search"></i> 搜尋
                                     </button>
-                                    @if(($filters['search'] ?? '') || ($filters['user_id'] ?? ''))
+                                    @if(($filters['search'] ?? '') || ($filters['user_id'] ?? '') || ($filters['category'] ?? ''))
                                         <a href="{{ route('admin.ai-fill-logs') }}" class="btn btn-secondary ml-1">
                                             <i class="fas fa-times"></i> 清除
                                         </a>
@@ -70,12 +81,16 @@
                             $statistics = $aiMatched['statistics'] ?? null;
                             $cardBorderClass = $log->user_submitted ? 'border-success' : 'border-info';
                             $cardHeaderClass = $log->user_submitted ? 'bg-success' : 'bg-info';
+                            $categoryLabels = ['posting' => '任官', 'assoc' => '社會關係', 'status' => '社會區分'];
+                            $categoryBadgeClasses = ['posting' => 'badge-primary', 'assoc' => 'badge-info', 'status' => 'badge-warning'];
+                            $logCategory = $log->category ?? 'posting';
                         @endphp
                         <div class="card mb-3 {{ $cardBorderClass }}">
                             <div class="card-header {{ $cardHeaderClass }}">
                                 <div class="d-flex justify-content-between align-items-center flex-wrap">
                                     <div>
                                         <strong>#{{ $log->id }}</strong>
+                                        <span class="badge {{ $categoryBadgeClasses[$logCategory] ?? 'badge-secondary' }} ml-2">{{ $categoryLabels[$logCategory] ?? $logCategory }}</span>
                                         <span class="ml-2">
                                             <i class="fas fa-user"></i>
                                             {{ $log->user_name ?? '未知用戶' }}
@@ -85,9 +100,19 @@
                                         </span>
                                         <span class="ml-2">
                                             <i class="fas fa-id-badge"></i>
-                                            <a href="{{ route('basicinformation.edit', $log->c_personid) }}" class="text-white" target="_blank">
-                                                人物 #{{ $log->c_personid }}
-                                            </a>
+                                            @if($logCategory === 'assoc')
+                                                <a href="{{ route('basicinformation.assoc.index', ['basicinformation' => $log->c_personid]) }}" class="text-white" target="_blank">
+                                                    人物 #{{ $log->c_personid }}
+                                                </a>
+                                            @elseif($logCategory === 'status')
+                                                <a href="{{ route('basicinformation.statuses.index', ['basicinformation' => $log->c_personid]) }}" class="text-white" target="_blank">
+                                                    人物 #{{ $log->c_personid }}
+                                                </a>
+                                            @else
+                                                <a href="{{ route('basicinformation.offices.index', ['basicinformation' => $log->c_personid]) }}" class="text-white" target="_blank">
+                                                    人物 #{{ $log->c_personid }}
+                                                </a>
+                                            @endif
                                         </span>
                                         <span class="ml-2">
                                             <i class="fas fa-clock"></i>

--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -27,6 +27,7 @@
         {{ method_field('PATCH') }}
     @endif
     {{ csrf_field() }}
+    <input type="hidden" name="ai_fill_log_id" id="ai-fill-log-id" value="">
 
     <x-forms.person-id-display :personId="$id" />
 
@@ -364,6 +365,56 @@
     </div>
 </form>
 
+{{-- AI 智能識別社會關係代碼（已啟用用戶 + Gemini API 已配置） --}}
+@if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+    <div class="card card-info mt-3" id="ai-code-lookup-section">
+        <div class="card-header d-flex align-items-center">
+            <h3 class="card-title mb-0">
+                <i class="fas fa-magic"></i> AI 智能識別社會關係代碼
+            </h3>
+            <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
+               data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
+                <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
+            </a>
+        </div>
+        <div class="collapse" id="ai-code-privacy-notice">
+            <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
+                <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
+                <ul class="mb-0">
+                    <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
+                    <li>您的文本將發送至第三方 AI 服務進行處理</li>
+                    <li>AI 識別結果僅供參考，請務必核實後再提交</li>
+                </ul>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="form-group">
+                <label for="ai-code-query">輸入描述（AI 將從 ASSOC_CODES 中識別相關代碼）</label>
+                <textarea class="form-control" id="ai-code-query" rows="3"
+                          placeholder="例如：為釋顯達作塔記"></textarea>
+                <small class="form-text text-muted">AI 會語義理解您的描述，從社會關係代碼表中找出最相關的代碼</small>
+            </div>
+            <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
+                <i class="fas fa-bolt"></i> AI 智能識別
+            </button>
+            <span class="ml-3" id="ai-code-status"></span>
+
+            {{-- 候選結果區 --}}
+            <div id="ai-code-results" style="display:none;" class="mt-3">
+                <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
+                <div id="ai-code-candidates" class="mb-3"></div>
+
+                <div id="ai-code-not-found" style="display:none;">
+                    <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
+                    <div id="ai-code-not-found-list"></div>
+                </div>
+
+                <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
+            </div>
+        </div>
+    </div>
+@endif
+
 @section('js')
     <script>
     onViteReady(function() {
@@ -536,6 +587,122 @@
                 alert('更新[出處]與[頁數/條目]成功');
             });
         });
+        // === AI 智能識別社會關係代碼 ===
+        @if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+        $('#btn-ai-code-lookup').on('click', function() {
+            var query = $('#ai-code-query').val().trim();
+            if (!query) {
+                alert('請輸入描述文字');
+                return;
+            }
+
+            var $btn = $(this);
+            var $status = $('#ai-code-status');
+            $btn.prop('disabled', true);
+            $status.html('<i class="fas fa-spinner fa-spin"></i> AI 識別中，請稍候...');
+            $('#ai-code-results').hide();
+
+            $.ajax({
+                url: '{{ route("ai.code-lookup.suggest", [], false) }}',
+                method: 'POST',
+                data: {
+                    query: query,
+                    table: 'ASSOC_CODES',
+                    person_id: {{ $id }},
+                    route_name: '{{ Route::currentRouteName() ?? "" }}',
+                    route_url: window.location.pathname,
+                    _token: '{{ csrf_token() }}'
+                },
+                success: function(response) {
+                    $btn.prop('disabled', false);
+                    $status.text('');
+                    if (response.ai_fill_log_id) {
+                        $('#ai-fill-log-id').val(response.ai_fill_log_id);
+                    }
+                    renderCodeResults(response.data);
+                },
+                error: function(xhr) {
+                    $btn.prop('disabled', false);
+                    var msg = (xhr.responseJSON && xhr.responseJSON.error) || '識別失敗';
+                    $status.html('<span class="text-danger"><i class="fas fa-times-circle"></i> ' + msg + '</span>');
+                }
+            });
+        });
+
+        function renderCodeResults(data) {
+            var $results = $('#ai-code-results');
+            var $candidates = $('#ai-code-candidates');
+            var $notFound = $('#ai-code-not-found');
+            var $notFoundList = $('#ai-code-not-found-list');
+            var $summary = $('#ai-code-summary');
+
+            $candidates.empty();
+            $notFoundList.empty();
+
+            // 渲染候選代碼按鈕
+            if (data.matched_codes && data.matched_codes.length > 0) {
+                data.matched_codes.forEach(function(code) {
+                    var btnClass = code.relevance === '高' ? 'btn-success' : (code.relevance === '中' ? 'btn-warning' : 'btn-secondary');
+                    var $btn = $('<button type="button" class="btn ' + btnClass + ' m-1"></button>');
+                    $btn.html('<strong>' + code.code_id + '</strong> ' + code.desc_chn + ' <small>(' + code.desc_en + ')</small>');
+                    $btn.attr('title', code.reason);
+                    $btn.data('code', code);
+                    $btn.on('click', function() {
+                        applyAssocCode($(this).data('code'));
+                    });
+                    $candidates.append($btn);
+
+                    // 顯示成對關係資訊
+                    if (code.paired_codes && code.paired_codes.length > 0) {
+                        var pairText = code.paired_codes.map(function(p) {
+                            return p.code_id + ' ' + p.desc_chn + ' (' + p.desc_en + ')';
+                        }).join(', ');
+                        $candidates.append('<small class="d-block text-muted ml-2 mb-1"><i class="fas fa-exchange-alt"></i> 成對：' + pairText + '</small>');
+                    }
+                });
+            } else {
+                $candidates.html('<span class="text-muted">未找到匹配的代碼</span>');
+            }
+
+            // 渲染未找到的概念
+            if (data.not_found && data.not_found.length > 0) {
+                $notFoundList.html(data.not_found.map(function(item) {
+                    return '<span class="badge badge-light mr-1">' + item + '</span>';
+                }).join(''));
+                $notFound.show();
+            } else {
+                $notFound.hide();
+            }
+
+            // 渲染總結
+            if (data.summary) {
+                $summary.text(data.summary).show();
+            } else {
+                $summary.hide();
+            }
+
+            $results.show();
+        }
+
+        function applyAssocCode(code) {
+            // 填入 c_assoc_code
+            var $select = $('select.c_assoc_code');
+            $select.empty();
+            $select.append(new Option(code.code_id + ' ' + code.desc_chn + ' ' + code.desc_en, code.code_id, true, true));
+            $select.trigger('change');
+
+            // 觸發成對關係更新
+            assocship_pair();
+
+            // 標記已填充
+            $select.closest('.form-group').find('label').css('color', '#28a745');
+
+            // 滾動到 c_assoc_code 欄位
+            $('html, body').animate({
+                scrollTop: $select.closest('.form-group').offset().top - 100
+            }, 300);
+        }
+        @endif
     });
     </script>
 @endsection

--- a/resources/views/biogmains/statuses/_form.blade.php
+++ b/resources/views/biogmains/statuses/_form.blade.php
@@ -21,6 +21,7 @@
         {{ method_field('PATCH') }}
     @endif
     {{ csrf_field() }}
+    <input type="hidden" name="ai_fill_log_id" id="ai-fill-log-id" value="">
 
     <x-forms.person-id-display :personId="$id" />
 
@@ -156,6 +157,56 @@
     </div>
 </form>
 
+{{-- AI 智能識別社會區分類別代碼（已啟用用戶 + Gemini API 已配置） --}}
+@if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+    <div class="card card-info mt-3" id="ai-code-lookup-section">
+        <div class="card-header d-flex align-items-center">
+            <h3 class="card-title mb-0">
+                <i class="fas fa-magic"></i> AI 智能識別社會區分類別代碼
+            </h3>
+            <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
+               data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
+                <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
+            </a>
+        </div>
+        <div class="collapse" id="ai-code-privacy-notice">
+            <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
+                <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
+                <ul class="mb-0">
+                    <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
+                    <li>您的文本將發送至第三方 AI 服務進行處理</li>
+                    <li>AI 識別結果僅供參考，請務必核實後再提交</li>
+                </ul>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="form-group">
+                <label for="ai-code-query">輸入描述（AI 將從 STATUS_CODES 中識別相關代碼）</label>
+                <textarea class="form-control" id="ai-code-query" rows="3"
+                          placeholder="例如：通醫學"></textarea>
+                <small class="form-text text-muted">AI 會語義理解您的描述，從社會區分類別代碼表中找出最相關的代碼</small>
+            </div>
+            <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
+                <i class="fas fa-bolt"></i> AI 智能識別
+            </button>
+            <span class="ml-3" id="ai-code-status"></span>
+
+            {{-- 候選結果區 --}}
+            <div id="ai-code-results" style="display:none;" class="mt-3">
+                <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
+                <div id="ai-code-candidates" class="mb-3"></div>
+
+                <div id="ai-code-not-found" style="display:none;">
+                    <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
+                    <div id="ai-code-not-found-list"></div>
+                </div>
+
+                <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
+            </div>
+        </div>
+    </div>
+@endif
+
 @section('js')
     <script>
 
@@ -206,6 +257,112 @@
                 alert('更新[出處]與[頁數/條目]成功');
             });
         });
+
+        // === AI 智能識別社會區分類別代碼 ===
+        @if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+        $('#btn-ai-code-lookup').on('click', function() {
+            var query = $('#ai-code-query').val().trim();
+            if (!query) {
+                alert('請輸入描述文字');
+                return;
+            }
+
+            var $btn = $(this);
+            var $status = $('#ai-code-status');
+            $btn.prop('disabled', true);
+            $status.html('<i class="fas fa-spinner fa-spin"></i> AI 識別中，請稍候...');
+            $('#ai-code-results').hide();
+
+            $.ajax({
+                url: '{{ route("ai.code-lookup.suggest", [], false) }}',
+                method: 'POST',
+                data: {
+                    query: query,
+                    table: 'STATUS_CODES',
+                    person_id: {{ $id }},
+                    route_name: '{{ Route::currentRouteName() ?? "" }}',
+                    route_url: window.location.pathname,
+                    _token: '{{ csrf_token() }}'
+                },
+                success: function(response) {
+                    $btn.prop('disabled', false);
+                    $status.text('');
+                    if (response.ai_fill_log_id) {
+                        $('#ai-fill-log-id').val(response.ai_fill_log_id);
+                    }
+                    renderCodeResults(response.data);
+                },
+                error: function(xhr) {
+                    $btn.prop('disabled', false);
+                    var msg = (xhr.responseJSON && xhr.responseJSON.error) || '識別失敗';
+                    $status.html('<span class="text-danger"><i class="fas fa-times-circle"></i> ' + msg + '</span>');
+                }
+            });
+        });
+
+        function renderCodeResults(data) {
+            var $results = $('#ai-code-results');
+            var $candidates = $('#ai-code-candidates');
+            var $notFound = $('#ai-code-not-found');
+            var $notFoundList = $('#ai-code-not-found-list');
+            var $summary = $('#ai-code-summary');
+
+            $candidates.empty();
+            $notFoundList.empty();
+
+            // 渲染候選代碼按鈕
+            if (data.matched_codes && data.matched_codes.length > 0) {
+                data.matched_codes.forEach(function(code) {
+                    var btnClass = code.relevance === '高' ? 'btn-success' : (code.relevance === '中' ? 'btn-warning' : 'btn-secondary');
+                    var $btn = $('<button type="button" class="btn ' + btnClass + ' m-1"></button>');
+                    $btn.html('<strong>' + code.code_id + '</strong> ' + code.desc_chn + ' <small>(' + code.desc_en + ')</small>');
+                    $btn.attr('title', code.reason);
+                    $btn.data('code', code);
+                    $btn.on('click', function() {
+                        applyStatusCode($(this).data('code'));
+                    });
+                    $candidates.append($btn);
+                });
+            } else {
+                $candidates.html('<span class="text-muted">未找到匹配的代碼</span>');
+            }
+
+            // 渲染未找到的概念
+            if (data.not_found && data.not_found.length > 0) {
+                $notFoundList.html(data.not_found.map(function(item) {
+                    return '<span class="badge badge-light mr-1">' + item + '</span>';
+                }).join(''));
+                $notFound.show();
+            } else {
+                $notFound.hide();
+            }
+
+            // 渲染總結
+            if (data.summary) {
+                $summary.text(data.summary).show();
+            } else {
+                $summary.hide();
+            }
+
+            $results.show();
+        }
+
+        function applyStatusCode(code) {
+            // 填入 c_status_code
+            var $select = $('select.c_status_code');
+            $select.empty();
+            $select.append(new Option(code.code_id + ' ' + code.desc_chn + ' ' + code.desc_en, code.code_id, true, true));
+            $select.trigger('change');
+
+            // 標記已填充
+            $select.closest('.form-group').find('label').css('color', '#28a745');
+
+            // 滾動到 c_status_code 欄位
+            $('html, body').animate({
+                scrollTop: $select.closest('.form-group').offset().top - 100
+            }, 300);
+        }
+        @endif
     });
 
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -258,6 +258,9 @@ Route::middleware('auth')->group(function () {
     // AI 智能填充任官信息
     Route::post('api/ai/posting/extract', 'AiPostingAutofillController@extract')->name('ai.posting.extract');
 
+    // AI 智能識別代碼（社會關係 / 社會區分）
+    Route::post('api/ai/code-lookup/suggest', 'CodeLookupController@suggest')->name('ai.code-lookup.suggest');
+
     // AI 填充日誌（管理員工具）
     Route::get('admin/ai-fill-logs', 'AiFillLogController@index')->name('admin.ai-fill-logs');
     Route::get('admin/audit-logs', 'AdminAuditLogController@index')->name('admin.audit-logs');


### PR DESCRIPTION
## Summary
- 在 assoc/edit 和 statuses/edit 表單底部新增 AI 智能識別區塊，透過 Gemini LLM 語義理解用戶描述，從 ASSOC_CODES / STATUS_CODES 中找出候選代碼並以按鈕呈現
- assoc 填入時自動觸發成對社會關係更新
- ai_fill_logs 新增 category 欄位，日誌頁面支援類別篩選、標籤及依類別跳轉
- 安全性：過濾 AI 幻覺 code_id、日誌更新綁定 category + c_personid 防篡改（含 offices 同型修復）
- Repository 層排除 ai_fill_log_id 避免寫入資料表

## 新增檔案
- `app/Services/CodeLookupService.php` — LLM 語義查詢服務（結構化 JSON + 幻覺過濾 + 成對關係補充）
- `app/Http/Controllers/CodeLookupController.php` — API 端點 `POST /api/ai/code-lookup/suggest`
- `database/migrations/2026_03_24_000000_add_category_to_ai_fill_logs.php` — category 欄位

## 修改檔案
- `resources/views/biogmains/assoc/_form.blade.php` — AI 識別區塊 + JS
- `resources/views/biogmains/statuses/_form.blade.php` — AI 識別區塊 + JS
- `resources/views/admin/ai_fill_logs/index.blade.php` — 類別篩選、標籤、比較視圖
- `app/Http/Controllers/AiFillLogController.php` — category 篩選 + 代碼比較邏輯
- `app/Http/Controllers/AiPostingAutofillController.php` — 寫入 category: posting
- `app/Http/Controllers/BasicInformation{Assoc,Statuses,Offices}Controller.php` — ai_fill_log_id 處理 + 日誌安全綁定
- `app/Repositories/BiogMainRepository.php`, `EventStatusRepository.php` — Arr::except 排除 ai_fill_log_id
- `routes/web.php` — 新增 API 路由

## Test plan
- [x] `./vendor/bin/phpunit`（702 測試全部通過）
- [x] 在 assoc/create 頁面輸入描述，確認 AI 回傳候選按鈕可點選填入
- [x] 在 statuses/create 頁面同上測試
- [x] 確認 assoc 填入後成對社會關係自動更新
- [x] 確認 ai_fill_logs 頁面顯示類別標籤、篩選功能正常
- [x] 確認比較 modal 正確顯示每個 AI 候選與用戶選擇
- [x] 確認未激活用戶看不到 AI 區塊

🤖 Generated with [Claude Code](https://claude.com/claude-code)