### PR TITLE
修正 operations 年號查閱連結

### DIFF
--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -582,4 +582,22 @@ class CompositePrimaryKey {
 
         return self::buildUrl($routeName, ['id' => $personId], $pk);
     }
+
+    /**
+     * 將單一主鍵的 resource_id 正規化為 codes 路由可用的 path id。
+     *
+     * 某些全域代碼表歷史上曾把單主鍵也存成 query-string 格式
+     * （如 c_nianhao_id=464）。codes.edit 需要的是純 path segment，
+     * 因此這裡在可安全判定為單一主鍵時抽出其值，其餘情況保持原值。
+     */
+    public static function normalizeSingleKeyResourceIdForCodeRoute(string $resource, string $resourceId): string {
+        $pk = self::parseStoredResourceId($resourceId, $resource);
+        if (!is_array($pk) || count($pk) !== 1) {
+            return $resourceId;
+        }
+
+        $value = reset($pk);
+
+        return is_scalar($value) || $value === null ? (string) $value : $resourceId;
+    }
 }

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -199,7 +199,8 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 }
                                 // 对于代码表资源（无论是否涉及人物），如果没有特定资源链接，则使用 codes 路由
                                 elseif ($isCodeResource && $item->op_type != 4) {
-                                    $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $originalResourceId], false);
+                                    $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($item->resource, $originalResourceId);
+                                    $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $codeRouteId], false);
                                 }
                                 $showPerPersonResourceButtons = in_array(strtoupper($item->resource), ['KIN_DATA', 'ASSOC_DATA'], true) && $personRowspan > 1;
                             @endphp

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -12,6 +12,11 @@ class OperationsIndexLinksTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
+        config()->set('app.env', 'testing');
+        $this->app['env'] = 'testing';
+        config()->set('prometheus.enabled', false);
+        config()->set('prometheus.storage_adapter', 'memory');
+
         // 使用 SQLite 内存数据库
         config()->set('database.default', 'sqlite');
         config()->set('database.connections.sqlite', [
@@ -57,6 +62,11 @@ class OperationsIndexLinksTest extends TestCase {
             $table->integer('c_posting_id');
             $table->integer('c_personid')->nullable();
             $table->integer('c_fy_intercalary')->nullable();
+        });
+
+        Schema::create('NIAN_HAO', function ($table) {
+            $table->integer('c_nianhao_id')->primary();
+            $table->string('c_nianhao_chn')->nullable();
         });
 
         Schema::create('KIN_DATA', function ($table) {
@@ -153,6 +163,40 @@ class OperationsIndexLinksTest extends TestCase {
         // 验证可以生成正确的路由
         $expectedLink = route('codes.edit', ['table_name' => $resource, 'id' => $resourceId], false);
         $this->assertEquals('/codes/OFFICE_CODES/803819/edit', $expectedLink);
+    }
+
+    #[Test]
+    public function test_operations_index_normalizes_single_key_query_string_resource_id_for_code_links(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'nianhao-link@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'NIAN_HAO',
+            'resource_id' => 'c_nianhao_id=464',
+            'resource_data' => json_encode(['c_nianhao_id' => 464, 'c_nianhao_chn' => '測試年號']),
+            'resource_original' => json_encode(['c_nianhao_id' => 464, 'c_nianhao_chn' => '舊年號']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        \DB::table('NIAN_HAO')->insert([
+            'c_nianhao_id' => 464,
+            'c_nianhao_chn' => '測試年號',
+        ]);
+
+        $response = $this->actingAs($user)->get('/operations');
+
+        $response->assertStatus(200);
+        $response->assertSee('/codes/NIAN_HAO/464/edit', false);
+        $response->assertDontSee('/codes/NIAN_HAO/c_nianhao_id=464/edit', false);
     }
 
     #[Test]

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -985,4 +985,14 @@ class CompositePrimaryKeyTest extends TestCase {
         $this->assertStringContainsString('c_office_id=448', $url);
         $this->assertStringContainsString('c_posting_id=130', $url);
     }
+
+    /** @test */
+    public function it_normalizes_single_key_query_string_resource_id_for_code_route(): void {
+        $result = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute(
+            'NIAN_HAO',
+            'c_nianhao_id=464'
+        );
+
+        $this->assertSame('464', $result);
+    }
 }


### PR DESCRIPTION
- 保留 NIAN_HAO 的複合格式 resource_id 寫法
- 在 operations codes 連結生成時兼容單主鍵 query-string resource_id
- 補上 operations 與 CompositePrimaryKey 的回歸測試

- 測試：
    ./vendor/bin/phpunit --filter "(OperationsIndexLinksTest|CompositePrimaryKeyTest)"