### PR TITLE
修正 BIOG_MAIN FK 欄位在表單提交時被寫入無效預設值

### DIFF
--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -264,6 +264,9 @@ class BiogMainRepository {
         $data['c_by_intercalary'] = (int)($data['c_by_intercalary']);
         $data['c_dy_intercalary'] = (int)($data['c_dy_intercalary']);
 
+        // FK 欄位空字串轉 null，避免表單提交時將空值寫為無效外鍵
+        $data = self::nullifyEmptyForeignKeys($data);
+
         // 提取註解與動作，並從更新數據中移除，避免 SQL unknown column 錯誤
         $comment = $data['__proposal_comment'] ?? null;
         $data = array_diff_key($data, array_flip(['_method', '_token', '_wysihtml5_mode', 'action', '__proposal_comment', 'c_created_by', 'c_created_date']));
@@ -318,6 +321,29 @@ class BiogMainRepository {
             'no_changes' => false,
             'operation_id' => isset($operation) && $operation ? $operation->id : null,
         ];
+    }
+
+    /**
+     * BIOG_MAIN 中可為 NULL 的外鍵欄位：空字串轉 null。
+     * 避免表單提交空值時被寫為無效外鍵（如 ''）或因 select 無空選項而帶入第一筆預設值。
+     */
+    public static function nullifyEmptyForeignKeys(array $data): array {
+        $nullableFkFields = [
+            'c_by_nh_code', 'c_by_range', 'c_by_day_gz',
+            'c_dy_nh_code', 'c_dy_range', 'c_dy_day_gz',
+            'c_death_age_range',
+            'c_fl_ey_nh_code', 'c_fl_ly_nh_code',
+            'c_ethnicity_code', 'c_choronym_code', 'c_household_status_code',
+            'c_dy',
+        ];
+
+        foreach ($nullableFkFields as $field) {
+            if (array_key_exists($field, $data) && ($data[$field] === '' || $data[$field] === 'null')) {
+                $data[$field] = null;
+            }
+        }
+
+        return $data;
     }
 
     public function store(Request $request) {

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -187,6 +187,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         $payload = array_replace($base, $allowedChanges);
         $payload['c_by_intercalary'] = $payload['c_by_intercalary'] ?? 0;
         $payload['c_dy_intercalary'] = $payload['c_dy_intercalary'] ?? 0;
+        $payload = BiogMainRepository::nullifyEmptyForeignKeys($payload);
 
         return [$payload, array_keys($allowedChanges)];
     }
@@ -205,6 +206,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
             : (int) $female;
         $payload['c_by_intercalary'] = (int) ($payload['c_by_intercalary'] ?? 0);
         $payload['c_dy_intercalary'] = (int) ($payload['c_dy_intercalary'] ?? 0);
+        $payload = BiogMainRepository::nullifyEmptyForeignKeys($payload);
 
         return (new ToolsRepository())->timestamp($payload);
     }

--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -1264,7 +1264,9 @@ function buildSaveChanges(form: BasicInfoForm, values: FormState): Record<string
         }
 
         let value = values[key] ?? '';
-        if (key === 'c_female' && value === '') {
+
+        // enum（含 c_female）及 FK 欄位：空字串視為「未選擇」，送 null
+        if (field.input === 'enum' && value === '') {
             changes[key] = null;
 
             return;

--- a/resources/views/biogmains/basicinformation/edit.blade.php
+++ b/resources/views/biogmains/basicinformation/edit.blade.php
@@ -291,7 +291,7 @@
                     <label for="c_death_age_range" class="col-sm-2 col-form-label">範圍 (c_death_age_range)</label>
                     <div class="col-sm-4">
                         <select class="form-control select2" name="c_death_age_range" id="c_death_age_range" {{ $disabled }}>
-                            {{--<option value="null"></option>--}}
+                            <option value="" {{ $basicinformation->c_death_age_range === null ? 'selected' : '' }}>請選擇</option>
                             @foreach($yearRange as $item )
                                 @if($item->c_range_code === $basicinformation->c_death_age_range)
                                     <option value="{{ $item->c_range_code }}"

--- a/tests/Unit/BiogMainRepositoryTest.php
+++ b/tests/Unit/BiogMainRepositoryTest.php
@@ -46,6 +46,43 @@ class BiogMainRepositoryTest extends TestCase {
     }
 
     #[Test]
+    public function testNullifyEmptyForeignKeysConvertsEmptyStringsToNull() {
+        $data = [
+            'c_death_age_range' => '',
+            'c_by_range' => '',
+            'c_dy_range' => 'null',
+            'c_dy' => '',
+            'c_birthyear' => '',
+            'c_name_chn' => '',
+        ];
+
+        $result = BiogMainRepository::nullifyEmptyForeignKeys($data);
+
+        $this->assertNull($result['c_death_age_range']);
+        $this->assertNull($result['c_by_range']);
+        $this->assertNull($result['c_dy_range']);
+        $this->assertNull($result['c_dy']);
+        // 非 FK 欄位不受影響
+        $this->assertSame('', $result['c_birthyear']);
+        $this->assertSame('', $result['c_name_chn']);
+    }
+
+    #[Test]
+    public function testNullifyEmptyForeignKeysPreservesValidValues() {
+        $data = [
+            'c_death_age_range' => '-1',
+            'c_by_range' => '3',
+            'c_dy' => '15',
+        ];
+
+        $result = BiogMainRepository::nullifyEmptyForeignKeys($data);
+
+        $this->assertSame('-1', $result['c_death_age_range']);
+        $this->assertSame('3', $result['c_by_range']);
+        $this->assertSame('15', $result['c_dy']);
+    }
+
+    #[Test]
     public function testNormalizeSelectionListHandlesMinus999AndSorts() {
         $input = ['-999', 123, '456', 123];
         $expected = ['0', '123', '456'];


### PR DESCRIPTION
## Summary

- Blade 版基本資料編輯頁的 `c_death_age_range` `<select>` 缺少空選項，導致使用者未主動選擇時自動提交 `YEAR_RANGE_CODES` 的第一筆值（`-1`，即「之前/小於」），造成大量人物記錄的享年範圍被錯誤填入
- 後端新增 `BiogMainRepository::nullifyEmptyForeignKeys()`，在 `updateById()`（Blade 直接更新）與 `BiogMainMutationHandler`（React/API 更新）中統一將 FK 欄位空字串轉為 `null`
- 前端 React `buildSaveChanges()` 中所有 `enum` 類型欄位空字串統一轉為 `null`（原本只有 `c_female` 有此處理）

## 影響範圍

| 路徑 | 修復方式 |
|------|----------|
| Blade 表單 → HTTP middleware `ConvertEmptyStringsToNull` | 新空選項送出 `value=""`，middleware 轉 `null` ✅ |
| React/Inertia → `BiogMainMutationHandler` | `buildSaveChanges()` 前端轉 `null` + `nullifyEmptyForeignKeys()` 後端兜底 ✅ |
| 內部 `Request::create()` 等非 middleware 路徑 | `nullifyEmptyForeignKeys()` 兜底 ✅ |

## Test plan

- [x] `BiogMainRepositoryTest`：新增 2 個測試驗證空字串轉 null、有效值保留
- [x] `ApiV2Mutate*` 199 個測試全部通過
- [x] 手動測試：Blade 版編輯頁面，不選擇享年範圍直接儲存，確認不會寫入 `-1`
- [x] 手動測試：React Person Browser 編輯模式，清空範圍欄位後儲存，確認寫入 `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)