### PR TITLE
改善 AI 任官智能填充：修正地名拆分與日誌狀態

### DIFF
--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -172,7 +172,7 @@ class BasicInformationOfficesController extends Controller {
 
         // 更新 AI 填充日誌（如果本次提交使用了 AI 填充）
         if ($aiFillLogId) {
-            $this->updateAiFillLog($aiFillLogId, $request);
+            $this->updateAiFillLog($aiFillLogId, $request, $id);
         }
 
         // 解析主鍵（officeStoreById 返回查詢參數格式，如 c_office_id=87473&c_posting_id=2104406）
@@ -653,7 +653,7 @@ class BasicInformationOfficesController extends Controller {
     /**
      * 更新 AI 填充日誌，記錄用戶實際提交的數據
      */
-    private function updateAiFillLog(int $logId, Request $request): void {
+    private function updateAiFillLog(int $logId, Request $request, $personId = null): void {
         try {
             $relevantFields = [
                 'c_office_id', 'c_addr', 'c_sequence', 'c_source', 'c_pages',
@@ -666,7 +666,7 @@ class BasicInformationOfficesController extends Controller {
             ];
             $submittedData = $request->only($relevantFields);
 
-            $personId = $request->input('c_personid') ?? $request->route('id') ?? $request->input('_id');
+            $personId = $personId ?? $request->input('c_personid') ?? $request->route('id') ?? $request->input('_id');
 
             DB::table('ai_fill_logs')
                 ->where('id', $logId)

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -278,9 +278,9 @@ class PostingAutofillService {
             ]);
         }
 
-        // 1. 官名匹配（posting_str）
-        if (!empty($aiData['posting_str'])) {
-            $officeMatch = $this->fuzzyMatchOffice($aiData['posting_str'], $effectiveDynasty);
+        // 1. 官名匹配（title_str）
+        if (!empty($aiData['title_str'])) {
+            $officeMatch = $this->fuzzyMatchOffice($aiData['title_str'], $effectiveDynasty);
             if ($officeMatch) {
                 // 根據匹配類型決定是確認匹配還是建議
                 if ($officeMatch['match_type'] === 'exact') {
@@ -288,22 +288,22 @@ class PostingAutofillService {
                     $matched['c_office_id'] = [
                         'value' => $officeMatch['id'],
                         'text' => $officeMatch['text'],
-                        'ai_extracted' => $aiData['posting_str'],
+                        'ai_extracted' => $aiData['title_str'],
                     ];
                 } else {
                     // 模糊匹配 → 黃色（建議）
                     $suggested['c_office_id'] = [
                         'value' => $officeMatch['id'],
                         'text' => $officeMatch['text'],
-                        'ai_extracted' => $aiData['posting_str'],
-                        'search_query' => $aiData['posting_str'],
+                        'ai_extracted' => $aiData['title_str'],
+                        'search_query' => $aiData['title_str'],
                     ];
                 }
             } else {
                 // 完全找不到 → 黃色（建議）
                 $suggested['c_office_id'] = [
-                    'ai_extracted' => $aiData['posting_str'],
-                    'search_query' => $aiData['posting_str'],
+                    'ai_extracted' => $aiData['title_str'],
+                    'search_query' => $aiData['title_str'],
                 ];
             }
         } else {
@@ -920,7 +920,7 @@ class PostingAutofillService {
                     'items' => [
                         'type' => 'object',
                         'properties' => [
-                            'posting_str' => ['type' => 'string'],
+                            'title_str' => ['type' => 'string'],
                             'addr_str' => [
                                 'type' => ['object', 'null'],
                                 'properties' => [
@@ -952,7 +952,7 @@ class PostingAutofillService {
                             'c_assume_office_code' => ['type' => ['integer', 'null']],
                         ],
                         'required' => [
-                            'posting_str',
+                            'title_str',
                             'addr_str',
                             'c_firstyear',
                             'c_fy_nh_code',

--- a/docs/AI_POSTING_AUTOFILL_DESIGN.md
+++ b/docs/AI_POSTING_AUTOFILL_DESIGN.md
@@ -51,7 +51,7 @@ sequenceDiagram
     User->>Frontend: 點擊「AI 智能填充」
     Frontend->>API: POST /api/ai/extract-posting
     API->>AI: 調用 Gemini（使用 ai-posting-extraction-prompt.txt）
-    AI-->>API: 返回 JSON（posting_str, addr_str, 日期等）
+    AI-->>API: 返回 JSON（title_str, addr_str, 日期等）
     API->>DB: 模糊搜索官名、地名、社會機構
     API-->>Frontend: 返回填充建議（含匹配狀態）
     Frontend->>User: 顯示填充結果（綠色/黃色標記）
@@ -332,19 +332,19 @@ class PostingAutofillService {
         $suggested = [];
         $empty = [];
 
-        // 1. 官名匹配（posting_str）
-        if (!empty($aiData['posting_str'])) {
-            $officeMatch = $this->fuzzyMatchOffice($aiData['posting_str']);
+        // 1. 官名匹配（title_str）
+        if (!empty($aiData['title_str'])) {
+            $officeMatch = $this->fuzzyMatchOffice($aiData['title_str']);
             if ($officeMatch) {
                 $matched['c_office_id'] = [
                     'value' => $officeMatch['id'],
                     'text' => $officeMatch['text'],
-                    'ai_extracted' => $aiData['posting_str'],
+                    'ai_extracted' => $aiData['title_str'],
                 ];
             } else {
                 $suggested['c_office_id'] = [
-                    'ai_extracted' => $aiData['posting_str'],
-                    'search_query' => $aiData['posting_str'],
+                    'ai_extracted' => $aiData['title_str'],
+                    'search_query' => $aiData['title_str'],
                 ];
             }
         } else {
@@ -468,7 +468,7 @@ class PostingAutofillService {
                     'items' => [
                         'type' => 'object',
                         'properties' => [
-                            'posting_str' => ['type' => 'string'],
+                            'title_str' => ['type' => 'string'],
                             'addr_str' => ['type' => ['string', 'null']],
                             'c_firstyear' => ['type' => ['integer', 'null']],
                             'c_fy_nh_code' => ['type' => ['string', 'null']],
@@ -489,7 +489,7 @@ class PostingAutofillService {
                             'c_appt_code' => ['type' => ['integer', 'null']],
                             'c_assume_office_code' => ['type' => ['integer', 'null']],
                         ],
-                        'required' => ['posting_str'],
+                        'required' => ['title_str'],
                         'additionalProperties' => false,
                     ],
                 ],

--- a/resources/prompts/ai-posting-extraction-prompt.txt
+++ b/resources/prompts/ai-posting-extraction-prompt.txt
@@ -14,7 +14,7 @@ Return exactly one JSON object with the following structure:
 {
   "postings": [
     {
-      "posting_str": "",
+      "title_str": "",
       "addr_str": {
         "full_text": "",
         "parent": null,
@@ -50,7 +50,7 @@ Return exactly one JSON object with the following structure:
 * If a value is **not mentioned, unknown, or cannot be reliably inferred**, set it to **`null`**.
 * The only exception is:
 
-  * `posting_str` is **required** and must be a non-empty string for each posting.
+  * `title_str` is **required** and must be a non-empty string for each posting.
 
 If **no posting information** can be extracted at all, return:
 
@@ -66,13 +66,17 @@ If **no posting information** can be extracted at all, return:
 
 For each posting in `postings`, fill the following fields:
 
-1. **posting_str** (required)
+1. **title_str** (required)
 
    * Type: string (never `null`)
-   * The official title in **traditional Chinese**.
+   * The official title (官職名稱) in **traditional Chinese** — **only the title itself, nothing else**.
    * Normalize aberrant, abbreviated, or informal titles to the **standard official title** when possible.
    * Do **not** include appointment markers like 守、權、試、兼、贈、封, etc.; those are encoded only in `c_appt_code`.
-   * Do **not** include any address information; those are encoded only in `addr_str`.
+   * Do **not** include any address or location information (地名); those are encoded only in `addr_str`.
+   * In particular, when the source text contains a pattern like `<地名><官職>` (e.g., "康定軍主簿"), you must **separate** the place name into `addr_str` and put **only** the title in `title_str`.
+     - Example: "康定軍主簿" → `"title_str": "主簿"`, `"addr_str": {"full_text": "康定軍", ...}`
+     - Example: "奉國軍簽判" → `"title_str": "簽判"`, `"addr_str": {"full_text": "奉國軍", ...}`
+     - Example: "泉州知州" → `"title_str": "知州"`, `"addr_str": {"full_text": "泉州", ...}`
 
 2. **addr_str**
 
@@ -114,6 +118,13 @@ For each posting in `postings`, fill the following fields:
         → Example: "新城縣" → `"name": "新城", "admin_type": "縣"`
         → Example: "保定府" → `"name": "保定", "admin_type": "府"`
         → Example: "西安府" → `"name": "西安", "admin_type": "府"`
+      * For names ending with **軍** or **監** (military/supervisory administrative units):
+        → **ALWAYS** extract the admin suffix separately
+        → Example: "康定軍" → `"name": "康定", "admin_type": "軍"`
+        → Example: "奉國軍" → `"name": "奉國", "admin_type": "軍"`
+        → Example: "永興軍" → `"name": "永興", "admin_type": "軍"`
+        → Example: "安豐軍" → `"name": "安豐", "admin_type": "軍"`
+        → Example: "西京監" → `"name": "西京", "admin_type": "監"`
       * For **2-character names** ending with 州/府:
         → The last character is likely part of the place name itself
         → Example: "涿州" → `"name": "涿州", "admin_type": "州"`
@@ -293,7 +304,7 @@ For each posting in `postings`, fill the following fields:
 ### 3. Additional rules
 
 * Extract **all distinct postings** in the passage. For promotions, transfers, or multiple appointments, create **one posting object per distinct position**.
-* When the passage describes cumulative promotions without dates, still record each posting with `posting_str` and `addr_str` (if any), and leave all unknown date-related or type-related fields as `null`.
+* When the passage describes cumulative promotions without dates, still record each posting with `title_str` and `addr_str` (if any), and leave all unknown date-related or type-related fields as `null`.
 * Do **not** output any fields other than those specified.
 * The final answer must be **valid JSON** and must consist **only** of the JSON object described above (no leading/trailing characters, no comments, no formatting outside JSON).
 

--- a/tests/Feature/AiFillLogTest.php
+++ b/tests/Feature/AiFillLogTest.php
@@ -77,7 +77,7 @@ class AiFillLogTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知縣',
+                                        'title_str' => '知縣',
                                         'addr_str' => null,
                                         'c_firstyear' => 1723,
                                         'c_fy_nh_code' => '雍正',
@@ -149,7 +149,7 @@ class AiFillLogTest extends TestCase {
             'route_name' => 'basicinformation.offices.create',
             'route_url' => '/basicinformation/1/offices/create',
             'source_text' => '雍正元年正月初三知新城縣',
-            'ai_raw' => json_encode(['posting_str' => '知縣']),
+            'ai_raw' => json_encode(['title_str' => '知縣']),
             'ai_matched' => json_encode([
                 'matched_fields' => ['c_firstyear' => ['value' => 1723, 'text' => '1723']],
                 'suggested_fields' => [],

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -132,7 +132,7 @@ class AiPostingAutofillTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知縣',
+                                        'title_str' => '知縣',
                                         'addr_str' => '新城',
                                         'c_firstyear' => 1723,
                                         'c_fy_nh_code' => '雍正',
@@ -236,7 +236,7 @@ class AiPostingAutofillTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知縣',
+                                        'title_str' => '知縣',
                                         'addr_str' => ['full_text' => '新城', 'parent' => '陝西', 'name' => '新城', 'admin_type' => '縣'],
                                         'c_firstyear' => 1723, // 清朝
                                         'c_fy_nh_code' => '雍正',
@@ -296,7 +296,7 @@ class AiPostingAutofillTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知府',
+                                        'title_str' => '知府',
                                         'addr_str' => ['full_text' => '杭州', 'parent' => '浙江', 'name' => '杭州', 'admin_type' => '府'],
                                         'c_firstyear' => 1573, // 明朝
                                         'c_fy_nh_code' => '萬曆',
@@ -354,7 +354,7 @@ class AiPostingAutofillTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知府',
+                                        'title_str' => '知府',
                                         'addr_str' => ['full_text' => '南京', 'parent' => '應天', 'name' => '南京', 'admin_type' => '府'],
                                         'c_firstyear' => 1367, // 元朝
                                         'c_fy_nh_code' => '至正',
@@ -417,7 +417,7 @@ class AiPostingAutofillTest extends TestCase {
                             'content' => json_encode([
                                 'postings' => [
                                     [
-                                        'posting_str' => '知府',
+                                        'title_str' => '知府',
                                         'addr_str' => ['full_text' => '應天', 'parent' => null, 'name' => '應天', 'admin_type' => '府'],
                                         'c_firstyear' => 1368, // 邊界年份：同時屬於元和明
                                         'c_fy_nh_code' => null,


### PR DESCRIPTION
## Summary
- 將 AI prompt 的 `posting_str` 重命名為 `title_str`，語義更明確，降低 AI 將地名混入官職名的機率
- 在 prompt 中補充「軍」「監」等行政區劃的拆分規則與範例（如「康定軍主簿」→ title_str: 主簿, addr_str: 康定軍）
- 修正任官新增後 AI 填充日誌未顯示為綠色（已提交）的問題：`updateAiFillLog()` 在新增模式下無法取得 personId，導致 WHERE 條件匹配失敗

## Test plan
- [x] `./vendor/bin/phpunit --filter "AiPostingAutofill|AiFillLog"` 全部 18 測試通過
- [x] 手動測試：輸入「前守康定軍主簿」確認 title_str 為「主簿」，addr_str 為「康定軍」
- [x] 手動測試：輸入「奉國軍簽判」確認 title_str 為「簽判」，addr_str 為「奉國軍」
- [x] 手動測試：新增任官後確認 AI 填充日誌頁面該筆記錄顯示為綠色

🤖 Generated with [Claude Code](https://claude.com/claude-code)