### PR TITLE
任官自動填充：從資料庫動態載入代碼表取代硬編碼

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -115,6 +115,10 @@ class PostingAutofillService {
         }
 
         $promptContent = file_get_contents($this->promptTemplate);
+
+        // 從資料庫動態載入代碼表，替換 prompt 中的佔位符
+        $promptContent = $this->injectCodeMappings($promptContent);
+
         $fullPrompt = $promptContent . "\n\n" . $sourceText;
 
         // 調用 LLM API
@@ -187,6 +191,39 @@ class PostingAutofillService {
             'data' => $postings[0], // 返回第一筆
             'error' => null,
         ];
+    }
+
+    /**
+     * 從資料庫載入代碼表，替換 prompt 模板中的佔位符
+     */
+    protected function injectCodeMappings(string $promptContent): string {
+        // APPOINTMENT_CODES
+        $apptCodes = DB::table('APPOINTMENT_CODES')
+            ->select(['c_appt_code', 'c_appt_desc_chn', 'c_appt_desc'])
+            ->orderBy('c_appt_code')
+            ->get();
+
+        $apptLines = $apptCodes->map(function ($row) {
+            $desc = trim(($row->c_appt_desc_chn ?? '') . ' / ' . ($row->c_appt_desc ?? ''), ' /');
+            return sprintf('    %d -> %s', $row->c_appt_code, $desc);
+        })->implode("\n");
+
+        $promptContent = str_replace('{{APPT_CODE_MAPPINGS}}', $apptLines, $promptContent);
+
+        // ASSUME_OFFICE_CODES
+        $assumeCodes = DB::table('ASSUME_OFFICE_CODES')
+            ->select(['c_assume_office_code', 'c_assume_office_desc_chn', 'c_assume_office_desc'])
+            ->orderBy('c_assume_office_code')
+            ->get();
+
+        $assumeLines = $assumeCodes->map(function ($row) {
+            $desc = trim(($row->c_assume_office_desc_chn ?? '') . ' / ' . ($row->c_assume_office_desc ?? ''), ' /');
+            return sprintf('    %d -> %s', $row->c_assume_office_code, $desc);
+        })->implode("\n");
+
+        $promptContent = str_replace('{{ASSUME_OFFICE_CODE_MAPPINGS}}', $assumeLines, $promptContent);
+
+        return $promptContent;
     }
 
     /**

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -205,6 +205,7 @@ class PostingAutofillService {
 
         $apptLines = $apptCodes->map(function ($row) {
             $desc = trim(($row->c_appt_desc_chn ?? '') . ' / ' . ($row->c_appt_desc ?? ''), ' /');
+
             return sprintf('    %d -> %s', $row->c_appt_code, $desc);
         })->implode("\n");
 
@@ -218,6 +219,7 @@ class PostingAutofillService {
 
         $assumeLines = $assumeCodes->map(function ($row) {
             $desc = trim(($row->c_assume_office_desc_chn ?? '') . ' / ' . ($row->c_assume_office_desc ?? ''), ' /');
+
             return sprintf('    %d -> %s', $row->c_assume_office_code, $desc);
         })->implode("\n");
 

--- a/resources/prompts/ai-posting-extraction-prompt.txt
+++ b/resources/prompts/ai-posting-extraction-prompt.txt
@@ -255,28 +255,11 @@ For each posting in `postings`, fill the following fields:
 19. **c_appt_code**
 
     * Type: integer or `null`
-    * The appointment type code, based on explicit markers in the text (權、行、守、試、攝、封、贈、追封、追贈、卒封、累封、襲封、署、判、兼、蔭襲, etc.).
+    * The appointment type code, based on explicit markers in the text (權、行、守、試、攝、封、贈、追封、追贈、卒封、累封、襲封、署、判、兼、蔭襲、援例, etc.).
     * Use one of the following integer codes; if the type is not clear, set to `null` (not 0):
 
     ```json
-    0  -> 未詳 / Unknown
-    1  -> 正授 / Regular Appointment
-    2  -> 權 / Provisional Appointment
-    3  -> 行 / Lower Acting Appointment
-    4  -> 守 / Higher Acting Appointment
-    5  -> 試 / Exceptional Acting Appointment
-    13 -> 攝 / Irregular Appointment
-    21 -> 封 / Enfoeffed As
-    22 -> 贈 / Granted The Nominal Title Of
-    27 -> 追封 / Posthumously Enfoeffed
-    28 -> 追贈 / Posthumously Granted The Nominal Title Of
-    29 -> 卒封 / Enfoeffed At Death As
-    30 -> 累封 / Further Enfoeffed As
-    31 -> 襲封 / Inherited Enfoeffement As
-    32 -> 署 / Acting (or deputy)
-    33 -> 判 / Rank Higher Than Position Expects
-    37 -> 兼 / Concurrent Appointment
-    41 -> 蔭襲
+    {{APPT_CODE_MAPPINGS}}
     ```
 
     * If the text **explicitly** marks a type but you cannot map it, set `c_appt_code` to `0`.
@@ -289,12 +272,7 @@ For each posting in `postings`, fill the following fields:
     * Use one of:
 
     ```json
-    0 -> 未詳 / Unknown
-    1 -> 赴任 / Assumed the office
-    2 -> 辭不就 / Declined the office
-    3 -> 未赴任而卒 / Died before assuming the office
-    4 -> 未赴任而改命 / Appointment changed before assuming the office
-    5 -> 未赴任 / Did not assume the office
+    {{ASSUME_OFFICE_CODE_MAPPINGS}}
     ```
 
     * If there is no information, set `c_assume_office_code` to `null`.


### PR DESCRIPTION
## Summary
- 將 AI 提取 prompt 中硬編碼的 `c_appt_code` 與 `c_assume_office_code` 映射表改為佔位符
- 新增 `injectCodeMappings()` 方法，從 `APPOINTMENT_CODES` / `ASSUME_OFFICE_CODES` 表動態查詢後注入 prompt
- 解決「援例」(code 54) 等未列入硬編碼映射的除授類別無法被 AI 辨識的問題

## Test plan
- [x] `./vendor/bin/phpunit --filter PostingAutofill` 12 tests 全數通過
- [x] 手動測試：以「遂援例為兵馬司指揮」觸發 AI 自動填充，確認 c_appt_code 能正確辨識為 54

🤖 Generated with [Claude Code](https://claude.com/claude-code)