### PR TITLE
批次匯入書稿：自動將中文括號與冒號替換為英文標點

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -217,6 +217,7 @@ class AdminBatchLoadBookTitlesController extends Controller {
      */
     protected function normalizeTitle(string $title): string {
         $title = preg_replace('/\s+/u', '', $title);
+        $title = str_replace(['（', '）'], ['(', ')'], $title);
         $title = preg_replace('/[:：]\s*/u', ': ', $title);
 
         return trim($title);

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -179,6 +179,83 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
     }
 
     #[Test]
+    public function test_fullwidth_parentheses_are_converted(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 100,
+            'c_dy' => '1',
+        ]);
+
+        $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "100\t測試稿（附錄）\t99999",
+        ]);
+
+        $record = DB::table('TEXT_CODES')->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('測試稿(附錄)', $record->c_title_chn);
+    }
+
+    #[Test]
+    public function test_fullwidth_colon_is_converted_with_single_space(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 101,
+            'c_dy' => '2',
+        ]);
+
+        $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "101\t測試稿：卷一\t99998",
+        ]);
+
+        $record = DB::table('TEXT_CODES')->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('測試稿: 卷一', $record->c_title_chn);
+    }
+
+    #[Test]
+    public function test_fullwidth_colon_with_spaces_does_not_add_extra(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 102,
+            'c_dy' => '3',
+        ]);
+
+        $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "102\t測試稿：  卷一\t99997",
+        ]);
+
+        $record = DB::table('TEXT_CODES')->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        // Spaces are removed first, then colon adds exactly one space
+        $this->assertSame('測試稿: 卷一', $record->c_title_chn);
+    }
+
+    #[Test]
+    public function test_combined_fullwidth_punctuation_normalization(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 103,
+            'c_dy' => '4',
+        ]);
+
+        $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "103\t測試稿（附錄）： 卷一\t99996",
+        ]);
+
+        $record = DB::table('TEXT_CODES')->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('測試稿(附錄): 卷一', $record->c_title_chn);
+    }
+
+    #[Test]
     public function test_blank_source_is_rejected(): void {
         $user = $this->makeUser();
         $this->actingAs($user);


### PR DESCRIPTION
## Summary
- `normalizeTitle()` 新增全形括號 `（）` → 半形 `()` 的自動轉換
- 既有冒號正規化（`：` → `: `）與空格移除邏輯已確認正確，不會產生多餘空格
- 補充 4 組測試涵蓋括號、冒號及組合情境

🤖 Generated with [Claude Code](https://claude.com/claude-code)