### PR TITLE
利用 ADDRESSES 表行政層級鏈消歧並存朝代下的同名地名

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -710,7 +710,26 @@ class PostingAutofillService {
                 }
             }
 
-            // 當使用朝代範圍過濾且仍有多條同名結果時，優先選有效期與朝代重疊最多的
+            // 朝代消歧：利用 ADDRESSES 表的層級鏈（最頂層為朝代）進行精確朝代匹配
+            // 若朝代匹配無結果，則 fallback 到時間段重疊排序
+            if ($isAmbiguous && $dynastyCode !== null) {
+                $dynastyFiltered = $this->filterByDynastyHierarchy(
+                    $results->pluck('id')->toArray(),
+                    $dynastyCode,
+                    $effectiveYear,
+                    $dynastyRangeFilter
+                );
+
+                if ($dynastyFiltered !== null && $dynastyFiltered->count() > 0) {
+                    $results = $results->whereIn('id', $dynastyFiltered->toArray());
+                    $isAmbiguous = $results->count() > 1;
+                    if (!$isAmbiguous) {
+                        $parentMatched = true; // 朝代匹配成功視同消歧成功
+                    }
+                }
+            }
+
+            // Fallback：仍有歧義時，優先選有效期與朝代重疊最多的
             if ($isAmbiguous && $dynastyRangeFilter !== null) {
                 $dyStart = $dynastyRangeFilter['start'];
                 $dyEnd = $dynastyRangeFilter['end'];
@@ -764,6 +783,129 @@ class PostingAutofillService {
             'match_type' => 'fuzzy',  // 前綴匹配視為模糊匹配
             'matched_length' => mb_strlen($result->text),
         ] : null;
+    }
+
+    /**
+     * 利用 ADDRESSES 表的行政層級鏈進行朝代消歧
+     *
+     * ADDRESSES 表的 belongsX_Name_chn 記錄了完整的行政層級，最頂層為朝代（如「宋朝」「遼朝」）。
+     * 透過匹配層級鏈中的朝代名稱，可精確區分宋/遼/金等並存朝代下的同名地名。
+     *
+     * @param array $candidateIds 候選地址 ID 列表
+     * @param int $dynastyCode 朝代代碼
+     * @param int|null $effectiveYear 任官年份（用於過濾 ADDRESSES 的時間段）
+     * @param array|null $dynastyRangeFilter 朝代年份範圍（無具體年份時使用）
+     * @return \Illuminate\Support\Collection|null 匹配的地址 ID 集合，無法匹配時返回 null
+     */
+    protected function filterByDynastyHierarchy(array $candidateIds, int $dynastyCode, ?int $effectiveYear, ?array $dynastyRangeFilter): ?\Illuminate\Support\Collection {
+        if (empty($candidateIds)) {
+            return null;
+        }
+
+        // 取得朝代中文名（如「宋」「遼」「金」）
+        $dynastyChn = DB::table('DYNASTIES')
+            ->where('c_dy', $dynastyCode)
+            ->value('c_dynasty_chn');
+
+        if (empty($dynastyChn)) {
+            return null;
+        }
+
+        // 從 ADDRESSES 表查詢候選地址的層級記錄
+        $query = DB::table('ADDRESSES')
+            ->whereIn('c_addr_id', $candidateIds)
+            ->select(
+                'c_addr_id',
+                'c_belongs_firstyear',
+                'c_belongs_lastyear',
+                'belongs1_Name_chn',
+                'belongs2_Name_chn',
+                'belongs3_Name_chn',
+                'belongs4_Name_chn',
+                'belongs5_Name_chn'
+            );
+
+        // 加入時間過濾：只匹配任官時間內有效的層級記錄
+        // 處理 NULL 值：視為開放式邊界（與 applyAddrTimeFilter 一致）
+        if ($effectiveYear !== null) {
+            $query->where(function ($q) use ($effectiveYear) {
+                $q->where(function ($sub) use ($effectiveYear) {
+                    $sub->where('c_belongs_firstyear', '<=', $effectiveYear)
+                        ->where('c_belongs_lastyear', '>=', $effectiveYear);
+                })->orWhere(function ($sub) {
+                    $sub->whereNull('c_belongs_firstyear')
+                        ->whereNull('c_belongs_lastyear');
+                })->orWhere(function ($sub) use ($effectiveYear) {
+                    $sub->where('c_belongs_firstyear', '<=', $effectiveYear)
+                        ->whereNull('c_belongs_lastyear');
+                })->orWhere(function ($sub) use ($effectiveYear) {
+                    $sub->whereNull('c_belongs_firstyear')
+                        ->where('c_belongs_lastyear', '>=', $effectiveYear);
+                });
+            });
+        } elseif ($dynastyRangeFilter !== null) {
+            $dyStart = $dynastyRangeFilter['start'];
+            $dyEnd = $dynastyRangeFilter['end'];
+            $query->where(function ($q) use ($dyStart, $dyEnd) {
+                $q->where(function ($sub) use ($dyStart, $dyEnd) {
+                    $sub->where('c_belongs_firstyear', '<=', $dyEnd)
+                        ->where('c_belongs_lastyear', '>=', $dyStart);
+                })->orWhere(function ($sub) {
+                    $sub->whereNull('c_belongs_firstyear')
+                        ->whereNull('c_belongs_lastyear');
+                })->orWhere(function ($sub) use ($dyEnd) {
+                    $sub->where('c_belongs_firstyear', '<=', $dyEnd)
+                        ->whereNull('c_belongs_lastyear');
+                })->orWhere(function ($sub) use ($dyStart) {
+                    $sub->whereNull('c_belongs_firstyear')
+                        ->where('c_belongs_lastyear', '>=', $dyStart);
+                });
+            });
+        }
+
+        $rows = $query->get();
+
+        if ($rows->isEmpty()) {
+            Log::info('[AI Autofill] ADDRESSES 表無匹配記錄，跳過朝代消歧', [
+                'candidate_ids' => $candidateIds,
+                'dynasty_code' => $dynastyCode,
+            ]);
+
+            return null;
+        }
+
+        // 檢查每個候選地址層級鏈的最頂層（最後一個有值的 belongsX）是否為目標朝代
+        // ADDRESSES 中朝代格式為「宋朝」「遼朝」，DYNASTIES 為「宋」「遼」，使用 contains 匹配
+        $matchedIds = $rows->filter(function ($row) use ($dynastyChn) {
+            // 取最後一個有值的 belongsX_Name_chn（即最頂層，通常是朝代）
+            $levels = [
+                $row->belongs5_Name_chn,
+                $row->belongs4_Name_chn,
+                $row->belongs3_Name_chn,
+                $row->belongs2_Name_chn,
+                $row->belongs1_Name_chn,
+            ];
+
+            $topLevel = null;
+            foreach ($levels as $levelName) {
+                if ($levelName !== null) {
+                    $topLevel = $levelName;
+
+                    break;
+                }
+            }
+
+            return $topLevel !== null && str_contains($topLevel, $dynastyChn);
+        })->pluck('c_addr_id')->unique();
+
+        Log::info('[AI Autofill] 朝代層級消歧結果', [
+            'candidate_ids' => $candidateIds,
+            'dynasty_chn' => $dynastyChn,
+            'matched_addr_ids' => $matchedIds->values()->toArray(),
+            'total_addresses_rows' => $rows->count(),
+        ]);
+
+        return $matchedIds->isNotEmpty() ? $matchedIds : null;
     }
 
     /**

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -552,4 +552,127 @@ class AiPostingAutofillTest extends TestCase {
         $data = $response->json('data');
         $this->assertArrayNotHasKey('c_dy', $data['matched_fields'] ?? []);
     }
+
+    /**
+     * 測試並存朝代（宋/遼）地名消歧：利用 ADDRESSES 表的層級鏈區分同名地名
+     */
+    public function test_concurrent_dynasty_address_disambiguation_via_hierarchy() {
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        // 插入遼朝（測試 setUp 中沒有）
+        DB::table('DYNASTIES')->insert([
+            'c_dy' => 16, 'c_dynasty_chn' => '遼', 'c_dynasty' => 'Liao', 'c_start' => 947, 'c_end' => 1125, 'c_sort' => 16,
+        ]);
+
+        // 設定人物朝代為宋
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 88888,
+            'c_dy' => 15,
+        ]);
+
+        // 插入兩個同名地址：宋的鳳州和遼的鳳州，時間範圍重疊
+        DB::table('ADDR_CODES')->insert([
+            [
+                'c_addr_id' => 13691,
+                'c_name' => 'Feng Zhou',
+                'c_name_chn' => '鳳州',
+                'c_firstyear' => 1144,
+                'c_lastyear' => 1279,
+            ],
+            [
+                'c_addr_id' => 3862,
+                'c_name' => 'Feng Zhou',
+                'c_name_chn' => '鳳州',
+                'c_firstyear' => 908,
+                'c_lastyear' => 1121,
+            ],
+        ]);
+
+        // 插入 ADDRESSES 表的層級記錄（模擬真實數據）
+        DB::table('ADDRESSES')->insert([
+            [
+                'c_addr_id' => 13691,
+                'c_name' => 'Feng Zhou',
+                'c_name_chn' => '鳳州',
+                'c_admin_type' => 'Zhou',
+                'c_firstyear' => 1144,
+                'c_lastyear' => 1279,
+                'c_belongs_firstyear' => 1144,
+                'c_belongs_lastyear' => 1279,
+                'belongs1_Name' => '利州路',
+                'belongs1_Name_chn' => '利州路',
+                'belongs2_Name' => '宋朝',
+                'belongs2_Name_chn' => '宋朝',
+            ],
+            [
+                'c_addr_id' => 3862,
+                'c_name' => 'Feng Zhou',
+                'c_name_chn' => '鳳州',
+                'c_admin_type' => 'Zhou',
+                'c_firstyear' => 908,
+                'c_lastyear' => 1121,
+                'c_belongs_firstyear' => 947,
+                'c_belongs_lastyear' => 1115,
+                'belongs1_Name' => '上京道',
+                'belongs1_Name_chn' => '上京道',
+                'belongs2_Name' => '遼朝',
+                'belongs2_Name_chn' => '遼朝',
+            ],
+        ]);
+
+        // Mock AI 響應：鳳州，任官年份 1200（宋朝時期）
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => json_encode([
+                                'postings' => [
+                                    [
+                                        'title_str' => '',
+                                        'addr_str' => ['full_text' => '鳳州', 'parent' => null, 'name' => '鳳州', 'admin_type' => '州'],
+                                        'c_firstyear' => 1200,
+                                        'c_fy_nh_code' => null,
+                                        'c_fy_nh_year' => null,
+                                        'c_fy_range' => null,
+                                        'c_fy_intercalary' => null,
+                                        'c_fy_month' => null,
+                                        'c_fy_day' => null,
+                                        'c_fy_day_gz' => null,
+                                        'c_lastyear' => null,
+                                        'c_ly_nh_code' => null,
+                                        'c_ly_nh_year' => null,
+                                        'c_ly_range' => null,
+                                        'c_ly_intercalary' => null,
+                                        'c_ly_month' => null,
+                                        'c_ly_day' => null,
+                                        'c_ly_day_gz' => null,
+                                        'c_appt_code' => null,
+                                        'c_assume_office_code' => null,
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '嘉泰元年知鳳州',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $data = $response->json('data');
+
+        // 地址應匹配到宋的鳳州（13691），而非遼的鳳州（3862）
+        $addrField = $data['matched_fields']['c_addr'] ?? $data['suggested_fields']['c_addr'] ?? null;
+        $this->assertNotNull($addrField, '地址欄位應有匹配結果');
+        $this->assertContains(13691, (array) $addrField['value'], '應選擇宋朝的鳳州（13691），而非遼朝的鳳州（3862）');
+    }
 }


### PR DESCRIPTION
## Summary
- AI 任官自動填充的地址匹配新增朝代消歧：查詢 ADDRESSES 表的 belongsX_Name_chn 最頂層（即朝代），精確區分宋/遼/金等並存朝代下的同名地名（如鳳州）
- 消歧優先順序：上層地名 → 朝代層級(ADDRESSES 表) → 時間重疊排序(fallback)
- 時間過濾處理 NULL 值，與 applyAddrTimeFilter 保持一致

## Test plan
- [x] 既有 12 個 AiPostingAutofillTest 全部通過
- [x] 新增並存朝代消歧測試：宋朝人物 + 鳳州 → 正確選到宋的鳳州(13691)而非遼的鳳州(3862)
- [x] 實際數據庫驗證：鳳州在宋/遼/唐/元四個朝代均能正確消歧
- [x] 在生產環境中測試 AI 自動填充功能，確認並存朝代地名的填充準確性

🤖 Generated with [Claude Code](https://claude.com/claude-code)