### PR TITLE
重構「按入仕查詢」 React 介面與篩選流程

### DIFF
--- a/app/Http/Controllers/SearchByEntryController.php
+++ b/app/Http/Controllers/SearchByEntryController.php
@@ -2,210 +2,124 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Database\Query\Builder;
+use App\Services\EntryQueryService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
 class SearchByEntryController extends Controller {
-    /**
-     * 顯示按入仕查詢頁面
-     */
-    public function index() {
-        return view('search-by.entry.index');
+    public function __construct(
+        private readonly EntryQueryService $entryQueryService
+    ) {
     }
 
-    /**
-     * 獲取入仕類型樹狀結構（AJAX API）
-     */
-    public function getEntryTypes() {
-        $types = DB::table('ENTRY_TYPES')
-            ->select(
-                'c_entry_type',
-                'c_entry_type_desc',
-                'c_entry_type_desc_chn',
-                'c_entry_type_parent_id',
-                'c_entry_type_level',
-                'c_entry_type_sortorder'
-            )
-            ->orderBy('c_entry_type_sortorder')
-            ->orderBy('c_entry_type')
-            ->get();
-
-        return response()->json([
-            'success' => true,
-            'data' => $types,
-        ]);
-    }
-
-    /**
-     * 根據入仕類型獲取對應的入仕代碼（AJAX API）
-     */
-    public function getEntryCodes(Request $request) {
-        $typeId = $request->input('type_id');
-
-        $query = DB::table('ENTRY_CODES as ec')
-            ->select(
-                'ec.c_entry_code',
-                'ec.c_entry_desc',
-                'ec.c_entry_desc_chn'
-            )
-            ->orderBy('ec.c_entry_code');
-
-        // 如果指定了類型，則通過關聯表過濾
-        if ($typeId) {
-            $query->join('ENTRY_CODE_TYPE_REL as rel', 'ec.c_entry_code', '=', 'rel.c_entry_code')
-                ->where('rel.c_entry_type', $typeId);
-        }
-
-        $codes = $query->get();
-
-        return response()->json([
-            'success' => true,
-            'data' => $codes,
-        ]);
-    }
-
-    /**
-     * 執行搜索查詢（Blade 版）
-     */
-    public function search(Request $request) {
-        $request->validate([
-            'entry_codes' => 'nullable|array',
-            'entry_codes.*' => 'integer',
-            'year_from' => 'nullable|integer',
-            'year_to' => 'nullable|integer',
-            'addr_id' => 'nullable|integer',
-        ]);
-
-        $entryCodes = $request->input('entry_codes', []);
-        $yearFrom = $request->input('year_from');
-        $yearTo = $request->input('year_to');
-        $addrId = $request->input('addr_id');
-
-        $query = $this->buildEntrySearchQuery($entryCodes, $yearFrom, $yearTo, $addrId);
-
-        // 執行查詢並分頁
-        $results = $query
-            ->paginate(50)
-            ->appends($request->all());
-
-        return view('search-by.entry.results', compact('results'));
-    }
-
-    /**
-     * Inertia 版按入仕查詢頁面
-     */
-    public function appIndex(Request $request): InertiaResponse {
-        $request->validate([
-            'entry_codes' => 'nullable|array',
-            'entry_codes.*' => 'integer',
-            'year_from' => 'nullable|integer|lte:year_to',
-            'year_to' => 'nullable|integer',
-            'addr_id' => 'nullable|integer',
-            'type_id' => 'nullable|string',
-        ]);
-
-        $entryCodes = $request->input('entry_codes', []);
-        $yearFrom = $request->input('year_from');
-        $yearTo = $request->input('year_to');
-        $addrId = $request->input('addr_id');
-        $typeId = $request->input('type_id');
-
-        // 載入入仕類型
-        $entryTypes = DB::table('ENTRY_TYPES')
-            ->select(
-                'c_entry_type',
-                'c_entry_type_desc',
-                'c_entry_type_desc_chn',
-                'c_entry_type_parent_id',
-                'c_entry_type_level',
-                'c_entry_type_sortorder'
-            )
-            ->orderBy('c_entry_type_sortorder')
-            ->orderBy('c_entry_type')
-            ->get();
-
-        // 若有 type_id，預載該類型的 entry codes
-        $preloadedCodes = [];
-        if ($typeId) {
-            $preloadedCodes = DB::table('ENTRY_CODES as ec')
-                ->join('ENTRY_CODE_TYPE_REL as rel', 'ec.c_entry_code', '=', 'rel.c_entry_code')
-                ->where('rel.c_entry_type', $typeId)
-                ->select('ec.c_entry_code', 'ec.c_entry_desc', 'ec.c_entry_desc_chn')
-                ->orderBy('ec.c_entry_code')
-                ->get();
-        }
-
-        // 判斷是否有搜尋條件
-        $hasConditions = !empty($entryCodes) || $yearFrom !== null || $yearTo !== null || $addrId !== null;
-
-        $results = null;
-        if ($hasConditions) {
-            $query = $this->buildEntrySearchQuery($entryCodes, $yearFrom, $yearTo, $addrId);
-            $results = $query->paginate(50)->appends($request->except('page'));
-        }
+    public function index(Request $request): InertiaResponse {
+        $filters = $this->validatedFilters($request, false);
+        $normalizedFilters = $this->entryQueryService->normalizeFilters($filters);
+        $preloadedCodes = $this->entryQueryService->getEntryCodes($normalizedFilters['type_id'])
+            ->merge($this->entryQueryService->getEntryCodesByIds($normalizedFilters['entry_codes']))
+            ->unique('c_entry_code')
+            ->values();
 
         return Inertia::render('SearchByEntry/Index', [
-            'entryTypes' => $entryTypes,
+            'entryTypes' => $this->entryQueryService->getEntryTypes(),
+            'dynasties' => $this->entryQueryService->getDynasties(),
             'preloadedCodes' => $preloadedCodes,
-            'results' => $results,
-            'filters' => [
-                'entry_codes' => array_map('intval', $entryCodes),
-                'year_from' => $yearFrom !== null ? (int) $yearFrom : null,
-                'year_to' => $yearTo !== null ? (int) $yearTo : null,
-                'addr_id' => $addrId !== null ? (int) $addrId : null,
-                'type_id' => $typeId,
-            ],
-            'pageUrl' => route('app.search-by.entry.index', [], false),
+            'preloadedPlaces' => $this->entryQueryService->getPlacesByIds($normalizedFilters['place_ids']),
+            'initialFilters' => $normalizedFilters,
+            'pageUrl' => route('search-by.entry.index', [], false),
             'typesEndpoint' => route('search-by.entry.types', [], false),
             'codesEndpoint' => route('search-by.entry.codes', [], false),
+            'placesEndpoint' => route('search-by.entry.places', [], false),
+            'queryEndpoint' => route('search-by.entry.query', [], false),
         ]);
     }
 
-    /**
-     * 構建入仕搜尋查詢（共用邏輯）
-     */
-    private function buildEntrySearchQuery(array $entryCodes, ?int $yearFrom, ?int $yearTo, ?int $addrId): Builder {
-        $query = DB::table('ENTRY_DATA as ed')
-            ->join('BIOG_MAIN as bm', 'ed.c_personid', '=', 'bm.c_personid')
-            ->join('ENTRY_CODES as ec', 'ed.c_entry_code', '=', 'ec.c_entry_code')
-            ->leftJoin('DYNASTIES as dy', 'dy.c_dy', '=', 'bm.c_dy')
-            ->leftJoin('ADDR_CODES as addr', 'addr.c_addr_id', '=', 'bm.c_index_addr_id')
-            ->select(
-                'bm.c_personid',
-                'bm.c_name_chn',
-                'bm.c_name',
-                'bm.c_dy',
-                'dy.c_dynasty',
-                'dy.c_dynasty_chn',
-                'bm.c_index_year',
-                'bm.c_index_addr_id',
-                'addr.c_name as c_index_addr_name',
-                'addr.c_name_chn as c_index_addr_chn',
-                'ec.c_entry_code',
-                'ec.c_entry_desc_chn',
-                'ec.c_entry_desc',
-                'ed.c_year',
-                'ed.c_sequence'
-            );
+    public function appIndex(Request $request): InertiaResponse {
+        return $this->index($request);
+    }
 
-        if (!empty($entryCodes)) {
-            $query->whereIn('ed.c_entry_code', $entryCodes);
+    public function getEntryTypes(): JsonResponse {
+        return response()->json([
+            'success' => true,
+            'data' => $this->entryQueryService->getEntryTypes(),
+        ]);
+    }
+
+    public function getEntryCodes(Request $request): JsonResponse {
+        $validated = $request->validate([
+            'type_id' => 'nullable|string|max:255',
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data' => $this->entryQueryService->getEntryCodes($validated['type_id'] ?? null),
+        ]);
+    }
+
+    public function getPlaces(Request $request): JsonResponse {
+        $validated = $request->validate([
+            'q' => 'nullable|string|max:100',
+            'limit' => 'nullable|integer|min:1|max:50',
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data' => $this->entryQueryService->searchPlaces($validated['q'] ?? null, (int) ($validated['limit'] ?? 20)),
+        ]);
+    }
+
+    public function query(Request $request): JsonResponse {
+        $validated = $this->validatedFilters($request, true);
+        $filters = $this->entryQueryService->normalizeFilters($validated);
+
+        if (!$this->entryQueryService->hasConditions($filters)) {
+            return response()->json([
+                'message' => '請至少設定一項搜尋條件。',
+                'errors' => [
+                    'filters' => ['請至少設定一項搜尋條件。'],
+                ],
+            ], 422);
         }
 
-        if ($yearFrom !== null) {
-            $query->where('ed.c_year', '>=', $yearFrom);
-        }
-        if ($yearTo !== null) {
-            $query->where('ed.c_year', '<=', $yearTo);
+        $result = $this->entryQueryService->search($filters);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'filters' => $result['filters'],
+                'records' => $result['records']->toArray(),
+                'people' => $result['people']->toArray(),
+                'summary' => $result['summary'],
+            ],
+        ]);
+    }
+
+    private function validatedFilters(Request $request, bool $includePagination): array {
+        $rules = [
+            'person_keyword' => 'nullable|string|max:100',
+            'type_id' => 'nullable|string|max:255',
+            'entry_codes' => 'nullable|array',
+            'entry_codes.*' => 'integer',
+            'place_ids' => 'nullable|array',
+            'place_ids.*' => 'integer',
+            'include_sub_units' => 'nullable|boolean',
+            'use_index_year_range' => 'nullable|boolean',
+            'index_year_from' => 'nullable|integer',
+            'index_year_to' => 'nullable|integer',
+            'use_entry_year_range' => 'nullable|boolean',
+            'entry_year_from' => 'nullable|integer',
+            'entry_year_to' => 'nullable|integer',
+            'dynasty_codes' => 'nullable|array',
+            'dynasty_codes.*' => 'string|max:255',
+        ];
+
+        if ($includePagination) {
+            $rules['records_page'] = 'nullable|integer|min:1';
+            $rules['people_page'] = 'nullable|integer|min:1';
         }
 
-        if ($addrId !== null) {
-            $query->where('ed.c_entry_addr_id', $addrId);
-        }
-
-        return $query->orderBy('bm.c_index_year')->orderBy('bm.c_personid');
+        return $request->validate($rules);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -18,6 +18,9 @@ class HandleInertiaRequests extends Middleware {
      */
     public function share(Request $request): array {
         return array_merge(parent::share($request), [
+            'app' => [
+                'version' => get_app_version(),
+            ],
             'auth' => [
                 'user' => $request->user() ? [
                     'id' => $request->user()->id,

--- a/app/Services/EntryQueryService.php
+++ b/app/Services/EntryQueryService.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class EntryQueryService {
+    public function getEntryTypes(): Collection {
+        return DB::table('ENTRY_TYPES')
+            ->select(
+                'c_entry_type',
+                'c_entry_type_desc',
+                'c_entry_type_desc_chn',
+                'c_entry_type_parent_id',
+                'c_entry_type_level',
+                'c_entry_type_sortorder'
+            )
+            ->orderBy('c_entry_type_sortorder')
+            ->orderBy('c_entry_type')
+            ->get();
+    }
+
+    public function getEntryCodes(?string $typeId = null): Collection {
+        $query = DB::table('ENTRY_CODES as ec')
+            ->select(
+                'ec.c_entry_code',
+                'ec.c_entry_desc',
+                'ec.c_entry_desc_chn'
+            )
+            ->orderBy('ec.c_entry_code');
+
+        if ($typeId) {
+            $query->join('ENTRY_CODE_TYPE_REL as rel', 'ec.c_entry_code', '=', 'rel.c_entry_code')
+                ->where('rel.c_entry_type', $typeId);
+        }
+
+        return $query->get();
+    }
+
+    public function getEntryCodesByIds(array $entryCodes): Collection {
+        if ($entryCodes === []) {
+            return collect();
+        }
+
+        return DB::table('ENTRY_CODES')
+            ->select('c_entry_code', 'c_entry_desc', 'c_entry_desc_chn')
+            ->whereIn('c_entry_code', $entryCodes)
+            ->orderBy('c_entry_code')
+            ->get();
+    }
+
+    public function getDynasties(): Collection {
+        return DB::table('DYNASTIES')
+            ->select('c_dy', 'c_dynasty', 'c_dynasty_chn', 'c_start', 'c_end')
+            ->orderByRaw("
+                CASE
+                    WHEN COALESCE(c_dynasty_chn, c_dynasty) IN ('朝鮮', '韓國', '高麗', '新羅') THEN 1
+                    ELSE 0
+                END
+            ")
+            ->orderBy('c_start')
+            ->orderBy('c_end')
+            ->orderBy('c_dy')
+            ->get();
+    }
+
+    public function searchPlaces(?string $keyword = null, int $limit = 20): Collection {
+        $query = DB::table('ADDR_CODES')
+            ->select('c_addr_id', 'c_name', 'c_name_chn')
+            ->orderBy('c_name_chn')
+            ->orderBy('c_name')
+            ->orderBy('c_addr_id');
+
+        if ($keyword !== null && $keyword !== '') {
+            $query->where(function (Builder $builder) use ($keyword) {
+                $builder->where('c_name_chn', 'like', "%{$keyword}%")
+                    ->orWhere('c_name', 'like', "%{$keyword}%")
+                    ->orWhere('c_addr_id', 'like', "%{$keyword}%");
+            });
+        }
+
+        return $query->limit(max(1, min($limit, 50)))->get();
+    }
+
+    public function getPlacesByIds(array $placeIds): Collection {
+        if ($placeIds === []) {
+            return collect();
+        }
+
+        return DB::table('ADDR_CODES')
+            ->select('c_addr_id', 'c_name', 'c_name_chn')
+            ->whereIn('c_addr_id', $placeIds)
+            ->orderBy('c_name_chn')
+            ->orderBy('c_name')
+            ->get();
+    }
+
+    public function normalizeFilters(array $filters): array {
+        $entryCodes = array_values(array_unique(array_map('intval', array_filter($filters['entry_codes'] ?? [], static fn ($value) => $value !== null && $value !== ''))));
+        $placeIds = array_values(array_unique(array_map('intval', array_filter($filters['place_ids'] ?? [], static fn ($value) => $value !== null && $value !== ''))));
+        sort($entryCodes);
+        sort($placeIds);
+
+        $normalized = [
+            'person_keyword' => $this->normalizeText($filters['person_keyword'] ?? null),
+            'type_id' => $this->normalizeText($filters['type_id'] ?? null),
+            'entry_codes' => $entryCodes,
+            'place_ids' => $placeIds,
+            'include_sub_units' => $this->toBoolean($filters['include_sub_units'] ?? false),
+            'use_index_year_range' => $this->toBoolean($filters['use_index_year_range'] ?? false),
+            'index_year_from' => $this->normalizeNullableInt($filters['index_year_from'] ?? null),
+            'index_year_to' => $this->normalizeNullableInt($filters['index_year_to'] ?? null),
+            'use_entry_year_range' => $this->toBoolean($filters['use_entry_year_range'] ?? false),
+            'entry_year_from' => $this->normalizeNullableInt($filters['entry_year_from'] ?? null),
+            'entry_year_to' => $this->normalizeNullableInt($filters['entry_year_to'] ?? null),
+            'dynasty_codes' => $this->normalizeStringArray($filters['dynasty_codes'] ?? []),
+            'records_page' => max(1, (int) ($filters['records_page'] ?? 1)),
+            'people_page' => max(1, (int) ($filters['people_page'] ?? 1)),
+        ];
+
+        if ($normalized['use_index_year_range']) {
+            $normalized['index_year_from'] ??= -200;
+            $normalized['index_year_to'] ??= 1911;
+        }
+
+        if ($normalized['use_entry_year_range']) {
+            $normalized['entry_year_from'] ??= -200;
+            $normalized['entry_year_to'] ??= 1911;
+        }
+
+        return $normalized;
+    }
+
+    public function hasConditions(array $filters): bool {
+        return $filters['person_keyword'] !== null
+            || $filters['entry_codes'] !== []
+            || $filters['place_ids'] !== []
+            || $filters['use_index_year_range']
+            || $filters['use_entry_year_range']
+            || $filters['dynasty_codes'] !== [];
+    }
+
+    public function search(array $filters): array {
+        $normalized = $this->normalizeFilters($filters);
+        $recordsQuery = $this->buildRecordsQuery($normalized);
+        $peopleQuery = $this->buildPeopleQuery($normalized);
+
+        $records = (clone $recordsQuery)
+            ->orderBy('ec.c_entry_desc_chn')
+            ->orderBy('ec.c_entry_desc')
+            ->orderBy('ed.c_year')
+            ->orderBy('bm.c_personid')
+            ->orderBy('ed.c_sequence')
+            ->paginate(20, ['*'], 'records_page', $normalized['records_page']);
+
+        $people = (clone $peopleQuery)
+            ->orderBy('c_personid')
+            ->paginate(20, ['*'], 'people_page', $normalized['people_page']);
+
+        return [
+            'filters' => $normalized,
+            'records' => $records,
+            'people' => $people,
+            'summary' => [
+                'record_count' => $records->total(),
+                'person_count' => $people->total(),
+                'selected_entry_code_count' => count($normalized['entry_codes']),
+                'selected_place_count' => count($normalized['place_ids']),
+            ],
+        ];
+    }
+
+    private function buildRecordsQuery(array $filters): Builder {
+        $query = DB::table('ENTRY_DATA as ed')
+            ->join('BIOG_MAIN as bm', 'ed.c_personid', '=', 'bm.c_personid')
+            ->join('ENTRY_CODES as ec', 'ed.c_entry_code', '=', 'ec.c_entry_code')
+            ->leftJoin('DYNASTIES as dynasties', 'dynasties.c_dy', '=', 'bm.c_dy')
+            ->leftJoin('ADDR_CODES as index_addr', 'index_addr.c_addr_id', '=', 'bm.c_index_addr_id')
+            ->leftJoin('ADDR_CODES as entry_addr', 'entry_addr.c_addr_id', '=', 'ed.c_entry_addr_id')
+            ->select(
+                'bm.c_personid',
+                'bm.c_name_chn',
+                'bm.c_name',
+                'bm.c_dy',
+                'dynasties.c_dynasty',
+                'dynasties.c_dynasty_chn',
+                'bm.c_index_year',
+                'bm.c_index_addr_id',
+                'index_addr.c_name as c_index_addr_name',
+                'index_addr.c_name_chn as c_index_addr_chn',
+                'ed.c_entry_code',
+                'ec.c_entry_desc_chn',
+                'ec.c_entry_desc',
+                'ed.c_year',
+                'ed.c_sequence',
+                'ed.c_entry_addr_id',
+                'entry_addr.c_name as c_entry_addr_name',
+                'entry_addr.c_name_chn as c_entry_addr_chn',
+                'ed.c_exam_rank',
+                'ed.c_notes',
+                'ed.c_posting_notes'
+            )
+            ->selectRaw("
+                CASE
+                    WHEN bm.c_female = 1 THEN 'F'
+                    WHEN bm.c_female = 0 THEN 'M'
+                    ELSE NULL
+                END AS c_sex_label
+            ");
+
+        if (Schema::hasTable('INDEXYEAR_TYPE_CODES')) {
+            $query->leftJoin('INDEXYEAR_TYPE_CODES as index_year_types', 'index_year_types.c_index_year_type_code', '=', 'bm.c_index_year_type_code')
+                ->addSelect(DB::raw('COALESCE(index_year_types.c_index_year_type_hz, index_year_types.c_index_year_type_desc) as c_index_year_type_label'));
+        } else {
+            $query->addSelect(DB::raw('NULL as c_index_year_type_label'));
+        }
+
+        if (Schema::hasTable('NIAN_HAO')) {
+            $query->leftJoin('NIAN_HAO as nianhao', 'nianhao.c_nianhao_id', '=', 'ed.c_entry_nh_id')
+                ->addSelect('ed.c_entry_nh_year')
+                ->addSelect(DB::raw('COALESCE(nianhao.c_nianhao_chn, nianhao.c_nianhao_pin) as c_entry_nianhao_label'));
+        } else {
+            $query->addSelect(DB::raw('NULL as c_entry_nh_year'))
+                ->addSelect(DB::raw('NULL as c_entry_nianhao_label'));
+        }
+
+        if (Schema::hasTable('YEAR_RANGE_CODES')) {
+            $query->leftJoin('YEAR_RANGE_CODES as year_ranges', 'year_ranges.c_range_code', '=', 'ed.c_entry_range')
+                ->addSelect(DB::raw('COALESCE(year_ranges.c_range_chn, year_ranges.c_range) as c_entry_range_label'));
+        } else {
+            $query->addSelect(DB::raw('NULL as c_entry_range_label'));
+        }
+
+        if (Schema::hasTable('PARENTAL_STATUS_CODES')) {
+            $query->leftJoin('PARENTAL_STATUS_CODES as parental_status', 'parental_status.c_parental_status_code', '=', 'ed.c_parental_status_code')
+                ->addSelect(DB::raw('COALESCE(parental_status.c_parental_status_desc_chn, parental_status.c_parental_status_desc) as c_parental_status_label'));
+        } else {
+            $query->addSelect(DB::raw('NULL as c_parental_status_label'));
+        }
+
+        if (Schema::hasTable('TEXT_CODES')) {
+            $query->leftJoin('TEXT_CODES as sources', 'sources.c_textid', '=', 'ed.c_source')
+                ->addSelect(DB::raw('COALESCE(sources.c_title_chn, sources.c_title) as c_source_label'));
+        } else {
+            $query->addSelect(DB::raw('NULL as c_source_label'));
+        }
+
+        if ($filters['person_keyword'] !== null) {
+            $keyword = "%{$filters['person_keyword']}%";
+
+            $query->where(function (Builder $builder) use ($keyword) {
+                $builder->where('bm.c_name_chn', 'like', $keyword)
+                    ->orWhere('bm.c_name', 'like', $keyword);
+
+                if (Schema::hasTable('ALTNAME_DATA')) {
+                    $builder->orWhereExists(function (Builder $subquery) use ($keyword) {
+                        $subquery->select(DB::raw(1))
+                            ->from('ALTNAME_DATA as alt')
+                            ->whereColumn('alt.c_personid', 'bm.c_personid')
+                            ->where(function (Builder $altQuery) use ($keyword) {
+                                $altQuery->where('alt.c_alt_name_chn', 'like', $keyword)
+                                    ->orWhere('alt.c_alt_name', 'like', $keyword);
+                            });
+                    });
+                }
+            });
+        }
+
+        if ($filters['entry_codes'] !== []) {
+            $query->whereIn('ed.c_entry_code', $filters['entry_codes']);
+        }
+
+        if ($filters['use_entry_year_range']) {
+            $entryYearFrom = min($filters['entry_year_from'], $filters['entry_year_to']);
+            $entryYearTo = max($filters['entry_year_from'], $filters['entry_year_to']);
+            $query->whereBetween('ed.c_year', [$entryYearFrom, $entryYearTo]);
+        }
+
+        if ($filters['use_index_year_range']) {
+            $indexYearFrom = min($filters['index_year_from'], $filters['index_year_to']);
+            $indexYearTo = max($filters['index_year_from'], $filters['index_year_to']);
+            $query->whereBetween('bm.c_index_year', [$indexYearFrom, $indexYearTo]);
+        }
+
+        if ($filters['place_ids'] !== []) {
+            $query->where(function (Builder $builder) use ($filters) {
+                $builder->whereIn('ed.c_entry_addr_id', $filters['place_ids']);
+
+                if ($filters['include_sub_units'] && Schema::hasTable('ADDR_BELONGS_DATA')) {
+                    $builder->orWhereExists(function (Builder $subquery) use ($filters) {
+                        $subquery->select(DB::raw(1))
+                            ->from('ADDR_BELONGS_DATA as belongs')
+                            ->whereColumn('belongs.c_addr_id', 'ed.c_entry_addr_id')
+                            ->whereIn('belongs.c_belongs_to', $filters['place_ids']);
+                    });
+                }
+            });
+        }
+
+        if ($filters['dynasty_codes'] !== []) {
+            $query->whereIn('bm.c_dy', $filters['dynasty_codes']);
+        }
+
+        return $query;
+    }
+
+    private function buildPeopleQuery(array $filters): Builder {
+        return DB::query()
+            ->fromSub($this->buildRecordsQuery($filters), 'records')
+            ->select(
+                'c_personid',
+                'c_name_chn',
+                'c_name',
+                'c_dy',
+                'c_dynasty',
+                'c_dynasty_chn',
+                'c_index_year',
+                'c_index_addr_id',
+                'c_index_addr_name',
+                'c_index_addr_chn',
+                'c_index_year_type_label',
+                'c_sex_label'
+            )
+            ->selectRaw('MIN(c_entry_addr_id) as c_entry_addr_id')
+            ->selectRaw('MIN(c_entry_addr_name) as c_entry_addr_name')
+            ->selectRaw('MIN(c_entry_addr_chn) as c_entry_addr_chn')
+            ->selectRaw('COUNT(*) as entry_count')
+            ->groupBy(
+                'c_personid',
+                'c_name_chn',
+                'c_name',
+                'c_dy',
+                'c_dynasty',
+                'c_dynasty_chn',
+                'c_index_year',
+                'c_index_addr_id',
+                'c_index_addr_name',
+                'c_index_addr_chn',
+                'c_index_year_type_label',
+                'c_sex_label'
+            );
+    }
+
+    private function normalizeText(mixed $value): ?string {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeNullableInt(mixed $value): ?int {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function normalizeStringArray(mixed $value): array {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $normalized = array_values(array_unique(array_filter(array_map(
+            fn ($item) => $this->normalizeText($item),
+            $value
+        ))));
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    private function toBoolean(mixed $value): bool {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/resources/js/inertia/Layouts/AppShell.tsx
+++ b/resources/js/inertia/Layouts/AppShell.tsx
@@ -11,7 +11,7 @@ export default function AppShell({ children }: AppShellProps) {
                 <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>CBDB 中國歷代人物傳記資料庫</h1>
                 <a href="/" style={{ color: '#adb5bd', textDecoration: 'none', fontSize: '0.875rem' }}>← 返回首頁</a>
             </header>
-            <main style={{ padding: '24px', maxWidth: '1400px', margin: '0 auto' }}>
+            <main style={{ padding: 0, margin: 0 }}>
                 {children}
             </main>
         </div>

--- a/resources/js/inertia/Layouts/AppShell.tsx
+++ b/resources/js/inertia/Layouts/AppShell.tsx
@@ -1,19 +1,46 @@
 import React from 'react';
+import { usePage } from '@inertiajs/react';
 
 interface AppShellProps {
     children: React.ReactNode;
 }
 
 export default function AppShell({ children }: AppShellProps) {
+    const { app } = usePage<{ app?: { version?: string } }>().props;
+    const version = app?.version || 'unknown';
+
     return (
-        <div style={{ minHeight: '100vh', backgroundColor: '#f4f6f9', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' }}>
+        <div style={{ minHeight: '100vh', backgroundColor: '#f4f6f9', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', display: 'flex', flexDirection: 'column' }}>
             <header style={{ backgroundColor: '#343a40', color: '#fff', padding: '12px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>CBDB 中國歷代人物傳記資料庫</h1>
                 <a href="/" style={{ color: '#adb5bd', textDecoration: 'none', fontSize: '0.875rem' }}>← 返回首頁</a>
             </header>
-            <main style={{ padding: 0, margin: 0 }}>
+            <main style={{ padding: 0, margin: 0, flex: 1 }}>
                 {children}
             </main>
+            <footer style={{ backgroundColor: '#fff', borderTop: '1px solid #dee2e6', padding: '12px 16px', fontSize: '0.875rem', color: '#495057' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+                    <div>
+                        <strong>Copyright &copy; </strong>
+                        <a href="https://cbdb.hsites.harvard.edu/" target="_blank" rel="noreferrer" style={footerLinkStyle}>
+                            Chinese Biographical Database Project (CBDB)
+                        </a>
+                        . Content licensed under{' '}
+                        <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noreferrer" style={footerLinkStyle}>
+                            CC BY-NC-SA 4.0 International
+                        </a>
+                        .
+                    </div>
+                    <div>
+                        <strong>Version:</strong> {version}
+                    </div>
+                </div>
+            </footer>
         </div>
     );
 }
+
+const footerLinkStyle: React.CSSProperties = {
+    color: '#007bff',
+    textDecoration: 'none',
+};

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -1,343 +1,1536 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { router, usePage } from '@inertiajs/react';
+import React, { useEffect, useRef, useState } from 'react';
+import { usePage } from '@inertiajs/react';
 import AppShell from '../../Layouts/AppShell';
-import EntryTypeTree, { EntryType } from '../../components/EntryTypeTree';
 import EntryCodeList, { EntryCode } from '../../components/EntryCodeList';
+import EntryPeopleTable, { EntryPersonRow } from '../../components/EntryPeopleTable';
+import EntryTypeTree, { EntryType } from '../../components/EntryTypeTree';
+import PlaceMultiSelect, { PlaceOption } from '../../components/PlaceMultiSelect';
+import SearchResultTable, { ResultRow } from '../../components/SearchResultTable';
 import SelectedCodeChips from '../../components/SelectedCodeChips';
-import SearchResultTable, { ResultRow, PaginationData } from '../../components/SearchResultTable';
+import SelectionDialog from '../../components/SelectionDialog';
+import { PaginationData } from '../../components/PaginationControls';
+
+interface DynastyOption {
+    c_dy: string;
+    c_dynasty: string | null;
+    c_dynasty_chn: string | null;
+    c_start: number | null;
+    c_end: number | null;
+}
+
+interface FiltersState {
+    person_keyword: string;
+    type_id: string | null;
+    entry_codes: number[];
+    place_ids: number[];
+    include_sub_units: boolean;
+    use_index_year_range: boolean;
+    index_year_from: number | null;
+    index_year_to: number | null;
+    use_entry_year_range: boolean;
+    entry_year_from: number | null;
+    entry_year_to: number | null;
+    dynasty_codes: string[];
+}
+
+interface QueryResultState {
+    records: PaginationData<ResultRow>;
+    people: PaginationData<EntryPersonRow>;
+    summary: {
+        record_count: number;
+        person_count: number;
+        selected_entry_code_count: number;
+        selected_place_count: number;
+    };
+}
 
 interface PageProps {
     entryTypes: EntryType[];
+    dynasties: DynastyOption[];
     preloadedCodes: EntryCode[];
-    results: {
-        data: ResultRow[];
-        current_page: number;
-        last_page: number;
-        per_page: number;
-        total: number;
-        from: number | null;
-        to: number | null;
-    } | null;
-    filters: {
-        entry_codes: number[];
-        year_from: number | null;
-        year_to: number | null;
-        addr_id: number | null;
+    preloadedPlaces: PlaceOption[];
+    initialFilters: {
+        person_keyword: string | null;
         type_id: string | null;
+        entry_codes: number[];
+        place_ids: number[];
+        include_sub_units: boolean;
+        use_index_year_range: boolean;
+        index_year_from: number | null;
+        index_year_to: number | null;
+        use_entry_year_range: boolean;
+        entry_year_from: number | null;
+        entry_year_to: number | null;
+        dynasty_codes: string[];
     };
-    errors: Record<string, string>;
     pageUrl: string;
-    typesEndpoint: string;
     codesEndpoint: string;
-    [key: string]: unknown;
+    placesEndpoint: string;
+    queryEndpoint: string;
 }
 
+type ActiveDialog = 'entry' | 'personKeyword' | 'places' | 'indexYear' | 'entryYear' | 'dynasty' | null;
+
 export default function Index() {
-    const { entryTypes, preloadedCodes, results, filters, errors, pageUrl, typesEndpoint, codesEndpoint } = usePage<PageProps>().props;
+    const {
+        entryTypes,
+        dynasties,
+        preloadedCodes,
+        preloadedPlaces,
+        initialFilters,
+        pageUrl,
+        codesEndpoint,
+        placesEndpoint,
+        queryEndpoint,
+    } = usePage<PageProps>().props;
 
-    // Local state
-    const [selectedTypeId, setSelectedTypeId] = useState<string | null>(filters.type_id ?? null);
+    const [filters, setFilters] = useState<FiltersState>({
+        person_keyword: initialFilters.person_keyword ?? '',
+        type_id: initialFilters.type_id ?? null,
+        entry_codes: initialFilters.entry_codes ?? [],
+        place_ids: initialFilters.place_ids ?? [],
+        include_sub_units: initialFilters.include_sub_units ?? false,
+        use_index_year_range: initialFilters.use_index_year_range ?? false,
+        index_year_from: initialFilters.index_year_from,
+        index_year_to: initialFilters.index_year_to,
+        use_entry_year_range: initialFilters.use_entry_year_range ?? false,
+        entry_year_from: initialFilters.entry_year_from,
+        entry_year_to: initialFilters.entry_year_to,
+        dynasty_codes: initialFilters.dynasty_codes ?? [],
+    });
     const [availableCodes, setAvailableCodes] = useState<EntryCode[]>(preloadedCodes ?? []);
-    const [selectedCodes, setSelectedCodes] = useState<number[]>(filters.entry_codes ?? []);
-    const [yearFrom, setYearFrom] = useState<string>(filters.year_from != null ? String(filters.year_from) : '');
-    const [yearTo, setYearTo] = useState<string>(filters.year_to != null ? String(filters.year_to) : '');
-    const [addrId, setAddrId] = useState<string>(filters.addr_id != null ? String(filters.addr_id) : '');
-    const [loadingTypes] = useState(false);
-    const [typesError] = useState<string | null>(null);
-    const [loadingCodes, setLoadingCodes] = useState(false);
-    const [codesError, setCodesError] = useState<string | null>(null);
-    const [submitting, setSubmitting] = useState(false);
-
-    // All known codes (for chips display)
     const [allKnownCodes, setAllKnownCodes] = useState<EntryCode[]>(preloadedCodes ?? []);
+    const [selectedPlaces, setSelectedPlaces] = useState<PlaceOption[]>(preloadedPlaces ?? []);
+    const [placeQuery, setPlaceQuery] = useState('');
+    const [placeResults, setPlaceResults] = useState<PlaceOption[]>([]);
+    const [activeTab, setActiveTab] = useState<'records' | 'people'>('records');
+    const [results, setResults] = useState<QueryResultState | null>(null);
+    const [queryErrors, setQueryErrors] = useState<Record<string, string[]>>({});
+    const [resultsError, setResultsError] = useState<string | null>(null);
+    const [loadingCodes, setLoadingCodes] = useState(false);
+    const [loadingPlaces, setLoadingPlaces] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
+    const initialQueryRan = useRef(false);
+    const shouldFocusResultsRef = useRef(false);
+    const resultsSectionRef = useRef<HTMLDivElement | null>(null);
 
-    // Update allKnownCodes when new codes load
     useEffect(() => {
-        if (availableCodes.length > 0) {
-            setAllKnownCodes((prev) => {
-                const map = new Map(prev.map((c) => [c.c_entry_code, c]));
-                availableCodes.forEach((c) => map.set(c.c_entry_code, c));
-                return Array.from(map.values());
-            });
+        if (availableCodes.length === 0) {
+            return;
         }
+
+        setAllKnownCodes((previous) => {
+            const map = new Map(previous.map((code) => [code.c_entry_code, code]));
+            availableCodes.forEach((code) => map.set(code.c_entry_code, code));
+            return Array.from(map.values()).sort((left, right) => left.c_entry_code - right.c_entry_code);
+        });
     }, [availableCodes]);
 
-    // Load codes when type changes (client-side fetch)
-    const loadCodes = useCallback(async (typeId: string) => {
-        setLoadingCodes(true);
-        setCodesError(null);
-        try {
-            const url = `${codesEndpoint}?type_id=${encodeURIComponent(typeId)}`;
-            const res = await fetch(url, {
-                headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-            });
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            const json = await res.json();
-            if (json.success) {
-                setAvailableCodes(json.data);
-            } else {
-                setCodesError('載入失敗');
+    useEffect(() => {
+        if (!filters.type_id || availableCodes.length > 0) {
+            return;
+        }
+
+        void loadCodes(filters.type_id);
+    }, []);
+
+    useEffect(() => {
+        if (placeQuery.trim() === '') {
+            setPlaceResults([]);
+            setLoadingPlaces(false);
+            return;
+        }
+
+        const controller = new AbortController();
+        const timer = window.setTimeout(async () => {
+            setLoadingPlaces(true);
+            try {
+                const response = await fetch(`${placesEndpoint}?${buildQueryString({ q: placeQuery, limit: 20 })}`, {
+                    headers: { Accept: 'application/json' },
+                    signal: controller.signal,
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+
+                const payload = await response.json();
+                setPlaceResults(payload.data ?? []);
+            } catch (error) {
+                if (!controller.signal.aborted) {
+                    setPlaceResults([]);
+                }
+            } finally {
+                if (!controller.signal.aborted) {
+                    setLoadingPlaces(false);
+                }
             }
-        } catch {
-            setCodesError('載入入仕代碼失敗');
+        }, 250);
+
+        return () => {
+            controller.abort();
+            window.clearTimeout(timer);
+        };
+    }, [placeQuery, placesEndpoint]);
+
+    useEffect(() => {
+        if (initialQueryRan.current) {
+            return;
+        }
+
+        initialQueryRan.current = true;
+
+        if (!hasAnyCondition(filters)) {
+            return;
+        }
+
+        void runQuery({ records_page: 1, people_page: 1 }, false);
+    }, []);
+
+    useEffect(() => {
+        if (!results || !shouldFocusResultsRef.current) {
+            return;
+        }
+
+        shouldFocusResultsRef.current = false;
+        window.requestAnimationFrame(() => {
+            resultsSectionRef.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+            });
+        });
+    }, [results]);
+
+    async function loadCodes(typeId: string) {
+        setLoadingCodes(true);
+
+        try {
+            const response = await fetch(`${codesEndpoint}?${buildQueryString({ type_id: typeId })}`, {
+                headers: { Accept: 'application/json' },
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const payload = await response.json();
+            setAvailableCodes(payload.data ?? []);
+        } catch (error) {
+            setAvailableCodes([]);
         } finally {
             setLoadingCodes(false);
         }
-    }, [codesEndpoint]);
+    }
 
-    const handleTypeSelect = (typeId: string) => {
-        setSelectedTypeId(typeId);
-        loadCodes(typeId);
-    };
+    function updateFilter<K extends keyof FiltersState>(key: K, value: FiltersState[K]) {
+        setFilters((previous) => ({
+            ...previous,
+            [key]: value,
+        }));
+    }
 
-    const handleCodeToggle = (code: number) => {
-        setSelectedCodes((prev) =>
-            prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code]
-        );
-    };
-
-    const handleSelectAll = () => {
-        setSelectedCodes((prev) => {
-            const existing = new Set(prev);
-            availableCodes.forEach((c) => existing.add(c.c_entry_code));
-            return Array.from(existing);
-        });
-    };
-
-    const handleDeselectAll = () => {
-        const currentSet = new Set(availableCodes.map((c) => c.c_entry_code));
-        setSelectedCodes((prev) => prev.filter((c) => !currentSet.has(c)));
-    };
-
-    const handleRemoveCode = (code: number) => {
-        setSelectedCodes((prev) => prev.filter((c) => c !== code));
-    };
-
-    const handleSearch = (e: React.FormEvent) => {
-        e.preventDefault();
-        setSubmitting(true);
-
-        const params: Record<string, unknown> = {};
-        if (selectedCodes.length > 0) params.entry_codes = selectedCodes;
-        if (yearFrom) params.year_from = yearFrom;
-        if (yearTo) params.year_to = yearTo;
-        if (addrId) params.addr_id = addrId;
-        if (selectedTypeId) params.type_id = selectedTypeId;
-
-        router.get(pageUrl, params as Record<string, string>, {
-            preserveState: false,
-            onFinish: () => setSubmitting(false),
-        });
-    };
-
-    const handlePageChange = (page: number) => {
-        const params: Record<string, unknown> = { page };
-        if (selectedCodes.length > 0) params.entry_codes = selectedCodes;
-        if (filters.year_from != null) params.year_from = filters.year_from;
-        if (filters.year_to != null) params.year_to = filters.year_to;
-        if (filters.addr_id != null) params.addr_id = filters.addr_id;
-        if (filters.type_id) params.type_id = filters.type_id;
-
-        router.get(pageUrl, params as Record<string, string>, {
-            preserveState: false,
-        });
-    };
-
-    const handleReset = () => {
-        setSelectedTypeId(null);
+    function handleTypeSelect(typeId: string) {
+        setFilters((previous) => ({
+            ...previous,
+            type_id: typeId,
+            entry_codes: [],
+        }));
         setAvailableCodes([]);
-        setSelectedCodes([]);
-        setYearFrom('');
-        setYearTo('');
-        setAddrId('');
-        router.get(pageUrl, {}, { preserveState: false });
-    };
+        void loadCodes(typeId);
+    }
 
-    const hasFilters = selectedCodes.length > 0 || yearFrom || yearTo || addrId;
-    const hasResults = results !== null;
+    function handleClearType() {
+        setFilters((previous) => ({
+            ...previous,
+            type_id: null,
+            entry_codes: [],
+        }));
+        setAvailableCodes([]);
+    }
 
-    const pagination: PaginationData | null = results
-        ? {
-            current_page: results.current_page,
-            last_page: results.last_page,
-            per_page: results.per_page,
-            total: results.total,
-            from: results.from,
-            to: results.to,
+    function handleDynastyToggle(code: string) {
+        setFilters((previous) => ({
+            ...previous,
+            dynasty_codes: previous.dynasty_codes.includes(code)
+                ? previous.dynasty_codes.filter((existing) => existing !== code)
+                : [...previous.dynasty_codes, code].sort(),
+        }));
+    }
+
+    function handleCodeToggle(code: number) {
+        setFilters((previous) => ({
+            ...previous,
+            entry_codes: previous.entry_codes.includes(code)
+                ? previous.entry_codes.filter((existing) => existing !== code)
+                : [...previous.entry_codes, code].sort((left, right) => left - right),
+        }));
+    }
+
+    function handleSelectAllCodes() {
+        setFilters((previous) => {
+            const codes = new Set(previous.entry_codes);
+            availableCodes.forEach((code) => codes.add(code.c_entry_code));
+
+            return {
+                ...previous,
+                entry_codes: Array.from(codes).sort((left, right) => left - right),
+            };
+        });
+    }
+
+    function handleDeselectAllCodes() {
+        const visibleCodes = new Set(availableCodes.map((code) => code.c_entry_code));
+
+        setFilters((previous) => ({
+            ...previous,
+            entry_codes: previous.entry_codes.filter((code) => !visibleCodes.has(code)),
+        }));
+    }
+
+    function handleRemoveCode(code: number) {
+        setFilters((previous) => ({
+            ...previous,
+            entry_codes: previous.entry_codes.filter((existing) => existing !== code),
+        }));
+    }
+
+    function handleAddPlace(place: PlaceOption) {
+        setSelectedPlaces((previous) => {
+            if (previous.some((item) => item.c_addr_id === place.c_addr_id)) {
+                return previous;
+            }
+
+            const next = [...previous, place];
+            updateFilter('place_ids', next.map((item) => item.c_addr_id));
+            return next;
+        });
+    }
+
+    function handleRemovePlace(placeId: number) {
+        setSelectedPlaces((previous) => {
+            const next = previous.filter((place) => place.c_addr_id !== placeId);
+            updateFilter('place_ids', next.map((place) => place.c_addr_id));
+            return next;
+        });
+    }
+
+    function handleClearPlaces() {
+        setSelectedPlaces([]);
+        updateFilter('place_ids', []);
+    }
+
+    function handleReset() {
+        setFilters({
+            person_keyword: '',
+            type_id: null,
+            entry_codes: [],
+            place_ids: [],
+            include_sub_units: false,
+            use_index_year_range: false,
+            index_year_from: null,
+            index_year_to: null,
+            use_entry_year_range: false,
+            entry_year_from: null,
+            entry_year_to: null,
+            dynasty_codes: [],
+        });
+        setAvailableCodes([]);
+        setSelectedPlaces([]);
+        setPlaceQuery('');
+        setPlaceResults([]);
+        setResults(null);
+        setResultsError(null);
+        setQueryErrors({});
+        setActiveDialog(null);
+        window.history.replaceState(null, '', pageUrl);
+    }
+
+    async function runQuery(overrides: { records_page?: number; people_page?: number } = {}, switchToRecords = true) {
+        const payload = buildRequestPayload(filters, selectedPlaces, overrides);
+
+        setSubmitting(true);
+        setResultsError(null);
+        setQueryErrors({});
+
+        if (switchToRecords) {
+            setActiveTab('records');
         }
-        : null;
+
+        try {
+            const queryString = buildQueryString(payload);
+            window.history.replaceState(null, '', queryString ? `${pageUrl}?${queryString}` : pageUrl);
+
+            const response = await fetch(`${queryEndpoint}?${queryString}`, {
+                headers: { Accept: 'application/json' },
+            });
+            const data = await response.json();
+
+            if (!response.ok) {
+                setResults(null);
+                setResultsError(data.message ?? '查詢失敗');
+                setQueryErrors(data.errors ?? {});
+                return;
+            }
+
+            shouldFocusResultsRef.current = true;
+            setResults(data.data);
+        } catch (error) {
+            setResults(null);
+            setResultsError('查詢時發生錯誤，請稍後再試。');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    const selectedTypeLabel = findSelectedTypeLabel(entryTypes, filters.type_id);
+    const errorMessages = collectErrorMessages(queryErrors);
+    const selectedCodePreview = formatCodePreview(filters.entry_codes, allKnownCodes);
+    const selectedPlacePreview = formatPlacePreview(selectedPlaces, filters.include_sub_units);
+    const selectedDynastyPreview = formatDynastyPreview(filters.dynasty_codes, dynasties);
 
     return (
         <AppShell>
-            <h2 style={{ marginTop: 0, marginBottom: 20, fontSize: '1.3rem', fontWeight: 600 }}>按入仕查詢</h2>
+            <div style={workspaceStyle}>
+                <div>
+                    <h2 style={{ margin: 0, fontSize: '1.55rem', fontWeight: 700 }}>按入仕查詢</h2>
+                </div>
 
-            {/* Three-column layout */}
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16, marginBottom: 24 }}>
-                {/* Column 1: Entry types */}
-                <EntryTypeTree
-                    types={entryTypes}
-                    selectedTypeId={selectedTypeId}
-                    loading={loadingTypes}
-                    error={typesError}
-                    onSelect={handleTypeSelect}
-                />
-
-                {/* Column 2: Entry codes */}
-                <EntryCodeList
-                    codes={availableCodes}
-                    selectedCodes={selectedCodes}
-                    loading={loadingCodes}
-                    error={codesError}
-                    onToggle={handleCodeToggle}
-                    onSelectAll={handleSelectAll}
-                    onDeselectAll={handleDeselectAll}
-                />
-
-                {/* Column 3: Search form */}
-                <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', overflow: 'hidden' }}>
-                    <div style={{ padding: '10px 14px', borderBottom: '1px solid #dee2e6', fontWeight: 600, fontSize: '0.95rem' }}>
-                        搜尋條件
-                    </div>
-                    <div style={{ padding: 14 }}>
-                        <form onSubmit={handleSearch}>
-                            {/* Selected codes */}
-                            <div style={{ marginBottom: 14 }}>
-                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>
-                                    已選擇的入仕代碼：
-                                </label>
-                                <SelectedCodeChips
-                                    selectedCodes={selectedCodes}
-                                    allCodes={allKnownCodes}
-                                    onRemove={handleRemoveCode}
-                                />
-                            </div>
-
-                            <hr style={{ border: 'none', borderTop: '1px solid #e9ecef', margin: '12px 0' }} />
-
-                            {/* Year range */}
-                            <div style={{ marginBottom: 14 }}>
-                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>年份範圍</label>
-                                <div style={{ display: 'flex', gap: 8 }}>
-                                    <input
-                                        type="number"
-                                        value={yearFrom}
-                                        onChange={(e) => setYearFrom(e.target.value)}
-                                        placeholder="起始年"
-                                        style={inputStyle}
-                                    />
-                                    <input
-                                        type="number"
-                                        value={yearTo}
-                                        onChange={(e) => setYearTo(e.target.value)}
-                                        placeholder="結束年"
-                                        style={inputStyle}
-                                    />
-                                </div>
-                                {errors.year_from && <div style={errorStyle}>{errors.year_from}</div>}
-                                {errors.year_to && <div style={errorStyle}>{errors.year_to}</div>}
-                                <div style={{ fontSize: '0.75rem', color: '#6c757d', marginTop: 2 }}>可留空表示不限制</div>
-                            </div>
-
-                            {/* Address ID */}
-                            <div style={{ marginBottom: 14 }}>
-                                <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 4 }}>入仕地址 ID</label>
-                                <input
-                                    type="number"
-                                    value={addrId}
-                                    onChange={(e) => setAddrId(e.target.value)}
-                                    placeholder="請輸入地址 ID"
-                                    style={inputStyle}
-                                />
-                                {errors.addr_id && <div style={errorStyle}>{errors.addr_id}</div>}
-                                <div style={{ fontSize: '0.75rem', color: '#6c757d', marginTop: 2 }}>可留空表示不限制</div>
-                            </div>
-
-                            <hr style={{ border: 'none', borderTop: '1px solid #e9ecef', margin: '12px 0' }} />
-
-                            {/* Actions */}
-                            <div style={{ display: 'flex', gap: 8 }}>
-                                <button
-                                    type="submit"
-                                    disabled={submitting}
-                                    style={{
-                                        flex: 1,
-                                        padding: '8px 16px',
-                                        backgroundColor: '#007bff',
-                                        color: '#fff',
-                                        border: 'none',
-                                        borderRadius: 4,
-                                        cursor: submitting ? 'wait' : 'pointer',
-                                        fontSize: '0.9rem',
-                                        opacity: submitting ? 0.7 : 1,
-                                    }}
-                                >
-                                    {submitting ? '搜尋中...' : '執行搜尋'}
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={handleReset}
-                                    style={{
-                                        padding: '8px 16px',
-                                        backgroundColor: '#6c757d',
-                                        color: '#fff',
-                                        border: 'none',
-                                        borderRadius: 4,
-                                        cursor: 'pointer',
-                                        fontSize: '0.9rem',
-                                    }}
-                                >
+                <div style={workspaceSummaryCardStyle}>
+                    <div style={{ display: 'grid', gap: 12 }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+                                <div style={{ fontWeight: 700, fontSize: '1rem' }}>目前篩選摘要</div>
+                                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                                    <button
+                                        type="button"
+                                        onClick={() => void runQuery({ records_page: 1, people_page: 1 })}
+                                        disabled={submitting}
+                                        style={toolbarPrimaryButtonStyle(submitting)}
+                                    >
+                                        {submitting ? '查詢中...' : '執行查詢'}
+                                    </button>
+                                <button type="button" onClick={handleReset} style={toolbarSecondaryButtonStyle}>
                                     重置
                                 </button>
                             </div>
-                        </form>
+                        </div>
+                        <div style={summaryGridStyle}>
+                            <FilterSummaryTile
+                                label="入仕類型與代碼"
+                                value={selectedTypeLabel || '不限'}
+                                detail={selectedCodePreview}
+                                onClick={() => setActiveDialog('entry')}
+                            />
+                            <FilterSummaryTile
+                                label="人物關鍵字"
+                                value={filters.person_keyword || '不限'}
+                                onClick={() => setActiveDialog('personKeyword')}
+                            />
+                            <FilterSummaryTile
+                                label="地點"
+                                value={selectedPlaces.length > 0 ? `${selectedPlaces.length} 項` : '不限'}
+                                detail={selectedPlacePreview}
+                                onClick={() => setActiveDialog('places')}
+                            />
+                            <FilterSummaryTile
+                                label="索引年"
+                                value={filters.use_index_year_range ? `${filters.index_year_from ?? '-200'} 至 ${filters.index_year_to ?? '1911'}` : '不限'}
+                                onClick={() => setActiveDialog('indexYear')}
+                            />
+                            <FilterSummaryTile
+                                label="入仕年"
+                                value={filters.use_entry_year_range ? `${filters.entry_year_from ?? '-200'} 至 ${filters.entry_year_to ?? '1911'}` : '不限'}
+                                onClick={() => setActiveDialog('entryYear')}
+                            />
+                            <FilterSummaryTile
+                                label="朝代"
+                                value={filters.dynasty_codes.length > 0 ? `${filters.dynasty_codes.length} 項` : '不限'}
+                                detail={selectedDynastyPreview}
+                                onClick={() => setActiveDialog('dynasty')}
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {(resultsError || errorMessages.length > 0) && (
+                    <div style={workspaceErrorStackStyle}>
+                        {resultsError && <div style={errorBoxStyle}>{resultsError}</div>}
+                        {errorMessages.map((message) => (
+                            <div key={message} style={errorBoxStyle}>{message}</div>
+                        ))}
+                    </div>
+                )}
+
+                <div ref={resultsSectionRef} style={resultsWorkspaceStyle}>
+                    <div style={{ ...panelHeaderStyle, display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8 }}>
+                        <span>查詢結果工作區</span>
+                        {results && (
+                            <span style={{ color: '#6c757d', fontSize: '0.82rem', fontWeight: 500 }}>
+                                記錄 {results.summary.record_count} 筆 / 人物 {results.summary.person_count} 位
+                            </span>
+                        )}
+                    </div>
+                    <div style={{ padding: 16, display: 'grid', gap: 14 }}>
+                        {!results && !resultsError && (
+                            <div style={{ color: '#6c757d', fontSize: '0.92rem' }}>
+                                先在上方設定條件；每一格都可以直接點開 modal 編輯，再執行查詢。
+                            </div>
+                        )}
+
+                        {results && (
+                            <>
+                                <div style={tabStripStyle}>
+                                    <button type="button" onClick={() => setActiveTab('records')} style={tabButtonStyle(activeTab === 'records')}>
+                                        入仕記錄
+                                    </button>
+                                    <button type="button" onClick={() => setActiveTab('people')} style={tabButtonStyle(activeTab === 'people')}>
+                                        人物摘要
+                                    </button>
+                                </div>
+
+                                <div style={resultsViewportStyle}>
+                                    {activeTab === 'records' ? (
+                                        <SearchResultTable
+                                            rows={results.records.data}
+                                            pagination={results.records}
+                                            onPageChange={(page) => void runQuery({ records_page: page, people_page: results.people.current_page }, false)}
+                                        />
+                                    ) : (
+                                        <EntryPeopleTable
+                                            rows={results.people.data}
+                                            pagination={results.people}
+                                            onPageChange={(page) => void runQuery({ records_page: results.records.current_page, people_page: page }, false)}
+                                        />
+                                    )}
+                                </div>
+                            </>
+                        )}
                     </div>
                 </div>
             </div>
 
-            {/* Condition summary & results */}
-            {hasResults && (
-                <div style={{ border: '1px solid #dee2e6', borderRadius: 4, backgroundColor: '#fff', padding: 16 }}>
-                    {/* Condition summary */}
-                    {hasFilters && (
-                        <div style={{ padding: '10px 14px', backgroundColor: '#d1ecf1', border: '1px solid #bee5eb', borderRadius: 4, marginBottom: 16, fontSize: '0.85rem' }}>
-                            <strong>搜尋條件：</strong>
-                            {filters.entry_codes.length > 0 && (
-                                <span style={{ marginLeft: 8 }}>
-                                    入仕代碼：
-                                    {filters.entry_codes.map((c) => (
-                                        <span key={c} style={{ display: 'inline-block', padding: '1px 6px', backgroundColor: '#007bff', color: '#fff', borderRadius: 10, fontSize: '0.75rem', marginLeft: 4 }}>
-                                            {c}
-                                        </span>
-                                    ))}
-                                </span>
-                            )}
-                            {filters.year_from != null && <span style={{ marginLeft: 8 }}>起始年：{filters.year_from}</span>}
-                            {filters.year_to != null && <span style={{ marginLeft: 8 }}>結束年：{filters.year_to}</span>}
-                            {filters.addr_id != null && <span style={{ marginLeft: 8 }}>地址 ID：{filters.addr_id}</span>}
-                        </div>
-                    )}
-
-                    <SearchResultTable
-                        rows={results.data}
-                        pagination={pagination}
-                        onPageChange={handlePageChange}
+            <SelectionDialog
+                isOpen={activeDialog === 'entry'}
+                title="選擇入仕類型與代碼"
+                description="先選類型，再勾選代碼；右側摘要會即時顯示目前已選內容。"
+                width={1240}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={handleClearType}
+                            disabled={!filters.type_id && filters.entry_codes.length === 0}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空選擇
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <div style={entrySelectionDialogGridStyle}>
+                    <EntryTypeTree
+                        types={entryTypes}
+                        selectedTypeId={filters.type_id}
+                        loading={false}
+                        error={null}
+                        onSelect={handleTypeSelect}
                     />
+                    <EntryCodeList
+                        codes={availableCodes}
+                        selectedCodes={filters.entry_codes}
+                        loading={loadingCodes}
+                        error={null}
+                        onToggle={handleCodeToggle}
+                        onSelectAll={handleSelectAllCodes}
+                        onDeselectAll={handleDeselectAllCodes}
+                    />
+                    <div style={entrySelectionSummaryPanelStyle}>
+                        <div style={panelHeaderStyle}>目前已選</div>
+                        <div style={{ padding: 16, display: 'grid', gap: 14 }}>
+                            <div>
+                                <div style={selectionCaptionStyle}>入仕類型</div>
+                                <div style={selectionValueStyle}>{selectedTypeLabel || '尚未選擇'}</div>
+                            </div>
+                            <div>
+                                <div style={selectionCaptionStyle}>入仕代碼</div>
+                                <SelectedCodeChips
+                                    selectedCodes={filters.entry_codes}
+                                    allCodes={allKnownCodes}
+                                    onRemove={handleRemoveCode}
+                                />
+                            </div>
+                            <div style={modalHintBoxStyle}>
+                                {loadingCodes
+                                    ? '正在載入該類型的代碼...'
+                                    : (filters.type_id
+                                        ? `目前已選 ${filters.entry_codes.length} 項代碼`
+                                        : '請先選擇入仕類型，再到中間勾選代碼。')}
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            )}
+            </SelectionDialog>
+
+            <SelectionDialog
+                isOpen={activeDialog === 'personKeyword'}
+                title="設定人物關鍵字"
+                description="會比對人物姓名與 ALTNAME_DATA 異名。"
+                width={560}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={() => updateFilter('person_keyword', '')}
+                            disabled={filters.person_keyword.trim() === ''}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空關鍵字
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <div style={{ display: 'grid', gap: 10 }}>
+                    <label style={labelStyle}>人物關鍵字</label>
+                    <input
+                        type="text"
+                        value={filters.person_keyword}
+                        onChange={(event) => updateFilter('person_keyword', event.target.value)}
+                        placeholder="姓名、別名或人物關鍵字"
+                        style={textInputStyle}
+                    />
+                    <div style={hintStyle}>留空表示不限。</div>
+                </div>
+            </SelectionDialog>
+
+            <SelectionDialog
+                isOpen={activeDialog === 'places'}
+                title="選擇入仕地點"
+                description="可多選地點，搜尋結果會比對 ENTRY_DATA.c_entry_addr_id。"
+                width={860}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={handleClearPlaces}
+                            disabled={selectedPlaces.length === 0}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空地點
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <PlaceMultiSelect
+                    query={placeQuery}
+                    selectedPlaces={selectedPlaces}
+                    searchResults={placeResults}
+                    loading={loadingPlaces}
+                    includeSubUnits={filters.include_sub_units}
+                    onQueryChange={setPlaceQuery}
+                    onAddPlace={handleAddPlace}
+                    onRemovePlace={handleRemovePlace}
+                    onClearPlaces={handleClearPlaces}
+                    onToggleIncludeSubUnits={(checked) => updateFilter('include_sub_units', checked)}
+                />
+            </SelectionDialog>
+
+            <SelectionDialog
+                isOpen={activeDialog === 'indexYear'}
+                title="設定索引年範圍"
+                width={620}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                updateFilter('use_index_year_range', false);
+                                updateFilter('index_year_from', null);
+                                updateFilter('index_year_to', null);
+                            }}
+                            disabled={!filters.use_index_year_range && filters.index_year_from === null && filters.index_year_to === null}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空索引年
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <div style={{ display: 'grid', gap: 14 }}>
+                    <label style={checkboxLabelStyle}>
+                        <input
+                            type="checkbox"
+                            checked={filters.use_index_year_range}
+                            onChange={(event) => updateFilter('use_index_year_range', event.target.checked)}
+                        />
+                        啟用索引年範圍
+                    </label>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                        <input
+                            type="number"
+                            value={filters.index_year_from ?? ''}
+                            onChange={(event) => updateFilter('index_year_from', normalizeNumberInput(event.target.value))}
+                            disabled={!filters.use_index_year_range}
+                            placeholder="-200"
+                            style={numberInputStyle}
+                        />
+                        <input
+                            type="number"
+                            value={filters.index_year_to ?? ''}
+                            onChange={(event) => updateFilter('index_year_to', normalizeNumberInput(event.target.value))}
+                            disabled={!filters.use_index_year_range}
+                            placeholder="1911"
+                            style={numberInputStyle}
+                        />
+                    </div>
+                </div>
+            </SelectionDialog>
+
+            <SelectionDialog
+                isOpen={activeDialog === 'entryYear'}
+                title="設定入仕年範圍"
+                width={620}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                updateFilter('use_entry_year_range', false);
+                                updateFilter('entry_year_from', null);
+                                updateFilter('entry_year_to', null);
+                            }}
+                            disabled={!filters.use_entry_year_range && filters.entry_year_from === null && filters.entry_year_to === null}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空入仕年
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <div style={{ display: 'grid', gap: 14 }}>
+                    <label style={checkboxLabelStyle}>
+                        <input
+                            type="checkbox"
+                            checked={filters.use_entry_year_range}
+                            onChange={(event) => updateFilter('use_entry_year_range', event.target.checked)}
+                        />
+                        啟用入仕年範圍
+                    </label>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                        <input
+                            type="number"
+                            value={filters.entry_year_from ?? ''}
+                            onChange={(event) => updateFilter('entry_year_from', normalizeNumberInput(event.target.value))}
+                            disabled={!filters.use_entry_year_range}
+                            placeholder="-200"
+                            style={numberInputStyle}
+                        />
+                        <input
+                            type="number"
+                            value={filters.entry_year_to ?? ''}
+                            onChange={(event) => updateFilter('entry_year_to', normalizeNumberInput(event.target.value))}
+                            disabled={!filters.use_entry_year_range}
+                            placeholder="1911"
+                            style={numberInputStyle}
+                        />
+                    </div>
+                </div>
+            </SelectionDialog>
+
+            <SelectionDialog
+                isOpen={activeDialog === 'dynasty'}
+                title="設定朝代範圍"
+                width={760}
+                onClose={() => setActiveDialog(null)}
+                footer={(
+                    <div style={dialogFooterStyle}>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                updateFilter('dynasty_codes', []);
+                            }}
+                            disabled={filters.dynasty_codes.length === 0}
+                            style={dialogSecondaryButtonStyle}
+                        >
+                            清空朝代
+                        </button>
+                        <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
+                            完成
+                        </button>
+                    </div>
+                )}
+            >
+                <div style={{ display: 'grid', gap: 14 }}>
+                    <div style={checkboxListStyle}>
+                        {dynasties.map((dynasty) => {
+                            const checked = filters.dynasty_codes.includes(dynasty.c_dy);
+
+                            return (
+                                <label key={dynasty.c_dy} style={checkboxListItemStyle}>
+                                    <input
+                                        type="checkbox"
+                                        checked={checked}
+                                        onChange={() => handleDynastyToggle(dynasty.c_dy)}
+                                    />
+                                    <span>{formatDynastyLabel(dynasty)}</span>
+                                </label>
+                            );
+                        })}
+                    </div>
+                </div>
+            </SelectionDialog>
         </AppShell>
     );
 }
 
-const inputStyle: React.CSSProperties = {
-    flex: 1,
+function FilterSummaryTile({
+    label,
+    value,
+    detail,
+    onClick,
+}: {
+    label: string;
+    value: string;
+    detail?: string;
+    onClick: () => void;
+}) {
+    return (
+        <button type="button" onClick={onClick} style={filterSummaryTileStyle}>
+            <div style={summaryLabelStyle}>{label}</div>
+            <div style={summaryValueStyle}>{value}</div>
+            {detail && <div style={filterSummaryDetailStyle}>{detail}</div>}
+        </button>
+    );
+}
+
+function SummaryItem({ label, value }: { label: string; value: string }) {
+    return (
+        <div style={summaryItemStyle}>
+            <div style={summaryLabelStyle}>{label}</div>
+            <div style={summaryValueStyle}>{value}</div>
+        </div>
+    );
+}
+
+function SelectorCard({
+    title,
+    summary,
+    actionLabel,
+    onOpen,
+    actionDisabled = false,
+    clearLabel,
+    onClear,
+    children,
+}: {
+    title: string;
+    summary: string;
+    actionLabel: string;
+    onOpen: () => void;
+    actionDisabled?: boolean;
+    clearLabel?: string;
+    onClear?: () => void;
+    children?: React.ReactNode;
+}) {
+    return (
+        <div style={panelStyle}>
+            <div style={selectorCardHeaderStyle}>
+                <div>
+                    <div style={{ fontWeight: 700, fontSize: '0.92rem' }}>{title}</div>
+                    <div style={{ marginTop: 4, color: '#6c757d', fontSize: '0.82rem' }}>{summary}</div>
+                </div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                    {onClear && clearLabel && (
+                        <button type="button" onClick={onClear} style={selectorSecondaryButtonStyle}>
+                            {clearLabel}
+                        </button>
+                    )}
+                    <button type="button" onClick={onOpen} disabled={actionDisabled} style={selectorPrimaryButtonStyle(actionDisabled)}>
+                        {actionLabel}
+                    </button>
+                </div>
+            </div>
+            {children && <div style={{ padding: 16 }}>{children}</div>}
+        </div>
+    );
+}
+
+function SelectedPlaceChips({
+    places,
+    onRemove,
+}: {
+    places: PlaceOption[];
+    onRemove: (placeId: number) => void;
+}) {
+    if (places.length === 0) {
+        return <span style={{ color: '#6c757d', fontSize: '0.85rem' }}>尚未選擇</span>;
+    }
+
+    return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {places.map((place) => (
+                <span key={place.c_addr_id} style={placeChipStyle}>
+                    {place.c_name_chn || place.c_name || `ADDR ${place.c_addr_id}`}
+                    <button
+                        type="button"
+                        onClick={() => onRemove(place.c_addr_id)}
+                        style={chipRemoveButtonStyle}
+                        aria-label={`移除地點 ${place.c_addr_id}`}
+                    >
+                        ×
+                    </button>
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function RailButton({
+    label,
+    onClick,
+    disabled = false,
+    primary = false,
+}: {
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+    primary?: boolean;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            style={railButtonStyle(disabled, primary)}
+        >
+            {label}
+        </button>
+    );
+}
+
+function buildRequestPayload(filters: FiltersState, selectedPlaces: PlaceOption[], overrides: { records_page?: number; people_page?: number }) {
+    const payload: Record<string, unknown> = {
+        records_page: overrides.records_page ?? 1,
+        people_page: overrides.people_page ?? 1,
+    };
+
+    if (filters.person_keyword.trim() !== '') {
+        payload.person_keyword = filters.person_keyword.trim();
+    }
+
+    if (filters.type_id) {
+        payload.type_id = filters.type_id;
+    }
+
+    if (filters.entry_codes.length > 0) {
+        payload.entry_codes = filters.entry_codes;
+    }
+
+    if (selectedPlaces.length > 0) {
+        payload.place_ids = selectedPlaces.map((place) => place.c_addr_id);
+        payload.include_sub_units = filters.include_sub_units;
+    }
+
+    if (filters.use_index_year_range) {
+        payload.use_index_year_range = true;
+        if (filters.index_year_from !== null) {
+            payload.index_year_from = filters.index_year_from;
+        }
+        if (filters.index_year_to !== null) {
+            payload.index_year_to = filters.index_year_to;
+        }
+    }
+
+    if (filters.use_entry_year_range) {
+        payload.use_entry_year_range = true;
+        if (filters.entry_year_from !== null) {
+            payload.entry_year_from = filters.entry_year_from;
+        }
+        if (filters.entry_year_to !== null) {
+            payload.entry_year_to = filters.entry_year_to;
+        }
+    }
+
+    if (filters.dynasty_codes.length > 0) {
+        payload.dynasty_codes = filters.dynasty_codes;
+    }
+
+    return payload;
+}
+
+function buildQueryString(payload: Record<string, unknown>) {
+    const params = new URLSearchParams();
+
+    Object.entries(payload).forEach(([key, value]) => {
+        if (value === null || value === undefined || value === '' || value === false) {
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => params.append(`${key}[]`, String(item)));
+            return;
+        }
+
+        params.set(key, String(value));
+    });
+
+    return params.toString();
+}
+
+function normalizeNumberInput(value: string): number | null {
+    if (value.trim() === '') {
+        return null;
+    }
+
+    const parsed = Number(value);
+
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+function hasAnyCondition(filters: FiltersState) {
+    return filters.person_keyword.trim() !== ''
+        || filters.entry_codes.length > 0
+        || filters.place_ids.length > 0
+        || filters.use_index_year_range
+        || filters.use_entry_year_range
+        || filters.dynasty_codes.length > 0;
+}
+
+function formatDynastyLabel(dynasty: DynastyOption) {
+    const label = dynasty.c_dynasty_chn || dynasty.c_dynasty || dynasty.c_dy;
+    const start = dynasty.c_start ?? '?';
+    const end = dynasty.c_end ?? '?';
+
+    return `${label} (${start} - ${end})`;
+}
+
+function findSelectedTypeLabel(types: EntryType[], typeId: string | null) {
+    if (!typeId) {
+        return null;
+    }
+
+    const matched = types.find((type) => type.c_entry_type === typeId);
+
+    return matched ? (matched.c_entry_type_desc_chn || matched.c_entry_type_desc || matched.c_entry_type) : typeId;
+}
+
+function collectErrorMessages(errors: Record<string, string[]>) {
+    const messages = new Set<string>();
+
+    Object.values(errors).forEach((items) => {
+        items.forEach((message) => {
+            if (message.trim() !== '') {
+                messages.add(message);
+            }
+        });
+    });
+
+    return Array.from(messages);
+}
+
+function formatCodePreview(selectedCodes: number[], allCodes: EntryCode[]) {
+    if (selectedCodes.length === 0) {
+        return '點擊後開啟入仕方式選擇';
+    }
+
+    const codeMap = new Map(allCodes.map((code) => [code.c_entry_code, code]));
+    const preview = selectedCodes.slice(0, 3).map((code) => {
+        const matched = codeMap.get(code);
+        return matched ? (matched.c_entry_desc_chn || matched.c_entry_desc || String(code)) : String(code);
+    });
+
+    return selectedCodes.length > 3
+        ? `${preview.join('、')} 等 ${selectedCodes.length} 項`
+        : preview.join('、');
+}
+
+function formatPlacePreview(places: PlaceOption[], includeSubUnits: boolean) {
+    if (places.length === 0) {
+        return includeSubUnits ? '包含下屬地點' : '點擊後開啟地點選擇';
+    }
+
+    const preview = places.slice(0, 3).map((place) => place.c_name_chn || place.c_name || `ADDR ${place.c_addr_id}`);
+    const label = places.length > 3 ? `${preview.join('、')} 等 ${places.length} 項` : preview.join('、');
+
+    return includeSubUnits ? `${label}；含下屬地點` : label;
+}
+
+function formatDynastyPreview(selectedDynastyCodes: string[], dynasties: DynastyOption[]) {
+    if (selectedDynastyCodes.length === 0) {
+        return '點擊後開啟朝代多選';
+    }
+
+    const dynastyMap = new Map(dynasties.map((dynasty) => [dynasty.c_dy, dynasty]));
+    const preview = selectedDynastyCodes.slice(0, 3).map((code) => {
+        const matched = dynastyMap.get(code);
+        return matched ? (matched.c_dynasty_chn || matched.c_dynasty || matched.c_dy) : code;
+    });
+
+    return selectedDynastyCodes.length > 3
+        ? `${preview.join('、')} 等 ${selectedDynastyCodes.length} 項`
+        : preview.join('、');
+}
+
+const pageGridStyle = (isSidebarOpen: boolean, isCompactLayout: boolean): React.CSSProperties => ({
+    display: 'grid',
+    gridTemplateColumns: isCompactLayout ? 'minmax(0, 1fr)' : (isSidebarOpen ? '340px minmax(0, 1fr)' : '88px minmax(0, 1fr)'),
+    gap: 18,
+    alignItems: 'start',
+});
+
+const sidebarContainerStyle = (isCompactLayout: boolean): React.CSSProperties => ({
+    position: isCompactLayout ? 'static' : 'sticky',
+    top: isCompactLayout ? undefined : 12,
+    alignSelf: 'start',
+});
+
+const sidebarCardStyle = (isCompactLayout: boolean, isSidebarOpen: boolean): React.CSSProperties => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+    minHeight: isCompactLayout ? 'auto' : (isSidebarOpen ? 'calc(100vh - 120px)' : 'auto'),
+    border: '1px solid #d7dee6',
+    borderRadius: 4,
+    backgroundColor: '#f8fafc',
+    boxShadow: '0 12px 36px rgba(15, 23, 42, 0.08)',
+    overflow: 'hidden',
+});
+
+const sidebarHeaderStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: '16px 18px',
+    borderBottom: '1px solid #dee2e6',
+    backgroundColor: '#fff',
+};
+
+const sidebarBodyStyle: React.CSSProperties = {
+    display: 'grid',
+    gap: 14,
+    padding: 14,
+};
+
+const sidebarRailStyle: React.CSSProperties = {
+    display: 'grid',
+    gap: 10,
+    padding: 12,
+};
+
+const collapseButtonStyle: React.CSSProperties = {
+    padding: '7px 12px',
+    borderRadius: 4,
+    border: '1px solid #d0d8e2',
+    backgroundColor: '#fff',
+    color: '#334155',
+    cursor: 'pointer',
+    fontSize: '0.82rem',
+    fontWeight: 600,
+};
+
+const expandRailButtonStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '8px 10px',
+    borderRadius: 4,
+    border: '1px solid #d0d8e2',
+    backgroundColor: '#fff',
+    color: '#334155',
+    cursor: 'pointer',
+    fontSize: '0.82rem',
+    fontWeight: 700,
+};
+
+const panelStyle: React.CSSProperties = {
+    border: '1px solid #dee2e6',
+    borderRadius: 4,
+    backgroundColor: '#fff',
+    overflow: 'hidden',
+};
+
+const selectorCardHeaderStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 10,
+    padding: '14px 16px',
+    borderBottom: '1px solid #eef2f6',
+};
+
+function selectorPrimaryButtonStyle(disabled: boolean): React.CSSProperties {
+    return {
+        padding: '6px 12px',
+        borderRadius: 4,
+        border: 'none',
+        backgroundColor: disabled ? '#cbd5e1' : '#0d6efd',
+        color: '#fff',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        fontSize: '0.82rem',
+        fontWeight: 700,
+    };
+}
+
+const selectorSecondaryButtonStyle: React.CSSProperties = {
     padding: '6px 10px',
+    borderRadius: 4,
+    border: '1px solid #cbd5e1',
+    backgroundColor: '#fff',
+    color: '#475569',
+    cursor: 'pointer',
+    fontSize: '0.82rem',
+    fontWeight: 600,
+};
+
+const selectionCaptionStyle: React.CSSProperties = {
+    marginBottom: 6,
+    fontSize: '0.74rem',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+    letterSpacing: '0.02em',
+};
+
+const selectionValueStyle: React.CSSProperties = {
+    fontSize: '0.92rem',
+    color: '#0f172a',
+    fontWeight: 600,
+};
+
+function railButtonStyle(disabled: boolean, primary: boolean): React.CSSProperties {
+    return {
+        width: '100%',
+        minHeight: 48,
+        padding: '10px 8px',
+        borderRadius: 4,
+        border: primary ? 'none' : '1px solid #d0d8e2',
+        backgroundColor: primary ? '#0d6efd' : '#fff',
+        color: primary ? '#fff' : '#334155',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.55 : 1,
+        fontSize: '0.82rem',
+        fontWeight: 700,
+    };
+}
+
+const workspaceStyle: React.CSSProperties = {
+    display: 'grid',
+    gap: 16,
+    minWidth: 0,
+};
+
+const workspaceErrorStackStyle: React.CSSProperties = {
+    display: 'grid',
+    gap: 10,
+};
+
+const workspaceSummaryCardStyle: React.CSSProperties = {
+    border: '1px solid #d8e0e8',
+    borderRadius: 4,
+    backgroundColor: '#fff',
+    padding: 16,
+    boxShadow: '0 10px 28px rgba(15, 23, 42, 0.05)',
+};
+
+const summaryGridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+    gap: 10,
+};
+
+const summaryItemStyle: React.CSSProperties = {
+    padding: '10px 12px',
+    borderRadius: 4,
+    backgroundColor: '#f8fafc',
+    border: '1px solid #e4ebf2',
+};
+
+const filterSummaryTileStyle: React.CSSProperties = {
+    ...summaryItemStyle,
+    width: '100%',
+    textAlign: 'left',
+    cursor: 'pointer',
+};
+
+const summaryLabelStyle: React.CSSProperties = {
+    fontSize: '0.72rem',
+    letterSpacing: '0.02em',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+};
+
+const summaryValueStyle: React.CSSProperties = {
+    marginTop: 4,
+    fontSize: '0.92rem',
+    color: '#111827',
+    fontWeight: 600,
+};
+
+const filterSummaryDetailStyle: React.CSSProperties = {
+    marginTop: 6,
+    fontSize: '0.78rem',
+    color: '#6b7280',
+    lineHeight: 1.4,
+};
+
+const summaryActionButtonStyle: React.CSSProperties = {
+    padding: '7px 12px',
+    borderRadius: 4,
+    border: '1px solid #cfd6de',
+    backgroundColor: '#f8fafc',
+    color: '#334155',
+    cursor: 'pointer',
+    fontSize: '0.83rem',
+    fontWeight: 600,
+};
+
+const resultsWorkspaceStyle: React.CSSProperties = {
+    ...panelStyle,
+    minHeight: '76vh',
+    scrollMarginTop: '24px',
+};
+
+const resultsViewportStyle: React.CSSProperties = {
+    minHeight: '56vh',
+    maxHeight: '72vh',
+    overflow: 'auto',
+    border: '1px solid #e3e8ee',
+    borderRadius: 4,
+    backgroundColor: '#fff',
+};
+
+const panelHeaderStyle: React.CSSProperties = {
+    padding: '12px 16px',
+    borderBottom: '1px solid #dee2e6',
+    fontWeight: 700,
+    fontSize: '0.96rem',
+};
+
+const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontWeight: 500,
+    fontSize: '0.85rem',
+    marginBottom: 6,
+};
+
+const checkboxLabelStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    fontWeight: 500,
+    fontSize: '0.85rem',
+};
+
+const checkboxListStyle: React.CSSProperties = {
+    display: 'grid',
+    gap: 8,
+    maxHeight: 320,
+    overflowY: 'auto',
+    paddingRight: 4,
+};
+
+const checkboxListItemStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: 8,
+    padding: '8px 10px',
+    border: '1px solid #dbe2ea',
+    borderRadius: 4,
+    backgroundColor: '#fff',
+    fontSize: '0.85rem',
+    cursor: 'pointer',
+};
+
+const hintStyle: React.CSSProperties = {
+    fontSize: '0.75rem',
+    color: '#6c757d',
+    marginTop: 4,
+};
+
+const dividerStyle: React.CSSProperties = {
+    border: 'none',
+    borderTop: '1px solid #e9ecef',
+    margin: '14px 0',
+};
+
+const textInputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '7px 10px',
     border: '1px solid #ced4da',
     borderRadius: 4,
     fontSize: '0.875rem',
 };
 
-const errorStyle: React.CSSProperties = {
-    color: '#dc3545',
-    fontSize: '0.8rem',
-    marginTop: 2,
+const numberInputStyle: React.CSSProperties = {
+    flex: 1,
+    padding: '7px 10px',
+    border: '1px solid #ced4da',
+    borderRadius: 4,
+    fontSize: '0.875rem',
+};
+
+const selectStyle: React.CSSProperties = {
+    flex: 1,
+    padding: '7px 10px',
+    border: '1px solid #ced4da',
+    borderRadius: 4,
+    fontSize: '0.875rem',
+    backgroundColor: '#fff',
+};
+
+function primaryButtonStyle(disabled: boolean): React.CSSProperties {
+    return {
+        flex: 1,
+        padding: '9px 14px',
+        backgroundColor: '#0d6efd',
+        color: '#fff',
+        border: 'none',
+        borderRadius: 4,
+        cursor: disabled ? 'wait' : 'pointer',
+        opacity: disabled ? 0.75 : 1,
+        fontSize: '0.9rem',
+        fontWeight: 600,
+    };
+}
+
+function toolbarPrimaryButtonStyle(disabled: boolean): React.CSSProperties {
+    return {
+        ...primaryButtonStyle(disabled),
+        flex: 'none',
+    };
+}
+
+const secondaryButtonStyle: React.CSSProperties = {
+    padding: '9px 14px',
+    backgroundColor: '#6c757d',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+    fontWeight: 600,
+};
+
+const toolbarSecondaryButtonStyle: React.CSSProperties = {
+    ...secondaryButtonStyle,
+    flex: 'none',
+};
+
+const errorBoxStyle: React.CSSProperties = {
+    padding: '10px 12px',
+    borderRadius: 4,
+    backgroundColor: '#f8d7da',
+    color: '#842029',
+    fontSize: '0.85rem',
+};
+
+function tabButtonStyle(active: boolean): React.CSSProperties {
+    return {
+        padding: '9px 16px',
+        borderRadius: '4px 4px 0 0',
+        border: '1px solid #cfd8e3',
+        borderBottomColor: active ? '#fff' : '#cfd8e3',
+        backgroundColor: active ? '#fff' : '#eef3f8',
+        color: active ? '#0f172a' : '#526071',
+        cursor: 'pointer',
+        fontSize: '0.85rem',
+        fontWeight: 600,
+        marginBottom: -1,
+    };
+}
+
+const tabStripStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: 6,
+    alignItems: 'flex-end',
+    borderBottom: '1px solid #cfd8e3',
+    paddingBottom: 0,
+};
+
+const placeChipStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '4px 9px',
+    backgroundColor: '#198754',
+    color: '#fff',
+    borderRadius: 4,
+    fontSize: '0.75rem',
+};
+
+const chipRemoveButtonStyle: React.CSSProperties = {
+    marginLeft: 4,
+    background: 'none',
+    border: 'none',
+    color: '#fff',
+    cursor: 'pointer',
+    padding: '0 2px',
+    fontSize: '0.85rem',
+    lineHeight: 1,
+};
+
+const dialogFooterStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 8,
+    width: '100%',
+};
+
+const dialogPrimaryButtonStyle: React.CSSProperties = {
+    padding: '8px 14px',
+    borderRadius: 4,
+    border: 'none',
+    backgroundColor: '#0d6efd',
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: '0.85rem',
+    fontWeight: 700,
+};
+
+const dialogSecondaryButtonStyle: React.CSSProperties = {
+    padding: '8px 14px',
+    borderRadius: 4,
+    border: '1px solid #cbd5e1',
+    backgroundColor: '#fff',
+    color: '#475569',
+    cursor: 'pointer',
+    fontSize: '0.85rem',
+    fontWeight: 600,
+};
+
+const entrySelectionDialogGridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+    gap: 16,
+    alignItems: 'start',
+};
+
+const entrySelectionSummaryPanelStyle: React.CSSProperties = {
+    ...panelStyle,
+    minHeight: 402,
+};
+
+const modalHintBoxStyle: React.CSSProperties = {
+    padding: '12px 14px',
+    borderRadius: 0,
+    backgroundColor: '#eff6ff',
+    border: '1px solid #dbeafe',
+    color: '#1d4ed8',
+    fontSize: '0.85rem',
+    lineHeight: 1.5,
 };

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -994,6 +994,11 @@ function buildQueryString(payload: Record<string, unknown>) {
             return;
         }
 
+        if (typeof value === 'boolean') {
+            params.set(key, value ? '1' : '0');
+            return;
+        }
+
         params.set(key, String(value));
     });
 

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -385,6 +385,7 @@ export default function Index() {
 
     const selectedTypeLabel = findSelectedTypeLabel(entryTypes, filters.type_id);
     const errorMessages = collectErrorMessages(queryErrors);
+    const displayErrorMessages = errorMessages.filter((message) => message !== resultsError);
     const selectedCodePreview = formatCodePreview(filters.entry_codes, allKnownCodes);
     const selectedPlacePreview = formatPlacePreview(selectedPlaces, filters.include_sub_units);
     const selectedDynastyPreview = formatDynastyPreview(filters.dynasty_codes, dynasties);
@@ -433,7 +434,7 @@ export default function Index() {
                                 onClick={() => setActiveDialog('places')}
                             />
                             <FilterSummaryTile
-                                label="索引年"
+                                label="指數年"
                                 value={filters.use_index_year_range ? `${filters.index_year_from ?? '-200'} 至 ${filters.index_year_to ?? '1911'}` : '不限'}
                                 onClick={() => setActiveDialog('indexYear')}
                             />
@@ -455,7 +456,7 @@ export default function Index() {
                 {(resultsError || errorMessages.length > 0) && (
                     <div style={workspaceErrorStackStyle}>
                         {resultsError && <div style={errorBoxStyle}>{resultsError}</div>}
-                        {errorMessages.map((message) => (
+                        {displayErrorMessages.map((message) => (
                             <div key={message} style={errorBoxStyle}>{message}</div>
                         ))}
                     </div>
@@ -648,7 +649,7 @@ export default function Index() {
 
             <SelectionDialog
                 isOpen={activeDialog === 'indexYear'}
-                title="設定索引年範圍"
+                title="設定指數年範圍"
                 width={620}
                 onClose={() => setActiveDialog(null)}
                 footer={(
@@ -663,7 +664,7 @@ export default function Index() {
                             disabled={!filters.use_index_year_range && filters.index_year_from === null && filters.index_year_to === null}
                             style={dialogSecondaryButtonStyle}
                         >
-                            清空索引年
+                            清空指數年
                         </button>
                         <button type="button" onClick={() => setActiveDialog(null)} style={dialogPrimaryButtonStyle}>
                             完成
@@ -678,7 +679,7 @@ export default function Index() {
                             checked={filters.use_index_year_range}
                             onChange={(event) => updateFilter('use_index_year_range', event.target.checked)}
                         />
-                        啟用索引年範圍
+                        啟用指數年範圍
                     </label>
                     <div style={{ display: 'flex', gap: 8 }}>
                         <input
@@ -1264,8 +1265,10 @@ const summaryItemStyle: React.CSSProperties = {
 const filterSummaryTileStyle: React.CSSProperties = {
     ...summaryItemStyle,
     width: '100%',
+    minWidth: 0,
     textAlign: 'left',
     cursor: 'pointer',
+    whiteSpace: 'normal',
 };
 
 const summaryLabelStyle: React.CSSProperties = {
@@ -1280,6 +1283,7 @@ const summaryValueStyle: React.CSSProperties = {
     fontSize: '0.92rem',
     color: '#111827',
     fontWeight: 600,
+    overflowWrap: 'anywhere',
 };
 
 const filterSummaryDetailStyle: React.CSSProperties = {
@@ -1287,6 +1291,7 @@ const filterSummaryDetailStyle: React.CSSProperties = {
     fontSize: '0.78rem',
     color: '#6b7280',
     lineHeight: 1.4,
+    overflowWrap: 'anywhere',
 };
 
 const summaryActionButtonStyle: React.CSSProperties = {
@@ -1339,6 +1344,7 @@ const checkboxLabelStyle: React.CSSProperties = {
 
 const checkboxListStyle: React.CSSProperties = {
     display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
     gap: 8,
     maxHeight: 320,
     overflowY: 'auto',

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -1377,6 +1377,8 @@ const dividerStyle: React.CSSProperties = {
 
 const textInputStyle: React.CSSProperties = {
     width: '100%',
+    maxWidth: '100%',
+    boxSizing: 'border-box',
     padding: '7px 10px',
     border: '1px solid #ced4da',
     borderRadius: 4,

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -1234,6 +1234,7 @@ const workspaceStyle: React.CSSProperties = {
     display: 'grid',
     gap: 16,
     minWidth: 0,
+    padding: '16px 20px 24px',
 };
 
 const workspaceErrorStackStyle: React.CSSProperties = {
@@ -1272,6 +1273,10 @@ const filterSummaryTileStyle: React.CSSProperties = {
 };
 
 const summaryLabelStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'flex-start',
+    minHeight: '2.2em',
+    lineHeight: 1.2,
     fontSize: '0.72rem',
     letterSpacing: '0.02em',
     color: '#6b7280',

--- a/resources/js/inertia/Pages/SearchByEntry/Index.tsx
+++ b/resources/js/inertia/Pages/SearchByEntry/Index.tsx
@@ -420,6 +420,7 @@ export default function Index() {
                                 label="入仕類型與代碼"
                                 value={selectedTypeLabel || '不限'}
                                 detail={selectedCodePreview}
+                                size="large"
                                 onClick={() => setActiveDialog('entry')}
                             />
                             <FilterSummaryTile
@@ -431,6 +432,7 @@ export default function Index() {
                                 label="地點"
                                 value={selectedPlaces.length > 0 ? `${selectedPlaces.length} 項` : '不限'}
                                 detail={selectedPlacePreview}
+                                size="large"
                                 onClick={() => setActiveDialog('places')}
                             />
                             <FilterSummaryTile
@@ -807,18 +809,20 @@ function FilterSummaryTile({
     label,
     value,
     detail,
+    size = 'normal',
     onClick,
 }: {
     label: string;
     value: string;
     detail?: string;
+    size?: 'normal' | 'large';
     onClick: () => void;
 }) {
     return (
-        <button type="button" onClick={onClick} style={filterSummaryTileStyle}>
+        <button type="button" onClick={onClick} style={filterSummaryTileStyle(size)}>
             <div style={summaryLabelStyle}>{label}</div>
             <div style={summaryValueStyle}>{value}</div>
-            {detail && <div style={filterSummaryDetailStyle}>{detail}</div>}
+            <div style={filterSummaryDetailStyle}>{detail || '\u00A0'}</div>
         </button>
     );
 }
@@ -1252,7 +1256,7 @@ const workspaceSummaryCardStyle: React.CSSProperties = {
 
 const summaryGridStyle: React.CSSProperties = {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
     gap: 10,
 };
 
@@ -1263,19 +1267,25 @@ const summaryItemStyle: React.CSSProperties = {
     border: '1px solid #e4ebf2',
 };
 
-const filterSummaryTileStyle: React.CSSProperties = {
-    ...summaryItemStyle,
-    width: '100%',
-    minWidth: 0,
-    textAlign: 'left',
-    cursor: 'pointer',
-    whiteSpace: 'normal',
-};
+function filterSummaryTileStyle(size: 'normal' | 'large'): React.CSSProperties {
+    return {
+        ...summaryItemStyle,
+        width: '100%',
+        minWidth: 0,
+        textAlign: 'left',
+        cursor: 'pointer',
+        whiteSpace: 'normal',
+        display: 'grid',
+        gridTemplateRows: '2.3em 2.4em minmax(2.8em, auto)',
+        alignContent: 'start',
+        gridColumn: size === 'large' ? 'span 2' : 'span 1',
+    };
+}
 
 const summaryLabelStyle: React.CSSProperties = {
     display: 'flex',
     alignItems: 'flex-start',
-    minHeight: '2.2em',
+    minHeight: '2.3em',
     lineHeight: 1.2,
     fontSize: '0.72rem',
     letterSpacing: '0.02em',
@@ -1289,6 +1299,7 @@ const summaryValueStyle: React.CSSProperties = {
     color: '#111827',
     fontWeight: 600,
     overflowWrap: 'anywhere',
+    alignSelf: 'start',
 };
 
 const filterSummaryDetailStyle: React.CSSProperties = {
@@ -1297,6 +1308,8 @@ const filterSummaryDetailStyle: React.CSSProperties = {
     color: '#6b7280',
     lineHeight: 1.4,
     overflowWrap: 'anywhere',
+    minHeight: '2.8em',
+    alignSelf: 'start',
 };
 
 const summaryActionButtonStyle: React.CSSProperties = {

--- a/resources/js/inertia/components/EntryCodeList.tsx
+++ b/resources/js/inertia/components/EntryCodeList.tsx
@@ -30,7 +30,7 @@ export default function EntryCodeList({ codes, selectedCodes, loading, error, on
                         disabled={codes.length === 0}
                         style={{
                             padding: '2px 10px', marginRight: 4, fontSize: '0.8rem', cursor: 'pointer',
-                            border: '1px solid #007bff', borderRadius: 3, backgroundColor: 'transparent', color: '#007bff',
+                            border: '1px solid #007bff', borderRadius: 4, backgroundColor: 'transparent', color: '#007bff',
                         }}
                     >
                         全選
@@ -41,7 +41,7 @@ export default function EntryCodeList({ codes, selectedCodes, loading, error, on
                         disabled={codes.length === 0}
                         style={{
                             padding: '2px 10px', fontSize: '0.8rem', cursor: 'pointer',
-                            border: '1px solid #6c757d', borderRadius: 3, backgroundColor: 'transparent', color: '#6c757d',
+                            border: '1px solid #6c757d', borderRadius: 4, backgroundColor: 'transparent', color: '#6c757d',
                         }}
                     >
                         取消全選

--- a/resources/js/inertia/components/EntryPeopleTable.tsx
+++ b/resources/js/inertia/components/EntryPeopleTable.tsx
@@ -46,7 +46,7 @@ export default function EntryPeopleTable({ rows, pagination, onPageChange }: Pro
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
                     <thead>
                         <tr style={{ backgroundColor: '#f8f9fa' }}>
-                            {['人物 ID', '姓名', '朝代', '索引年', '索引年類型', '性別', '索引地址', '入仕地址', '入仕筆數', '操作'].map((heading) => (
+                            {['人物 ID', '姓名', '朝代', '指數年', '指數年類型', '性別', '索引地址', '入仕地址', '入仕筆數', '操作'].map((heading) => (
                                 <th key={heading} style={headerCellStyle}>{heading}</th>
                             ))}
                         </tr>

--- a/resources/js/inertia/components/EntryPeopleTable.tsx
+++ b/resources/js/inertia/components/EntryPeopleTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PaginationControls, { PaginationData } from './PaginationControls';
 
-export interface ResultRow {
+export interface EntryPersonRow {
     c_personid: number;
     c_name_chn: string | null;
     c_name: string | null;
@@ -13,36 +13,24 @@ export interface ResultRow {
     c_index_addr_name: string | null;
     c_index_addr_chn: string | null;
     c_index_year_type_label: string | null;
-    c_entry_code: number;
-    c_entry_desc_chn: string | null;
-    c_entry_desc: string | null;
-    c_year: number | null;
-    c_sequence: number | null;
     c_entry_addr_id: number | null;
     c_entry_addr_name: string | null;
     c_entry_addr_chn: string | null;
-    c_entry_nianhao_label: string | null;
-    c_entry_nh_year: number | null;
-    c_entry_range_label: string | null;
-    c_exam_rank: string | null;
-    c_parental_status_label: string | null;
-    c_source_label: string | null;
-    c_notes: string | null;
-    c_posting_notes: string | null;
     c_sex_label: string | null;
+    entry_count: number;
 }
 
 interface Props {
-    rows: ResultRow[];
-    pagination: PaginationData<ResultRow>;
+    rows: EntryPersonRow[];
+    pagination: PaginationData<EntryPersonRow>;
     onPageChange: (page: number) => void;
 }
 
-export default function SearchResultTable({ rows, pagination, onPageChange }: Props) {
+export default function EntryPeopleTable({ rows, pagination, onPageChange }: Props) {
     if (rows.length === 0) {
         return (
             <div style={{ padding: 24, textAlign: 'center', color: '#6c757d' }}>
-                無符合條件的入仕記錄
+                無符合條件的人物摘要
             </div>
         );
     }
@@ -50,7 +38,7 @@ export default function SearchResultTable({ rows, pagination, onPageChange }: Pr
     return (
         <div>
             <div style={{ marginBottom: 12, color: '#6c757d', fontSize: '0.875rem' }}>
-                共找到 <strong>{pagination.total}</strong> 筆入仕記錄
+                共找到 <strong>{pagination.total}</strong> 位人物
                 （顯示第 {pagination.from ?? 0} - {pagination.to ?? 0} 筆）
             </div>
 
@@ -58,14 +46,14 @@ export default function SearchResultTable({ rows, pagination, onPageChange }: Pr
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
                     <thead>
                         <tr style={{ backgroundColor: '#f8f9fa' }}>
-                            {['人物 ID', '姓名', '朝代', '索引年', '索引年類型', '性別', '索引地址', '入仕地址', '入仕代碼', '入仕方式', '入仕年', '年號', '範圍', '考試等第', '父母狀態', '來源', '備註', '任官備註', '操作'].map((heading) => (
+                            {['人物 ID', '姓名', '朝代', '索引年', '索引年類型', '性別', '索引地址', '入仕地址', '入仕筆數', '操作'].map((heading) => (
                                 <th key={heading} style={headerCellStyle}>{heading}</th>
                             ))}
                         </tr>
                     </thead>
                     <tbody>
-                        {rows.map((row, index) => (
-                            <tr key={`${row.c_personid}-${row.c_entry_code}-${row.c_sequence}-${index}`} style={{ borderBottom: '1px solid #dee2e6' }}>
+                        {rows.map((row) => (
+                            <tr key={row.c_personid} style={{ borderBottom: '1px solid #dee2e6' }}>
                                 <td style={cellStyle}>{row.c_personid}</td>
                                 <td style={cellStyle}>
                                     <div>{row.c_name_chn || '—'}</div>
@@ -77,18 +65,7 @@ export default function SearchResultTable({ rows, pagination, onPageChange }: Pr
                                 <td style={cellStyle}>{row.c_sex_label ?? '—'}</td>
                                 <td style={cellStyle}>{row.c_index_addr_chn ?? row.c_index_addr_name ?? '—'}</td>
                                 <td style={cellStyle}>{row.c_entry_addr_chn ?? row.c_entry_addr_name ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_entry_code}</td>
-                                <td style={cellStyle}>{row.c_entry_desc_chn ?? row.c_entry_desc ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_year ?? '—'}</td>
-                                <td style={cellStyle}>
-                                    {row.c_entry_nianhao_label ? `${row.c_entry_nianhao_label}${row.c_entry_nh_year ? ` ${row.c_entry_nh_year}年` : ''}` : '—'}
-                                </td>
-                                <td style={cellStyle}>{row.c_entry_range_label ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_exam_rank ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_parental_status_label ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_source_label ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_notes ?? '—'}</td>
-                                <td style={cellStyle}>{row.c_posting_notes ?? '—'}</td>
+                                <td style={cellStyle}>{row.entry_count}</td>
                                 <td style={cellStyle}>
                                     <a
                                         href={`/basicinformation/${row.c_personid}`}

--- a/resources/js/inertia/components/PaginationControls.tsx
+++ b/resources/js/inertia/components/PaginationControls.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+export interface PaginationData<T> {
+    data: T[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+interface Props {
+    pagination: PaginationData<unknown>;
+    onPageChange: (page: number) => void;
+}
+
+export default function PaginationControls({ pagination, onPageChange }: Props) {
+    if (pagination.last_page <= 1) {
+        return null;
+    }
+
+    return (
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 4, marginTop: 16, flexWrap: 'wrap' }}>
+            <button
+                disabled={pagination.current_page <= 1}
+                onClick={() => onPageChange(pagination.current_page - 1)}
+                style={paginationBtnStyle(pagination.current_page <= 1)}
+            >
+                ‹ 上一頁
+            </button>
+            {getPageNumbers(pagination.current_page, pagination.last_page).map((page, index) =>
+                page === null ? (
+                    <span key={`ellipsis-${index}`} style={{ padding: '4px 6px', color: '#6c757d' }}>…</span>
+                ) : (
+                    <button
+                        key={page}
+                        onClick={() => onPageChange(page)}
+                        style={{
+                            ...paginationBtnStyle(false),
+                            backgroundColor: page === pagination.current_page ? '#007bff' : 'transparent',
+                            color: page === pagination.current_page ? '#fff' : '#007bff',
+                        }}
+                    >
+                        {page}
+                    </button>
+                )
+            )}
+            <button
+                disabled={pagination.current_page >= pagination.last_page}
+                onClick={() => onPageChange(pagination.current_page + 1)}
+                style={paginationBtnStyle(pagination.current_page >= pagination.last_page)}
+            >
+                下一頁 ›
+            </button>
+        </div>
+    );
+}
+
+function paginationBtnStyle(disabled: boolean): React.CSSProperties {
+    return {
+        padding: '4px 10px',
+        border: '1px solid #dee2e6',
+        borderRadius: 3,
+        backgroundColor: 'transparent',
+        color: disabled ? '#adb5bd' : '#007bff',
+        cursor: disabled ? 'default' : 'pointer',
+        fontSize: '0.85rem',
+    };
+}
+
+function getPageNumbers(current: number, last: number): (number | null)[] {
+    if (last <= 7) {
+        return Array.from({ length: last }, (_, index) => index + 1);
+    }
+
+    const pages: (number | null)[] = [1];
+
+    if (current > 3) {
+        pages.push(null);
+    }
+
+    for (let page = Math.max(2, current - 1); page <= Math.min(last - 1, current + 1); page += 1) {
+        pages.push(page);
+    }
+
+    if (current < last - 2) {
+        pages.push(null);
+    }
+
+    pages.push(last);
+
+    return pages;
+}

--- a/resources/js/inertia/components/PlaceMultiSelect.tsx
+++ b/resources/js/inertia/components/PlaceMultiSelect.tsx
@@ -103,6 +103,8 @@ export default function PlaceMultiSelect({
 
 const inputStyle: React.CSSProperties = {
     width: '100%',
+    maxWidth: '100%',
+    boxSizing: 'border-box',
     padding: '6px 10px',
     border: '1px solid #ced4da',
     borderRadius: 4,

--- a/resources/js/inertia/components/PlaceMultiSelect.tsx
+++ b/resources/js/inertia/components/PlaceMultiSelect.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+
+export interface PlaceOption {
+    c_addr_id: number;
+    c_name: string | null;
+    c_name_chn: string | null;
+}
+
+interface Props {
+    query: string;
+    selectedPlaces: PlaceOption[];
+    searchResults: PlaceOption[];
+    loading: boolean;
+    includeSubUnits: boolean;
+    onQueryChange: (value: string) => void;
+    onAddPlace: (place: PlaceOption) => void;
+    onRemovePlace: (placeId: number) => void;
+    onClearPlaces: () => void;
+    onToggleIncludeSubUnits: (checked: boolean) => void;
+}
+
+export default function PlaceMultiSelect({
+    query,
+    selectedPlaces,
+    searchResults,
+    loading,
+    includeSubUnits,
+    onQueryChange,
+    onAddPlace,
+    onRemovePlace,
+    onClearPlaces,
+    onToggleIncludeSubUnits,
+}: Props) {
+    return (
+        <div style={{ marginBottom: 14 }}>
+            <label style={{ display: 'block', fontWeight: 500, fontSize: '0.85rem', marginBottom: 6 }}>入仕地點</label>
+            <input
+                type="text"
+                value={query}
+                onChange={(event) => onQueryChange(event.target.value)}
+                placeholder="輸入地址名稱或 ID"
+                style={inputStyle}
+            />
+            <div style={{ fontSize: '0.75rem', color: '#6c757d', marginTop: 4 }}>
+                可多選，會比對 `ENTRY_DATA.c_entry_addr_id`
+            </div>
+
+            <div style={{ marginTop: 8, border: '1px solid #e3e7eb', borderRadius: 4, maxHeight: 260, overflowY: 'auto', backgroundColor: '#fff' }}>
+                {loading && <div style={emptyStateStyle}>搜尋中...</div>}
+                {!loading && query.trim() === '' && <div style={emptyStateStyle}>輸入關鍵字後顯示候選地點</div>}
+                {!loading && query.trim() !== '' && searchResults.length === 0 && <div style={emptyStateStyle}>查無符合地點</div>}
+                {!loading && searchResults.map((place) => (
+                    <button
+                        key={place.c_addr_id}
+                        type="button"
+                        onClick={() => onAddPlace(place)}
+                        style={resultButtonStyle}
+                    >
+                        <span>{place.c_name_chn || place.c_name || `ADDR ${place.c_addr_id}`}</span>
+                        <span style={{ color: '#6c757d', fontSize: '0.78rem' }}>#{place.c_addr_id}</span>
+                    </button>
+                ))}
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.8rem', color: '#495057' }}>
+                    <input
+                        type="checkbox"
+                        checked={includeSubUnits}
+                        onChange={(event) => onToggleIncludeSubUnits(event.target.checked)}
+                    />
+                    包含下屬地點
+                </label>
+                <button
+                    type="button"
+                    onClick={onClearPlaces}
+                    disabled={selectedPlaces.length === 0}
+                    style={smallButtonStyle}
+                >
+                    清空地點
+                </button>
+            </div>
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
+                {selectedPlaces.length === 0 && <span style={{ color: '#6c757d', fontSize: '0.85rem' }}>不限地點</span>}
+                {selectedPlaces.map((place) => (
+                    <span key={place.c_addr_id} style={chipStyle}>
+                        {(place.c_name_chn || place.c_name || `ADDR ${place.c_addr_id}`)} #{place.c_addr_id}
+                        <button
+                            type="button"
+                            onClick={() => onRemovePlace(place.c_addr_id)}
+                            style={chipRemoveStyle}
+                            aria-label={`移除地點 ${place.c_addr_id}`}
+                        >
+                            ×
+                        </button>
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 10px',
+    border: '1px solid #ced4da',
+    borderRadius: 4,
+    fontSize: '0.875rem',
+};
+
+const emptyStateStyle: React.CSSProperties = {
+    padding: '12px 14px',
+    color: '#6c757d',
+    fontSize: '0.85rem',
+};
+
+const resultButtonStyle: React.CSSProperties = {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '8px 10px',
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderBottom: '1px solid #f0f0f0',
+    cursor: 'pointer',
+    textAlign: 'left',
+};
+
+const smallButtonStyle: React.CSSProperties = {
+    padding: '4px 10px',
+    border: '1px solid #6c757d',
+    borderRadius: 4,
+    backgroundColor: 'transparent',
+    color: '#6c757d',
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+};
+
+const chipStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '3px 8px',
+    backgroundColor: '#198754',
+    color: '#fff',
+    borderRadius: 4,
+    fontSize: '0.75rem',
+};
+
+const chipRemoveStyle: React.CSSProperties = {
+    marginLeft: 4,
+    background: 'none',
+    border: 'none',
+    color: '#fff',
+    cursor: 'pointer',
+    padding: '0 2px',
+    fontSize: '0.85rem',
+    lineHeight: 1,
+};

--- a/resources/js/inertia/components/SearchResultTable.tsx
+++ b/resources/js/inertia/components/SearchResultTable.tsx
@@ -58,7 +58,7 @@ export default function SearchResultTable({ rows, pagination, onPageChange }: Pr
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
                     <thead>
                         <tr style={{ backgroundColor: '#f8f9fa' }}>
-                            {['人物 ID', '姓名', '朝代', '索引年', '索引年類型', '性別', '索引地址', '入仕地址', '入仕代碼', '入仕方式', '入仕年', '年號', '範圍', '考試等第', '父母狀態', '來源', '備註', '任官備註', '操作'].map((heading) => (
+                            {['人物 ID', '姓名', '朝代', '指數年', '指數年類型', '性別', '索引地址', '入仕地址', '入仕代碼', '入仕方式', '入仕年', '年號', '範圍', '考試等第', '父母狀態', '來源', '備註', '任官備註', '操作'].map((heading) => (
                                 <th key={heading} style={headerCellStyle}>{heading}</th>
                             ))}
                         </tr>

--- a/resources/js/inertia/components/SelectedCodeChips.tsx
+++ b/resources/js/inertia/components/SelectedCodeChips.tsx
@@ -28,7 +28,7 @@ export default function SelectedCodeChips({ selectedCodes, allCodes, onRemove }:
                             padding: '2px 8px',
                             backgroundColor: '#007bff',
                             color: '#fff',
-                            borderRadius: 12,
+                            borderRadius: 4,
                             fontSize: '0.75rem',
                         }}
                     >

--- a/resources/js/inertia/components/SelectionDialog.tsx
+++ b/resources/js/inertia/components/SelectionDialog.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect } from 'react';
+
+interface Props {
+    isOpen: boolean;
+    title: string;
+    description?: string;
+    width?: number;
+    footer?: React.ReactNode;
+    onClose: () => void;
+    children: React.ReactNode;
+}
+
+export default function SelectionDialog({
+    isOpen,
+    title,
+    description,
+    width = 860,
+    footer,
+    onClose,
+    children,
+}: Props) {
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const previousOverflow = document.body.style.overflow;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.body.style.overflow = 'hidden';
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <div style={backdropStyle} onClick={onClose}>
+            <div
+                style={{ ...dialogStyle, width: `min(${width}px, calc(100vw - 32px))` }}
+                onClick={(event) => event.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-label={title}
+            >
+                <div style={headerStyle}>
+                    <div>
+                        <div style={{ fontSize: '1.05rem', fontWeight: 700 }}>{title}</div>
+                        {description && (
+                            <div style={{ marginTop: 4, color: '#6c757d', fontSize: '0.86rem' }}>
+                                {description}
+                            </div>
+                        )}
+                    </div>
+                    <button type="button" onClick={onClose} style={closeButtonStyle} aria-label="關閉對話框">
+                        ×
+                    </button>
+                </div>
+
+                <div style={bodyStyle}>
+                    {children}
+                </div>
+
+                {footer && (
+                    <div style={footerStyle}>
+                        {footer}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+const backdropStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 1200,
+    backgroundColor: 'rgba(15, 23, 42, 0.42)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+};
+
+const dialogStyle: React.CSSProperties = {
+    maxHeight: 'calc(100vh - 32px)',
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: '#fff',
+    borderRadius: 4,
+    boxShadow: '0 28px 72px rgba(15, 23, 42, 0.28)',
+    overflow: 'hidden',
+};
+
+const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: '18px 20px',
+    borderBottom: '1px solid #e5e7eb',
+};
+
+const closeButtonStyle: React.CSSProperties = {
+    width: 36,
+    height: 36,
+    borderRadius: 4,
+    border: '1px solid #d0d8e2',
+    backgroundColor: '#fff',
+    color: '#334155',
+    cursor: 'pointer',
+    fontSize: '1.2rem',
+    lineHeight: 1,
+};
+
+const bodyStyle: React.CSSProperties = {
+    flex: 1,
+    overflowY: 'auto',
+    padding: 20,
+    backgroundColor: '#f8fafc',
+};
+
+const footerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: 8,
+    padding: '14px 20px',
+    borderTop: '1px solid #e5e7eb',
+    backgroundColor: '#fff',
+};

--- a/resources/views/inertia.blade.php
+++ b/resources/views/inertia.blade.php
@@ -4,6 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ config('app.name', 'CBDB') }}</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
     @viteReactRefresh
     @vite('resources/js/inertia/app.tsx')
     @inertiaHead

--- a/routes/web.php
+++ b/routes/web.php
@@ -219,16 +219,17 @@ Route::middleware('auth')->group(function () {
     Route::delete('api-tokens/{tokenId}', 'ApiTokenController@destroy')->name('api-tokens.destroy');
     Route::delete('api-tokens', 'ApiTokenController@destroyAll')->name('api-tokens.destroy-all');
 
-    // 按入仕查詢
-    Route::get('search-by/entry', 'SearchByEntryController@index')->name('search-by.entry.index');
-    Route::get('search-by/entry/types', 'SearchByEntryController@getEntryTypes')->name('search-by.entry.types');
-    Route::get('search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('search-by.entry.codes');
-    Route::get('search-by/entry/search', 'SearchByEntryController@search')->name('search-by.entry.search');
-
-    // Inertia + React 版按入仕查詢（PoC）
+    // 按入仕查詢（Inertia + React）
+    Route::get('search-by/entry', 'SearchByEntryController@index')
+        ->middleware('inertia')
+        ->name('search-by.entry.index');
     Route::get('app/search-by/entry', 'SearchByEntryController@appIndex')
         ->middleware('inertia')
         ->name('app.search-by.entry.index');
+    Route::get('search-by/entry/types', 'SearchByEntryController@getEntryTypes')->name('search-by.entry.types');
+    Route::get('search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('search-by.entry.codes');
+    Route::get('search-by/entry/places', 'SearchByEntryController@getPlaces')->name('search-by.entry.places');
+    Route::get('search-by/entry/query', 'SearchByEntryController@query')->name('search-by.entry.query');
 
     Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
     Route::post('admin/explainsql', 'AdminExplainSqlController@explain');

--- a/tests/Feature/InertiaSearchByEntryTest.php
+++ b/tests/Feature/InertiaSearchByEntryTest.php
@@ -9,17 +9,15 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class InertiaSearchByEntryTest extends TestCase {
-    protected $user;
+    protected User $user;
 
     protected function setUp(): void {
         parent::setUp();
 
         $this->createTestTables();
-
         $this->user = User::factory()->create([
             'is_active' => 1,
         ]);
-
         $this->seedTestData();
     }
 
@@ -43,7 +41,7 @@ class InertiaSearchByEntryTest extends TestCase {
 
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_TYPES (
-                c_entry_type VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_entry_type VARCHAR(255) PRIMARY KEY,
                 c_entry_type_desc VARCHAR(255),
                 c_entry_type_desc_chn VARCHAR(255),
                 c_entry_type_parent_id VARCHAR(255),
@@ -54,7 +52,7 @@ class InertiaSearchByEntryTest extends TestCase {
 
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_CODES (
-                c_entry_code SMALLINT NOT NULL PRIMARY KEY,
+                c_entry_code INTEGER PRIMARY KEY,
                 c_entry_desc VARCHAR(255),
                 c_entry_desc_chn VARCHAR(255)
             )
@@ -62,53 +60,25 @@ class InertiaSearchByEntryTest extends TestCase {
 
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_CODE_TYPE_REL (
-                c_entry_code SMALLINT NOT NULL,
+                c_entry_code INTEGER NOT NULL,
                 c_entry_type VARCHAR(255) NOT NULL,
                 PRIMARY KEY (c_entry_code, c_entry_type)
             )
         ');
 
         DB::statement('
-            CREATE TABLE IF NOT EXISTS ENTRY_DATA (
-                c_personid INT NOT NULL,
-                c_entry_code SMALLINT NOT NULL,
-                c_sequence SMALLINT NOT NULL,
-                c_year INT,
-                c_entry_addr_id INT,
-                c_exam_rank VARCHAR(255),
-                c_kin_code SMALLINT NOT NULL DEFAULT 0,
-                c_kin_id INT NOT NULL DEFAULT 0,
-                c_assoc_code SMALLINT NOT NULL DEFAULT 0,
-                c_assoc_id INT NOT NULL DEFAULT 0,
-                c_inst_code INT NOT NULL DEFAULT 0,
-                c_inst_name_code INT NOT NULL DEFAULT 0,
-                c_notes TEXT,
-                PRIMARY KEY (c_personid, c_entry_code, c_sequence, c_kin_code, c_assoc_code, c_kin_id, c_year, c_assoc_id, c_inst_code, c_inst_name_code)
-            )
-        ');
-
-        DB::statement('
-            CREATE TABLE IF NOT EXISTS BIOG_MAIN (
-                c_personid INT NOT NULL PRIMARY KEY,
-                c_name VARCHAR(255),
-                c_name_chn VARCHAR(255),
-                c_dy VARCHAR(255),
-                c_index_year INT,
-                c_index_addr_id INT
-            )
-        ');
-
-        DB::statement('
             CREATE TABLE IF NOT EXISTS DYNASTIES (
-                c_dy VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_dy VARCHAR(255) PRIMARY KEY,
                 c_dynasty VARCHAR(255),
-                c_dynasty_chn VARCHAR(255)
+                c_dynasty_chn VARCHAR(255),
+                c_start INTEGER,
+                c_end INTEGER
             )
         ');
 
         DB::statement('
             CREATE TABLE IF NOT EXISTS ADDR_CODES (
-                c_addr_id INT NOT NULL PRIMARY KEY,
+                c_addr_id INTEGER PRIMARY KEY,
                 c_name VARCHAR(255),
                 c_name_chn VARCHAR(255)
             )
@@ -145,235 +115,71 @@ class InertiaSearchByEntryTest extends TestCase {
             ['c_entry_code' => 2, 'c_entry_type' => 'TYPE2'],
         ]);
 
-        DB::table('BIOG_MAIN')->insert([
-            ['c_personid' => 1, 'c_name' => 'Test Person 1', 'c_name_chn' => '測試人物一', 'c_dy' => 'DY1', 'c_index_year' => 1000, 'c_index_addr_id' => 10],
-            ['c_personid' => 2, 'c_name' => 'Test Person 2', 'c_name_chn' => '測試人物二', 'c_dy' => 'DY2', 'c_index_year' => 1100, 'c_index_addr_id' => 20],
-        ]);
-
         DB::table('DYNASTIES')->insert([
-            ['c_dy' => 'DY1', 'c_dynasty' => 'Dynasty 1', 'c_dynasty_chn' => '朝代一'],
-            ['c_dy' => 'DY2', 'c_dynasty' => 'Dynasty 2', 'c_dynasty_chn' => '朝代二'],
+            ['c_dy' => 'DY1', 'c_dynasty' => 'Dynasty 1', 'c_dynasty_chn' => '朝代一', 'c_start' => 900, 'c_end' => 1050],
+            ['c_dy' => 'DY2', 'c_dynasty' => 'Dynasty 2', 'c_dynasty_chn' => '朝代二', 'c_start' => 1051, 'c_end' => 1200],
         ]);
 
         DB::table('ADDR_CODES')->insert([
-            ['c_addr_id' => 10, 'c_name' => 'Address 1', 'c_name_chn' => '地址一'],
-            ['c_addr_id' => 20, 'c_name' => 'Address 2', 'c_name_chn' => '地址二'],
-        ]);
-
-        DB::table('ENTRY_DATA')->insert([
-            [
-                'c_personid' => 1, 'c_entry_code' => 1, 'c_sequence' => 1, 'c_year' => 1020,
-                'c_entry_addr_id' => 100, 'c_kin_code' => 0, 'c_kin_id' => 0,
-                'c_assoc_code' => 0, 'c_assoc_id' => 0, 'c_inst_code' => 0, 'c_inst_name_code' => 0,
-            ],
-            [
-                'c_personid' => 2, 'c_entry_code' => 2, 'c_sequence' => 1, 'c_year' => 1120,
-                'c_entry_addr_id' => 200, 'c_kin_code' => 0, 'c_kin_id' => 0,
-                'c_assoc_code' => 0, 'c_assoc_id' => 0, 'c_inst_code' => 0, 'c_inst_name_code' => 0,
-            ],
+            ['c_addr_id' => 100, 'c_name' => 'Entry Addr 1', 'c_name_chn' => '入仕地一'],
         ]);
     }
 
-    /**
-     * 新入口需要登入
-     */
     #[Test]
-    public function test_app_index_requires_authentication(): void {
-        $response = $this->get(route('app.search-by.entry.index'));
+    public function test_index_requires_authentication(): void {
+        $response = $this->get(route('search-by.entry.index'));
         $response->assertRedirect(route('login'));
     }
 
-    /**
-     * 無條件時可渲染 Inertia page
-     */
     #[Test]
-    public function test_app_index_returns_inertia_page(): void {
-        $response = $this->actingAs($this->user)->get(route('app.search-by.entry.index'));
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->component('SearchByEntry/Index')
-            ->has('entryTypes', 2)
-            ->where('results', null)
-        );
-    }
-
-    /**
-     * Inertia 回應包含正確的 props 結構
-     */
-    #[Test]
-    public function test_app_index_has_correct_props_structure(): void {
-        $response = $this->actingAs($this->user)->get(route('app.search-by.entry.index'));
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->component('SearchByEntry/Index')
-            ->has('entryTypes')
-            ->has('preloadedCodes')
-            ->has('filters')
-            ->has('typesEndpoint')
-            ->has('codesEndpoint')
-            ->where('filters.entry_codes', [])
-            ->where('filters.year_from', null)
-            ->where('filters.year_to', null)
-            ->where('filters.addr_id', null)
-            ->where('filters.type_id', null)
-        );
-    }
-
-    /**
-     * 帶搜尋條件時返回結果
-     */
-    #[Test]
-    public function test_app_index_with_search_conditions_returns_results(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'entry_codes' => [1],
-            ]));
-
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->component('SearchByEntry/Index')
-            ->has('results')
-            ->where('results.total', 1)
-            ->has('results.data', 1)
-            ->where('results.data.0.c_personid', 1)
-        );
-    }
-
-    /**
-     * 分頁可保留條件
-     */
-    #[Test]
-    public function test_app_index_pagination_preserves_conditions(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'entry_codes' => [1, 2],
-                'page' => 1,
-            ]));
-
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->component('SearchByEntry/Index')
-            ->has('results')
-            ->where('results.total', 2)
-            ->where('filters.entry_codes', [1, 2])
-        );
-    }
-
-    /**
-     * year_from > year_to 有驗證錯誤
-     */
-    #[Test]
-    public function test_app_index_validates_year_range(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'year_from' => 1200,
-                'year_to' => 1000,
-            ]));
-
-        // GET 驗證失敗會重定向
-        $response->assertStatus(302);
-        $response->assertSessionHasErrors('year_from');
-    }
-
-    /**
-     * 舊路由仍正常
-     */
-    #[Test]
-    public function test_old_blade_routes_still_work(): void {
-        // 舊首頁
+    public function test_index_returns_inertia_page(): void {
         $response = $this->actingAs($this->user)->get(route('search-by.entry.index'));
-        $response->assertStatus(200);
-        $response->assertViewIs('search-by.entry.index');
 
-        // 舊搜尋
-        $response = $this->actingAs($this->user)->get(route('search-by.entry.search', [
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('SearchByEntry/Index')
+                ->has('entryTypes', 2)
+                ->has('dynasties', 2)
+                ->where('initialFilters.person_keyword', null)
+                ->where('initialFilters.entry_codes', [])
+                ->where('initialFilters.dynasty_codes', [])
+                ->where('initialFilters.place_ids', [])
+                ->where('pageUrl', route('search-by.entry.index', [], false))
+                ->where('queryEndpoint', route('search-by.entry.query', [], false))
+        );
+    }
+
+    #[Test]
+    public function test_index_can_preload_codes_and_places_from_query_string(): void {
+        $response = $this->actingAs($this->user)->get(route('search-by.entry.index', [
+            'type_id' => 'TYPE1',
             'entry_codes' => [1],
+            'place_ids' => [100],
         ]));
-        $response->assertStatus(200);
-        $response->assertViewIs('search-by.entry.results');
 
-        // 舊 API
-        $response = $this->actingAs($this->user)->getJson(route('search-by.entry.types'));
-        $response->assertStatus(200)->assertJson(['success' => true]);
-    }
-
-    /**
-     * type_id 可預載 entry codes
-     */
-    #[Test]
-    public function test_app_index_preloads_codes_for_type(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'type_id' => 'TYPE1',
-            ]));
-
-        $response->assertStatus(200);
+        $response->assertOk();
         $response->assertInertia(
             fn (Assert $page) => $page
-            ->has('preloadedCodes', 1)
-            ->where('preloadedCodes.0.c_entry_code', 1)
+                ->component('SearchByEntry/Index')
+                ->has('preloadedCodes', 1)
+                ->where('preloadedCodes.0.c_entry_code', 1)
+                ->has('preloadedPlaces', 1)
+                ->where('preloadedPlaces.0.c_addr_id', 100)
+                ->where('initialFilters.type_id', 'TYPE1')
+                ->where('initialFilters.entry_codes', [1])
+                ->where('initialFilters.place_ids', [100])
         );
     }
 
-    /**
-     * 無搜尋條件（僅 type_id）不執行查詢
-     */
     #[Test]
-    public function test_app_index_no_results_without_search_conditions(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'type_id' => 'TYPE1',
-            ]));
+    public function test_legacy_app_route_still_points_to_same_page(): void {
+        $response = $this->actingAs($this->user)->get(route('app.search-by.entry.index'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
         $response->assertInertia(
             fn (Assert $page) => $page
-            ->where('results', null)
-        );
-    }
-
-    /**
-     * 地址過濾可正常運作
-     */
-    #[Test]
-    public function test_app_index_search_with_address_filter(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'entry_codes' => [1, 2],
-                'addr_id' => 100,
-            ]));
-
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->has('results')
-            ->where('results.total', 1)
-            ->where('results.data.0.c_personid', 1)
-        );
-    }
-
-    /**
-     * 年份範圍過濾可正常運作
-     */
-    #[Test]
-    public function test_app_index_search_with_year_range(): void {
-        $response = $this->actingAs($this->user)
-            ->get(route('app.search-by.entry.index', [
-                'entry_codes' => [1, 2],
-                'year_from' => 1100,
-                'year_to' => 1200,
-            ]));
-
-        $response->assertStatus(200);
-        $response->assertInertia(
-            fn (Assert $page) => $page
-            ->has('results')
-            ->where('results.total', 1)
-            ->where('results.data.0.c_personid', 2)
+                ->component('SearchByEntry/Index')
         );
     }
 }

--- a/tests/Feature/SearchByEntryControllerTest.php
+++ b/tests/Feature/SearchByEntryControllerTest.php
@@ -8,33 +8,21 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class SearchByEntryControllerTest extends TestCase {
-    // NOTE: Avoid RefreshDatabase; full migrations on SQLite can fail due to
-    // foreign key mismatch constraints.
-
-    protected $user;
+    protected User $user;
 
     protected function setUp(): void {
         parent::setUp();
 
-        // 創建測試數據表
         $this->createTestTables();
-
-        // 創建測試用戶
         $this->user = User::factory()->create([
             'is_active' => 1,
         ]);
-
         $this->seedTestData();
     }
 
-    /**
-     * 創建測試所需的數據表
-     */
     protected function createTestTables(): void {
-        // 禁用外鍵約束檢查
         DB::statement('PRAGMA foreign_keys = OFF');
 
-        // users 表（User factory 需要的最小欄位）
         DB::statement('
             CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -50,10 +38,9 @@ class SearchByEntryControllerTest extends TestCase {
             )
         ');
 
-        // ENTRY_TYPES 表
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_TYPES (
-                c_entry_type VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_entry_type VARCHAR(255) PRIMARY KEY,
                 c_entry_type_desc VARCHAR(255),
                 c_entry_type_desc_chn VARCHAR(255),
                 c_entry_type_parent_id VARCHAR(255),
@@ -62,80 +49,129 @@ class SearchByEntryControllerTest extends TestCase {
             )
         ');
 
-        // ENTRY_CODES 表
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_CODES (
-                c_entry_code SMALLINT NOT NULL PRIMARY KEY,
+                c_entry_code INTEGER PRIMARY KEY,
                 c_entry_desc VARCHAR(255),
                 c_entry_desc_chn VARCHAR(255)
             )
         ');
 
-        // ENTRY_CODE_TYPE_REL 表
         DB::statement('
             CREATE TABLE IF NOT EXISTS ENTRY_CODE_TYPE_REL (
-                c_entry_code SMALLINT NOT NULL,
+                c_entry_code INTEGER NOT NULL,
                 c_entry_type VARCHAR(255) NOT NULL,
                 PRIMARY KEY (c_entry_code, c_entry_type)
             )
         ');
 
-        // ENTRY_DATA 表
-        DB::statement('
-            CREATE TABLE IF NOT EXISTS ENTRY_DATA (
-                c_personid INT NOT NULL,
-                c_entry_code SMALLINT NOT NULL,
-                c_sequence SMALLINT NOT NULL,
-                c_year INT,
-                c_entry_addr_id INT,
-                c_exam_rank VARCHAR(255),
-                c_kin_code SMALLINT NOT NULL DEFAULT 0,
-                c_kin_id INT NOT NULL DEFAULT 0,
-                c_assoc_code SMALLINT NOT NULL DEFAULT 0,
-                c_assoc_id INT NOT NULL DEFAULT 0,
-                c_inst_code INT NOT NULL DEFAULT 0,
-                c_inst_name_code INT NOT NULL DEFAULT 0,
-                c_notes TEXT,
-                PRIMARY KEY (c_personid, c_entry_code, c_sequence, c_kin_code, c_assoc_code, c_kin_id, c_year, c_assoc_id, c_inst_code, c_inst_name_code)
-            )
-        ');
-
-        // BIOG_MAIN 表
         DB::statement('
             CREATE TABLE IF NOT EXISTS BIOG_MAIN (
-                c_personid INT NOT NULL PRIMARY KEY,
+                c_personid INTEGER PRIMARY KEY,
                 c_name VARCHAR(255),
                 c_name_chn VARCHAR(255),
                 c_dy VARCHAR(255),
-                c_index_year INT,
-                c_index_addr_id INT
+                c_index_year INTEGER,
+                c_index_addr_id INTEGER,
+                c_index_year_type_code VARCHAR(50),
+                c_female SMALLINT
             )
         ');
 
-        // DYNASTIES 表（供 leftJoin 使用）
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ENTRY_DATA (
+                c_personid INTEGER NOT NULL,
+                c_entry_code INTEGER NOT NULL,
+                c_sequence INTEGER NOT NULL,
+                c_year INTEGER,
+                c_entry_addr_id INTEGER,
+                c_entry_nh_id INTEGER,
+                c_entry_nh_year INTEGER,
+                c_entry_range VARCHAR(50),
+                c_exam_rank VARCHAR(255),
+                c_notes TEXT,
+                c_posting_notes TEXT,
+                c_parental_status_code VARCHAR(50),
+                c_source INTEGER,
+                PRIMARY KEY (c_personid, c_entry_code, c_sequence)
+            )
+        ');
+
         DB::statement('
             CREATE TABLE IF NOT EXISTS DYNASTIES (
-                c_dy VARCHAR(255) NOT NULL PRIMARY KEY,
+                c_dy VARCHAR(255) PRIMARY KEY,
                 c_dynasty VARCHAR(255),
-                c_dynasty_chn VARCHAR(255)
+                c_dynasty_chn VARCHAR(255),
+                c_start INTEGER,
+                c_end INTEGER
             )
         ');
 
-        // ADDR_CODES 表（供 leftJoin 使用）
         DB::statement('
             CREATE TABLE IF NOT EXISTS ADDR_CODES (
-                c_addr_id INT NOT NULL PRIMARY KEY,
+                c_addr_id INTEGER PRIMARY KEY,
                 c_name VARCHAR(255),
                 c_name_chn VARCHAR(255)
             )
         ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ALTNAME_DATA (
+                c_personid INTEGER NOT NULL,
+                c_alt_name VARCHAR(255),
+                c_alt_name_chn VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS ADDR_BELONGS_DATA (
+                c_addr_id INTEGER NOT NULL,
+                c_belongs_to INTEGER NOT NULL
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS INDEXYEAR_TYPE_CODES (
+                c_index_year_type_code VARCHAR(50) PRIMARY KEY,
+                c_index_year_type_desc VARCHAR(255),
+                c_index_year_type_hz VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS NIAN_HAO (
+                c_nianhao_id INTEGER PRIMARY KEY,
+                c_nianhao_chn VARCHAR(255),
+                c_nianhao_pin VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS YEAR_RANGE_CODES (
+                c_range_code VARCHAR(50) PRIMARY KEY,
+                c_range VARCHAR(255),
+                c_range_chn VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS PARENTAL_STATUS_CODES (
+                c_parental_status_code VARCHAR(50) PRIMARY KEY,
+                c_parental_status_desc VARCHAR(255),
+                c_parental_status_desc_chn VARCHAR(255)
+            )
+        ');
+
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS TEXT_CODES (
+                c_textid INTEGER PRIMARY KEY,
+                c_title VARCHAR(255),
+                c_title_chn VARCHAR(255)
+            )
+        ');
     }
 
-    /**
-     * 填充測試數據
-     */
     protected function seedTestData(): void {
-        // 插入入仕類型
         DB::table('ENTRY_TYPES')->insert([
             [
                 'c_entry_type' => 'TYPE1',
@@ -155,27 +191,29 @@ class SearchByEntryControllerTest extends TestCase {
             ],
         ]);
 
-        // 插入入仕代碼
         DB::table('ENTRY_CODES')->insert([
-            [
-                'c_entry_code' => 1,
-                'c_entry_desc' => 'Entry Code 1',
-                'c_entry_desc_chn' => '入仕代碼一',
-            ],
-            [
-                'c_entry_code' => 2,
-                'c_entry_desc' => 'Entry Code 2',
-                'c_entry_desc_chn' => '入仕代碼二',
-            ],
+            ['c_entry_code' => 1, 'c_entry_desc' => 'Entry Code 1', 'c_entry_desc_chn' => '入仕代碼一'],
+            ['c_entry_code' => 2, 'c_entry_desc' => 'Entry Code 2', 'c_entry_desc_chn' => '入仕代碼二'],
         ]);
 
-        // 插入代碼類型關聯
         DB::table('ENTRY_CODE_TYPE_REL')->insert([
             ['c_entry_code' => 1, 'c_entry_type' => 'TYPE1'],
             ['c_entry_code' => 2, 'c_entry_type' => 'TYPE2'],
         ]);
 
-        // 插入人物數據
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 'DY1', 'c_dynasty' => 'Dynasty 1', 'c_dynasty_chn' => '朝代一', 'c_start' => 900, 'c_end' => 1050],
+            ['c_dy' => 'DY2', 'c_dynasty' => 'Dynasty 2', 'c_dynasty_chn' => '朝代二', 'c_start' => 1051, 'c_end' => 1200],
+        ]);
+
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 10, 'c_name' => 'Index Addr 1', 'c_name_chn' => '索引地址一'],
+            ['c_addr_id' => 20, 'c_name' => 'Index Addr 2', 'c_name_chn' => '索引地址二'],
+            ['c_addr_id' => 100, 'c_name' => 'Entry Addr 1', 'c_name_chn' => '入仕地一'],
+            ['c_addr_id' => 101, 'c_name' => 'Entry Sub Addr 1', 'c_name_chn' => '入仕地下屬一'],
+            ['c_addr_id' => 200, 'c_name' => 'Entry Addr 2', 'c_name_chn' => '入仕地二'],
+        ]);
+
         DB::table('BIOG_MAIN')->insert([
             [
                 'c_personid' => 1,
@@ -184,6 +222,8 @@ class SearchByEntryControllerTest extends TestCase {
                 'c_dy' => 'DY1',
                 'c_index_year' => 1000,
                 'c_index_addr_id' => 10,
+                'c_index_year_type_code' => 'A',
+                'c_female' => 0,
             ],
             [
                 'c_personid' => 2,
@@ -192,37 +232,40 @@ class SearchByEntryControllerTest extends TestCase {
                 'c_dy' => 'DY2',
                 'c_index_year' => 1100,
                 'c_index_addr_id' => 20,
+                'c_index_year_type_code' => 'B',
+                'c_female' => 1,
             ],
         ]);
 
-        // 插入朝代與地址數據（leftJoin 需要表存在）
-        DB::table('DYNASTIES')->insert([
-            [
-                'c_dy' => 'DY1',
-                'c_dynasty' => 'Dynasty 1',
-                'c_dynasty_chn' => '朝代一',
-            ],
-            [
-                'c_dy' => 'DY2',
-                'c_dynasty' => 'Dynasty 2',
-                'c_dynasty_chn' => '朝代二',
-            ],
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 1, 'c_alt_name' => 'Alias A', 'c_alt_name_chn' => '別名甲'],
         ]);
 
-        DB::table('ADDR_CODES')->insert([
-            [
-                'c_addr_id' => 10,
-                'c_name' => 'Address 1',
-                'c_name_chn' => '地址一',
-            ],
-            [
-                'c_addr_id' => 20,
-                'c_name' => 'Address 2',
-                'c_name_chn' => '地址二',
-            ],
+        DB::table('ADDR_BELONGS_DATA')->insert([
+            ['c_addr_id' => 101, 'c_belongs_to' => 100],
         ]);
 
-        // 插入入仕數據
+        DB::table('INDEXYEAR_TYPE_CODES')->insert([
+            ['c_index_year_type_code' => 'A', 'c_index_year_type_desc' => 'Approximate', 'c_index_year_type_hz' => '約年'],
+            ['c_index_year_type_code' => 'B', 'c_index_year_type_desc' => 'Exact', 'c_index_year_type_hz' => '實年'],
+        ]);
+
+        DB::table('NIAN_HAO')->insert([
+            ['c_nianhao_id' => 1, 'c_nianhao_chn' => '景祐', 'c_nianhao_pin' => 'Jingyou'],
+        ]);
+
+        DB::table('YEAR_RANGE_CODES')->insert([
+            ['c_range_code' => 'R', 'c_range' => 'Range', 'c_range_chn' => '約'],
+        ]);
+
+        DB::table('PARENTAL_STATUS_CODES')->insert([
+            ['c_parental_status_code' => 'P1', 'c_parental_status_desc' => 'Parent living', 'c_parental_status_desc_chn' => '父母在'],
+        ]);
+
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 500, 'c_title' => 'Source A', 'c_title_chn' => '來源甲'],
+        ]);
+
         DB::table('ENTRY_DATA')->insert([
             [
                 'c_personid' => 1,
@@ -230,12 +273,29 @@ class SearchByEntryControllerTest extends TestCase {
                 'c_sequence' => 1,
                 'c_year' => 1020,
                 'c_entry_addr_id' => 100,
-                'c_kin_code' => 0,
-                'c_kin_id' => 0,
-                'c_assoc_code' => 0,
-                'c_assoc_id' => 0,
-                'c_inst_code' => 0,
-                'c_inst_name_code' => 0,
+                'c_entry_nh_id' => 1,
+                'c_entry_nh_year' => 3,
+                'c_entry_range' => 'R',
+                'c_exam_rank' => '甲',
+                'c_notes' => '備註一',
+                'c_posting_notes' => '任官備註一',
+                'c_parental_status_code' => 'P1',
+                'c_source' => 500,
+            ],
+            [
+                'c_personid' => 1,
+                'c_entry_code' => 1,
+                'c_sequence' => 2,
+                'c_year' => 1025,
+                'c_entry_addr_id' => 101,
+                'c_entry_nh_id' => 1,
+                'c_entry_nh_year' => 4,
+                'c_entry_range' => 'R',
+                'c_exam_rank' => '甲',
+                'c_notes' => '備註二',
+                'c_posting_notes' => '任官備註二',
+                'c_parental_status_code' => 'P1',
+                'c_source' => 500,
             ],
             [
                 'c_personid' => 2,
@@ -243,189 +303,110 @@ class SearchByEntryControllerTest extends TestCase {
                 'c_sequence' => 1,
                 'c_year' => 1120,
                 'c_entry_addr_id' => 200,
-                'c_kin_code' => 0,
-                'c_kin_id' => 0,
-                'c_assoc_code' => 0,
-                'c_assoc_id' => 0,
-                'c_inst_code' => 0,
-                'c_inst_name_code' => 0,
+                'c_entry_nh_id' => null,
+                'c_entry_nh_year' => null,
+                'c_entry_range' => null,
+                'c_exam_rank' => '乙',
+                'c_notes' => '備註三',
+                'c_posting_notes' => null,
+                'c_parental_status_code' => null,
+                'c_source' => null,
             ],
         ]);
     }
 
-    /**
-     * 測試主頁面是否正常顯示（需要登入）
-     */
-    #[Test]
-    public function test_index_requires_authentication(): void {
-        $response = $this->get(route('search-by.entry.index'));
-        $response->assertRedirect(route('login'));
-    }
-
-    /**
-     * 測試登入用戶可以訪問主頁面
-     */
-    #[Test]
-    public function test_authenticated_user_can_access_index(): void {
-        $response = $this->actingAs($this->user)->get(route('search-by.entry.index'));
-        $response->assertStatus(200);
-        $response->assertViewIs('search-by.entry.index');
-    }
-
-    /**
-     * 測試獲取入仕類型 API
-     */
     #[Test]
     public function test_can_get_entry_types(): void {
-        $response = $this->actingAs($this->user)
-            ->getJson(route('search-by.entry.types'));
+        $response = $this->actingAs($this->user)->getJson(route('search-by.entry.types'));
 
-        $response->assertStatus(200)
+        $response->assertOk()
             ->assertJson([
                 'success' => true,
             ])
-            ->assertJsonStructure([
-                'success',
-                'data' => [
-                    '*' => [
-                        'c_entry_type',
-                        'c_entry_type_desc',
-                        'c_entry_type_desc_chn',
-                        'c_entry_type_parent_id',
-                        'c_entry_type_level',
-                        'c_entry_type_sortorder',
-                    ],
-                ],
-            ]);
-
-        $this->assertCount(2, $response->json('data'));
+            ->assertJsonCount(2, 'data');
     }
 
-    /**
-     * 測試獲取入仕代碼 API（無類型過濾）
-     */
-    #[Test]
-    public function test_can_get_all_entry_codes(): void {
-        $response = $this->actingAs($this->user)
-            ->getJson(route('search-by.entry.codes'));
-
-        $response->assertStatus(200)
-            ->assertJson([
-                'success' => true,
-            ])
-            ->assertJsonStructure([
-                'success',
-                'data' => [
-                    '*' => [
-                        'c_entry_code',
-                        'c_entry_desc',
-                        'c_entry_desc_chn',
-                    ],
-                ],
-            ]);
-
-        $this->assertCount(2, $response->json('data'));
-    }
-
-    /**
-     * 測試根據類型獲取入仕代碼 API
-     */
     #[Test]
     public function test_can_get_entry_codes_by_type(): void {
         $response = $this->actingAs($this->user)
             ->getJson(route('search-by.entry.codes', ['type_id' => 'TYPE1']));
 
-        $response->assertStatus(200)
+        $response->assertOk()
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonPath('data.0.c_entry_code', 1);
+    }
+
+    #[Test]
+    public function test_can_search_places(): void {
+        $response = $this->actingAs($this->user)
+            ->getJson(route('search-by.entry.places', ['q' => '入仕地']));
+
+        $response->assertOk()
             ->assertJson([
                 'success' => true,
             ]);
 
-        $data = $response->json('data');
-        $this->assertCount(1, $data);
-        $this->assertEquals(1, $data[0]['c_entry_code']);
+        $this->assertGreaterThanOrEqual(2, count($response->json('data')));
     }
 
-    /**
-     * 測試搜索功能（基本搜索）
-     */
     #[Test]
-    public function test_can_search_by_entry_codes(): void {
+    public function test_query_requires_at_least_one_condition(): void {
         $response = $this->actingAs($this->user)
-            ->get(route('search-by.entry.search', [
-                'entry_codes' => [1],
-            ]));
+            ->getJson(route('search-by.entry.query'));
 
-        $response->assertStatus(200);
-        $response->assertViewIs('search-by.entry.results');
-        $response->assertViewHas('results');
-
-        $results = $response->viewData('results');
-        $this->assertCount(1, $results);
-        $this->assertEquals(1, $results[0]->c_personid);
+        $response->assertStatus(422)
+            ->assertJsonPath('errors.filters.0', '請至少設定一項搜尋條件。');
     }
 
-    /**
-     * 測試搜索功能（年份範圍過濾）
-     */
     #[Test]
-    public function test_can_search_with_year_range(): void {
+    public function test_query_can_match_person_keyword_from_alt_name(): void {
         $response = $this->actingAs($this->user)
-            ->get(route('search-by.entry.search', [
-                'entry_codes' => [1, 2],
-                'year_from' => 1100,
-                'year_to' => 1200,
+            ->getJson(route('search-by.entry.query', [
+                'person_keyword' => '別名甲',
             ]));
 
-        $response->assertStatus(200);
-        $results = $response->viewData('results');
-        $this->assertCount(1, $results);
-        $this->assertEquals(2, $results[0]->c_personid);
-        $this->assertEquals(1120, $results[0]->c_year);
+        $response->assertOk()
+            ->assertJsonPath('data.summary.record_count', 2)
+            ->assertJsonPath('data.summary.person_count', 1)
+            ->assertJsonPath('data.records.data.0.c_personid', 1);
     }
 
-    /**
-     * 測試搜索功能（地址過濾）
-     */
     #[Test]
-    public function test_can_search_with_address_filter(): void {
+    public function test_query_can_include_subordinate_places(): void {
         $response = $this->actingAs($this->user)
-            ->get(route('search-by.entry.search', [
-                'entry_codes' => [1, 2],
-                'addr_id' => 100,
+            ->getJson(route('search-by.entry.query', [
+                'place_ids' => [100],
+                'include_sub_units' => true,
             ]));
 
-        $response->assertStatus(200);
-        $results = $response->viewData('results');
-        $this->assertCount(1, $results);
-        $this->assertEquals(1, $results[0]->c_personid);
+        $response->assertOk()
+            ->assertJsonPath('data.summary.record_count', 2)
+            ->assertJsonPath('data.summary.person_count', 1);
     }
 
-    /**
-     * 測試搜索驗證（entry_codes 必須為陣列）
-     */
     #[Test]
-    public function test_search_validation_requires_entry_codes_as_array(): void {
+    public function test_query_can_filter_by_single_dynasty_checkbox(): void {
         $response = $this->actingAs($this->user)
-            ->get(route('search-by.entry.search', [
-                'entry_codes' => 'invalid',
+            ->getJson(route('search-by.entry.query', [
+                'dynasty_codes' => ['DY2'],
             ]));
 
-        // GET 請求驗證失敗會返回 302 重定向
-        $response->assertStatus(302);
+        $response->assertOk()
+            ->assertJsonPath('data.summary.record_count', 1)
+            ->assertJsonPath('data.people.data.0.c_personid', 2);
     }
 
-    /**
-     * 測試搜索驗證（年份必須為整數）
-     */
     #[Test]
-    public function test_search_validation_requires_integer_years(): void {
+    public function test_query_can_filter_by_multiple_dynasties(): void {
         $response = $this->actingAs($this->user)
-            ->get(route('search-by.entry.search', [
-                'entry_codes' => [1],
-                'year_from' => 'invalid',
+            ->getJson(route('search-by.entry.query', [
+                'dynasty_codes' => ['DY1', 'DY2'],
             ]));
 
-        // GET 請求驗證失敗會返回 302 重定向
-        $response->assertStatus(302);
+        $response->assertOk()
+            ->assertJsonPath('data.summary.record_count', 3)
+            ->assertJsonPath('data.summary.person_count', 2);
     }
 }


### PR DESCRIPTION
- 將按入仕查詢重構為 Inertia React 頁面並整理結果工作區互動
- 將入仕類型與代碼、地點及各項條件改為頂端摘要格搭配 modal 編輯
- 補上人物關鍵字、地點、年份條件與朝代多選篩選
- 調整朝代清單排序，將朝鮮、韓國、高麗與新羅排到最後