### PR TITLE
修正歷史問答 QA 模式表格渲染與 LLM 超時問題

### DIFF
--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -1453,7 +1453,7 @@ PROMPT;
     ): array {
         if ($heartbeatCallback === null && $abortCheck === null) {
             $response = Http::connectTimeout(10)
-                ->timeout(45)
+                ->timeout(120)
                 ->withHeaders([
                     'Content-Type' => 'application/json',
                     'Authorization' => 'Bearer ' . $this->apiKey,
@@ -1495,7 +1495,7 @@ PROMPT;
                 'Authorization: Bearer ' . $this->apiKey,
             ],
             CURLOPT_CONNECTTIMEOUT => 10,
-            CURLOPT_TIMEOUT => 45,
+            CURLOPT_TIMEOUT => 120,
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER => false,
             CURLOPT_ENCODING => '',  // 自動處理 gzip/deflate 壓縮回應

--- a/resources/js/inertia/components/QueryPlayground/HistoricalQaPanel.tsx
+++ b/resources/js/inertia/components/QueryPlayground/HistoricalQaPanel.tsx
@@ -472,7 +472,7 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
 
 /**
  * Simple Markdown to HTML renderer.
- * Handles headings, bold, italic, lists, blockquotes, code blocks, and paragraphs.
+ * Handles headings, bold, italic, lists, blockquotes, code blocks, tables, and paragraphs.
  */
 function renderMarkdown(md: string): string {
     // Escape HTML first
@@ -508,6 +508,48 @@ function renderMarkdown(md: string): string {
 
     // Wrap consecutive <li> in <ul>
     html = html.replace(/((?:<li[^>]*>.*?<\/li>\n?)+)/g, '<ul style="padding-left:8px;margin:8px 0;">$1</ul>');
+
+    // Markdown tables
+    html = html.replace(
+        /(^\|.+\|[ \t]*\n\|[ \t:|-]+\|[ \t]*\n(?:\|.+\|[ \t]*\n?)*)/gm,
+        (_tableBlock: string) => {
+            const lines = _tableBlock.trim().split('\n');
+            if (lines.length < 2) return _tableBlock;
+
+            const parseRow = (line: string) =>
+                line.replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim());
+
+            const headers = parseRow(lines[0]);
+
+            // Parse alignment from separator row
+            const separators = parseRow(lines[1]);
+            const aligns = separators.map(s => {
+                if (s.startsWith(':') && s.endsWith(':')) return 'center';
+                if (s.endsWith(':')) return 'right';
+                return 'left';
+            });
+
+            let table = '<div style="overflow-x:auto;margin:10px 0;"><table style="border-collapse:collapse;width:100%;font-size:0.85rem;">';
+            table += '<thead><tr>';
+            headers.forEach((h, i) => {
+                table += `<th style="border:1px solid #dee2e6;padding:6px 10px;background:#f8f9fa;text-align:${aligns[i] || 'left'};">${h}</th>`;
+            });
+            table += '</tr></thead><tbody>';
+
+            for (let i = 2; i < lines.length; i++) {
+                if (!lines[i].trim()) continue;
+                const cells = parseRow(lines[i]);
+                table += '<tr>';
+                cells.forEach((c, j) => {
+                    table += `<td style="border:1px solid #dee2e6;padding:6px 10px;text-align:${aligns[j] || 'left'};">${c}</td>`;
+                });
+                table += '</tr>';
+            }
+
+            table += '</tbody></table></div>';
+            return table;
+        },
+    );
 
     // Horizontal rule
     html = html.replace(/^---$/gm, '<hr style="border:none;border-top:1px solid #dee2e6;margin:12px 0;" />');


### PR DESCRIPTION
## Summary
- 歷史問答 QA 模式回答中的 Markdown 表格未正確渲染為 HTML table，以純文字顯示
- QA 多輪工具調用後，最終回答生成因 LLM API 45 秒超時而失敗（`status: 0`）

## Changes
- `HistoricalQaPanel.tsx`：`renderMarkdown()` 新增 Markdown 表格解析，支援多欄分隔行與對齊標記（`:---`、`:---:`、`---:`），輸出帶樣式的 HTML `<table>`
- `NaturalLanguageQueryService.php`：將 LLM HTTP 請求超時從 45 秒提升至 120 秒

## Test plan
- [x] 在 `/app/query-playground?mode=qa` 提問會回傳表格的問題，確認表格正確渲染
- [x] 測試多輪工具調用的複雜問題，確認不再出現「LLM API 调用失败」超時錯誤
- [x] 確認簡單問題的回答速度未受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)