### PR TITLE
保留手動登入前的回跳頁面

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class LoginController extends Controller {
     /*
@@ -36,7 +37,14 @@ class LoginController extends Controller {
         $this->middleware('guest')->except('logout');
     }
 
+    public function showLoginForm(Request $request) {
+        $this->storeIntendedRedirect($request);
+
+        return view('auth.login');
+    }
+
     public function login(Request $request) {
+        $this->storeIntendedRedirect($request);
         $this->validateLogin($request);
 
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
@@ -83,5 +91,41 @@ class LoginController extends Controller {
         // 使用 intended() 方法，如果 session 中有原始 URL，則重定向到該 URL
         // 否則重定向到默認的 /home
         return redirect()->intended($this->redirectTo)->getTargetUrl();
+    }
+
+    protected function storeIntendedRedirect(Request $request): void {
+        $redirect = $request->input('redirect');
+
+        if (!is_string($redirect)) {
+            return;
+        }
+
+        $redirect = trim($redirect);
+
+        if ($redirect === '' || !$this->isSafeRedirectPath($redirect)) {
+            return;
+        }
+
+        $request->session()->put('url.intended', $redirect);
+    }
+
+    protected function isSafeRedirectPath(string $redirect): bool {
+        if (!Str::startsWith($redirect, '/') || Str::startsWith($redirect, '//')) {
+            return false;
+        }
+
+        $path = parse_url($redirect, PHP_URL_PATH);
+
+        if (!is_string($path) || $path === '') {
+            return false;
+        }
+
+        foreach (['/login', '/register', '/password'] as $prefix) {
+            if ($path === $prefix || Str::startsWith($path, $prefix . '/')) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -41,6 +41,7 @@
                     <h1 class="h5 text-center mb-4">歡迎回來 · Welcome back</h1>
                     <form action="{{ route('login') }}" method="post" novalidate>
                         {{ csrf_field() }}
+                        <input type="hidden" name="redirect" value="{{ old('redirect', request('redirect', session('url.intended'))) }}">
                         <div class="form-group mb-3">
                             <label for="email" class="form-label small text-muted">電子郵件 / Email</label>
                             <input type="email" id="email" name="email" value="{{ old('email') }}" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" placeholder="name@example.com / 電子郵件" required>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -61,7 +61,7 @@
                         <ul class="nav navbar-nav navbar-right">
                             <!-- Authentication Links -->
                             @if (Auth::guest())
-                                <li><a href="{{ route('login') }}">Login</a></li>
+                                <li><a href="{{ route('login', ['redirect' => request()->getRequestUri()]) }}">Login</a></li>
                                 <li><a href="{{ route('register') }}">Register</a></li>
                             @else
                                 <li class="dropdown">

--- a/resources/views/layouts/header-v3.blade.php
+++ b/resources/views/layouts/header-v3.blade.php
@@ -42,7 +42,7 @@
 
         @if (Auth::guest())
             <li class="nav-item">
-                <a href="{{ route('login') }}" class="nav-link">Login</a>
+                <a href="{{ route('login', ['redirect' => request()->getRequestUri()]) }}" class="nav-link">Login</a>
             </li>
             <li class="nav-item">
                 <a href="{{ route('register') }}" class="nav-link">Register</a>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -190,7 +190,7 @@
                         <a href="{{ url('home') }}">Home</a>
                     @else
                         <a href="{{ url('home') }}">Guest</a>
-                        <a href="{{ url('login') }}">Login</a>
+                        <a href="{{ route('login', ['redirect' => request()->getRequestUri()]) }}">Login</a>
                         <a href="{{ url('register') }}">Register</a>
                     @endauth
                 </div>

--- a/tests/Feature/LoginRedirectTest.php
+++ b/tests/Feature/LoginRedirectTest.php
@@ -3,10 +3,17 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\Auth\LoginController;
+use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class LoginRedirectTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->withoutMiddleware(\App\Http\Middleware\PrometheusMetrics::class);
+    }
+
     /**
      * 測試：redirectPath() 方法應該使用 intended URL
      */
@@ -68,5 +75,39 @@ class LoginRedirectTest extends TestCase {
 
         // 應該重定向到登錄頁面
         $response->assertRedirect('/login');
+    }
+
+    /**
+     * 測試：手動打開登入頁時可保存公開頁面的回跳 URL
+     */
+    #[Test]
+    public function test_show_login_form_stores_safe_redirect_in_session() {
+        $controller = new LoginController();
+        $request = Request::create('/login', 'GET', [
+            'redirect' => '/basicinformation/4/edit?foo=bar',
+        ]);
+        $request->setLaravelSession(app('session.store'));
+
+        $controller->showLoginForm($request);
+
+        $this->assertSame('/basicinformation/4/edit?foo=bar', session('url.intended'));
+    }
+
+    /**
+     * 測試：登入頁不接受外部或危險的回跳 URL
+     */
+    #[Test]
+    public function test_show_login_form_ignores_unsafe_redirects() {
+        $controller = new LoginController();
+        session()->put('url.intended', '/dashboard');
+
+        $request = Request::create('/login', 'GET', [
+            'redirect' => 'https://example.com/phishing',
+        ]);
+        $request->setLaravelSession(app('session.store'));
+
+        $controller->showLoginForm($request);
+
+        $this->assertSame('/dashboard', session('url.intended'));
     }
 }


### PR DESCRIPTION
- 在登入連結與表單攜帶目前頁面，避免公開頁手動登入後回到 /basicinformation
- 在 LoginController 驗證並保存安全的回跳路徑，延續 intended redirect 流程
- 補上登入回跳相關測試，覆蓋安全與回退行為