### PR TITLE
修復歷史問答 QA 模式多項問題

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -197,6 +197,7 @@ class QueryPlaygroundController extends Controller {
      */
     protected function streamSseResponse(callable $producer) {
         return response()->stream(function () use ($producer) {
+            set_time_limit(300);  // SSE 串流需要較長時間（多輪工具呼叫 + LLM 回應）
             ignore_user_abort(true);
 
             $lastSentAt = microtime(true);

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -487,14 +487,26 @@ class NaturalLanguageQueryService {
             $allToolResults = [];
             $allSqlUsed = [];
 
+            // 預建不含工具描述的 system prompt，供最終輪使用
+            // Gemini 模型即使 request 不帶 tools，只要 system prompt 提及工具就會嘗試呼叫
+            $noToolSystemPrompt = $toolsEnabled
+                ? $this->buildQaSystemPrompt($schemaPrompt, false)
+                : null;
+
             while ($round < $maxRounds) {
                 $round++;
                 $allowTools = $toolsEnabled && $round < $maxRounds;
 
+                // 最終輪：替換 system prompt 為不含工具描述的版本，避免 Gemini MALFORMED_FUNCTION_CALL
+                $currentMessages = $messages;
+                if (!$allowTools && $noToolSystemPrompt !== null && !empty($currentMessages)) {
+                    $currentMessages[0] = ['role' => 'system', 'content' => $noToolSystemPrompt];
+                }
+
                 Log::info('歷史問答 LLM 輪次開始', [
                     'round' => $round,
                     'allow_tools' => $allowTools,
-                    'message_count' => count($messages),
+                    'message_count' => count($currentMessages),
                     'question_preview' => mb_substr($question, 0, 120),
                 ]);
 
@@ -504,7 +516,7 @@ class NaturalLanguageQueryService {
                     ]);
                 }
 
-                $response = $this->callLLMForQa($messages, $tools, $allowTools, $heartbeatCallback, $abortCheck);
+                $response = $this->callLLMForQa($currentMessages, $tools, $allowTools, $heartbeatCallback, $abortCheck);
 
                 if ($progressCallback) {
                     $progressCallback('status', [
@@ -573,6 +585,23 @@ class NaturalLanguageQueryService {
 
                 // 沒有工具調用 → 解析最終回答
                 $content = $data['choices'][0]['message']['content'] ?? '';
+
+                // 若 LLM 返回空 content（安全過濾、輸出截斷等），視為失敗
+                if (empty(trim($content))) {
+                    $finishReason = $data['choices'][0]['finish_reason'] ?? 'unknown';
+                    Log::warning('歷史問答 LLM 返回空 content', [
+                        'round' => $round,
+                        'finish_reason' => $finishReason,
+                    ]);
+
+                    $logData['error_message'] = "LLM 返回空回應（finish_reason: {$finishReason}）";
+                    $logData['llm_response'] = json_encode($data, JSON_UNESCAPED_UNICODE);
+                    $logData['execution_time_ms'] = (int) ((microtime(true) - $startTime) * 1000);
+                    $this->saveLog($logData);
+
+                    return ['success' => false, 'error' => 'LLM 未能生成回答，請稍後再試。'];
+                }
+
                 $parsed = $this->parseQaResponse($content);
 
                 $logData['llm_response'] = json_encode($data, JSON_UNESCAPED_UNICODE);
@@ -750,8 +779,8 @@ PROMPT;
             return $this->callLLM($messages, $tools, true, $heartbeatCallback, $abortCheck);
         }
 
-        // 最終回答輪：不使用 structured output，讓模型自由回答 JSON
-        return $this->callLLM($messages, [], false, $heartbeatCallback, $abortCheck);
+        // 最終回答輪：不使用 structured output，讓模型依 system prompt 自由回覆 QA JSON
+        return $this->callLLM($messages, [], false, $heartbeatCallback, $abortCheck, false);
     }
 
     /**
@@ -779,6 +808,28 @@ PROMPT;
         $parsed = json_decode($jsonContent, true, 512, JSON_INVALID_UTF8_IGNORE);
 
         if (json_last_error() === JSON_ERROR_NONE && is_array($parsed)) {
+            // 若 LLM 被強制回覆 SQL structured output 格式（{sql, explanation, error}），
+            // 將其轉換為 QA 格式
+            if (isset($parsed['sql']) && !isset($parsed['answer_markdown'])) {
+                $sqlText = $parsed['sql'] ?? '';
+                $explanation = $parsed['explanation'] ?? '';
+                $answerMd = '';
+                if ($explanation) {
+                    $answerMd .= $explanation . "\n\n";
+                }
+                if ($sqlText) {
+                    $answerMd .= "```sql\n{$sqlText}\n```";
+                }
+
+                return [
+                    'answer_markdown' => $answerMd ?: $content,
+                    'summary' => $explanation ?: '',
+                    'sql_used' => $sqlText ? [$sqlText] : [],
+                    'evidence' => [],
+                    'caveat' => $defaults['caveat'],
+                ];
+            }
+
             return [
                 'answer_markdown' => $parsed['answer_markdown'] ?? $content,
                 'summary' => $parsed['summary'] ?? '',
@@ -1248,7 +1299,8 @@ PROMPT;
         array $tools = [],
         bool $allowToolCalls = false,
         ?callable $heartbeatCallback = null,
-        ?callable $abortCheck = null
+        ?callable $abortCheck = null,
+        bool $useStructuredOutput = true
     ): array {
         try {
             $maxCompletionTokens = (int) config('services.gemini.max_completion_tokens', 8192);
@@ -1268,8 +1320,8 @@ PROMPT;
             if (!empty($tools) && $allowToolCalls) {
                 $requestData['tools'] = $tools;
                 $requestData['tool_choice'] = 'auto';
-            } else {
-                // 如果不允许工具调用，使用 structured output
+            } elseif ($useStructuredOutput) {
+                // SQL 生成模式：使用 structured output 強制回覆格式
                 $requestData['response_format'] = [
                     'type' => 'json_schema',
                     'json_schema' => [
@@ -1446,6 +1498,7 @@ PROMPT;
             CURLOPT_TIMEOUT => 45,
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER => false,
+            CURLOPT_ENCODING => '',  // 自動處理 gzip/deflate 壓縮回應
             CURLOPT_WRITEFUNCTION => static function ($curl, string $chunk) use (&$responseBody) {
                 $responseBody .= $chunk;
 

--- a/tests/Feature/HistoricalQaTest.php
+++ b/tests/Feature/HistoricalQaTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use App\Services\NaturalLanguageQueryService;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -392,5 +393,179 @@ class HistoricalQaTest extends TestCase {
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
         $this->assertStringContainsString('no-cache, no-transform', (string) $response->headers->get('Cache-Control'));
         $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
+    }
+
+    // ──── LLM 空 content 處理 ────
+
+    /**
+     * 輔助：建立使用 partial mock 的 NaturalLanguageQueryService，
+     * 攔截 performLlmHttpRequest 以避免依賴 Http::fake() 或真實 curl。
+     * 這確保不論內部走 Laravel Http 或 curl_multi 路徑，測試都能正確攔截。
+     *
+     * @param  array|callable  $responses  固定回應陣列或依序返回的 callable
+     * @param  bool  $stubToolExecution  是否同時 stub executeToolCalls（避免碰到測試 DB 缺少資料表）
+     * @return NaturalLanguageQueryService
+     */
+    protected function mockLlmService(array|callable $responses, bool $stubToolExecution = false): NaturalLanguageQueryService {
+        Config::set('services.gemini.api_key', 'test-api-key');
+        Config::set('services.gemini.api_endpoint', 'https://fake-gemini.test/v1/chat/completions');
+
+        $methods = ['performLlmHttpRequest'];
+        if ($stubToolExecution) {
+            $methods[] = 'executeToolCalls';
+        }
+
+        $service = $this->getMockBuilder(NaturalLanguageQueryService::class)
+            ->setConstructorArgs([
+                $this->app->make(\App\Services\DatabaseSchemaService::class),
+                $this->app->make(\App\Services\NlQueryToolsService::class),
+            ])
+            ->onlyMethods($methods)
+            ->getMock();
+
+        if (is_callable($responses)) {
+            $service->method('performLlmHttpRequest')
+                ->willReturnCallback($responses);
+        } else {
+            $service->method('performLlmHttpRequest')
+                ->willReturn($responses);
+        }
+
+        if ($stubToolExecution) {
+            $service->method('executeToolCalls')
+                ->willReturnCallback(function (array $toolCalls) {
+                    return array_map(fn ($tc) => [
+                        'tool_call_id' => $tc['id'] ?? 'stub_id',
+                        'tool_name' => $tc['function']['name'] ?? 'unknown',
+                        'arguments' => json_decode($tc['function']['arguments'] ?? '{}', true),
+                        'status' => 'completed',
+                        'result' => ['stub' => true],
+                        'result_summary' => ['row_count' => 0],
+                    ], $toolCalls);
+                });
+        }
+
+        return $service;
+    }
+
+    #[Test]
+    public function qa_returns_error_when_llm_content_is_null() {
+        Config::set('nl_query_tools.enabled', true);
+        Config::set('nl_query_tools.max_tool_calls', 5);
+
+        $service = $this->mockLlmService([
+            'successful' => true,
+            'status' => 200,
+            'body' => '',
+            'json' => [
+                'choices' => [[
+                    'message' => ['role' => 'assistant', 'content' => null],
+                    'finish_reason' => 'stop',
+                ]],
+            ],
+        ]);
+
+        $result = $service->answerQuestion('清代所有人物的任官記錄');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('未能生成回答', $result['error']);
+    }
+
+    #[Test]
+    public function qa_returns_error_when_llm_content_is_empty_string() {
+        Config::set('nl_query_tools.enabled', true);
+        Config::set('nl_query_tools.max_tool_calls', 5);
+
+        $service = $this->mockLlmService([
+            'successful' => true,
+            'status' => 200,
+            'body' => '',
+            'json' => [
+                'choices' => [[
+                    'message' => ['role' => 'assistant', 'content' => ''],
+                    'finish_reason' => 'stop',
+                ]],
+            ],
+        ]);
+
+        $result = $service->answerQuestion('清代所有人物的任官記錄');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('未能生成回答', $result['error']);
+    }
+
+    // ──── QA 最終輪不套用 SQL structured output ────
+
+    #[Test]
+    public function qa_last_round_does_not_apply_sql_structured_output() {
+        Config::set('nl_query_tools.enabled', true);
+        Config::set('nl_query_tools.max_tool_calls', 2);
+
+        $callCount = 0;
+        $capturedRequests = [];
+
+        $service = $this->mockLlmService(function (array $requestData) use (&$callCount, &$capturedRequests) {
+            $callCount++;
+            $capturedRequests[] = $requestData;
+
+            if ($callCount === 1) {
+                return [
+                    'successful' => true,
+                    'status' => 200,
+                    'body' => '',
+                    'json' => [
+                        'choices' => [[
+                            'message' => [
+                                'role' => 'assistant',
+                                'content' => null,
+                                'tool_calls' => [[
+                                    'id' => 'call_1',
+                                    'type' => 'function',
+                                    'function' => [
+                                        'name' => 'get_code_values',
+                                        'arguments' => json_encode(['code_type' => 'dynasties']),
+                                    ],
+                                ]],
+                            ],
+                            'finish_reason' => 'tool_calls',
+                        ]],
+                    ],
+                ];
+            }
+
+            // 第 2 輪（最後一輪）
+            return [
+                'successful' => true,
+                'status' => 200,
+                'body' => '',
+                'json' => [
+                    'choices' => [[
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => json_encode([
+                                'answer_markdown' => '## 清代人物任官記錄查詢結果',
+                                'summary' => '清代人物任官記錄。',
+                                'sql_used' => [],
+                                'evidence' => [],
+                                'caveat' => '部分歷史背景為模型補充。',
+                            ]),
+                        ],
+                        'finish_reason' => 'stop',
+                    ]],
+                ],
+            ];
+        }, true);  // stubToolExecution: 避免碰到測試 DB 缺少資料表
+
+        $result = $service->answerQuestion('清代所有人物的任官記錄');
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('清代人物任官記錄', $result['answer_markdown']);
+
+        // 驗證確實發了 2 次 LLM 請求
+        $this->assertCount(2, $capturedRequests, '應發出 2 次 LLM 請求（1 次工具輪 + 1 次最終輪）');
+
+        // 驗證最後一輪沒有被套用 response_format
+        $lastRequest = $capturedRequests[count($capturedRequests) - 1];
+        $this->assertArrayNotHasKey('response_format', $lastRequest, '最後一輪 QA 請求不應套用 SQL 的 response_format');
     }
 }


### PR DESCRIPTION
## Summary
- 修正 `callLLM` 在 QA 最終輪錯誤套用 SQL `response_format` schema，改為不使用 structured output
- QA 最終輪替換為不含工具描述的 system prompt，避免 Gemini `MALFORMED_FUNCTION_CALL`
- LLM 返回空 content 時改為 `success=false` 並提供明確錯誤訊息（原先靜默顯示「抱歉，無法生成回答」為 success）
- `parseQaResponse` 增加 SQL schema 格式的 fallback 轉換
- SSE 串流加入 `set_time_limit(300)` 避免多輪工具呼叫超時
- curl heartbeat 請求加入 `CURLOPT_ENCODING` 處理 gzip 壓縮回應

## Test plan
- [x] 20 個 HistoricalQaTest 全部通過（含 3 個新增回歸測試）
- [x] 40 個 QueryPlayground 相關測試全部通過
- [x] 已用 GPT-5.2 (Harvard) 和 Gemini 3 Pro 實際 API 驗證修復有效
- [x] 測試使用 partial mock 攔截 `performLlmHttpRequest`，不依賴 `Http::fake()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
