### PR TITLE
改善 Query Playground SSE 穩定性

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -191,50 +191,90 @@ class QueryPlaygroundController extends Controller {
     }
 
     /**
-     * 建立標準 SSE 回應，加入 keep-alive heartbeat 並安全 flush 緩衝區。
+     * 建立標準 SSE 回應，提供事件發送、heartbeat 與斷線檢查。
      *
-     * @param callable(callable(string, mixed): void): void $producer
+     * @param callable(callable(string, mixed): void, callable(): bool, callable(): bool): void $producer
      */
     protected function streamSseResponse(callable $producer) {
         return response()->stream(function () use ($producer) {
             ignore_user_abort(true);
 
             $lastSentAt = microtime(true);
+            $heartbeatInterval = max(0, (int) config('query_playground.sse_heartbeat_seconds', self::SSE_HEARTBEAT_INTERVAL_SECONDS));
+            $clientDisconnected = false;
 
-            $flush = function () {
+            $isClientDisconnected = function () use (&$clientDisconnected) {
+                if ($clientDisconnected) {
+                    return true;
+                }
+
+                $clientDisconnected = connection_aborted() !== 0;
+
+                return $clientDisconnected;
+            };
+
+            $flush = function () use (&$clientDisconnected) {
                 if (ob_get_level() > 0) {
                     @ob_flush();
                 }
 
                 flush();
+                $clientDisconnected = connection_aborted() !== 0;
             };
 
-            $sendComment = function (string $comment) use (&$lastSentAt, $flush) {
+            $sendComment = function (string $comment) use (&$lastSentAt, $flush, $isClientDisconnected) {
+                if ($isClientDisconnected()) {
+                    return false;
+                }
+
                 echo ': ' . $comment . "\n\n";
                 $lastSentAt = microtime(true);
                 $flush();
+
+                return !$isClientDisconnected();
             };
 
-            $sendEvent = function (string $event, $data) use (&$lastSentAt, $flush) {
+            $sendEvent = function (string $event, $data) use (&$lastSentAt, $flush, $isClientDisconnected) {
+                if ($isClientDisconnected()) {
+                    return false;
+                }
+
                 echo "event: {$event}\n";
                 echo 'data: ' . json_encode($data, JSON_UNESCAPED_UNICODE) . "\n\n";
                 $lastSentAt = microtime(true);
                 $flush();
+
+                return !$isClientDisconnected();
             };
 
-            $sendHeartbeatIfNeeded = function () use (&$lastSentAt, $sendComment) {
-                if ((microtime(true) - $lastSentAt) >= self::SSE_HEARTBEAT_INTERVAL_SECONDS) {
-                    $sendComment('keep-alive');
+            $sendHeartbeatIfNeeded = function () use (&$lastSentAt, $heartbeatInterval, $sendComment, $isClientDisconnected) {
+                if ($isClientDisconnected()) {
+                    return false;
                 }
+
+                if ((microtime(true) - $lastSentAt) >= $heartbeatInterval) {
+                    return $sendComment('keep-alive');
+                }
+
+                return true;
             };
 
             // 先送出一個 padding comment，降低代理 / 瀏覽器對小回應的緩衝影響。
-            $sendComment(str_repeat(' ', 2048));
+            if (!$sendComment(str_repeat(' ', (int) config('query_playground.sse_padding_bytes', 2048)))) {
+                return;
+            }
 
-            $producer(function (string $event, $data) use ($sendEvent, $sendHeartbeatIfNeeded) {
-                $sendHeartbeatIfNeeded();
-                $sendEvent($event, $data);
-            });
+            $producer(
+                function (string $event, $data) use ($sendEvent, $sendHeartbeatIfNeeded, $isClientDisconnected) {
+                    if (!$sendHeartbeatIfNeeded() || $isClientDisconnected()) {
+                        return;
+                    }
+
+                    $sendEvent($event, $data);
+                },
+                $sendHeartbeatIfNeeded,
+                $isClientDisconnected
+            );
         }, 200, [
             'Content-Type' => 'text/event-stream; charset=UTF-8',
             'Cache-Control' => 'no-cache, no-transform',
@@ -266,10 +306,10 @@ class QueryPlaygroundController extends Controller {
 
         $useTools = $request->boolean('use_tools', true);
 
-        return $this->streamSseResponse(function (callable $sendEvent) use ($question, $tables, $nlqService, $useTools) {
+        return $this->streamSseResponse(function (callable $sendEvent, callable $sendHeartbeatIfNeeded, callable $isClientDisconnected) use ($question, $tables, $nlqService, $useTools) {
             try {
                 // 调用服务并传入进度回调
-                $result = $nlqService->generateSQL($question, $tables, $sendEvent, $useTools);
+                $result = $nlqService->generateSQL($question, $tables, $sendEvent, $useTools, $sendHeartbeatIfNeeded, $isClientDisconnected);
 
                 // 发送最终结果
                 if ($result['success']) {
@@ -386,9 +426,9 @@ class QueryPlaygroundController extends Controller {
         $tables = $request->input('tables');
         $useTools = $request->boolean('use_tools', true);
 
-        return $this->streamSseResponse(function (callable $sendEvent) use ($question, $tables, $nlqService, $useTools) {
+        return $this->streamSseResponse(function (callable $sendEvent, callable $sendHeartbeatIfNeeded, callable $isClientDisconnected) use ($question, $tables, $nlqService, $useTools) {
             try {
-                $result = $nlqService->answerQuestion($question, $tables, $sendEvent, $useTools);
+                $result = $nlqService->answerQuestion($question, $tables, $sendEvent, $useTools, $sendHeartbeatIfNeeded, $isClientDisconnected);
 
                 if ($result['success']) {
                     $sendEvent('complete', [

--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -12,6 +12,8 @@ use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
 class QueryPlaygroundController extends Controller {
+    protected const SSE_HEARTBEAT_INTERVAL_SECONDS = 10;
+
     protected QueryPlaygroundService $playgroundService;
 
     public function __construct(QueryPlaygroundService $playgroundService) {
@@ -189,6 +191,58 @@ class QueryPlaygroundController extends Controller {
     }
 
     /**
+     * 建立標準 SSE 回應，加入 keep-alive heartbeat 並安全 flush 緩衝區。
+     *
+     * @param callable(callable(string, mixed): void): void $producer
+     */
+    protected function streamSseResponse(callable $producer) {
+        return response()->stream(function () use ($producer) {
+            ignore_user_abort(true);
+
+            $lastSentAt = microtime(true);
+
+            $flush = function () {
+                if (ob_get_level() > 0) {
+                    @ob_flush();
+                }
+
+                flush();
+            };
+
+            $sendComment = function (string $comment) use (&$lastSentAt, $flush) {
+                echo ': ' . $comment . "\n\n";
+                $lastSentAt = microtime(true);
+                $flush();
+            };
+
+            $sendEvent = function (string $event, $data) use (&$lastSentAt, $flush) {
+                echo "event: {$event}\n";
+                echo 'data: ' . json_encode($data, JSON_UNESCAPED_UNICODE) . "\n\n";
+                $lastSentAt = microtime(true);
+                $flush();
+            };
+
+            $sendHeartbeatIfNeeded = function () use (&$lastSentAt, $sendComment) {
+                if ((microtime(true) - $lastSentAt) >= self::SSE_HEARTBEAT_INTERVAL_SECONDS) {
+                    $sendComment('keep-alive');
+                }
+            };
+
+            // 先送出一個 padding comment，降低代理 / 瀏覽器對小回應的緩衝影響。
+            $sendComment(str_repeat(' ', 2048));
+
+            $producer(function (string $event, $data) use ($sendEvent, $sendHeartbeatIfNeeded) {
+                $sendHeartbeatIfNeeded();
+                $sendEvent($event, $data);
+            });
+        }, 200, [
+            'Content-Type' => 'text/event-stream; charset=UTF-8',
+            'Cache-Control' => 'no-cache, no-transform',
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+
+    /**
      * 使用自然语言生成 SQL 查询（SSE 流式响应）
      *
      * @param Request $request
@@ -212,20 +266,7 @@ class QueryPlaygroundController extends Controller {
 
         $useTools = $request->boolean('use_tools', true);
 
-        return response()->stream(function () use ($question, $tables, $nlqService, $useTools) {
-            // 設定 SSE 头部
-            header('Content-Type: text/event-stream');
-            header('Cache-Control: no-cache');
-            header('X-Accel-Buffering: no'); // 禁用 nginx 缓冲
-
-            // 发送事件的辅助函数
-            $sendEvent = function ($event, $data) {
-                echo "event: {$event}\n";
-                echo 'data: ' . json_encode($data, JSON_UNESCAPED_UNICODE) . "\n\n";
-                ob_flush();
-                flush();
-            };
-
+        return $this->streamSseResponse(function (callable $sendEvent) use ($question, $tables, $nlqService, $useTools) {
             try {
                 // 调用服务并传入进度回调
                 $result = $nlqService->generateSQL($question, $tables, $sendEvent, $useTools);
@@ -251,11 +292,7 @@ class QueryPlaygroundController extends Controller {
                     'error' => '生成 SQL 时发生错误: ' . $e->getMessage(),
                 ]);
             }
-        }, 200, [
-            'Content-Type' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
-            'X-Accel-Buffering' => 'no',
-        ]);
+        });
     }
 
     /**
@@ -349,18 +386,7 @@ class QueryPlaygroundController extends Controller {
         $tables = $request->input('tables');
         $useTools = $request->boolean('use_tools', true);
 
-        return response()->stream(function () use ($question, $tables, $nlqService, $useTools) {
-            header('Content-Type: text/event-stream');
-            header('Cache-Control: no-cache');
-            header('X-Accel-Buffering: no');
-
-            $sendEvent = function ($event, $data) {
-                echo "event: {$event}\n";
-                echo 'data: ' . json_encode($data, JSON_UNESCAPED_UNICODE) . "\n\n";
-                ob_flush();
-                flush();
-            };
-
+        return $this->streamSseResponse(function (callable $sendEvent) use ($question, $tables, $nlqService, $useTools) {
             try {
                 $result = $nlqService->answerQuestion($question, $tables, $sendEvent, $useTools);
 
@@ -387,11 +413,7 @@ class QueryPlaygroundController extends Controller {
                     'error' => '問答生成時發生錯誤: ' . $e->getMessage(),
                 ]);
             }
-        }, 200, [
-            'Content-Type' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
-            'X-Accel-Buffering' => 'no',
-        ]);
+        });
     }
 
     /**

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -449,6 +449,12 @@ class NaturalLanguageQueryService {
                     'question_preview' => mb_substr($question, 0, 120),
                 ]);
 
+                if ($progressCallback) {
+                    $progressCallback('status', [
+                        'message' => "正在等待 LLM 第 {$round} 輪回應",
+                    ]);
+                }
+
                 $response = $this->callLLMForQa($messages, $tools, $allowTools);
 
                 if ($progressCallback) {

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -31,7 +31,14 @@ class NaturalLanguageQueryService {
      * @param bool|null $useToolsOverride 是否強制啟用工具（為 null 時依配置）
      * @return array ['success' => bool, 'sql' => string|null, 'error' => string|null, 'explanation' => string|null, 'model' => string|null, 'tool_calls' => array|null]
      */
-    public function generateSQL(string $question, ?array $tableNames = null, ?callable $progressCallback = null, ?bool $useToolsOverride = null): array {
+    public function generateSQL(
+        string $question,
+        ?array $tableNames = null,
+        ?callable $progressCallback = null,
+        ?bool $useToolsOverride = null,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
         if (empty($this->apiKey)) {
             return [
                 'success' => false,
@@ -81,8 +88,15 @@ class NaturalLanguageQueryService {
                 ],
             ];
 
+            if ($progressCallback) {
+                $progressCallback('status', [
+                    'round' => 1,
+                    'message' => '正在等待 LLM 第 1 輪回應',
+                ]);
+            }
+
             // 第一次调用 LLM（可能返回工具调用请求）
-            $response = $this->callLLM($messages, $tools, $toolsEnabled);
+            $response = $this->callLLM($messages, $tools, $toolsEnabled, $heartbeatCallback, $abortCheck);
 
             // 发送进度：第一次 LLM 调用完成
             if ($progressCallback) {
@@ -94,7 +108,14 @@ class NaturalLanguageQueryService {
 
             if (!$response['success']) {
                 if ($toolsEnabled) {
-                    $fallback = $this->fallbackToNonToolMode($messages, $progressCallback, null, $response['error']);
+                    $fallback = $this->fallbackToNonToolMode(
+                        $messages,
+                        $progressCallback,
+                        null,
+                        $response['error'],
+                        $heartbeatCallback,
+                        $abortCheck
+                    );
                     if ($fallback['success']) {
                         $result = $fallback['result'];
                         $result['model'] = $this->model;
@@ -236,7 +257,14 @@ class NaturalLanguageQueryService {
                         }
 
                         if ($round >= $maxRounds) {
-                            $fallback = $this->fallbackToNonToolMode($messages, $progressCallback, $allToolResults, '工具調用次數超過上限');
+                            $fallback = $this->fallbackToNonToolMode(
+                                $messages,
+                                $progressCallback,
+                                $allToolResults,
+                                '工具調用次數超過上限',
+                                $heartbeatCallback,
+                                $abortCheck
+                            );
                             if ($fallback['success']) {
                                 $result = $fallback['result'];
                                 $result['tool_calls'] = $allToolResults;
@@ -277,7 +305,14 @@ class NaturalLanguageQueryService {
                             ];
                         }
 
-                        $response = $this->callLLM($messages, $tools, true);
+                        if ($progressCallback) {
+                            $progressCallback('status', [
+                                'round' => $round + 1,
+                                'message' => "正在等待 LLM 第 " . ($round + 1) . ' 輪回應',
+                            ]);
+                        }
+
+                        $response = $this->callLLM($messages, $tools, true, $heartbeatCallback, $abortCheck);
                         if ($progressCallback) {
                             $progressCallback('llm_call_complete', [
                                 'round' => $round + 1,
@@ -286,7 +321,14 @@ class NaturalLanguageQueryService {
                         }
 
                         if (!$response['success']) {
-                            $fallback = $this->fallbackToNonToolMode($messages, $progressCallback, $allToolResults, $response['error']);
+                            $fallback = $this->fallbackToNonToolMode(
+                                $messages,
+                                $progressCallback,
+                                $allToolResults,
+                                $response['error'],
+                                $heartbeatCallback,
+                                $abortCheck
+                            );
                             if ($fallback['success']) {
                                 $result = $fallback['result'];
                                 $result['tool_calls'] = $allToolResults;
@@ -394,7 +436,14 @@ class NaturalLanguageQueryService {
      * @param bool|null $useToolsOverride 是否強制啟用工具
      * @return array
      */
-    public function answerQuestion(string $question, ?array $tableNames = null, ?callable $progressCallback = null, ?bool $useToolsOverride = null): array {
+    public function answerQuestion(
+        string $question,
+        ?array $tableNames = null,
+        ?callable $progressCallback = null,
+        ?bool $useToolsOverride = null,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
         if (empty($this->apiKey)) {
             return [
                 'success' => false,
@@ -455,7 +504,7 @@ class NaturalLanguageQueryService {
                     ]);
                 }
 
-                $response = $this->callLLMForQa($messages, $tools, $allowTools);
+                $response = $this->callLLMForQa($messages, $tools, $allowTools, $heartbeatCallback, $abortCheck);
 
                 if ($progressCallback) {
                     $progressCallback('status', [
@@ -690,13 +739,19 @@ PROMPT;
     /**
      * 呼叫 LLM API（QA 模式：允許工具時不強制 structured output）
      */
-    protected function callLLMForQa(array $messages, array $tools = [], bool $allowToolCalls = false): array {
+    protected function callLLMForQa(
+        array $messages,
+        array $tools = [],
+        bool $allowToolCalls = false,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
         if ($allowToolCalls && !empty($tools)) {
-            return $this->callLLM($messages, $tools, true);
+            return $this->callLLM($messages, $tools, true, $heartbeatCallback, $abortCheck);
         }
 
         // 最終回答輪：不使用 structured output，讓模型自由回答 JSON
-        return $this->callLLM($messages, [], false);
+        return $this->callLLM($messages, [], false, $heartbeatCallback, $abortCheck);
     }
 
     /**
@@ -1188,7 +1243,13 @@ PROMPT;
      * @param bool $allowToolCalls 是否允许工具调用
      * @return array ['success' => bool, 'data' => array|null, 'error' => string|null]
      */
-    protected function callLLM(array $messages, array $tools = [], bool $allowToolCalls = false): array {
+    protected function callLLM(
+        array $messages,
+        array $tools = [],
+        bool $allowToolCalls = false,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
         try {
             $maxCompletionTokens = (int) config('services.gemini.max_completion_tokens', 8192);
             if ($maxCompletionTokens < 256) {
@@ -1244,22 +1305,18 @@ PROMPT;
 
             for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
                 try {
-                    $response = Http::connectTimeout(10)
-                        ->timeout(45)
-                        ->withHeaders([
-                            'Content-Type' => 'application/json',
-                            'Authorization' => 'Bearer ' . $this->apiKey,
-                        ])
-                        ->post($this->apiEndpoint, $requestData);
+                    $this->assertClientConnected($abortCheck);
+
+                    $response = $this->performLlmHttpRequest($requestData, $heartbeatCallback, $abortCheck);
                     // 收到任何 HTTP 回應後，清除先前重試留下的 exception 狀態
                     $lastException = null;
 
-                    if ($response->successful()) {
+                    if ($response['successful']) {
                         break;
                     }
 
                     if ($this->shouldRetryHttpResponse($response) && $attempt < $maxAttempts) {
-                        usleep($retryDelayMs * 1000);
+                        $this->sleepWithHeartbeat($retryDelayMs, $heartbeatCallback, $abortCheck);
 
                         continue;
                     }
@@ -1269,7 +1326,7 @@ PROMPT;
                     $lastException = $exception;
 
                     if ($this->shouldRetryException($exception) && $attempt < $maxAttempts) {
-                        usleep($retryDelayMs * 1000);
+                        $this->sleepWithHeartbeat($retryDelayMs, $heartbeatCallback, $abortCheck);
 
                         continue;
                     }
@@ -1282,10 +1339,10 @@ PROMPT;
                 throw $lastException;
             }
 
-            if (!$response->successful()) {
-                $errorMessage = $this->extractApiErrorMessage($response->json(), $response->body());
+            if (!$response['successful']) {
+                $errorMessage = $this->extractApiErrorMessage($response['json'], $response['body']);
                 Log::error('LLM API 调用失败', [
-                    'status' => $response->status(),
+                    'status' => $response['status'],
                     'error' => $errorMessage,
                     'model' => $this->model,
                     'endpoint' => $this->apiEndpoint,
@@ -1300,10 +1357,29 @@ PROMPT;
 
             return [
                 'success' => true,
-                'data' => $response->json(),
+                'data' => $response['json'],
                 'error' => null,
             ];
 
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() === 'Client disconnected') {
+                return [
+                    'success' => false,
+                    'data' => null,
+                    'error' => '客戶端已中斷連線，已停止生成。',
+                ];
+            }
+
+            Log::error('调用 LLM 时发生异常', [
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return [
+                'success' => false,
+                'data' => null,
+                'error' => '调用 LLM 时发生错误: ' . $e->getMessage(),
+            ];
         } catch (\Exception $e) {
             Log::error('调用 LLM 时发生异常', [
                 'exception' => $e->getMessage(),
@@ -1315,6 +1391,141 @@ PROMPT;
                 'data' => null,
                 'error' => '调用 LLM 时发生错误: ' . $e->getMessage(),
             ];
+        }
+    }
+
+    protected function performLlmHttpRequest(
+        array $requestData,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
+        if ($heartbeatCallback === null && $abortCheck === null) {
+            $response = Http::connectTimeout(10)
+                ->timeout(45)
+                ->withHeaders([
+                    'Content-Type' => 'application/json',
+                    'Authorization' => 'Bearer ' . $this->apiKey,
+                ])
+                ->post($this->apiEndpoint, $requestData);
+
+            return [
+                'successful' => $response->successful(),
+                'status' => $response->status(),
+                'body' => $response->body(),
+                'json' => $response->json(),
+            ];
+        }
+
+        return $this->performHeartbeatAwareLlmRequest($requestData, $heartbeatCallback, $abortCheck);
+    }
+
+    protected function performHeartbeatAwareLlmRequest(
+        array $requestData,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): array {
+        $body = json_encode($requestData, JSON_UNESCAPED_UNICODE);
+        if ($body === false) {
+            throw new \RuntimeException('LLM 請求序列化失敗。');
+        }
+
+        $responseBody = '';
+        $ch = curl_init($this->apiEndpoint);
+        if ($ch === false) {
+            throw new \RuntimeException('無法初始化 cURL。');
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $this->apiKey,
+            ],
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_TIMEOUT => 45,
+            CURLOPT_RETURNTRANSFER => false,
+            CURLOPT_HEADER => false,
+            CURLOPT_WRITEFUNCTION => static function ($curl, string $chunk) use (&$responseBody) {
+                $responseBody .= $chunk;
+
+                return strlen($chunk);
+            },
+        ]);
+
+        $multiHandle = curl_multi_init();
+        curl_multi_add_handle($multiHandle, $ch);
+
+        try {
+            $running = null;
+
+            do {
+                $this->assertClientConnected($abortCheck);
+
+                do {
+                    $multiExecResult = curl_multi_exec($multiHandle, $running);
+                } while ($multiExecResult === CURLM_CALL_MULTI_PERFORM);
+
+                if ($multiExecResult !== CURLM_OK) {
+                    throw new \RuntimeException('cURL multi exec 失敗: ' . curl_multi_strerror($multiExecResult));
+                }
+
+                if ($running > 0) {
+                    if ($heartbeatCallback) {
+                        $heartbeatCallback();
+                    }
+
+                    $selectResult = curl_multi_select($multiHandle, 1.0);
+                    if ($selectResult === -1) {
+                        usleep(100000);
+                    }
+                }
+            } while ($running > 0);
+
+            if (curl_errno($ch) !== 0) {
+                throw new \RuntimeException(curl_error($ch));
+            }
+
+            $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        } finally {
+            curl_multi_remove_handle($multiHandle, $ch);
+            curl_multi_close($multiHandle);
+            curl_close($ch);
+        }
+
+        $decoded = json_decode($responseBody, true);
+
+        return [
+            'successful' => $status >= 200 && $status < 300,
+            'status' => $status,
+            'body' => $responseBody,
+            'json' => is_array($decoded) ? $decoded : null,
+        ];
+    }
+
+    protected function sleepWithHeartbeat(
+        int $milliseconds,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
+    ): void {
+        $remainingMs = max(0, $milliseconds);
+
+        while ($remainingMs > 0) {
+            $this->assertClientConnected($abortCheck);
+
+            if ($heartbeatCallback) {
+                $heartbeatCallback();
+            }
+
+            $sleepChunkMs = min(200, $remainingMs);
+            usleep($sleepChunkMs * 1000);
+            $remainingMs -= $sleepChunkMs;
+        }
+    }
+
+    protected function assertClientConnected(?callable $abortCheck = null): void {
+        if ($abortCheck && $abortCheck()) {
+            throw new \RuntimeException('Client disconnected');
         }
     }
 
@@ -1347,11 +1558,12 @@ PROMPT;
     }
 
     protected function shouldRetryHttpResponse($response): bool {
-        if ($response->status() >= 500) {
+        $status = is_array($response) ? ($response['status'] ?? 0) : $response->status();
+        if ($status >= 500) {
             return true;
         }
 
-        $body = $response->body();
+        $body = is_array($response) ? ($response['body'] ?? '') : $response->body();
 
         return stripos($body, 'UnexpectedEOFAtTarget') !== false
             || stripos($body, 'Unexpected EOF at target') !== false;
@@ -1809,7 +2021,9 @@ PROMPT;
         array $messages,
         ?callable $progressCallback = null,
         ?array $toolResults = null,
-        ?string $reason = null
+        ?string $reason = null,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null
     ): array {
         if ($progressCallback) {
             $progressCallback('llm_fallback_start', [
@@ -1824,7 +2038,7 @@ PROMPT;
             'content' => '若工具不可用，請根據既有 schema 資訊直接生成最合理的 SQL，並嚴格返回 JSON。',
         ];
 
-        $fallbackResponse = $this->callLLM($fallbackMessages, [], false);
+        $fallbackResponse = $this->callLLM($fallbackMessages, [], false, $heartbeatCallback, $abortCheck);
         if (!$fallbackResponse['success']) {
             if ($progressCallback) {
                 $progressCallback('llm_fallback_failed', [

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": "^8.2",
+        "ext-curl": "*",
         "guzzlehttp/guzzle": "^7.2",
         "inertiajs/inertia-laravel": "^2.0",
         "laracasts/flash": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f84e61dd430cf8b98a2569005387331",
+    "content-hash": "69553b83e394834aaf637b4880fa4d95",
     "packages": [
         {
             "name": "brick/math",
@@ -10277,7 +10277,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-curl": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/query_playground.php
+++ b/config/query_playground.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'sse_heartbeat_seconds' => env('QUERY_PLAYGROUND_SSE_HEARTBEAT_SECONDS', 10),
+    'sse_padding_bytes' => env('QUERY_PLAYGROUND_SSE_PADDING_BYTES', 2048),
+];

--- a/tests/Feature/HistoricalQaTest.php
+++ b/tests/Feature/HistoricalQaTest.php
@@ -284,6 +284,8 @@ class HistoricalQaTest extends TestCase {
 
         $response->assertStatus(200);
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
+        $this->assertSame('no-cache, no-transform', $response->headers->get('Cache-Control'));
+        $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
     }
 
     // ──── Regression: existing NL endpoints still work ────
@@ -337,5 +339,8 @@ class HistoricalQaTest extends TestCase {
         ], json_encode(['question' => '顯示所有朝代']));
 
         $response->assertStatus(200);
+        $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
+        $this->assertSame('no-cache, no-transform', $response->headers->get('Cache-Control'));
+        $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
     }
 }

--- a/tests/Feature/HistoricalQaTest.php
+++ b/tests/Feature/HistoricalQaTest.php
@@ -288,6 +288,56 @@ class HistoricalQaTest extends TestCase {
         $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
     }
 
+    #[Test]
+    public function answer_from_nl_stream_includes_keep_alive_comments_when_service_requests_heartbeat() {
+        Config::set('query_playground.sse_heartbeat_seconds', 0);
+
+        $this->be($this->adminUser);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')
+            ->willReturnCallback(function (
+                string $question,
+                ?array $tables,
+                ?callable $progressCallback,
+                ?bool $useTools,
+                ?callable $heartbeatCallback,
+                ?callable $abortCheck
+            ) {
+                $this->assertNotNull($heartbeatCallback);
+                $this->assertNotNull($abortCheck);
+                $this->assertFalse($abortCheck());
+
+                $heartbeatCallback();
+
+                return [
+                    'success' => true,
+                    'answer_markdown' => '李白是唐代詩人。',
+                    'summary' => '唐代詩人',
+                    'sql_used' => [],
+                    'tool_calls' => [],
+                    'evidence' => [],
+                    'caveat' => '',
+                    'model' => 'gemini-test-model',
+                ];
+            });
+
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $response = $this->call('POST', route('query-playground.answer-from-nl-stream'), [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'text/event-stream',
+        ], json_encode(['question' => '李白是什麼時代的人？']));
+
+        $response->assertStatus(200);
+        $response->assertStreamed();
+
+        $content = $response->streamedContent();
+
+        $this->assertStringContainsString(': keep-alive', $content);
+        $this->assertStringContainsString('event: complete', $content);
+    }
+
     // ──── Regression: existing NL endpoints still work ────
 
     #[Test]

--- a/tests/Feature/HistoricalQaTest.php
+++ b/tests/Feature/HistoricalQaTest.php
@@ -284,7 +284,7 @@ class HistoricalQaTest extends TestCase {
 
         $response->assertStatus(200);
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
-        $this->assertSame('no-cache, no-transform', $response->headers->get('Cache-Control'));
+        $this->assertStringContainsString('no-cache, no-transform', (string) $response->headers->get('Cache-Control'));
         $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
     }
 
@@ -340,7 +340,7 @@ class HistoricalQaTest extends TestCase {
 
         $response->assertStatus(200);
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
-        $this->assertSame('no-cache, no-transform', $response->headers->get('Cache-Control'));
+        $this->assertStringContainsString('no-cache, no-transform', (string) $response->headers->get('Cache-Control'));
         $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
     }
 }

--- a/tests/Unit/NaturalLanguageQueryServiceTest.php
+++ b/tests/Unit/NaturalLanguageQueryServiceTest.php
@@ -187,4 +187,82 @@ class NaturalLanguageQueryServiceTest extends TestCase {
         $this->assertStringContainsString('無法執行此操作', $result['error']);
         $this->assertStringContainsString('僅支援查詢', $result['error']);
     }
+
+    #[Test]
+    public function it_triggers_heartbeat_callback_during_blocking_llm_requests() {
+        Config::set('nl_query_tools.enabled', false);
+
+        $this->schemaService->method('generateSchemaPrompt')
+            ->willReturn('Mock schema info');
+
+        $service = new class ($this->schemaService, $this->toolsService) extends NaturalLanguageQueryService {
+            protected function performHeartbeatAwareLlmRequest(
+                array $requestData,
+                ?callable $heartbeatCallback = null,
+                ?callable $abortCheck = null
+            ): array {
+                if ($heartbeatCallback) {
+                    $heartbeatCallback();
+                    $heartbeatCallback();
+                }
+
+                return [
+                    'successful' => true,
+                    'status' => 200,
+                    'body' => json_encode([
+                        'choices' => [
+                            [
+                                'message' => [
+                                    'role' => 'assistant',
+                                    'content' => json_encode([
+                                        'sql' => 'SELECT * FROM DYNASTIES',
+                                        'explanation' => '此查詢選擇所有朝代。',
+                                        'error' => null,
+                                    ]),
+                                ],
+                                'finish_reason' => 'stop',
+                            ],
+                        ],
+                    ], JSON_UNESCAPED_UNICODE),
+                    'json' => [
+                        'choices' => [
+                            [
+                                'message' => [
+                                    'role' => 'assistant',
+                                    'content' => json_encode([
+                                        'sql' => 'SELECT * FROM DYNASTIES',
+                                        'explanation' => '此查詢選擇所有朝代。',
+                                        'error' => null,
+                                    ]),
+                                ],
+                                'finish_reason' => 'stop',
+                            ],
+                        ],
+                    ],
+                ];
+            }
+        };
+
+        $heartbeatCount = 0;
+        $statusMessages = [];
+
+        $result = $service->generateSQL(
+            '顯示所有朝代',
+            null,
+            function (string $event, array $data) use (&$statusMessages) {
+                if ($event === 'status') {
+                    $statusMessages[] = $data['message'] ?? '';
+                }
+            },
+            false,
+            function () use (&$heartbeatCount) {
+                $heartbeatCount++;
+            },
+            fn () => false
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertGreaterThanOrEqual(2, $heartbeatCount);
+        $this->assertContains('正在等待 LLM 第 1 輪回應', $statusMessages);
+    }
 }


### PR DESCRIPTION
- 抽出共用 SSE 回應邏輯，統一 header 與 flush 行為
- 為 NL streaming 端點加入 keep-alive padding 與 no-transform 設定
- 在 QA 流程提早送出狀態事件，降低長時間靜默導致斷流的機率
- 補上 SSE 回應 header 的測試斷言