### PR TITLE
修正 AI 智能填充官名與地址無法正確填入表單的問題

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -631,20 +631,21 @@ class PostingAutofillService {
      */
     protected function fuzzyMatchAddress(string $addrName, ?int $year = null, ?int $dynastyCode = null, ?string $parentName = null): ?array {
         // ========== 年份 Fallback 邏輯 ==========
-        // 優先使用任官年份，如果為 null 則 fallback 到朝代年份範圍
+        // 優先使用任官年份；無具體年份時，改用朝代範圍交集過濾
         $effectiveYear = $year;
+        $dynastyRangeFilter = null; // 朝代範圍（僅在無具體年份時使用）
         if ($effectiveYear === null && $dynastyCode !== null) {
             $dynastyRange = $this->getDynastyYearRange($dynastyCode);
             if ($dynastyRange) {
-                // 使用朝代的中點年份作為過濾條件
-                $effectiveYear = (int)(($dynastyRange['start'] + $dynastyRange['end']) / 2);
+                // 無具體任官年份時，只要地名有效期與朝代有交集即可
+                $dynastyRangeFilter = $dynastyRange;
             }
         }
 
         // ========== Step 1: 精確匹配 c_name_chn ==========
         // 注意：使用 ADDR_CODES 表（與 Select2 API 一致）
         $query = DB::table('ADDR_CODES')
-            ->select('c_addr_id as id', 'c_name_chn as text')
+            ->select('c_addr_id as id', 'c_name_chn as text', 'c_firstyear', 'c_lastyear')
             ->where('c_name_chn', '=', $addrName)
             // AI 填充時過濾交通設施相關地名
             ->where('c_name_chn', 'not like', '%驛')  // 驛：全部過濾
@@ -654,28 +655,8 @@ class PostingAutofillService {
             // SQLite 使用 LENGTH，MySQL/MariaDB 使用 CHAR_LENGTH
             ->whereRaw('NOT (c_name_chn LIKE ? AND ' . (is_sqlite() ? 'LENGTH' : 'CHAR_LENGTH') . '(c_name_chn) > 2)', ['%津']);
 
-        // 加入時間範圍過濾（如果有提供年份）
-        if ($effectiveYear !== null) {
-            $query->where(function ($q) use ($effectiveYear) {
-                $q->where(function ($subQ) use ($effectiveYear) {
-                    // 地名有效期間包含任官年份（兩邊都有值）
-                    $subQ->where('c_firstyear', '<=', $effectiveYear)
-                        ->where('c_lastyear', '>=', $effectiveYear);
-                })->orWhere(function ($subQ) {
-                    // 時間範圍為 NULL（代表不限時間）
-                    $subQ->whereNull('c_firstyear')
-                        ->whereNull('c_lastyear');
-                })->orWhere(function ($subQ) use ($effectiveYear) {
-                    // 開放式結束（只有開始年份，沒有結束年份）
-                    $subQ->where('c_firstyear', '<=', $effectiveYear)
-                        ->whereNull('c_lastyear');
-                })->orWhere(function ($subQ) use ($effectiveYear) {
-                    // 開放式開始（只有結束年份，沒有開始年份）
-                    $subQ->whereNull('c_firstyear')
-                        ->where('c_lastyear', '>=', $effectiveYear);
-                });
-            });
-        }
+        // 加入時間過濾
+        $this->applyAddrTimeFilter($query, $effectiveYear, $dynastyRangeFilter);
 
         $results = $query->get();
         if ($results->count() > 0) {
@@ -729,6 +710,21 @@ class PostingAutofillService {
                 }
             }
 
+            // 當使用朝代範圍過濾且仍有多條同名結果時，優先選有效期與朝代重疊最多的
+            if ($isAmbiguous && $dynastyRangeFilter !== null) {
+                $dyStart = $dynastyRangeFilter['start'];
+                $dyEnd = $dynastyRangeFilter['end'];
+                $results = $results->sortByDesc(function ($addr) use ($dyStart, $dyEnd) {
+                    // 計算地名有效期與朝代的重疊天數（越大越優先）
+                    $addrStart = $addr->c_firstyear ?? $dyStart;
+                    $addrEnd = $addr->c_lastyear ?? $dyEnd;
+                    $overlapStart = max($addrStart, $dyStart);
+                    $overlapEnd = min($addrEnd, $dyEnd);
+
+                    return max(0, $overlapEnd - $overlapStart);
+                });
+            }
+
             $result = $results->first();
 
             // 判斷 match_type：
@@ -757,27 +753,8 @@ class PostingAutofillService {
             // SQLite 使用 LENGTH，MySQL/MariaDB 使用 CHAR_LENGTH
             ->whereRaw('NOT (c_name_chn LIKE ? AND ' . (is_sqlite() ? 'LENGTH' : 'CHAR_LENGTH') . '(c_name_chn) > 2)', ['%津']);
 
-        if ($effectiveYear !== null) {
-            $query->where(function ($q) use ($effectiveYear) {
-                $q->where(function ($subQ) use ($effectiveYear) {
-                    // 兩邊都有值且包含任官年份
-                    $subQ->where('c_firstyear', '<=', $effectiveYear)
-                        ->where('c_lastyear', '>=', $effectiveYear);
-                })->orWhere(function ($subQ) {
-                    // 兩邊都為 NULL
-                    $subQ->whereNull('c_firstyear')
-                        ->whereNull('c_lastyear');
-                })->orWhere(function ($subQ) use ($effectiveYear) {
-                    // 開放式結束（只有開始年份）
-                    $subQ->where('c_firstyear', '<=', $effectiveYear)
-                        ->whereNull('c_lastyear');
-                })->orWhere(function ($subQ) use ($effectiveYear) {
-                    // 開放式開始（只有結束年份）
-                    $subQ->whereNull('c_firstyear')
-                        ->where('c_lastyear', '>=', $effectiveYear);
-                });
-            });
-        }
+        // 加入時間過濾
+        $this->applyAddrTimeFilter($query, $effectiveYear, $dynastyRangeFilter);
 
         $result = $query->first();
 
@@ -787,6 +764,58 @@ class PostingAutofillService {
             'match_type' => 'fuzzy',  // 前綴匹配視為模糊匹配
             'matched_length' => mb_strlen($result->text),
         ] : null;
+    }
+
+    /**
+     * 為地址查詢加入時間過濾條件
+     *
+     * 兩種模式：
+     * 1. 精確年份：地名有效期包含該年份
+     * 2. 朝代範圍交集：地名有效期與朝代有任何重疊即可
+     */
+    protected function applyAddrTimeFilter($query, ?int $effectiveYear, ?array $dynastyRangeFilter): void {
+        if ($effectiveYear !== null) {
+            // 模式 1：有具體年份，地名有效期須包含該年份
+            $query->where(function ($q) use ($effectiveYear) {
+                $q->where(function ($subQ) use ($effectiveYear) {
+                    $subQ->where('c_firstyear', '<=', $effectiveYear)
+                        ->where('c_lastyear', '>=', $effectiveYear);
+                })->orWhere(function ($subQ) {
+                    $subQ->whereNull('c_firstyear')
+                        ->whereNull('c_lastyear');
+                })->orWhere(function ($subQ) use ($effectiveYear) {
+                    $subQ->where('c_firstyear', '<=', $effectiveYear)
+                        ->whereNull('c_lastyear');
+                })->orWhere(function ($subQ) use ($effectiveYear) {
+                    $subQ->whereNull('c_firstyear')
+                        ->where('c_lastyear', '>=', $effectiveYear);
+                });
+            });
+        } elseif ($dynastyRangeFilter !== null) {
+            // 模式 2：無具體年份，只要地名有效期與朝代範圍有交集即可
+            // 交集條件：addr.firstyear <= dynasty.end AND addr.lastyear >= dynasty.start
+            $dyStart = $dynastyRangeFilter['start'];
+            $dyEnd = $dynastyRangeFilter['end'];
+            $query->where(function ($q) use ($dyStart, $dyEnd) {
+                $q->where(function ($subQ) use ($dyStart, $dyEnd) {
+                    // 兩邊都有值，且與朝代範圍有交集
+                    $subQ->where('c_firstyear', '<=', $dyEnd)
+                        ->where('c_lastyear', '>=', $dyStart);
+                })->orWhere(function ($subQ) {
+                    // 時間範圍為 NULL（不限時間）
+                    $subQ->whereNull('c_firstyear')
+                        ->whereNull('c_lastyear');
+                })->orWhere(function ($subQ) use ($dyEnd) {
+                    // 開放式結束：開始年份在朝代結束之前
+                    $subQ->where('c_firstyear', '<=', $dyEnd)
+                        ->whereNull('c_lastyear');
+                })->orWhere(function ($subQ) use ($dyStart) {
+                    // 開放式開始：結束年份在朝代開始之後
+                    $subQ->whereNull('c_firstyear')
+                        ->where('c_lastyear', '>=', $dyStart);
+                });
+            });
+        }
     }
 
     /**

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -621,10 +621,10 @@
                                 const listModel = listApiMap[fieldName];
 
                                 if (searchModel) {
-                                    // 調用搜索 API 獲取完整格式化數據
+                                    // 用 ID 搜索以確保精確命中（文本搜索可能因分頁而遺漏）
                                     $.ajax({
                                         url: `/api/select/search/${searchModel}`,
-                                        data: { q: fieldData.text },
+                                        data: { q: fieldData.value },
                                         method: 'GET'
                                     }).done(response => {
                                         $field.empty();
@@ -797,11 +797,11 @@
                             } else {
                                 // 單選欄位
                                 if (isAjaxSelect) {
-                                    // AJAX Select2：調用 AJAX 獲取完整格式化數據
+                                    // AJAX Select2：用 ID 搜索以確保精確命中
                                     const model = ajaxModelMap[fieldName];
                                     $.ajax({
                                         url: `/api/select/search/${model}`,
-                                        data: { q: fieldData.text },
+                                        data: { q: fieldData.value },
                                         method: 'GET'
                                     }).done(response => {
                                         $field.empty();

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -396,6 +396,96 @@ class AiPostingAutofillTest extends TestCase {
     }
 
     /**
+     * 測試無具體年份時，地址按朝代範圍交集過濾，且優先選重疊最多的同名地址
+     *
+     * 場景：明代人物，AI 提取「禹州」但無年份信息。
+     * 數據庫有兩條禹州：明代（1575-1643）和清代（1644-1911）。
+     * 兩條都與明代（1368-1644）有交集，但明代禹州重疊更多，應優先選擇。
+     */
+    public function test_address_dynasty_range_overlap_prefers_best_match() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 設定人物朝代為明（c_dy=19）
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 99999,
+            'c_dy' => 19,
+        ]);
+
+        // 插入兩條同名地址：明代禹州和清代禹州
+        DB::table('ADDR_CODES')->insert([
+            [
+                'c_addr_id' => 303350,
+                'c_name' => 'Yuzhou',
+                'c_name_chn' => '禹州',
+                'c_firstyear' => 1575,
+                'c_lastyear' => 1643,
+            ],
+            [
+                'c_addr_id' => 8078,
+                'c_name' => 'Yu Zhou',
+                'c_name_chn' => '禹州',
+                'c_firstyear' => 1644,
+                'c_lastyear' => 1911,
+            ],
+        ]);
+
+        // Mock AI 響應：只有地名，無任何年份信息
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => json_encode([
+                                'postings' => [
+                                    [
+                                        'title_str' => '吏目',
+                                        'addr_str' => ['full_text' => '河南禹州', 'parent' => '河南', 'name' => '禹州', 'admin_type' => '州'],
+                                        'c_firstyear' => null,
+                                        'c_fy_nh_code' => null,
+                                        'c_fy_nh_year' => null,
+                                        'c_fy_range' => null,
+                                        'c_fy_intercalary' => null,
+                                        'c_fy_month' => null,
+                                        'c_fy_day' => null,
+                                        'c_fy_day_gz' => null,
+                                        'c_lastyear' => null,
+                                        'c_ly_nh_code' => null,
+                                        'c_ly_nh_year' => null,
+                                        'c_ly_range' => null,
+                                        'c_ly_intercalary' => null,
+                                        'c_ly_month' => null,
+                                        'c_ly_day' => null,
+                                        'c_ly_day_gz' => null,
+                                        'c_appt_code' => 1,
+                                        'c_assume_office_code' => null,
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '授河南禹州吏目',
+            'person_id' => 99999,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $data = $response->json('data');
+
+        // 地址應出現在 matched 或 suggested 中，且為明代禹州（303350）而非清代（8078）
+        $addrField = $data['matched_fields']['c_addr'] ?? $data['suggested_fields']['c_addr'] ?? null;
+        $this->assertNotNull($addrField, '地址欄位應有匹配結果');
+        $this->assertContains(303350, (array) $addrField['value'], '應優先選擇與朝代重疊最多的明代禹州（303350），而非邊界交集的清代禹州（8078）');
+    }
+
+    /**
      * 測試朝代邊界重叠處理：1368年同時屬於元和明，無法確定則 fallback
      */
     public function test_dynasty_boundary_overlap_fallback_to_person_dynasty() {


### PR DESCRIPTION
## Summary
- 前端 Select2 AJAX 搜索改用 ID 而非文本，避免分頁導致目標記錄遺漏（如「吏目」50 條結果中目標在第 2 頁）
- 無具體任官年份時，地址匹配從朝代中點年份過濾改為朝代範圍交集過濾，解決朝代中後期建置地名被排除的問題（如明代禹州 1575 年建置）
- 同名地址多條時按與朝代重疊年數排序，優先選最佳匹配（修正 select 缺少年份欄位導致排序失效）

## Test plan
- [x] `./vendor/bin/phpunit --filter AiPostingAutofill`（11 tests, 43 assertions 全部通過）
- [x] 新增回歸測試 `test_address_dynasty_range_overlap_prefers_best_match` 驗證無年份時的地址朝代交集過濾與排序
- [x] 實際測試「授河南禹州吏目」填充，官名（70680 明代吏目）與地址均正確匹配
- [x] `./vendor/bin/php-cs-fixer fix`（無格式問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)