### PR TITLE
新增 Inertia + React 版「按入仕查詢」頁面（PoC）

### DIFF
--- a/app/Http/Controllers/SearchByEntryController.php
+++ b/app/Http/Controllers/SearchByEntryController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
 
 class SearchByEntryController extends Controller {
     /**
@@ -65,7 +68,7 @@ class SearchByEntryController extends Controller {
     }
 
     /**
-     * 執行搜索查詢
+     * 執行搜索查詢（Blade 版）
      */
     public function search(Request $request) {
         $request->validate([
@@ -81,7 +84,90 @@ class SearchByEntryController extends Controller {
         $yearTo = $request->input('year_to');
         $addrId = $request->input('addr_id');
 
-        // 構建查詢
+        $query = $this->buildEntrySearchQuery($entryCodes, $yearFrom, $yearTo, $addrId);
+
+        // 執行查詢並分頁
+        $results = $query
+            ->paginate(50)
+            ->appends($request->all());
+
+        return view('search-by.entry.results', compact('results'));
+    }
+
+    /**
+     * Inertia 版按入仕查詢頁面
+     */
+    public function appIndex(Request $request): InertiaResponse {
+        $request->validate([
+            'entry_codes' => 'nullable|array',
+            'entry_codes.*' => 'integer',
+            'year_from' => 'nullable|integer|lte:year_to',
+            'year_to' => 'nullable|integer',
+            'addr_id' => 'nullable|integer',
+            'type_id' => 'nullable|string',
+        ]);
+
+        $entryCodes = $request->input('entry_codes', []);
+        $yearFrom = $request->input('year_from');
+        $yearTo = $request->input('year_to');
+        $addrId = $request->input('addr_id');
+        $typeId = $request->input('type_id');
+
+        // 載入入仕類型
+        $entryTypes = DB::table('ENTRY_TYPES')
+            ->select(
+                'c_entry_type',
+                'c_entry_type_desc',
+                'c_entry_type_desc_chn',
+                'c_entry_type_parent_id',
+                'c_entry_type_level',
+                'c_entry_type_sortorder'
+            )
+            ->orderBy('c_entry_type_sortorder')
+            ->orderBy('c_entry_type')
+            ->get();
+
+        // 若有 type_id，預載該類型的 entry codes
+        $preloadedCodes = [];
+        if ($typeId) {
+            $preloadedCodes = DB::table('ENTRY_CODES as ec')
+                ->join('ENTRY_CODE_TYPE_REL as rel', 'ec.c_entry_code', '=', 'rel.c_entry_code')
+                ->where('rel.c_entry_type', $typeId)
+                ->select('ec.c_entry_code', 'ec.c_entry_desc', 'ec.c_entry_desc_chn')
+                ->orderBy('ec.c_entry_code')
+                ->get();
+        }
+
+        // 判斷是否有搜尋條件
+        $hasConditions = !empty($entryCodes) || $yearFrom !== null || $yearTo !== null || $addrId !== null;
+
+        $results = null;
+        if ($hasConditions) {
+            $query = $this->buildEntrySearchQuery($entryCodes, $yearFrom, $yearTo, $addrId);
+            $results = $query->paginate(50)->appends($request->except('page'));
+        }
+
+        return Inertia::render('SearchByEntry/Index', [
+            'entryTypes' => $entryTypes,
+            'preloadedCodes' => $preloadedCodes,
+            'results' => $results,
+            'filters' => [
+                'entry_codes' => array_map('intval', $entryCodes),
+                'year_from' => $yearFrom !== null ? (int) $yearFrom : null,
+                'year_to' => $yearTo !== null ? (int) $yearTo : null,
+                'addr_id' => $addrId !== null ? (int) $addrId : null,
+                'type_id' => $typeId,
+            ],
+            'pageUrl' => route('app.search-by.entry.index', [], false),
+            'typesEndpoint' => route('search-by.entry.types', [], false),
+            'codesEndpoint' => route('search-by.entry.codes', [], false),
+        ]);
+    }
+
+    /**
+     * 構建入仕搜尋查詢（共用邏輯）
+     */
+    private function buildEntrySearchQuery(array $entryCodes, ?int $yearFrom, ?int $yearTo, ?int $addrId): Builder {
         $query = DB::table('ENTRY_DATA as ed')
             ->join('BIOG_MAIN as bm', 'ed.c_personid', '=', 'bm.c_personid')
             ->join('ENTRY_CODES as ec', 'ed.c_entry_code', '=', 'ec.c_entry_code')
@@ -105,12 +191,10 @@ class SearchByEntryController extends Controller {
                 'ed.c_sequence'
             );
 
-        // 過濾：入仕代碼
         if (!empty($entryCodes)) {
             $query->whereIn('ed.c_entry_code', $entryCodes);
         }
 
-        // 過濾：年份範圍
         if ($yearFrom !== null) {
             $query->where('ed.c_year', '>=', $yearFrom);
         }
@@ -118,18 +202,10 @@ class SearchByEntryController extends Controller {
             $query->where('ed.c_year', '<=', $yearTo);
         }
 
-        // 過濾：地址
         if ($addrId !== null) {
             $query->where('ed.c_entry_addr_id', $addrId);
         }
 
-        // 執行查詢並分頁
-        $results = $query
-            ->orderBy('bm.c_index_year')
-            ->orderBy('bm.c_personid')
-            ->paginate(50)
-            ->appends($request->all());
-
-        return view('search-by.entry.results', compact('results'));
+        return $query->orderBy('bm.c_index_year')->orderBy('bm.c_personid');
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -72,5 +72,6 @@ class Kernel extends HttpKernel {
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         // 20200909建安新增
         'cors' => \App\Http\Middleware\Cors::class,
+        'inertia' => \App\Http\Middleware\HandleInertiaRequests::class,
     ];
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Inertia\Middleware;
+
+class HandleInertiaRequests extends Middleware {
+    /**
+     * Inertia 使用的根模板
+     */
+    protected $rootView = 'inertia';
+
+    /**
+     * 每個 Inertia 回應共用的 props
+     *
+     * @return array<string, mixed>
+     */
+    public function share(Request $request): array {
+        return array_merge(parent::share($request), [
+            'auth' => [
+                'user' => $request->user() ? [
+                    'id' => $request->user()->id,
+                    'name' => $request->user()->name,
+                ] : null,
+            ],
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",
+        "inertiajs/inertia-laravel": "^2.0",
         "laracasts/flash": "^3.0",
         "laravel/framework": "^12.0",
         "laravel/mcp": "^0.5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b2959b02b49344bec57317aa013fe5f",
+    "content-hash": "2f84e61dd430cf8b98a2569005387331",
     "packages": [
         {
             "name": "brick/math",
@@ -1051,6 +1051,79 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "inertiajs/inertia-laravel",
+            "version": "v2.0.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/inertiajs/inertia-laravel.git",
+                "reference": "4d5849328d4c64231f886d1422fdc945882f9094"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/4d5849328d4c64231f886d1422fdc945882f9094",
+                "reference": "4d5849328d4c64231f886d1422fdc945882f9094",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1.0",
+                "symfony/console": "^6.2|^7.0|^8.0"
+            },
+            "conflict": {
+                "laravel/boost": "<2.2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.2",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.16",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "suggest": {
+                "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Inertia\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "./helpers.php"
+                ],
+                "psr-4": {
+                    "Inertia\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "https://reinink.ca"
+                }
+            ],
+            "description": "The Laravel adapter for Inertia.js.",
+            "keywords": [
+                "inertia",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/inertiajs/inertia-laravel/issues",
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v2.0.22"
+            },
+            "time": "2026-03-11T15:51:16+00:00"
         },
         {
             "name": "laracasts/flash",
@@ -10207,5 +10280,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,0 +1,61 @@
+<?php
+
+return [
+
+    'ssr' => [
+
+        'enabled' => false,
+
+        'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
+
+        'ensure_bundle_exists' => false,
+
+    ],
+
+    'ensure_pages_exist' => false,
+
+    'page_paths' => [
+
+        resource_path('js/inertia/Pages'),
+
+    ],
+
+    'page_extensions' => [
+
+        'js',
+        'jsx',
+        'ts',
+        'tsx',
+
+    ],
+
+    'use_script_element_for_initial_page' => false,
+
+    'testing' => [
+
+        'ensure_pages_exist' => true,
+
+        'page_paths' => [
+
+            resource_path('js/inertia/Pages'),
+
+        ],
+
+        'page_extensions' => [
+
+            'js',
+            'jsx',
+            'ts',
+            'tsx',
+
+        ],
+
+    ],
+
+    'history' => [
+
+        'encrypt' => false,
+
+    ],
+
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,20 @@
     "": {
       "name": "cbdb-online-main-server",
       "dependencies": {
+        "@inertiajs/react": "^2.3.18",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
+        "@vitejs/plugin-react": "^4.7.0",
         "admin-lte": "^3.2.0",
         "cn-era": "^0.4.1",
         "datatables.net": "^1.13.8",
         "datatables.net-bs4": "^2.3.5",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "sql-formatter": "^15.6.12"
       },
       "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-vue": "^6.0.2",
         "@vue/compiler-sfc": "^3.5.12",
         "axios": "^1.8.2",
@@ -25,6 +31,7 @@
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.79.4",
         "sass-loader": "^12.1.0",
+        "typescript": "^6.0.2",
         "vite": "^7.2.4",
         "vue": "^3.0.0"
       },
@@ -33,11 +40,149 @@
         "npm": ">=10 <11"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -47,20 +192,40 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -69,11 +234,72 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -90,7 +316,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -107,7 +332,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -124,7 +348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -141,7 +364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -158,7 +380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -175,7 +396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -192,7 +412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -209,7 +428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -226,7 +444,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -243,7 +460,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -260,7 +476,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -277,7 +492,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -294,7 +508,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -311,7 +524,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -328,7 +540,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -345,7 +556,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -362,7 +572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -379,7 +588,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,7 +604,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,7 +620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -430,7 +636,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -447,7 +652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -464,7 +668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -481,7 +684,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,7 +700,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -515,7 +716,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -580,15 +780,52 @@
         "node": ">=6"
       }
     },
+    "node_modules/@inertiajs/core": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.18.tgz",
+      "integrity": "sha512-StOszdE28nx9uxY4I28d7oLRGLdu/F9pRgWody2k29Qe9WqAoPHVQ5VJabTi2RTYHJXZrZZ+Wgtw3qVRZMrwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "axios": "^1.13.5",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23",
+        "qs": "^6.15.0"
+      }
+    },
+    "node_modules/@inertiajs/react": {
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.3.18.tgz",
+      "integrity": "sha512-kcoPveEDN7vyjqhyFEa9dlBjgvAsrz9k9YlrSK9PFJxRBGpCAnovmU37/a9AG2ORUP1zLw2P8y+5QfMgRdEPfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inertiajs/core": "2.3.18",
+        "@types/lodash-es": "^4.17.12",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -596,9 +833,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -607,7 +842,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -619,16 +854,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -644,7 +876,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -684,7 +915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,7 +935,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,7 +955,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,7 +975,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -768,7 +995,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,7 +1015,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -810,7 +1035,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -831,7 +1055,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -852,7 +1075,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -873,7 +1095,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,7 +1115,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -915,7 +1135,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,7 +1155,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -975,7 +1193,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,7 +1206,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,7 +1219,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,7 +1232,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1031,7 +1245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,7 +1258,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,7 +1271,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,7 +1284,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1087,7 +1297,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1101,7 +1310,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1115,7 +1323,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1129,7 +1336,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1349,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1157,7 +1362,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,7 +1375,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1185,7 +1388,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,7 +1401,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1213,7 +1414,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,7 +1427,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,7 +1440,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,7 +1453,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1269,7 +1466,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1283,7 +1479,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,7 +1492,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,7 +1505,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,6 +1523,47 @@
       "resolved": "https://registry.npmjs.org/@ttskch/select2-bootstrap4-theme/-/select2-bootstrap4-theme-1.5.2.tgz",
       "integrity": "sha512-gAj8qNy/VYwQDBkACm0USM66kxFai8flX83ayRXPNhzZckEgSqIBB9sM74SCM3ssgeX+ZVy4BifTnLis+KpIyg==",
       "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -1359,7 +1593,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1370,16 +1603,77 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
       "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.3",
@@ -1703,7 +1997,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -1903,18 +2197,16 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "dev": true,
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1928,9 +2220,7 @@
       "version": "2.9.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
       "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -2013,7 +2303,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2036,7 +2325,6 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2052,7 +2340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2089,7 +2376,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -2144,7 +2431,6 @@
       "version": "1.0.30001760",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
       "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2159,8 +2445,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/chart.js": {
       "version": "2.9.4",
@@ -2195,7 +2480,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -2264,7 +2549,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2737,6 +3021,23 @@
         "moment": "^2.9.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-equal": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
@@ -2795,7 +3096,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2805,7 +3105,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -2857,9 +3156,7 @@
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -2941,7 +3238,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2957,7 +3253,6 @@
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
       "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2999,9 +3294,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3127,7 +3420,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3164,7 +3456,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3185,7 +3476,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3216,7 +3506,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3249,6 +3538,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3429,7 +3727,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/inherits": {
@@ -3489,7 +3787,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3500,7 +3797,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3514,7 +3810,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3638,6 +3933,24 @@
         "jquery": "^3.4.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsgrid": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/jsgrid/-/jsgrid-1.5.3.tgz",
@@ -3664,7 +3977,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3705,6 +4017,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/laravel-precognition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
+      "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.4.0",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/laravel-vite-plugin": {
@@ -3773,6 +4095,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3804,7 +4141,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3819,7 +4155,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3829,7 +4164,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3865,11 +4199,16 @@
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3917,7 +4256,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3925,9 +4263,19 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-is": {
       "version": "1.1.6",
@@ -3995,14 +4343,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4031,7 +4378,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4066,8 +4412,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -4097,6 +4457,36 @@
         "eve-raphael": "0.5.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -4116,7 +4506,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -4194,7 +4584,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -4251,7 +4640,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
       "integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -4313,6 +4702,12 @@
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -4339,6 +4734,15 @@
       "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
       "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -4401,11 +4805,83 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4415,7 +4891,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4425,7 +4900,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4583,7 +5058,7 @@
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -4644,7 +5119,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4661,7 +5135,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4679,7 +5152,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4692,7 +5164,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4710,11 +5181,25 @@
         "jquery": ">=1.12.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -4757,7 +5242,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
       "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4773,7 +5257,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -4801,7 +5284,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -4887,7 +5369,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4905,7 +5386,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5039,6 +5519,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prod": "vite build"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-vue": "^6.0.2",
     "@vue/compiler-sfc": "^3.5.12",
     "axios": "^1.8.2",
@@ -18,15 +20,20 @@
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.79.4",
     "sass-loader": "^12.1.0",
+    "typescript": "^6.0.2",
     "vite": "^7.2.4",
     "vue": "^3.0.0"
   },
   "dependencies": {
+    "@inertiajs/react": "^2.3.18",
     "@ttskch/select2-bootstrap4-theme": "^1.5.2",
+    "@vitejs/plugin-react": "^4.7.0",
     "admin-lte": "^3.2.0",
     "cn-era": "^0.4.1",
     "datatables.net": "^1.13.8",
     "datatables.net-bs4": "^2.3.5",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "sql-formatter": "^15.6.12"
   },
   "engines": {

--- a/resources/js/inertia/Layouts/AppShell.tsx
+++ b/resources/js/inertia/Layouts/AppShell.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AppShellProps {
+    children: React.ReactNode;
+}
+
+export default function AppShell({ children }: AppShellProps) {
+    return (
+        <div style={{ minHeight: '100vh', backgroundColor: '#f4f6f9', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' }}>
+            <header style={{ backgroundColor: '#343a40', color: '#fff', padding: '12px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>CBDB 中國歷代人物傳記資料庫</h1>
+                <a href="/" style={{ color: '#adb5bd', textDecoration: 'none', fontSize: '0.875rem' }}>← 返回首頁</a>
+            </header>
+            <main style={{ padding: '24px', maxWidth: '1400px', margin: '0 auto' }}>
+                {children}
+            </main>
+        </div>
+    );
+}

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -1,0 +1,343 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { router, usePage } from '@inertiajs/react';
+import AppShell from '../../Layouts/AppShell';
+import EntryTypeTree, { EntryType } from '../../components/EntryTypeTree';
+import EntryCodeList, { EntryCode } from '../../components/EntryCodeList';
+import SelectedCodeChips from '../../components/SelectedCodeChips';
+import SearchResultTable, { ResultRow, PaginationData } from '../../components/SearchResultTable';
+
+interface PageProps {
+    entryTypes: EntryType[];
+    preloadedCodes: EntryCode[];
+    results: {
+        data: ResultRow[];
+        current_page: number;
+        last_page: number;
+        per_page: number;
+        total: number;
+        from: number | null;
+        to: number | null;
+    } | null;
+    filters: {
+        entry_codes: number[];
+        year_from: number | null;
+        year_to: number | null;
+        addr_id: number | null;
+        type_id: string | null;
+    };
+    errors: Record<string, string>;
+    pageUrl: string;
+    typesEndpoint: string;
+    codesEndpoint: string;
+    [key: string]: unknown;
+}
+
+export default function Index() {
+    const { entryTypes, preloadedCodes, results, filters, errors, pageUrl, typesEndpoint, codesEndpoint } = usePage<PageProps>().props;
+
+    // Local state
+    const [selectedTypeId, setSelectedTypeId] = useState<string | null>(filters.type_id ?? null);
+    const [availableCodes, setAvailableCodes] = useState<EntryCode[]>(preloadedCodes ?? []);
+    const [selectedCodes, setSelectedCodes] = useState<number[]>(filters.entry_codes ?? []);
+    const [yearFrom, setYearFrom] = useState<string>(filters.year_from != null ? String(filters.year_from) : '');
+    const [yearTo, setYearTo] = useState<string>(filters.year_to != null ? String(filters.year_to) : '');
+    const [addrId, setAddrId] = useState<string>(filters.addr_id != null ? String(filters.addr_id) : '');
+    const [loadingTypes] = useState(false);
+    const [typesError] = useState<string | null>(null);
+    const [loadingCodes, setLoadingCodes] = useState(false);
+    const [codesError, setCodesError] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    // All known codes (for chips display)
+    const [allKnownCodes, setAllKnownCodes] = useState<EntryCode[]>(preloadedCodes ?? []);
+
+    // Update allKnownCodes when new codes load
+    useEffect(() => {
+        if (availableCodes.length > 0) {
+            setAllKnownCodes((prev) => {
+                const map = new Map(prev.map((c) => [c.c_entry_code, c]));
+                availableCodes.forEach((c) => map.set(c.c_entry_code, c));
+                return Array.from(map.values());
+            });
+        }
+    }, [availableCodes]);
+
+    // Load codes when type changes (client-side fetch)
+    const loadCodes = useCallback(async (typeId: string) => {
+        setLoadingCodes(true);
+        setCodesError(null);
+        try {
+            const url = `${codesEndpoint}?type_id=${encodeURIComponent(typeId)}`;
+            const res = await fetch(url, {
+                headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const json = await res.json();
+            if (json.success) {
+                setAvailableCodes(json.data);
+            } else {
+                setCodesError('載入失敗');
+            }
+        } catch {
+            setCodesError('載入入仕代碼失敗');
+        } finally {
+            setLoadingCodes(false);
+        }
+    }, [codesEndpoint]);
+
+    const handleTypeSelect = (typeId: string) => {
+        setSelectedTypeId(typeId);
+        loadCodes(typeId);
+    };
+
+    const handleCodeToggle = (code: number) => {
+        setSelectedCodes((prev) =>
+            prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code]
+        );
+    };
+
+    const handleSelectAll = () => {
+        setSelectedCodes((prev) => {
+            const existing = new Set(prev);
+            availableCodes.forEach((c) => existing.add(c.c_entry_code));
+            return Array.from(existing);
+        });
+    };
+
+    const handleDeselectAll = () => {
+        const currentSet = new Set(availableCodes.map((c) => c.c_entry_code));
+        setSelectedCodes((prev) => prev.filter((c) => !currentSet.has(c)));
+    };
+
+    const handleRemoveCode = (code: number) => {
+        setSelectedCodes((prev) => prev.filter((c) => c !== code));
+    };
+
+    const handleSearch = (e: React.FormEvent) => {
+        e.preventDefault();
+        setSubmitting(true);
+
+        const params: Record<string, unknown> = {};
+        if (selectedCodes.length > 0) params.entry_codes = selectedCodes;
+        if (yearFrom) params.year_from = yearFrom;
+        if (yearTo) params.year_to = yearTo;
+        if (addrId) params.addr_id = addrId;
+        if (selectedTypeId) params.type_id = selectedTypeId;
+
+        router.get(pageUrl, params as Record<string, string>, {
+            preserveState: false,
+            onFinish: () => setSubmitting(false),
+        });
+    };
+
+    const handlePageChange = (page: number) => {
+        const params: Record<string, unknown> = { page };
+        if (selectedCodes.length > 0) params.entry_codes = selectedCodes;
+        if (filters.year_from != null) params.year_from = filters.year_from;
+        if (filters.year_to != null) params.year_to = filters.year_to;
+        if (filters.addr_id != null) params.addr_id = filters.addr_id;
+        if (filters.type_id) params.type_id = filters.type_id;
+
+        router.get(pageUrl, params as Record<string, string>, {
+            preserveState: false,
+        });
+    };
+
+    const handleReset = () => {
+        setSelectedTypeId(null);
+        setAvailableCodes([]);
+        setSelectedCodes([]);
+        setYearFrom('');
+        setYearTo('');
+        setAddrId('');
+        router.get(pageUrl, {}, { preserveState: false });
+    };
+
+    const hasFilters = selectedCodes.length > 0 || yearFrom || yearTo || addrId;
+    const hasResults = results !== null;
+
+    const pagination: PaginationData | null = results
+        ? {
+            current_page: results.current_page,
+            last_page: results.last_page,
+            per_page: results.per_page,
+            total: results.total,
+            from: results.from,
+            to: results.to,
+        }
+        : null;
+
+    return (
+        <AppShell>
+            <h2 style={{ marginTop: 0, marginBottom: 20, fontSize: '1.3rem', fontWeight: 600 }}>按入仕查詢</h2>
+
+            {/* Three-column layout */}
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16, marginBottom: 24 }}>
+                {/* Column 1: Entry types */}
+                <EntryTypeTree
+                    types={entryTypes}
+                    selectedTypeId={selectedTypeId}
+                    loading={loadingTypes}
+                    error={typesError}
+                    onSelect={handleTypeSelect}
+                />
+
+                {/* Column 2: Entry codes */}
+                <EntryCodeList
+                    codes={availableCodes}
+                    selectedCodes={selectedCodes}
+                    loading={loadingCodes}
+                    error={codesError}
+                    onToggle={handleCodeToggle}
+                    onSelectAll={handleSelectAll}
+                    onDeselectAll={handleDeselectAll}
+                />
+
+                {/* Column 3: Search form */}
+                <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', overflow: 'hidden' }}>
+                    <div style={{ padding: '10px 14px', borderBottom: '1px solid #dee2e6', fontWeight: 600, fontSize: '0.95rem' }}>
+                        搜尋條件
+                    </div>
+                    <div style={{ padding: 14 }}>
+                        <form onSubmit={handleSearch}>
+                            {/* Selected codes */}
+                            <div style={{ marginBottom: 14 }}>
+                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>
+                                    已選擇的入仕代碼：
+                                </label>
+                                <SelectedCodeChips
+                                    selectedCodes={selectedCodes}
+                                    allCodes={allKnownCodes}
+                                    onRemove={handleRemoveCode}
+                                />
+                            </div>
+
+                            <hr style={{ border: 'none', borderTop: '1px solid #e9ecef', margin: '12px 0' }} />
+
+                            {/* Year range */}
+                            <div style={{ marginBottom: 14 }}>
+                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>年份範圍</label>
+                                <div style={{ display: 'flex', gap: 8 }}>
+                                    <input
+                                        type="number"
+                                        value={yearFrom}
+                                        onChange={(e) => setYearFrom(e.target.value)}
+                                        placeholder="起始年"
+                                        style={inputStyle}
+                                    />
+                                    <input
+                                        type="number"
+                                        value={yearTo}
+                                        onChange={(e) => setYearTo(e.target.value)}
+                                        placeholder="結束年"
+                                        style={inputStyle}
+                                    />
+                                </div>
+                                {errors.year_from && <div style={errorStyle}>{errors.year_from}</div>}
+                                {errors.year_to && <div style={errorStyle}>{errors.year_to}</div>}
+                                <div style={{ fontSize: '0.75rem', color: '#6c757d', marginTop: 2 }}>可留空表示不限制</div>
+                            </div>
+
+                            {/* Address ID */}
+                            <div style={{ marginBottom: 14 }}>
+                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>入仕地址 ID</label>
+                                <input
+                                    type="number"
+                                    value={addrId}
+                                    onChange={(e) => setAddrId(e.target.value)}
+                                    placeholder="請輸入地址 ID"
+                                    style={inputStyle}
+                                />
+                                {errors.addr_id && <div style={errorStyle}>{errors.addr_id}</div>}
+                                <div style={{ fontSize: '0.75rem', color: '#6c757d', marginTop: 2 }}>可留空表示不限制</div>
+                            </div>
+
+                            <hr style={{ border: 'none', borderTop: '1px solid #e9ecef', margin: '12px 0' }} />
+
+                            {/* Actions */}
+                            <div style={{ display: 'flex', gap: 8 }}>
+                                <button
+                                    type="submit"
+                                    disabled={submitting}
+                                    style={{
+                                        flex: 1,
+                                        padding: '8px 16px',
+                                        backgroundColor: '#007bff',
+                                        color: '#fff',
+                                        border: 'none',
+                                        borderRadius: 4,
+                                        cursor: submitting ? 'wait' : 'pointer',
+                                        fontSize: '0.9rem',
+                                        opacity: submitting ? 0.7 : 1,
+                                    }}
+                                >
+                                    {submitting ? '搜尋中...' : '執行搜尋'}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleReset}
+                                    style={{
+                                        padding: '8px 16px',
+                                        backgroundColor: '#6c757d',
+                                        color: '#fff',
+                                        border: 'none',
+                                        borderRadius: 4,
+                                        cursor: 'pointer',
+                                        fontSize: '0.9rem',
+                                    }}
+                                >
+                                    重置
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            {/* Condition summary & results */}
+            {hasResults && (
+                <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', padding: 16 }}>
+                    {/* Condition summary */}
+                    {hasFilters && (
+                        <div style={{ padding: '10px 14px', backgroundColor: '#d1ecf1', border: '1px solid #bee5eb', borderRadius: 4, marginBottom: 16, fontSize: '0.85rem' }}>
+                            <strong>搜尋條件：</strong>
+                            {filters.entry_codes.length > 0 && (
+                                <span style={{ marginLeft: 8 }}>
+                                    入仕代碼：
+                                    {filters.entry_codes.map((c) => (
+                                        <span key={c} style={{ display: 'inline-block', padding: '1px 6px', backgroundColor: '#007bff', color: '#fff', borderRadius: 10, fontSize: '0.75rem', marginLeft: 4 }}>
+                                            {c}
+                                        </span>
+                                    ))}
+                                </span>
+                            )}
+                            {filters.year_from != null && <span style={{ marginLeft: 8 }}>起始年：{filters.year_from}</span>}
+                            {filters.year_to != null && <span style={{ marginLeft: 8 }}>結束年：{filters.year_to}</span>}
+                            {filters.addr_id != null && <span style={{ marginLeft: 8 }}>地址 ID：{filters.addr_id}</span>}
+                        </div>
+                    )}
+
+                    <SearchResultTable
+                        rows={results.data}
+                        pagination={pagination}
+                        onPageChange={handlePageChange}
+                    />
+                </div>
+            )}
+        </AppShell>
+    );
+}
+
+const inputStyle: React.CSSProperties = {
+    flex: 1,
+    padding: '6px 10px',
+    border: '1px solid #ced4da',
+    borderRadius: 4,
+    fontSize: '0.875rem',
+};
+
+const errorStyle: React.CSSProperties = {
+    color: '#dc3545',
+    fontSize: '0.8rem',
+    marginTop: 2,
+};

--- a/resources/js/inertia/app.tsx
+++ b/resources/js/inertia/app.tsx
@@ -1,0 +1,12 @@
+import { createInertiaApp } from '@inertiajs/react';
+import { createRoot } from 'react-dom/client';
+
+createInertiaApp({
+    resolve: (name) => {
+        const pages = import.meta.glob('./Pages/**/*.tsx', { eager: true });
+        return pages[`./Pages/${name}.tsx`];
+    },
+    setup({ el, App, props }) {
+        createRoot(el).render(<App {...props} />);
+    },
+});

--- a/resources/js/inertia/components/EntryCodeList.tsx
+++ b/resources/js/inertia/components/EntryCodeList.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+export interface EntryCode {
+    c_entry_code: number;
+    c_entry_desc: string | null;
+    c_entry_desc_chn: string | null;
+}
+
+interface Props {
+    codes: EntryCode[];
+    selectedCodes: number[];
+    loading: boolean;
+    error: string | null;
+    onToggle: (code: number) => void;
+    onSelectAll: () => void;
+    onDeselectAll: () => void;
+}
+
+export default function EntryCodeList({ codes, selectedCodes, loading, error, onToggle, onSelectAll, onDeselectAll }: Props) {
+    const selectedSet = new Set(selectedCodes);
+
+    return (
+        <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', overflow: 'hidden' }}>
+            <div style={{ padding: '10px 14px', borderBottom: '1px solid #dee2e6', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontWeight: 600, fontSize: '0.95rem' }}>入仕代碼</span>
+                <div>
+                    <button
+                        type="button"
+                        onClick={onSelectAll}
+                        disabled={codes.length === 0}
+                        style={{
+                            padding: '2px 10px', marginRight: 4, fontSize: '0.8rem', cursor: 'pointer',
+                            border: '1px solid #007bff', borderRadius: 3, backgroundColor: 'transparent', color: '#007bff',
+                        }}
+                    >
+                        全選
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onDeselectAll}
+                        disabled={codes.length === 0}
+                        style={{
+                            padding: '2px 10px', fontSize: '0.8rem', cursor: 'pointer',
+                            border: '1px solid #6c757d', borderRadius: 3, backgroundColor: 'transparent', color: '#6c757d',
+                        }}
+                    >
+                        取消全選
+                    </button>
+                </div>
+            </div>
+            <div style={{ height: 400, overflowY: 'auto' }}>
+                {loading && (
+                    <div style={{ padding: 16, textAlign: 'center', color: '#6c757d' }}>載入中...</div>
+                )}
+                {error && (
+                    <div style={{ padding: 16, color: '#dc3545' }}>{error}</div>
+                )}
+                {!loading && !error && codes.length === 0 && (
+                    <div style={{ padding: 16, color: '#6c757d' }}>請先選擇入仕類型</div>
+                )}
+                {!loading && !error && codes.map((code) => {
+                    const isChecked = selectedSet.has(code.c_entry_code);
+                    return (
+                        <label
+                            key={code.c_entry_code}
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                padding: '6px 12px',
+                                borderBottom: '1px solid #f0f0f0',
+                                cursor: 'pointer',
+                                margin: 0,
+                                fontSize: '0.875rem',
+                            }}
+                            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#f8f9fa')}
+                            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '')}
+                        >
+                            <input
+                                type="checkbox"
+                                checked={isChecked}
+                                onChange={() => onToggle(code.c_entry_code)}
+                                style={{ marginRight: 8 }}
+                            />
+                            <span>{code.c_entry_desc_chn || code.c_entry_desc || String(code.c_entry_code)}</span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/inertia/components/EntryTypeTree.tsx
+++ b/resources/js/inertia/components/EntryTypeTree.tsx
@@ -1,0 +1,119 @@
+import React, { useMemo } from 'react';
+
+export interface EntryType {
+    c_entry_type: string;
+    c_entry_type_desc: string | null;
+    c_entry_type_desc_chn: string | null;
+    c_entry_type_parent_id: string | null;
+    c_entry_type_level: number;
+    c_entry_type_sortorder: number;
+}
+
+interface TreeNode extends EntryType {
+    children: TreeNode[];
+}
+
+interface Props {
+    types: EntryType[];
+    selectedTypeId: string | null;
+    loading: boolean;
+    error: string | null;
+    onSelect: (typeId: string) => void;
+}
+
+function buildTree(types: EntryType[]): TreeNode[] {
+    const map: Record<string, TreeNode> = {};
+    const roots: TreeNode[] = [];
+
+    types.forEach((t) => {
+        map[t.c_entry_type] = { ...t, children: [] };
+    });
+
+    types.forEach((t) => {
+        const node = map[t.c_entry_type];
+        if (t.c_entry_type_parent_id && map[t.c_entry_type_parent_id]) {
+            map[t.c_entry_type_parent_id].children.push(node);
+        } else {
+            roots.push(node);
+        }
+    });
+
+    return roots;
+}
+
+function TreeNodeItem({ node, level, selectedTypeId, onSelect }: {
+    node: TreeNode;
+    level: number;
+    selectedTypeId: string | null;
+    onSelect: (id: string) => void;
+}) {
+    const isSelected = node.c_entry_type === selectedTypeId;
+    return (
+        <>
+            <div
+                onClick={() => onSelect(node.c_entry_type)}
+                style={{
+                    paddingLeft: level * 20 + 12,
+                    paddingTop: 6,
+                    paddingBottom: 6,
+                    paddingRight: 8,
+                    cursor: 'pointer',
+                    borderBottom: '1px solid #f0f0f0',
+                    backgroundColor: isSelected ? '#007bff' : 'transparent',
+                    color: isSelected ? '#fff' : '#333',
+                    fontSize: '0.875rem',
+                    transition: 'background-color 0.15s',
+                }}
+                onMouseEnter={(e) => {
+                    if (!isSelected) (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f8f9fa';
+                }}
+                onMouseLeave={(e) => {
+                    if (!isSelected) (e.currentTarget as HTMLDivElement).style.backgroundColor = 'transparent';
+                }}
+            >
+                {node.c_entry_type_desc_chn || node.c_entry_type_desc || node.c_entry_type}
+            </div>
+            {node.children.map((child) => (
+                <TreeNodeItem
+                    key={child.c_entry_type}
+                    node={child}
+                    level={level + 1}
+                    selectedTypeId={selectedTypeId}
+                    onSelect={onSelect}
+                />
+            ))}
+        </>
+    );
+}
+
+export default function EntryTypeTree({ types, selectedTypeId, loading, error, onSelect }: Props) {
+    const tree = useMemo(() => buildTree(types), [types]);
+
+    return (
+        <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', overflow: 'hidden' }}>
+            <div style={{ padding: '10px 14px', borderBottom: '1px solid #dee2e6', fontWeight: 600, fontSize: '0.95rem' }}>
+                入仕類型
+            </div>
+            <div style={{ height: 400, overflowY: 'auto' }}>
+                {loading && (
+                    <div style={{ padding: 16, textAlign: 'center', color: '#6c757d' }}>載入中...</div>
+                )}
+                {error && (
+                    <div style={{ padding: 16, color: '#dc3545' }}>{error}</div>
+                )}
+                {!loading && !error && tree.length === 0 && (
+                    <div style={{ padding: 16, color: '#6c757d' }}>無資料</div>
+                )}
+                {!loading && !error && tree.map((node) => (
+                    <TreeNodeItem
+                        key={node.c_entry_type}
+                        node={node}
+                        level={0}
+                        selectedTypeId={selectedTypeId}
+                        onSelect={onSelect}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/inertia/components/SearchResultTable.tsx
+++ b/resources/js/inertia/components/SearchResultTable.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+
+export interface ResultRow {
+    c_personid: number;
+    c_name_chn: string | null;
+    c_name: string | null;
+    c_dy: string | null;
+    c_dynasty: string | null;
+    c_dynasty_chn: string | null;
+    c_index_year: number | null;
+    c_index_addr_id: number | null;
+    c_index_addr_name: string | null;
+    c_index_addr_chn: string | null;
+    c_entry_code: number;
+    c_entry_desc_chn: string | null;
+    c_entry_desc: string | null;
+    c_year: number | null;
+    c_sequence: number | null;
+}
+
+export interface PaginationData {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+interface Props {
+    rows: ResultRow[];
+    pagination: PaginationData | null;
+    onPageChange: (page: number) => void;
+}
+
+export default function SearchResultTable({ rows, pagination, onPageChange }: Props) {
+    if (rows.length === 0) {
+        return (
+            <div style={{ padding: 24, textAlign: 'center', color: '#6c757d' }}>
+                無符合條件的結果
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            {pagination && (
+                <div style={{ marginBottom: 12, color: '#6c757d', fontSize: '0.875rem' }}>
+                    共找到 <strong>{pagination.total}</strong> 筆結果
+                    （顯示第 {pagination.from ?? 0} - {pagination.to ?? 0} 筆）
+                </div>
+            )}
+
+            <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+                    <thead>
+                        <tr style={{ backgroundColor: '#f8f9fa' }}>
+                            {['人物 ID', '中文名', '英文名', '朝代', '索引年', '索引地址', '入仕代碼', '入仕途徑（中文）', '入仕途徑（英文）', '入仕年份', '序號', '操作'].map((h) => (
+                                <th key={h} style={{ padding: '8px 10px', borderBottom: '2px solid #dee2e6', whiteSpace: 'nowrap', textAlign: 'left' }}>
+                                    {h}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row, i) => (
+                            <tr key={`${row.c_personid}-${row.c_entry_code}-${row.c_sequence}-${i}`} style={{ borderBottom: '1px solid #dee2e6' }}>
+                                <td style={{ padding: '6px 10px' }}>{row.c_personid}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_name_chn}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_name}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_dynasty_chn ?? row.c_dynasty}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_index_year}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_index_addr_chn ?? row.c_index_addr_name}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_entry_code}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_entry_desc_chn}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_entry_desc}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_year}</td>
+                                <td style={{ padding: '6px 10px' }}>{row.c_sequence}</td>
+                                <td style={{ padding: '6px 10px' }}>
+                                    <a
+                                        href={`/basicinformation/${row.c_personid}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        style={{
+                                            padding: '2px 10px',
+                                            backgroundColor: '#17a2b8',
+                                            color: '#fff',
+                                            borderRadius: 3,
+                                            textDecoration: 'none',
+                                            fontSize: '0.8rem',
+                                            whiteSpace: 'nowrap',
+                                        }}
+                                    >
+                                        查看
+                                    </a>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {pagination && pagination.last_page > 1 && (
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 4, marginTop: 16, flexWrap: 'wrap' }}>
+                    <button
+                        disabled={pagination.current_page <= 1}
+                        onClick={() => onPageChange(pagination.current_page - 1)}
+                        style={paginationBtnStyle(pagination.current_page <= 1)}
+                    >
+                        ‹ 上一頁
+                    </button>
+                    {getPageNumbers(pagination.current_page, pagination.last_page).map((p, i) =>
+                        p === null ? (
+                            <span key={`ellipsis-${i}`} style={{ padding: '4px 6px', color: '#6c757d' }}>…</span>
+                        ) : (
+                            <button
+                                key={p}
+                                onClick={() => onPageChange(p)}
+                                style={{
+                                    ...paginationBtnStyle(false),
+                                    backgroundColor: p === pagination.current_page ? '#007bff' : 'transparent',
+                                    color: p === pagination.current_page ? '#fff' : '#007bff',
+                                }}
+                            >
+                                {p}
+                            </button>
+                        )
+                    )}
+                    <button
+                        disabled={pagination.current_page >= pagination.last_page}
+                        onClick={() => onPageChange(pagination.current_page + 1)}
+                        style={paginationBtnStyle(pagination.current_page >= pagination.last_page)}
+                    >
+                        下一頁 ›
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function paginationBtnStyle(disabled: boolean): React.CSSProperties {
+    return {
+        padding: '4px 10px',
+        border: '1px solid #dee2e6',
+        borderRadius: 3,
+        backgroundColor: 'transparent',
+        color: disabled ? '#adb5bd' : '#007bff',
+        cursor: disabled ? 'default' : 'pointer',
+        fontSize: '0.85rem',
+    };
+}
+
+function getPageNumbers(current: number, last: number): (number | null)[] {
+    if (last <= 7) {
+        return Array.from({ length: last }, (_, i) => i + 1);
+    }
+    const pages: (number | null)[] = [1];
+    if (current > 3) pages.push(null);
+    for (let i = Math.max(2, current - 1); i <= Math.min(last - 1, current + 1); i++) {
+        pages.push(i);
+    }
+    if (current < last - 2) pages.push(null);
+    pages.push(last);
+    return pages;
+}

--- a/resources/js/inertia/components/SelectedCodeChips.tsx
+++ b/resources/js/inertia/components/SelectedCodeChips.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { EntryCode } from './EntryCodeList';
+
+interface Props {
+    selectedCodes: number[];
+    allCodes: EntryCode[];
+    onRemove: (code: number) => void;
+}
+
+export default function SelectedCodeChips({ selectedCodes, allCodes, onRemove }: Props) {
+    if (selectedCodes.length === 0) {
+        return <span style={{ color: '#6c757d', fontSize: '0.85rem' }}>尚未選擇</span>;
+    }
+
+    const codeMap = new Map(allCodes.map((c) => [c.c_entry_code, c]));
+
+    return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {selectedCodes.map((code) => {
+                const info = codeMap.get(code);
+                const label = info ? (info.c_entry_desc_chn || info.c_entry_desc || String(code)) : String(code);
+                return (
+                    <span
+                        key={code}
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            padding: '2px 8px',
+                            backgroundColor: '#007bff',
+                            color: '#fff',
+                            borderRadius: 12,
+                            fontSize: '0.75rem',
+                        }}
+                    >
+                        {label}
+                        <button
+                            type="button"
+                            onClick={() => onRemove(code)}
+                            style={{
+                                marginLeft: 4,
+                                background: 'none',
+                                border: 'none',
+                                color: '#fff',
+                                cursor: 'pointer',
+                                padding: '0 2px',
+                                fontSize: '0.85rem',
+                                lineHeight: 1,
+                            }}
+                            aria-label={`移除 ${label}`}
+                        >
+                            ×
+                        </button>
+                    </span>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/views/inertia.blade.php
+++ b/resources/views/inertia.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'CBDB') }}</title>
+    @viteReactRefresh
+    @vite('resources/js/inertia/app.tsx')
+    @inertiaHead
+</head>
+<body>
+    @inertia
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -225,6 +225,11 @@ Route::middleware('auth')->group(function () {
     Route::get('search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('search-by.entry.codes');
     Route::get('search-by/entry/search', 'SearchByEntryController@search')->name('search-by.entry.search');
 
+    // Inertia + React 版按入仕查詢（PoC）
+    Route::get('app/search-by/entry', 'SearchByEntryController@appIndex')
+        ->middleware('inertia')
+        ->name('app.search-by.entry.index');
+
     Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
     Route::post('admin/explainsql', 'AdminExplainSqlController@explain');
     Route::get('admin/batch-load-book-titles', 'AdminBatchLoadBookTitlesController@showForm')->name('admin.batch-load-book-titles');

--- a/tests/Feature/InertiaSearchByEntryTest.php
+++ b/tests/Feature/InertiaSearchByEntryTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InertiaSearchByEntryTest extends TestCase {
+    protected $user;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->createTestTables();
+
+        $this->user = User::factory()->create([
+            'is_active' => 1,
+        ]);
+
+        $this->seedTestData();
+    }
+
+    protected function createTestTables(): void {
+        DB::statement('PRAGMA foreign_keys = OFF');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                password VARCHAR(255) NOT NULL,
+                remember_token VARCHAR(100),
+                confirmation_token VARCHAR(255) NOT NULL,
+                is_active SMALLINT NOT NULL DEFAULT 0,
+                is_admin SMALLINT NOT NULL DEFAULT 0,
+                created_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NULL
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_TYPES (
+                c_entry_type VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_entry_type_desc VARCHAR(255),
+                c_entry_type_desc_chn VARCHAR(255),
+                c_entry_type_parent_id VARCHAR(255),
+                c_entry_type_level DOUBLE,
+                c_entry_type_sortorder DOUBLE
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_CODES (
+                c_entry_code SMALLINT NOT NULL PRIMARY KEY,
+                c_entry_desc VARCHAR(255),
+                c_entry_desc_chn VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_CODE_TYPE_REL (
+                c_entry_code SMALLINT NOT NULL,
+                c_entry_type VARCHAR(255) NOT NULL,
+                PRIMARY KEY (c_entry_code, c_entry_type)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_DATA (
+                c_personid INT NOT NULL,
+                c_entry_code SMALLINT NOT NULL,
+                c_sequence SMALLINT NOT NULL,
+                c_year INT,
+                c_entry_addr_id INT,
+                c_exam_rank VARCHAR(255),
+                c_kin_code SMALLINT NOT NULL DEFAULT 0,
+                c_kin_id INT NOT NULL DEFAULT 0,
+                c_assoc_code SMALLINT NOT NULL DEFAULT 0,
+                c_assoc_id INT NOT NULL DEFAULT 0,
+                c_inst_code INT NOT NULL DEFAULT 0,
+                c_inst_name_code INT NOT NULL DEFAULT 0,
+                c_notes TEXT,
+                PRIMARY KEY (c_personid, c_entry_code, c_sequence, c_kin_code, c_assoc_code, c_kin_id, c_year, c_assoc_id, c_inst_code, c_inst_name_code)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS BIOG_MAIN (
+                c_personid INT NOT NULL PRIMARY KEY,
+                c_name VARCHAR(255),
+                c_name_chn VARCHAR(255),
+                c_dy VARCHAR(255),
+                c_index_year INT,
+                c_index_addr_id INT
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS DYNASTIES (
+                c_dy VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_dynasty VARCHAR(255),
+                c_dynasty_chn VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ADDR_CODES (
+                c_addr_id INT NOT NULL PRIMARY KEY,
+                c_name VARCHAR(255),
+                c_name_chn VARCHAR(255)
+            )
+        ');
+    }
+
+    protected function seedTestData(): void {
+        DB::table('ENTRY_TYPES')->insert([
+            [
+                'c_entry_type' => 'TYPE1',
+                'c_entry_type_desc' => 'Type 1',
+                'c_entry_type_desc_chn' => '類型一',
+                'c_entry_type_parent_id' => null,
+                'c_entry_type_level' => 1,
+                'c_entry_type_sortorder' => 1,
+            ],
+            [
+                'c_entry_type' => 'TYPE2',
+                'c_entry_type_desc' => 'Type 2',
+                'c_entry_type_desc_chn' => '類型二',
+                'c_entry_type_parent_id' => 'TYPE1',
+                'c_entry_type_level' => 2,
+                'c_entry_type_sortorder' => 2,
+            ],
+        ]);
+
+        DB::table('ENTRY_CODES')->insert([
+            ['c_entry_code' => 1, 'c_entry_desc' => 'Entry Code 1', 'c_entry_desc_chn' => '入仕代碼一'],
+            ['c_entry_code' => 2, 'c_entry_desc' => 'Entry Code 2', 'c_entry_desc_chn' => '入仕代碼二'],
+        ]);
+
+        DB::table('ENTRY_CODE_TYPE_REL')->insert([
+            ['c_entry_code' => 1, 'c_entry_type' => 'TYPE1'],
+            ['c_entry_code' => 2, 'c_entry_type' => 'TYPE2'],
+        ]);
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name' => 'Test Person 1', 'c_name_chn' => '測試人物一', 'c_dy' => 'DY1', 'c_index_year' => 1000, 'c_index_addr_id' => 10],
+            ['c_personid' => 2, 'c_name' => 'Test Person 2', 'c_name_chn' => '測試人物二', 'c_dy' => 'DY2', 'c_index_year' => 1100, 'c_index_addr_id' => 20],
+        ]);
+
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 'DY1', 'c_dynasty' => 'Dynasty 1', 'c_dynasty_chn' => '朝代一'],
+            ['c_dy' => 'DY2', 'c_dynasty' => 'Dynasty 2', 'c_dynasty_chn' => '朝代二'],
+        ]);
+
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 10, 'c_name' => 'Address 1', 'c_name_chn' => '地址一'],
+            ['c_addr_id' => 20, 'c_name' => 'Address 2', 'c_name_chn' => '地址二'],
+        ]);
+
+        DB::table('ENTRY_DATA')->insert([
+            [
+                'c_personid' => 1, 'c_entry_code' => 1, 'c_sequence' => 1, 'c_year' => 1020,
+                'c_entry_addr_id' => 100, 'c_kin_code' => 0, 'c_kin_id' => 0,
+                'c_assoc_code' => 0, 'c_assoc_id' => 0, 'c_inst_code' => 0, 'c_inst_name_code' => 0,
+            ],
+            [
+                'c_personid' => 2, 'c_entry_code' => 2, 'c_sequence' => 1, 'c_year' => 1120,
+                'c_entry_addr_id' => 200, 'c_kin_code' => 0, 'c_kin_id' => 0,
+                'c_assoc_code' => 0, 'c_assoc_id' => 0, 'c_inst_code' => 0, 'c_inst_name_code' => 0,
+            ],
+        ]);
+    }
+
+    /**
+     * 新入口需要登入
+     */
+    #[Test]
+    public function test_app_index_requires_authentication(): void {
+        $response = $this->get(route('app.search-by.entry.index'));
+        $response->assertRedirect(route('login'));
+    }
+
+    /**
+     * 無條件時可渲染 Inertia page
+     */
+    #[Test]
+    public function test_app_index_returns_inertia_page(): void {
+        $response = $this->actingAs($this->user)->get(route('app.search-by.entry.index'));
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->component('SearchByEntry/Index')
+            ->has('entryTypes', 2)
+            ->where('results', null)
+        );
+    }
+
+    /**
+     * Inertia 回應包含正確的 props 結構
+     */
+    #[Test]
+    public function test_app_index_has_correct_props_structure(): void {
+        $response = $this->actingAs($this->user)->get(route('app.search-by.entry.index'));
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->component('SearchByEntry/Index')
+            ->has('entryTypes')
+            ->has('preloadedCodes')
+            ->has('filters')
+            ->has('typesEndpoint')
+            ->has('codesEndpoint')
+            ->where('filters.entry_codes', [])
+            ->where('filters.year_from', null)
+            ->where('filters.year_to', null)
+            ->where('filters.addr_id', null)
+            ->where('filters.type_id', null)
+        );
+    }
+
+    /**
+     * 帶搜尋條件時返回結果
+     */
+    #[Test]
+    public function test_app_index_with_search_conditions_returns_results(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'entry_codes' => [1],
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->component('SearchByEntry/Index')
+            ->has('results')
+            ->where('results.total', 1)
+            ->has('results.data', 1)
+            ->where('results.data.0.c_personid', 1)
+        );
+    }
+
+    /**
+     * 分頁可保留條件
+     */
+    #[Test]
+    public function test_app_index_pagination_preserves_conditions(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'entry_codes' => [1, 2],
+                'page' => 1,
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->component('SearchByEntry/Index')
+            ->has('results')
+            ->where('results.total', 2)
+            ->where('filters.entry_codes', [1, 2])
+        );
+    }
+
+    /**
+     * year_from > year_to 有驗證錯誤
+     */
+    #[Test]
+    public function test_app_index_validates_year_range(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'year_from' => 1200,
+                'year_to' => 1000,
+            ]));
+
+        // GET 驗證失敗會重定向
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors('year_from');
+    }
+
+    /**
+     * 舊路由仍正常
+     */
+    #[Test]
+    public function test_old_blade_routes_still_work(): void {
+        // 舊首頁
+        $response = $this->actingAs($this->user)->get(route('search-by.entry.index'));
+        $response->assertStatus(200);
+        $response->assertViewIs('search-by.entry.index');
+
+        // 舊搜尋
+        $response = $this->actingAs($this->user)->get(route('search-by.entry.search', [
+            'entry_codes' => [1],
+        ]));
+        $response->assertStatus(200);
+        $response->assertViewIs('search-by.entry.results');
+
+        // 舊 API
+        $response = $this->actingAs($this->user)->getJson(route('search-by.entry.types'));
+        $response->assertStatus(200)->assertJson(['success' => true]);
+    }
+
+    /**
+     * type_id 可預載 entry codes
+     */
+    #[Test]
+    public function test_app_index_preloads_codes_for_type(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'type_id' => 'TYPE1',
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->has('preloadedCodes', 1)
+            ->where('preloadedCodes.0.c_entry_code', 1)
+        );
+    }
+
+    /**
+     * 無搜尋條件（僅 type_id）不執行查詢
+     */
+    #[Test]
+    public function test_app_index_no_results_without_search_conditions(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'type_id' => 'TYPE1',
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->where('results', null)
+        );
+    }
+
+    /**
+     * 地址過濾可正常運作
+     */
+    #[Test]
+    public function test_app_index_search_with_address_filter(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'entry_codes' => [1, 2],
+                'addr_id' => 100,
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->has('results')
+            ->where('results.total', 1)
+            ->where('results.data.0.c_personid', 1)
+        );
+    }
+
+    /**
+     * 年份範圍過濾可正常運作
+     */
+    #[Test]
+    public function test_app_index_search_with_year_range(): void {
+        $response = $this->actingAs($this->user)
+            ->get(route('app.search-by.entry.index', [
+                'entry_codes' => [1, 2],
+                'year_from' => 1100,
+                'year_to' => 1200,
+            ]));
+
+        $response->assertStatus(200);
+        $response->assertInertia(
+            fn (Assert $page) => $page
+            ->has('results')
+            ->where('results.total', 1)
+            ->where('results.data.0.c_personid', 2)
+        );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "baseUrl": ".",
+        "paths": {
+            "@inertia/*": ["resources/js/inertia/*"]
+        }
+    },
+    "include": ["resources/js/inertia/**/*"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
     plugins: [
@@ -9,6 +10,8 @@ export default defineConfig({
                 // Modern World (AdminLTE v3 + Vue 3)
                 'resources/js/app.js',          // Main entry: AdminLTE v3 + base setup
                 'resources/js/datatables.js',   // DataTables plugin
+                // Inertia + React entry (PoC)
+                'resources/js/inertia/app.tsx',
             ],
             refresh: true,
         }),
@@ -20,6 +23,7 @@ export default defineConfig({
                 },
             },
         }),
+        react(),
     ],
     resolve: {
         alias: {


### PR DESCRIPTION
* 新增 Inertia + React 版「按入仕查詢」頁面（PoC）

- 安裝 inertiajs/inertia-laravel、@inertiajs/react、react、react-dom
- 新增 Vite React 入口 resources/js/inertia/app.tsx
- 新增 Inertia 根模板 resources/views/inertia.blade.php
- 新增 HandleInertiaRequests 中介層
- 新增路由 GET /app/search-by/entry (app.search-by.entry.index)
- 抽出 buildEntrySearchQuery() 共用查詢邏輯
- 新增 appIndex() Inertia action
- 建立 React 頁面與元件：EntryTypeTree、EntryCodeList、SelectedCodeChips、SearchResultTable
- 新增 11 個 Feature 測試
- 全部 713 個測試通過


Agent-Logs-Url: https://github.com/frankslin/cbdb-online-main-server/sessions/ef055483-65f4-4adf-821d-73586fd284c1

* 修正 appIndex 驗證規則重複，並將頁面 URL 改由後端 prop 傳入

- 合併重複的 year_from 驗證規則為 'nullable|integer|lte:year_to'
- 新增 pageUrl prop 取代前端硬編碼的 URL
- 前端 Inertia router.get() 改用 pageUrl prop


Agent-Logs-Url: https://github.com/frankslin/cbdb-online-main-server/sessions/ef055483-65f4-4adf-821d-73586fd284c1

---------