### PR TITLE
Person Browser 預設載入 person_id=1 並新增頁籤「顯示全部」功能

### DIFF
--- a/app/Http/Controllers/PersonBrowserController.php
+++ b/app/Http/Controllers/PersonBrowserController.php
@@ -21,6 +21,7 @@ class PersonBrowserController extends Controller {
      */
     public function index(Request $request): InertiaResponse {
         $user = $request->user();
+        $hasQueryParameters = !empty($request->query());
 
         return Inertia::render('PersonBrowser/Index', [
             'tabKeys' => PersonBrowserService::validTabKeys(),
@@ -30,7 +31,9 @@ class PersonBrowserController extends Controller {
             'mutateEndpoint' => route('api.v2.mutate.web', [], false),
             'pinyinEndpoint' => '/api/select/search/pinyin',
             'canEditBasicInfo' => $user ? ($user->isActive() && $user->canWriteDirectly()) : false,
-            'initialPersonId' => $request->input('person_id') ? (int) $request->input('person_id') : null,
+            'initialPersonId' => $request->has('person_id')
+                ? (int) $request->input('person_id')
+                : ($hasQueryParameters ? null : 1),
             'initialKeyword' => $request->input('keyword', ''),
             'initialDynasty' => $request->input('c_dy', ''),
             'initialTab' => $request->input('tab', 'basic_info'),

--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -71,7 +71,7 @@ class PersonBrowserService {
                 }
             }
         } else {
-            $idQuery->orderBy('BIOG_MAIN.c_personid', 'DESC');
+            $idQuery->orderBy('BIOG_MAIN.c_personid', 'ASC');
         }
 
         // 取得朝代分布（基於當前搜尋條件，不含朝代篩選）

--- a/resources/js/inertia/components/PersonBrowser/shared/TabPager.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/TabPager.tsx
@@ -4,10 +4,17 @@ interface Props {
     currentPage: number;
     totalPages: number;
     onPageChange: (page: number) => void;
+    showAll?: boolean;
+    onToggleShowAll?: () => void;
+    totalItems?: number;
 }
 
-export default function TabPager({ currentPage, totalPages, onPageChange }: Props) {
-    if (totalPages <= 1) return null;
+export default function TabPager({ currentPage, totalPages, onPageChange, showAll, onToggleShowAll, totalItems }: Props) {
+    const hasShowAllToggle = onToggleShowAll != null && (totalPages > 1 || showAll);
+
+    if (totalPages <= 1 && !showAll) {
+        return null;
+    }
 
     const pages: number[] = [];
     const range = 2;
@@ -29,44 +36,61 @@ export default function TabPager({ currentPage, totalPages, onPageChange }: Prop
 
     return (
         <div style={containerStyle}>
-            <button
-                type="button"
-                disabled={currentPage <= 1}
-                onClick={() => onPageChange(currentPage - 1)}
-                style={{ ...btnStyle, ...(currentPage <= 1 ? disabledStyle : {}) }}
-            >
-                ‹
-            </button>
-            {display.map((item, idx) =>
-                item === 'ellipsis' ? (
-                    <span key={`e-${idx}`} style={ellipsisStyle}>
-                        …
-                    </span>
-                ) : (
+            {!showAll ? (
+                <>
                     <button
                         type="button"
-                        key={item}
-                        onClick={() => onPageChange(item)}
-                        style={{
-                            ...btnStyle,
-                            ...(item === currentPage ? activeStyle : {}),
-                        }}
+                        disabled={currentPage <= 1}
+                        onClick={() => onPageChange(currentPage - 1)}
+                        style={{ ...btnStyle, ...(currentPage <= 1 ? disabledStyle : {}) }}
                     >
-                        {item}
+                        ‹
                     </button>
-                ),
+                    {display.map((item, idx) =>
+                        item === 'ellipsis' ? (
+                            <span key={`e-${idx}`} style={ellipsisStyle}>
+                                …
+                            </span>
+                        ) : (
+                            <button
+                                type="button"
+                                key={item}
+                                onClick={() => onPageChange(item)}
+                                style={{
+                                    ...btnStyle,
+                                    ...(item === currentPage ? activeStyle : {}),
+                                }}
+                            >
+                                {item}
+                            </button>
+                        ),
+                    )}
+                    <button
+                        type="button"
+                        disabled={currentPage >= totalPages}
+                        onClick={() => onPageChange(currentPage + 1)}
+                        style={{ ...btnStyle, ...(currentPage >= totalPages ? disabledStyle : {}) }}
+                    >
+                        ›
+                    </button>
+                    <span style={infoStyle}>
+                        第 {currentPage} / {totalPages} 頁
+                    </span>
+                </>
+            ) : (
+                <span style={infoStyle}>
+                    共 {totalItems ?? '—'} 筆記錄
+                </span>
             )}
-            <button
-                type="button"
-                disabled={currentPage >= totalPages}
-                onClick={() => onPageChange(currentPage + 1)}
-                style={{ ...btnStyle, ...(currentPage >= totalPages ? disabledStyle : {}) }}
-            >
-                ›
-            </button>
-            <span style={infoStyle}>
-                第 {currentPage} / {totalPages} 頁
-            </span>
+            {hasShowAllToggle ? (
+                <button
+                    type="button"
+                    onClick={onToggleShowAll}
+                    style={showAllBtnStyle}
+                >
+                    {showAll ? '分頁顯示' : '顯示全部'}
+                </button>
+            ) : null}
         </div>
     );
 }
@@ -111,4 +135,17 @@ const infoStyle: React.CSSProperties = {
     marginLeft: 8,
     fontSize: '0.75rem',
     color: '#6c757d',
+};
+
+const showAllBtnStyle: React.CSSProperties = {
+    all: 'unset',
+    marginLeft: 12,
+    padding: '3px 10px',
+    fontSize: '0.78rem',
+    cursor: 'pointer',
+    borderRadius: 4,
+    border: '1px solid #c9d5e2',
+    backgroundColor: '#f8fafc',
+    color: '#204467',
+    fontWeight: 600,
 };

--- a/resources/js/inertia/components/PersonBrowser/shared/useTabPager.ts
+++ b/resources/js/inertia/components/PersonBrowser/shared/useTabPager.ts
@@ -5,9 +5,11 @@ const DEFAULT_PAGE_SIZE = 20;
 /**
  * Tab-local 分頁 hook。
  * 管理頁碼、計算當前頁面的 slice、總頁數。
+ * 支援「顯示全部」模式，展開所有記錄。
  */
 export function useTabPager<T>(items: T[], pageSize: number = DEFAULT_PAGE_SIZE) {
     const [currentPage, setCurrentPage] = useState(1);
+    const [showAll, setShowAll] = useState(false);
 
     const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
 
@@ -21,9 +23,10 @@ export function useTabPager<T>(items: T[], pageSize: number = DEFAULT_PAGE_SIZE)
     const safePage = Math.min(Math.max(1, currentPage), totalPages);
 
     const pageItems = useMemo(() => {
+        if (showAll) return items;
         const start = (safePage - 1) * pageSize;
         return items.slice(start, start + pageSize);
-    }, [items, safePage, pageSize]);
+    }, [items, safePage, pageSize, showAll]);
 
     return {
         currentPage: safePage,
@@ -31,5 +34,7 @@ export function useTabPager<T>(items: T[], pageSize: number = DEFAULT_PAGE_SIZE)
         pageItems,
         setCurrentPage,
         totalItems: items.length,
+        showAll,
+        setShowAll,
     };
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
@@ -37,7 +37,7 @@ interface Props {
 }
 
 export default function AddressesTab({ data, canEdit, postCE }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
 
     return (
         <div style={containerStyle}>
@@ -69,7 +69,7 @@ export default function AddressesTab({ data, canEdit, postCE }: Props) {
                     <LegacyEditButton tabKey="addresses" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
@@ -34,7 +34,7 @@ interface Props {
 }
 
 export default function AltNamesTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -52,7 +52,7 @@ export default function AltNamesTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="alt_names" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
@@ -44,7 +44,7 @@ interface Props {
 }
 
 export default function AssociationsTab({ data, canEdit, postCE, onSelectPerson }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -66,7 +66,7 @@ export default function AssociationsTab({ data, canEdit, postCE, onSelectPerson 
                     <LegacyEditButton tabKey="associations" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/EntriesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/EntriesTab.tsx
@@ -39,7 +39,7 @@ interface Props {
 }
 
 export default function EntriesTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
 
     return (
         <div style={containerStyle}>
@@ -56,7 +56,7 @@ export default function EntriesTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="entries" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/EventsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/EventsTab.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 export default function EventsTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -55,7 +55,7 @@ export default function EventsTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="events" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/InstitutionsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/InstitutionsTab.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 export default function InstitutionsTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -54,7 +54,7 @@ export default function InstitutionsTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="social_institutions" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
@@ -39,7 +39,7 @@ interface Props {
  * 僅顯示直接關係，不做親屬的親屬展開（kinship network expansion）。
  */
 export default function KinshipTab({ data, canEdit, onSelectPerson }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -57,7 +57,7 @@ export default function KinshipTab({ data, canEdit, onSelectPerson }: Props) {
                     <LegacyEditButton tabKey="kinship" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/PossessionsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/PossessionsTab.tsx
@@ -33,7 +33,7 @@ interface Props {
 }
 
 export default function PossessionsTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -53,7 +53,7 @@ export default function PossessionsTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="possessions" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/PostingsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/PostingsTab.tsx
@@ -38,7 +38,7 @@ interface Props {
 }
 
 export default function PostingsTab({ data, canEdit, postCE }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -59,7 +59,7 @@ export default function PostingsTab({ data, canEdit, postCE }: Props) {
                     <LegacyEditButton tabKey="postings" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 export default function SourcesTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.text_id));
 
     return (
@@ -91,7 +91,7 @@ export default function SourcesTab({ data, canEdit }: Props) {
                     </TabCard>
                 );
             })}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/StatusesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/StatusesTab.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 export default function StatusesTab({ data, canEdit, postCE }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
     const { records: textRecords } = useTextCodes(data.items.map((item) => item.source_id));
 
     return (
@@ -54,7 +54,7 @@ export default function StatusesTab({ data, canEdit, postCE }: Props) {
                     <LegacyEditButton tabKey="statuses" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/tabs/TextsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/TextsTab.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 export default function TextsTab({ data, canEdit }: Props) {
-    const { pageItems, currentPage, totalPages, setCurrentPage } = useTabPager(data.items);
+    const { pageItems, currentPage, totalPages, setCurrentPage, showAll, setShowAll, totalItems } = useTabPager(data.items);
 
     return (
         <div style={containerStyle}>
@@ -45,7 +45,7 @@ export default function TextsTab({ data, canEdit }: Props) {
                     <LegacyEditButton tabKey="texts" pk={item.pk} canEdit={canEdit} />
                 </TabCard>
             ))}
-            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />
         </div>
     );
 }

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -761,7 +761,7 @@ class PersonBrowserTest extends TestCase {
             fn (Assert $page) => $page
                 ->component('PersonBrowser/Index')
                 ->where('canEditBasicInfo', true)
-                ->where('initialPersonId', null)
+                ->where('initialPersonId', 1)
                 ->where('initialKeyword', '')
                 ->where('initialTab', 'basic_info')
                 ->where('initialPage', 1)
@@ -791,6 +791,22 @@ class PersonBrowserTest extends TestCase {
     // ───────────────────────────────────
 
     #[Test]
+    public function test_person_browser_keeps_initial_person_id_null_when_query_omits_person_id(): void {
+        $response = $this->actingAs($this->user)->get(
+            route('app.person-browser.index') . '?keyword=%E7%8E%8B&page=3'
+        );
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('PersonBrowser/Index')
+                ->where('initialPersonId', null)
+                ->where('initialKeyword', '王')
+                ->where('initialPage', 3)
+        );
+    }
+
+    #[Test]
     public function test_search_requires_authentication(): void {
         $response = $this->getJson(route('app.person-browser.search'));
         $response->assertStatus(401);
@@ -807,9 +823,9 @@ class PersonBrowserTest extends TestCase {
             'pagination' => ['current_page', 'last_page', 'per_page', 'total'],
         ]);
         $response->assertJsonPath('pagination.total', 3);
-        $response->assertJsonPath('data.0.c_personid', 3);
+        $response->assertJsonPath('data.0.c_personid', 1);
         $response->assertJsonPath('data.1.c_personid', 2);
-        $response->assertJsonPath('data.2.c_personid', 1);
+        $response->assertJsonPath('data.2.c_personid', 3);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- 純登入 `/app/person-browser` 時預設選取 person_id=1，左側列表改為 ID 升冪排列（1, 2, 3...）
- 帶有查詢參數但未指定 `person_id` 時維持 `null`，避免搜尋結果與右側面板不一致
- 所有非 `basic_info` 頁籤新增「顯示全部」/「分頁顯示」切換按鈕，可一次展開所有記錄

## Test plan
- [x] 直接訪問 `/app/person-browser`，確認預設載入 person_id=1 且左側列表從 1 開始升冪排列
- [x] 訪問 `/app/person-browser?keyword=王`，確認右側不會自動載入任何人物
- [x] 訪問 `/app/person-browser?person_id=1762&tab=postings`，確認正確載入指定人物
- [x] 在 postings、associations 等頁籤確認「顯示全部」按鈕出現且可正常切換
- [x] `vendor/bin/phpunit --filter PersonBrowser` 全部 40 tests 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)