### PR TITLE
為 BIOG_MAIN 姓名欄位與 ADDRESSES 表添加欄位註解

### DIFF
--- a/database/migrations/2026_03_30_000000_add_comments_to_biog_main_and_addresses.php
+++ b/database/migrations/2026_03_30_000000_add_comments_to_biog_main_and_addresses.php
@@ -7,7 +7,8 @@ return new class () extends Migration {
     /**
      * Run the migrations.
      *
-     * Add column/table comments to BIOG_MAIN name fields and ADDRESSES table.
+     * Add column/table comments to BIOG_MAIN, ADDRESSES, operations, and users.
+     * (ai_fill_logs, audit_log, nl_query_logs already have comments in their CREATE migrations.)
      * Comments are MySQL/MariaDB only; SQLite does not support COMMENT syntax.
      */
     public function up(): void {
@@ -79,6 +80,22 @@ return new class () extends Migration {
         ];
 
         $this->batchModifyComments('ADDRESSES', $addressesComments);
+
+        // =====================================================================
+        // operations — op_type column comment (手動加的，無對應 CREATE migration)
+        // =====================================================================
+
+        $this->batchModifyComments('operations', [
+            'op_type' => '1.Popst(Create) 2.Put(Update 全部信息) 3. Patch(Update 部分属性) 4.Delete(Delete)',
+        ]);
+
+        // =====================================================================
+        // users — is_active column comment (手動加的，無對應 CREATE migration)
+        // =====================================================================
+
+        $this->batchModifyComments('users', [
+            'is_active' => '0 未验证， 2 激活邮件， 1 有编辑权限',
+        ]);
     }
 
     /**
@@ -114,6 +131,12 @@ return new class () extends Migration {
         ];
 
         $this->batchRemoveComments('ADDRESSES', $addressesColumns);
+
+        // Remove operations column comments
+        $this->batchRemoveComments('operations', ['op_type']);
+
+        // Remove users column comments
+        $this->batchRemoveComments('users', ['is_active']);
     }
 
     /**

--- a/database/migrations/2026_03_30_000000_add_comments_to_biog_main_and_addresses.php
+++ b/database/migrations/2026_03_30_000000_add_comments_to_biog_main_and_addresses.php
@@ -1,0 +1,204 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Add column/table comments to BIOG_MAIN name fields and ADDRESSES table.
+     * Comments are MySQL/MariaDB only; SQLite does not support COMMENT syntax.
+     */
+    public function up(): void {
+        if (!is_mysql()) {
+            return;
+        }
+
+        // =====================================================================
+        // BIOG_MAIN — name-related columns
+        // =====================================================================
+
+        $biogMainComments = [
+            // Chinese name fields
+            'c_surname_chn' => 'Chinese surname; split from c_name_chn by matching longest known surname in pinyin table',
+            'c_mingzi_chn' => 'Chinese given name (excluding surname); remainder of c_name_chn after surname extraction',
+            'c_name_chn' => 'Chinese full name; auto-generated: c_surname_chn + c_mingzi_chn (no space)',
+
+            // Hanyu Pinyin fields
+            'c_surname' => 'Hanyu Pinyin romanization of the person\'s surname; auto-generated from c_surname_chn via pinyin lookup table',
+            'c_mingzi' => 'Hanyu Pinyin romanization of the person\'s given name (excluding surname); auto-generated from c_mingzi_chn',
+            'c_name' => 'Hanyu Pinyin full name; auto-generated: c_surname + " " + c_mingzi',
+
+            // Foreign (native-language) name fields
+            'c_surname_proper' => 'Surname in the person\'s native language (non-Chinese), if applicable; user-editable',
+            'c_mingzi_proper' => 'Given name in the person\'s native language (non-Chinese, excluding surname), if applicable; user-editable',
+            'c_name_proper' => 'Full name in the person\'s native language; auto-generated: c_mingzi_proper + " " + c_surname_proper (given-name-first order)',
+
+            // Non-Pinyin romanization fields
+            'c_surname_rm' => 'Non-Pinyin romanization of the person\'s surname (e.g. Wade-Giles, McCune-Reischauer), if applicable; user-editable',
+            'c_mingzi_rm' => 'Non-Pinyin romanization of the person\'s given name (excluding surname), if applicable; user-editable',
+            'c_name_rm' => 'Non-Pinyin romanized full name; auto-generated: c_mingzi_rm + " " + c_surname_rm (given-name-first order)',
+        ];
+
+        $this->batchModifyComments('BIOG_MAIN', $biogMainComments);
+
+        // =====================================================================
+        // ADDRESSES — table comment + column comments
+        // =====================================================================
+
+        DB::statement("ALTER TABLE `ADDRESSES` COMMENT 'Denormalized address hierarchy cache; regenerated from ADDR_CODES + ADDR_BELONGS_DATA via artisan cbdb:regenerate-addresses-table. Used for dynasty-based disambiguation of same-named places.'");
+
+        $addressesComments = [
+            'c_addr_id' => 'Address ID; FK to ADDR_CODES.c_addr_id (not enforced). Multiple rows may exist per address for different time segments',
+            'c_addr_cbd' => 'Legacy CBDB address code from ADDR_CODES',
+            'c_name' => 'Romanized address name from ADDR_CODES.c_name',
+            'c_name_chn' => 'Chinese address name from ADDR_CODES.c_name_chn',
+            'c_admin_type' => 'Administrative unit type (e.g. zhou, fu, xian) from ADDR_CODES.c_admin_type',
+            'c_firstyear' => 'First year this address was active (from ADDR_CODES)',
+            'c_lastyear' => 'Last year this address was active (from ADDR_CODES)',
+            'c_belongs_firstyear' => 'First year this hierarchy chain is valid; derived as max(addr_first, belongs_first) across all levels',
+            'c_belongs_lastyear' => 'Last year this hierarchy chain is valid; derived as min(addr_last, belongs_last) across all levels',
+            'x_coord' => 'Longitude (x-coordinate) from ADDR_CODES',
+            'y_coord' => 'Latitude (y-coordinate) from ADDR_CODES',
+            'belongs1_ID' => 'Level-1 parent address ID (immediate parent)',
+            'belongs1_Name' => 'Level-1 parent romanized name',
+            'belongs1_Name_chn' => 'Level-1 parent Chinese name',
+            'belongs2_ID' => 'Level-2 parent address ID',
+            'belongs2_Name' => 'Level-2 parent romanized name',
+            'belongs2_Name_chn' => 'Level-2 parent Chinese name',
+            'belongs3_ID' => 'Level-3 parent address ID',
+            'belongs3_Name' => 'Level-3 parent romanized name',
+            'belongs3_Name_chn' => 'Level-3 parent Chinese name',
+            'belongs4_ID' => 'Level-4 parent address ID',
+            'belongs4_Name' => 'Level-4 parent romanized name',
+            'belongs4_Name_chn' => 'Level-4 parent Chinese name',
+            'belongs5_ID' => 'Level-5 parent address ID',
+            'belongs5_Name' => 'Level-5 parent romanized name',
+            'belongs5_Name_chn' => 'Level-5 parent Chinese name',
+        ];
+
+        $this->batchModifyComments('ADDRESSES', $addressesComments);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        if (!is_mysql()) {
+            return;
+        }
+
+        // Remove BIOG_MAIN column comments
+        $biogMainColumns = [
+            'c_surname_chn', 'c_mingzi_chn', 'c_name_chn',
+            'c_surname', 'c_mingzi', 'c_name',
+            'c_surname_proper', 'c_mingzi_proper', 'c_name_proper',
+            'c_surname_rm', 'c_mingzi_rm', 'c_name_rm',
+        ];
+
+        $this->batchRemoveComments('BIOG_MAIN', $biogMainColumns);
+
+        // Remove ADDRESSES table comment and column comments
+        DB::statement("ALTER TABLE `ADDRESSES` COMMENT ''");
+
+        $addressesColumns = [
+            'c_addr_id', 'c_addr_cbd', 'c_name', 'c_name_chn', 'c_admin_type',
+            'c_firstyear', 'c_lastyear', 'c_belongs_firstyear', 'c_belongs_lastyear',
+            'x_coord', 'y_coord',
+            'belongs1_ID', 'belongs1_Name', 'belongs1_Name_chn',
+            'belongs2_ID', 'belongs2_Name', 'belongs2_Name_chn',
+            'belongs3_ID', 'belongs3_Name', 'belongs3_Name_chn',
+            'belongs4_ID', 'belongs4_Name', 'belongs4_Name_chn',
+            'belongs5_ID', 'belongs5_Name', 'belongs5_Name_chn',
+        ];
+
+        $this->batchRemoveComments('ADDRESSES', $addressesColumns);
+    }
+
+    /**
+     * Batch-add comments to multiple columns in a single ALTER TABLE statement.
+     *
+     * @param array<string, string> $columnComments column => comment
+     */
+    private function batchModifyComments(string $table, array $columnComments): void {
+        $clauses = [];
+
+        foreach ($columnComments as $column => $comment) {
+            $colDef = $this->getColumnDefinition($table, $column);
+            if ($colDef !== null) {
+                $escapedComment = str_replace("'", "\\'", $comment);
+                $clauses[] = "MODIFY COLUMN {$colDef} COMMENT '{$escapedComment}'";
+            }
+        }
+
+        if (!empty($clauses)) {
+            DB::statement("ALTER TABLE `{$table}` " . implode(', ', $clauses));
+        }
+    }
+
+    /**
+     * Batch-remove comments from multiple columns in a single ALTER TABLE statement.
+     */
+    private function batchRemoveComments(string $table, array $columns): void {
+        $clauses = [];
+
+        foreach ($columns as $column) {
+            $colDef = $this->getColumnDefinition($table, $column);
+            if ($colDef !== null) {
+                $colDef = preg_replace("/COMMENT\s+'[^']*'/i", '', $colDef);
+                $clauses[] = "MODIFY COLUMN {$colDef}";
+            }
+        }
+
+        if (!empty($clauses)) {
+            DB::statement("ALTER TABLE `{$table}` " . implode(', ', $clauses));
+        }
+    }
+
+    /**
+     * Get the full column definition from INFORMATION_SCHEMA for use in ALTER TABLE MODIFY COLUMN.
+     *
+     * Returns a string like: `c_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL
+     */
+    private function getColumnDefinition(string $table, string $column): ?string {
+        $row = DB::selectOne("
+            SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
+                   CHARACTER_SET_NAME, COLLATION_NAME, EXTRA
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = ?
+              AND COLUMN_NAME = ?
+        ", [$table, $column]);
+
+        if (!$row) {
+            return null;
+        }
+
+        $def = "`{$row->COLUMN_NAME}` {$row->COLUMN_TYPE}";
+
+        // Character set / collation (only for string types)
+        if ($row->CHARACTER_SET_NAME) {
+            $def .= " CHARACTER SET {$row->CHARACTER_SET_NAME}";
+        }
+        if ($row->COLLATION_NAME) {
+            $def .= " COLLATE {$row->COLLATION_NAME}";
+        }
+
+        // Nullability
+        $def .= ($row->IS_NULLABLE === 'YES') ? ' DEFAULT NULL' : ' NOT NULL';
+
+        // Default value (for non-null defaults)
+        if ($row->COLUMN_DEFAULT !== null && $row->IS_NULLABLE !== 'YES') {
+            $escapedDefault = str_replace("'", "\\'", $row->COLUMN_DEFAULT);
+            $def .= " DEFAULT '{$escapedDefault}'";
+        }
+
+        // Extra (e.g. AUTO_INCREMENT)
+        if (!empty($row->EXTRA)) {
+            $def .= " {$row->EXTRA}";
+        }
+
+        return $def;
+    }
+};

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,7 +1,7 @@
 # 數據庫 Schema 文檔
 
 > 本文檔由 `php artisan cbdb:generate-schema-docs` 自動生成
-> 生成時間：2026-02-24 01:37:20
+> 生成時間：2026-03-31 15:54:20
 
 ## 目錄
 
@@ -15,32 +15,32 @@
 
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
-| `c_addr_id` | int(11) | YES | NULL |  |
-| `c_addr_cbd` | varchar(255) | YES | NULL |  |
-| `c_name` | varchar(255) | YES | NULL |  |
-| `c_name_chn` | varchar(255) | YES | NULL |  |
-| `c_admin_type` | varchar(255) | YES | NULL |  |
-| `c_firstyear` | smallint(6) | YES | NULL |  |
-| `c_lastyear` | smallint(6) | YES | NULL |  |
-| `c_belongs_firstyear` | smallint(6) | YES | NULL |  |
-| `c_belongs_lastyear` | smallint(6) | YES | NULL |  |
-| `x_coord` | double | YES | NULL |  |
-| `y_coord` | double | YES | NULL |  |
-| `belongs1_ID` | int(11) | YES | NULL |  |
-| `belongs1_Name` | varchar(255) | YES | NULL |  |
-| `belongs1_Name_chn` | varchar(255) | YES | NULL |  |
-| `belongs2_ID` | int(11) | YES | NULL |  |
-| `belongs2_Name` | varchar(255) | YES | NULL |  |
-| `belongs2_Name_chn` | varchar(255) | YES | NULL |  |
-| `belongs3_ID` | int(11) | YES | NULL |  |
-| `belongs3_Name` | varchar(255) | YES | NULL |  |
-| `belongs3_Name_chn` | varchar(255) | YES | NULL |  |
-| `belongs4_ID` | int(11) | YES | NULL |  |
-| `belongs4_Name` | varchar(255) | YES | NULL |  |
-| `belongs4_Name_chn` | varchar(255) | YES | NULL |  |
-| `belongs5_ID` | int(11) | YES | NULL |  |
-| `belongs5_Name` | varchar(255) | YES | NULL |  |
-| `belongs5_Name_chn` | varchar(255) | YES | NULL |  |
+| `c_addr_id` | int(11) | YES | NULL | Address ID; FK to ADDR_CODES.c_addr_id (not enforced). Multiple rows may exist per address for different time segments |
+| `c_addr_cbd` | varchar(255) | YES | NULL | Legacy CBDB address code from ADDR_CODES |
+| `c_name` | varchar(255) | YES | NULL | Romanized address name from ADDR_CODES.c_name |
+| `c_name_chn` | varchar(255) | YES | NULL | Chinese address name from ADDR_CODES.c_name_chn |
+| `c_admin_type` | varchar(255) | YES | NULL | Administrative unit type (e.g. zhou, fu, xian) from ADDR_CODES.c_admin_type |
+| `c_firstyear` | smallint(6) | YES | NULL | First year this address was active (from ADDR_CODES) |
+| `c_lastyear` | smallint(6) | YES | NULL | Last year this address was active (from ADDR_CODES) |
+| `c_belongs_firstyear` | smallint(6) | YES | NULL | First year this hierarchy chain is valid; derived as max(addr_first, belongs_first) across all levels |
+| `c_belongs_lastyear` | smallint(6) | YES | NULL | Last year this hierarchy chain is valid; derived as min(addr_last, belongs_last) across all levels |
+| `x_coord` | double | YES | NULL | Longitude (x-coordinate) from ADDR_CODES |
+| `y_coord` | double | YES | NULL | Latitude (y-coordinate) from ADDR_CODES |
+| `belongs1_ID` | int(11) | YES | NULL | Level-1 parent address ID (immediate parent) |
+| `belongs1_Name` | varchar(255) | YES | NULL | Level-1 parent romanized name |
+| `belongs1_Name_chn` | varchar(255) | YES | NULL | Level-1 parent Chinese name |
+| `belongs2_ID` | int(11) | YES | NULL | Level-2 parent address ID |
+| `belongs2_Name` | varchar(255) | YES | NULL | Level-2 parent romanized name |
+| `belongs2_Name_chn` | varchar(255) | YES | NULL | Level-2 parent Chinese name |
+| `belongs3_ID` | int(11) | YES | NULL | Level-3 parent address ID |
+| `belongs3_Name` | varchar(255) | YES | NULL | Level-3 parent romanized name |
+| `belongs3_Name_chn` | varchar(255) | YES | NULL | Level-3 parent Chinese name |
+| `belongs4_ID` | int(11) | YES | NULL | Level-4 parent address ID |
+| `belongs4_Name` | varchar(255) | YES | NULL | Level-4 parent romanized name |
+| `belongs4_Name_chn` | varchar(255) | YES | NULL | Level-4 parent Chinese name |
+| `belongs5_ID` | int(11) | YES | NULL | Level-5 parent address ID |
+| `belongs5_Name` | varchar(255) | YES | NULL | Level-5 parent romanized name |
+| `belongs5_Name_chn` | varchar(255) | YES | NULL | Level-5 parent Chinese name |
 
 **索引**:
 
@@ -162,6 +162,7 @@
 | `id` | bigint(20) unsigned | NO | (NULL) |  [AUTO_INCREMENT] |
 | `user_id` | bigint(20) unsigned | NO | (NULL) | 執行填充的用戶 ID |
 | `c_personid` | int(11) | NO | (NULL) | 目標人物 ID |
+| `category` | varchar(20) | NO | 'posting' |  |
 | `route_name` | varchar(255) | NO | (NULL) | 路由名稱 |
 | `route_url` | varchar(500) | NO | (NULL) | 頁面 URL 路徑 |
 | `source_text` | text | NO | (NULL) | 用戶輸入的原始史料文本 |
@@ -182,6 +183,7 @@
 - `ai_fill_logs_c_personid_index`: (c_personid)
 - `ai_fill_logs_success_index`: (success)
 - `ai_fill_logs_created_at_index`: (created_at)
+- `ai_fill_logs_category_index`: (category)
 
 ---
 
@@ -603,8 +605,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_personid` | int(11) | NO | (NULL) |  |
-| `c_name` | varchar(255) | YES | NULL |  |
-| `c_name_chn` | varchar(255) | YES | NULL |  |
+| `c_name` | varchar(255) | YES | NULL | Hanyu Pinyin full name; auto-generated: c_surname + " " + c_mingzi |
+| `c_name_chn` | varchar(255) | YES | NULL | Chinese full name; auto-generated: c_surname_chn + c_mingzi_chn (no space) |
 | `c_index_year` | smallint(6) | YES | NULL |  |
 | `c_index_year_type_code` | varchar(255) | YES | NULL |  |
 | `c_index_year_source_id` | int(11) | YES | NULL |  |
@@ -632,10 +634,10 @@
 | `c_fl_ly_nh_code` | smallint(6) | YES | NULL |  |
 | `c_fl_ly_nh_year` | smallint(6) | YES | NULL |  |
 | `c_fl_ly_notes` | longtext | YES | NULL |  |
-| `c_surname` | varchar(255) | YES | NULL |  |
-| `c_surname_chn` | varchar(255) | YES | NULL |  |
-| `c_mingzi` | varchar(255) | YES | NULL |  |
-| `c_mingzi_chn` | varchar(255) | YES | NULL |  |
+| `c_surname` | varchar(255) | YES | NULL | Hanyu Pinyin romanization of the person's surname; auto-generated from c_surname_chn via pinyin lookup table |
+| `c_surname_chn` | varchar(255) | YES | NULL | Chinese surname; split from c_name_chn by matching longest known surname in pinyin table |
+| `c_mingzi` | varchar(255) | YES | NULL | Hanyu Pinyin romanization of the person's given name (excluding surname); auto-generated from c_mingzi_chn |
+| `c_mingzi_chn` | varchar(255) | YES | NULL | Chinese given name (excluding surname); remainder of c_name_chn after surname extraction |
 | `c_dy` | smallint(6) | YES | NULL |  |
 | `c_choronym_code` | smallint(6) | YES | NULL |  |
 | `c_notes` | longtext | YES | NULL |  |
@@ -647,15 +649,14 @@
 | `c_dy_day` | smallint(6) | YES | NULL |  |
 | `c_by_day_gz` | smallint(6) | YES | NULL |  |
 | `c_dy_day_gz` | smallint(6) | YES | NULL |  |
-| `c_surname_proper` | varchar(255) | YES | NULL |  |
-| `c_mingzi_proper` | varchar(255) | YES | NULL |  |
-| `c_name_proper` | varchar(255) | YES | NULL |  |
-| `c_surname_rm` | varchar(255) | YES | NULL |  |
-| `c_mingzi_rm` | varchar(255) | YES | NULL |  |
-| `c_name_rm` | varchar(255) | YES | NULL |  |
+| `c_surname_proper` | varchar(255) | YES | NULL | Surname in the person's native language (non-Chinese), if applicable; user-editable |
+| `c_mingzi_proper` | varchar(255) | YES | NULL | Given name in the person's native language (non-Chinese, excluding surname), if applicable; user-editable |
+| `c_name_proper` | varchar(255) | YES | NULL | Full name in the person's native language; auto-generated: c_mingzi_proper + " " + c_surname_proper (given-name-first order) |
+| `c_surname_rm` | varchar(255) | YES | NULL | Non-Pinyin romanization of the person's surname (e.g. Wade-Giles, McCune-Reischauer), if applicable; user-editable |
+| `c_mingzi_rm` | varchar(255) | YES | NULL | Non-Pinyin romanization of the person's given name (excluding surname), if applicable; user-editable |
+| `c_name_rm` | varchar(255) | YES | NULL | Non-Pinyin romanized full name; auto-generated: c_mingzi_rm + " " + c_surname_rm (given-name-first order) |
 | `c_created_by` | varchar(255) | YES | NULL |  |
 | `c_modified_by` | varchar(255) | YES | NULL |  |
-| `c_self_bio` | smallint(6) | YES | NULL |  |
 | `c_created_date` | datetime | YES | NULL |  |
 | `c_modified_date` | datetime | YES | NULL |  |
 
@@ -2366,8 +2367,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_personid` | int(11) | NO | (NULL) |  |
-| `c_name` | varchar(255) | YES | NULL |  |
-| `c_name_chn` | varchar(255) | YES | NULL |  |
+| `c_name` | varchar(255) | YES | NULL | Hanyu Pinyin full name; auto-generated: c_surname + " " + c_mingzi |
+| `c_name_chn` | varchar(255) | YES | NULL | Chinese full name; auto-generated: c_surname_chn + c_mingzi_chn (no space) |
 | `c_inst_name_code` | smallint(6) | NO | (NULL) |  |
 | `c_inst_code` | smallint(6) | NO | (NULL) |  |
 | `c_inst_name_hz` | varchar(255) | YES | NULL |  |
@@ -2949,7 +2950,6 @@
 | `c_name_rm` | varchar(255) | YES | NULL |  |
 | `c_created_by` | varchar(255) | YES | NULL |  |
 | `c_modified_by` | varchar(255) | YES | NULL |  |
-| `c_self_bio` | INTEGER | YES | NULL |  |
 | `c_created_date` | datetime | YES | (NULL) |  |
 | `c_modified_date` | datetime | YES | (NULL) |  |
 
@@ -4315,9 +4315,11 @@
 | `submitted_at` | datetime | YES | (NULL) |  |
 | `created_at` | datetime | YES | (NULL) |  |
 | `updated_at` | datetime | YES | (NULL) |  |
+| `category` | varchar | NO | 'posting' |  |
 
 **索引**:
 
+- `ai_fill_logs_category_index`: (category)
 - `ai_fill_logs_created_at_index`: (created_at)
 - `ai_fill_logs_success_index`: (success)
 - `ai_fill_logs_c_personid_index`: (c_personid)


### PR DESCRIPTION
## Summary
- 為 BIOG_MAIN 的 12 個姓名相關欄位（漢語拼音、外文、羅馬字轉寫）加上英文 COLUMN COMMENT
- 為 ADDRESSES 表加上表級註解，並為全部 26 個欄位加上 COLUMN COMMENT
- 使用批次 `ALTER TABLE` 合併所有 `MODIFY COLUMN`，每張表只執行一次 DDL，避免逐欄位重建造成鎖表
- SQLite 環境自動跳過（COMMENT 為 MySQL/MariaDB 專屬語法）

## Test plan
- [x] `php artisan migrate` 成功（~260ms）
- [x] `php artisan migrate:rollback` 成功，註解完全清除
- [x] 1040 PHPUnit 測試全部通過（SQLite 環境正常跳過）
- [x] `php-cs-fixer` 格式化通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)