### PR TITLE
任官自動填充：修正二字地名 name 被錯誤剝離為單字的問題

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -665,8 +665,7 @@ class PostingAutofillService {
      *
      * 例如 AI 可能回傳 name=黃, admin_type=縣，應修正為 name=黃縣, admin_type=縣。
      */
-    protected function normalizeAddrName(array $addrData): array
-    {
+    protected function normalizeAddrName(array $addrData): array {
         $name = $addrData['name'] ?? null;
         $adminType = $addrData['admin_type'] ?? null;
 

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -352,6 +352,7 @@ class PostingAutofillService {
         // 2. 地名匹配（addr_str）
         if (!empty($aiData['addr_str']) && is_array($aiData['addr_str'])) {
             $addrData = $aiData['addr_str'];
+            $addrData = $this->normalizeAddrName($addrData);
             $searchName = $addrData['name'] ?? null;
             $parentName = $addrData['parent'] ?? null;
 
@@ -657,6 +658,23 @@ class PostingAutofillService {
         }
 
         return null;
+    }
+
+    /**
+     * 正規化 addr_str：當 name 剝離 admin_type 後只剩一個字時，將 admin_type 補回 name。
+     *
+     * 例如 AI 可能回傳 name=黃, admin_type=縣，應修正為 name=黃縣, admin_type=縣。
+     */
+    protected function normalizeAddrName(array $addrData): array
+    {
+        $name = $addrData['name'] ?? null;
+        $adminType = $addrData['admin_type'] ?? null;
+
+        if ($name !== null && $adminType !== null && mb_strlen($name) === 1) {
+            $addrData['name'] = $name.$adminType;
+        }
+
+        return $addrData;
     }
 
     /**

--- a/resources/prompts/ai-posting-extraction-prompt.txt
+++ b/resources/prompts/ai-posting-extraction-prompt.txt
@@ -125,11 +125,13 @@ For each posting in `postings`, fill the following fields:
         → Example: "永興軍" → `"name": "永興", "admin_type": "軍"`
         → Example: "安豐軍" → `"name": "安豐", "admin_type": "軍"`
         → Example: "西京監" → `"name": "西京", "admin_type": "監"`
-      * For **2-character names** ending with 州/府:
-        → The last character is likely part of the place name itself
+      * For **2-character names** (e.g. 黃縣、涿州、泉州):
+        → The last character is the admin_type, but name must **keep the full 2-character form**
         → Example: "涿州" → `"name": "涿州", "admin_type": "州"`
         → Example: "泉州" → `"name": "泉州", "admin_type": "州"`
         → Example: "杭州" → `"name": "杭州", "admin_type": "州"`
+        → Example: "黃縣" → `"name": "黃縣", "admin_type": "縣"`
+        → Example: "吳郡" → `"name": "吳郡", "admin_type": "郡"`
       * If admin unit cannot be determined, set to `null`
 
  **If no location is explicitly stated, return `null` for the entire addr_str.**


### PR DESCRIPTION
## Summary
- AI 解析「黃縣」等二字地名時，會將 name 剝離為單字（如 `name: "黃"`），導致後續地名匹配失敗
- 擴展 prompt 中二字地名保留規則，從僅限州/府擴展到縣、郡等所有行政區劃類型
- 新增 `normalizeAddrName()` 程式端防護，當 name 為單字且有 admin_type 時自動補回完整地名

## Test plan
- [x] 既有 `AiPostingAutofillTest` 全部通過（12 tests, 47 assertions）
- [x] 手動測試輸入「補黃縣教諭」，確認 addr_str.name 為「黃縣」而非「黃」

🤖 Generated with [Claude Code](https://claude.com/claude-code)