### PR TITLE
修正 AI 填充日誌因路由參數名錯誤導致提交狀態未更新

### DIFF
--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -200,7 +200,7 @@ class BasicInformationAssocController extends Controller {
         flash('Store success @ '.Carbon::now(), 'success');
 
         if ($aiFillLogId) {
-            $this->updateAiFillLog($aiFillLogId, $request);
+            $this->updateAiFillLog($aiFillLogId, $request, $id);
         }
 
         // 使用新的查詢參數模式重定向
@@ -520,7 +520,7 @@ class BasicInformationAssocController extends Controller {
         flash('Update success @ '.Carbon::now(), 'success');
 
         if ($aiFillLogId) {
-            $this->updateAiFillLog($aiFillLogId, $request);
+            $this->updateAiFillLog($aiFillLogId, $request, $id);
         }
 
         // 重定向到新的查詢參數格式（使用更新後的值）
@@ -581,7 +581,7 @@ class BasicInformationAssocController extends Controller {
     /**
      * 更新 AI 填充日誌，記錄用戶實際提交的數據
      */
-    private function updateAiFillLog(int $logId, Request $request): void {
+    private function updateAiFillLog(int $logId, Request $request, $personId = null): void {
         try {
             $relevantFields = [
                 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id',
@@ -592,7 +592,7 @@ class BasicInformationAssocController extends Controller {
             ];
             $submittedData = $request->only($relevantFields);
 
-            $personId = $request->input('c_personid') ?? $request->route('id');
+            $personId = $personId ?? $request->input('c_personid') ?? $request->route('basicinformation');
 
             DB::table('ai_fill_logs')
                 ->where('id', $logId)

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -666,7 +666,7 @@ class BasicInformationOfficesController extends Controller {
             ];
             $submittedData = $request->only($relevantFields);
 
-            $personId = $personId ?? $request->input('c_personid') ?? $request->route('id') ?? $request->input('_id');
+            $personId = $personId ?? $request->input('c_personid') ?? $request->route('basicinformation') ?? $request->input('_id');
 
             DB::table('ai_fill_logs')
                 ->where('id', $logId)

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -143,7 +143,7 @@ class BasicInformationStatusesController extends Controller {
         flash('Store success @ '.Carbon::now(), 'success');
 
         if ($aiFillLogId) {
-            $this->updateAiFillLog($aiFillLogId, $request);
+            $this->updateAiFillLog($aiFillLogId, $request, $id);
         }
 
         // 使用新的查詢參數模式重定向
@@ -429,7 +429,7 @@ class BasicInformationStatusesController extends Controller {
         flash('Update success @ '.Carbon::now(), 'success');
 
         if ($aiFillLogId) {
-            $this->updateAiFillLog($aiFillLogId, $request);
+            $this->updateAiFillLog($aiFillLogId, $request, $id);
         }
 
         // 重定向到新的查詢參數格式
@@ -485,7 +485,7 @@ class BasicInformationStatusesController extends Controller {
     /**
      * 更新 AI 填充日誌，記錄用戶實際提交的數據
      */
-    private function updateAiFillLog(int $logId, Request $request): void {
+    private function updateAiFillLog(int $logId, Request $request, $personId = null): void {
         try {
             $relevantFields = [
                 'c_status_code', 'c_sequence', 'c_supplement',
@@ -495,7 +495,7 @@ class BasicInformationStatusesController extends Controller {
             ];
             $submittedData = $request->only($relevantFields);
 
-            $personId = $request->input('c_personid') ?? $request->route('id');
+            $personId = $personId ?? $request->input('c_personid') ?? $request->route('basicinformation');
 
             DB::table('ai_fill_logs')
                 ->where('id', $logId)


### PR DESCRIPTION
## Summary
- `updateAiFillLog()` 透過 `$request->route('id')` 取得 person ID，但 Laravel resource 路由參數名為 `{basicinformation}`，導致 `$personId` 為 null，WHERE 條件永遠匹配不到記錄，update 靜默影響 0 行
- 社會關係（Assoc）和社會區分（Statuses）的 AI 填充日誌在用戶提交表單後始終顯示藍色（未提交），而非綠色（已提交）
- Offices 控制器因呼叫時已直接傳入 `$id`，實際不受影響，僅修正後備路由參數名

## Test plan
- [x] 在社會關係新增頁面觸發 AI 智能填充，選擇代碼後儲存，確認日誌顯示為綠色（已提交）
- [x] 在社會區分新增頁面同樣測試
- [x] 確認任官頁面 AI 填充日誌功能不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)