### PR TITLE
Person Browser 編輯體驗改進與各頁籤刪除功能

### DIFF
--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -255,6 +255,35 @@ class PersonBrowserService {
             ->first();
 
         if (!$row) {
+            // person_id=0 是「未詳」哨兵值，沒有 BIOG_MAIN 記錄但在系統中合法使用
+            if ($personId === 0) {
+                $counts = $this->tabCounts($personId);
+
+                return [
+                    'c_personid' => 0,
+                    'c_name_chn' => '未詳',
+                    'c_name' => 'Unknown',
+                    'c_name_proper' => null,
+                    'c_name_rm' => null,
+                    'c_surname_chn' => null,
+                    'c_mingzi_chn' => null,
+                    'gender' => null,
+                    'c_birthyear' => null,
+                    'c_deathyear' => null,
+                    'c_index_year' => null,
+                    'index_year_type' => null,
+                    'dynasty_chn' => null,
+                    'dynasty' => null,
+                    'dynasty_start' => null,
+                    'index_addr_chn' => null,
+                    'index_addr' => null,
+                    'c_notes' => null,
+                    'alt_name_zi' => '',
+                    'alt_name_hao' => '',
+                    'tab_counts' => $counts,
+                ];
+            }
+
             return null;
         }
 

--- a/resources/js/inertia/Pages/PersonBrowser/Index.tsx
+++ b/resources/js/inertia/Pages/PersonBrowser/Index.tsx
@@ -259,7 +259,7 @@ export default function PersonBrowserIndex() {
 
     // ── Load summary when selectedId changes ──
     useEffect(() => {
-        if (!selectedId) {
+        if (selectedId == null) {
             setSummary(null);
             return;
         }
@@ -457,7 +457,7 @@ export default function PersonBrowserIndex() {
                                 人物列表
                             </button>
                             <div style={mobileToolbarMetaStyle}>
-                                {selectedId ? `人物 #${selectedId}` : '尚未選擇人物'}
+                                {selectedId != null ? `人物 #${selectedId}` : '尚未選擇人物'}
                             </div>
                         </div>
                     ) : null}

--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 
 interface Props {
     sections: Section[];
@@ -84,6 +84,10 @@ export default function BasicInfoView({
         () => buildDirtyFieldSet(form, initialState, formState),
         [form, initialState, formState],
     );
+    const editableKeys = useMemo(() => {
+        if (!form?.fields) return new Set<string>();
+        return new Set(Object.entries(form.fields).filter(([, f]) => f.editable).map(([k]) => k));
+    }, [form]);
 
     useEffect(() => {
         setEditing(false);
@@ -138,13 +142,30 @@ export default function BasicInfoView({
         setError(null);
     };
 
-    const cancelEdit = () => {
+    const deleteFormRef = useRef<HTMLFormElement | null>(null);
+
+    const handleDelete = useCallback(() => {
+        if (!canEdit || !personId) return;
+        if (!window.confirm('您真的確定要刪除此人物嗎？\n\n此操作無法撤銷，請確認！')) return;
+        deleteFormRef.current?.submit();
+    }, [canEdit, personId]);
+
+    const cancelEdit = useCallback(() => {
         setEditing(false);
         setFormState(initialState);
         setFieldErrors({});
         setMessage(null);
         setError(null);
-    };
+    }, [initialState]);
+
+    useEffect(() => {
+        if (!editing) return;
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') cancelEdit();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [editing, cancelEdit]);
 
     const updateField = (key: string, value: string) => {
         setFormState((prev) => applyDerivedFields({
@@ -255,9 +276,18 @@ export default function BasicInfoView({
                     </div>
                     <div style={toolbarButtonGroupStyle}>
                         {!editing && canEdit ? (
-                            <button type="button" style={primaryButtonStyle} onClick={beginEdit}>
-                                編輯基本信息
-                            </button>
+                            <>
+                                <button type="button" style={primaryButtonStyle} onClick={beginEdit}>
+                                    編輯基本信息
+                                </button>
+                                <form ref={deleteFormRef} method="POST" action={`/basicinformation/${personId}`} style={{ display: 'none' }}>
+                                    <input type="hidden" name="_method" value="DELETE" />
+                                    <input type="hidden" name="_token" value={getCsrfToken()} />
+                                </form>
+                                <button type="button" style={dangerButtonStyle} onClick={handleDelete}>
+                                    刪除人物
+                                </button>
+                            </>
                         ) : editing ? (
                             <>
                                 <button
@@ -295,11 +325,12 @@ export default function BasicInfoView({
                 generatingPinyin,
                 save,
                 saving,
+                cancelEdit,
             ) : (
                 <div style={{ paddingBottom: 16 }}>
                     {sections.map((section, index) => (
                         <div key={section.title} style={index === 0 ? sectionStyle : sectionWithDividerStyle}>
-                            {renderReadOnlySection(section)}
+                            {renderReadOnlySection(section, canEdit ? beginEdit : undefined, editableKeys)}
                         </div>
                     ))}
                 </div>
@@ -318,6 +349,7 @@ function renderEditor(
     generatingPinyin?: boolean,
     onSave?: () => void,
     saving?: boolean,
+    onCancel?: () => void,
 ) {
     return (
         <>
@@ -565,14 +597,24 @@ function renderEditor(
 
             <div style={editorBottomBarStyle}>
                 <div style={editorBottomBarHintStyle}>確認內容後再整頁儲存，儲存將調用 `/api/v2/mutate` 更新 BIOG_MAIN。</div>
-                <button
-                    type="button"
-                    style={primaryButtonStyle}
-                    onClick={onSave}
-                    disabled={saving}
-                >
-                    {saving ? '儲存中…' : '整頁儲存'}
-                </button>
+                <div style={editorBottomBarButtonsStyle}>
+                    <button
+                        type="button"
+                        style={neutralButtonStyle}
+                        onClick={onCancel}
+                        disabled={saving}
+                    >
+                        取消
+                    </button>
+                    <button
+                        type="button"
+                        style={primaryButtonStyle}
+                        onClick={onSave}
+                        disabled={saving}
+                    >
+                        {saving ? '儲存中…' : '整頁儲存'}
+                    </button>
+                </div>
             </div>
         </>
     );
@@ -882,20 +924,35 @@ function EnumAutocompleteField({
     );
 }
 
-function renderReadOnlySection(section: Section) {
+function extractFieldKey(label: string): string | null {
+    const match = label.match(/\(([^)]+)\)\s*$/);
+    return match ? match[1] : null;
+}
+
+function editableClickHandler(label: string, editableKeys: Set<string>, onClickEdit?: () => void): (() => void) | undefined {
+    if (!onClickEdit) return undefined;
+    const key = extractFieldKey(label);
+    if (key && editableKeys.has(key)) return onClickEdit;
+    // 允許直接傳入 field key（無括號）
+    if (editableKeys.has(label)) return onClickEdit;
+    return undefined;
+}
+
+function renderReadOnlySection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
+    const ek = editableKeys ?? new Set<string>();
     switch (section.title) {
         case '姓名資料':
-            return renderNameSection(section);
+            return renderNameSection(section, onClickEdit, ek);
         case '生卒年':
-            return renderLifeSection(section);
+            return renderLifeSection(section, onClickEdit, ek);
         case '基本屬性':
-            return renderPropertySection(section);
+            return renderPropertySection(section, onClickEdit, ek);
         case '指數資料':
-            return renderIndexSection(section);
+            return renderIndexSection(section, onClickEdit, ek);
         case '活動年份':
-            return renderActiveYearsSection(section);
+            return renderActiveYearsSection(section, onClickEdit, ek);
         case '備註':
-            return renderNotesSection(section);
+            return renderNotesSection(section, onClickEdit, ek);
         case '建立 / 修改資訊':
             return renderAuditSection(section);
         default:
@@ -903,7 +960,7 @@ function renderReadOnlySection(section: Section) {
     }
 }
 
-function renderNameSection(section: Section) {
+function renderNameSection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
     const fields = fieldMap(section);
     const groups = [
         {
@@ -954,6 +1011,7 @@ function renderNameSection(section: Section) {
                                     label={label}
                                     value={sectionValue}
                                     derived={index === group.items.length - 1}
+                                    onClickEdit={editableClickHandler(label, editableKeys ?? new Set(), onClickEdit)}
                                 />
                             ))}
                         </div>
@@ -964,7 +1022,7 @@ function renderNameSection(section: Section) {
     );
 }
 
-function renderLifeSection(section: Section) {
+function renderLifeSection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
     const fields = fieldMap(section);
 
     return (
@@ -983,6 +1041,8 @@ function renderLifeSection(section: Section) {
                         ['日期 (c_by_day)', fields['出生日']],
                         ['日干支 (c_by_day_gz)', prefixId(fields['出生日時干支 ID'], String(fields['出生日時干支'] ?? ''))],
                     ]}
+                    onClickEdit={onClickEdit}
+                    editableKeys={editableKeys}
                 />
                 <TimelineCard
                     title="卒年"
@@ -996,17 +1056,19 @@ function renderLifeSection(section: Section) {
                         ['日期 (c_dy_day)', fields['死亡日']],
                         ['日干支 (c_dy_day_gz)', prefixId(fields['死亡日時干支 ID'], String(fields['死亡日時干支'] ?? ''))],
                     ]}
+                    onClickEdit={onClickEdit}
+                    editableKeys={editableKeys}
                 />
             </div>
             <div style={compactGridStyle}>
-                <ReadOnlyField label="享年 (c_death_age)" value={fields['享年']} />
-                <ReadOnlyField label="享年範圍 (c_death_age_range)" value={prefixId(fields['享年範圍 ID'], String(fields['享年範圍'] ?? ''))} />
+                <ReadOnlyField label="享年 (c_death_age)" value={fields['享年']} onClickEdit={editableClickHandler('c_death_age', editableKeys ?? new Set(), onClickEdit)} />
+                <ReadOnlyField label="享年範圍 (c_death_age_range)" value={prefixId(fields['享年範圍 ID'], String(fields['享年範圍'] ?? ''))} onClickEdit={editableClickHandler('c_death_age_range', editableKeys ?? new Set(), onClickEdit)} />
             </div>
         </>
     );
 }
 
-function renderPropertySection(section: Section) {
+function renderPropertySection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
     const fields = fieldMap(section);
     const mergedFields = [
         { label: '性別 (c_female)', value: fields['性別'] },
@@ -1021,14 +1083,14 @@ function renderPropertySection(section: Section) {
             <SectionHeading title={section.title} />
             <div style={compactGridStyle}>
                 {mergedFields.map((field) => (
-                    <ReadOnlyField key={field.label} label={field.label} value={field.value} />
+                    <ReadOnlyField key={field.label} label={field.label} value={field.value} onClickEdit={editableClickHandler(field.label, editableKeys ?? new Set(), onClickEdit)} />
                 ))}
             </div>
         </>
     );
 }
 
-function renderIndexSection(section: Section) {
+function renderIndexSection(section: Section, _onClickEdit?: () => void, _editableKeys?: Set<string>) {
     const fields = fieldMap(section);
     const indexYearType = prefixId(fields['Index Year Type'], joinDisplayValues(fields['Index Year Type（中文）'], fields['Index Year Type（英文）']));
     const indexAddress = prefixId(fields['Index Address ID'], joinDisplayValues(fields['Index Address（中文）'], fields['Index Address（英文）']));
@@ -1052,7 +1114,7 @@ function renderIndexSection(section: Section) {
     );
 }
 
-function renderActiveYearsSection(section: Section) {
+function renderActiveYearsSection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
     const fields = fieldMap(section);
 
     return (
@@ -1067,6 +1129,8 @@ function renderActiveYearsSection(section: Section) {
                         ['年號年 (c_fl_ey_nh_year)', fields['在世始年號年']],
                     ]}
                     note={fields['在世始年註']}
+                    onClickEdit={onClickEdit}
+                    editableKeys={editableKeys}
                 />
                 <TimelineCard
                     title="在世終年 (c_fl_latest_year)"
@@ -1076,20 +1140,38 @@ function renderActiveYearsSection(section: Section) {
                         ['年號年 (c_fl_ly_nh_year)', fields['在世終年號年']],
                     ]}
                     note={fields['在世終年註']}
+                    onClickEdit={onClickEdit}
+                    editableKeys={editableKeys}
                 />
             </div>
         </>
     );
 }
 
-function renderNotesSection(section: Section) {
+function renderNotesSection(section: Section, onClickEdit?: () => void, editableKeys?: Set<string>) {
     const fields = fieldMap(section);
 
     return (
         <>
             <SectionHeading title={section.title} />
             <div style={notesLabelStyle}>備註 (c_notes)</div>
-            <div style={notesBoxStyle}>{displayValue(fields['備註'])}</div>
+            {(() => {
+                const handler = editableClickHandler('c_notes', editableKeys ?? new Set(), onClickEdit);
+                return (
+                    <div
+                        style={{
+                            ...notesBoxStyle,
+                            ...(handler ? clickableFieldStyle : {}),
+                        }}
+                        onClick={handler}
+                        role={handler ? 'button' : undefined}
+                        tabIndex={handler ? 0 : undefined}
+                        onKeyDown={handler ? (e) => { if (e.key === 'Enter' || e.key === ' ') handler(); } : undefined}
+                    >
+                        {displayValue(fields['備註'])}
+                    </div>
+                );
+            })()}
         </>
     );
 }
@@ -1136,19 +1218,24 @@ function TimelineCard({
     title,
     items,
     note,
+    onClickEdit,
+    editableKeys,
 }: {
     title: string;
     items: Array<[string, FieldValue]>;
     note?: FieldValue;
+    onClickEdit?: () => void;
+    editableKeys?: Set<string>;
 }) {
+    const ek = editableKeys ?? new Set<string>();
     return (
         <div style={timelineCardStyle}>
             <div style={timelineTitleStyle}>{title}</div>
             <div style={timelineItemsGridStyle}>
                 {items.map(([label, sectionValue]) => (
-                    <ReadOnlyField key={label} label={label} value={sectionValue} />
+                    <ReadOnlyField key={label} label={label} value={sectionValue} onClickEdit={editableClickHandler(label, ek, onClickEdit)} />
                 ))}
-                {note !== undefined ? <ReadOnlyField label={`${title.includes('始') ? '備註 (c_fl_ey_notes)' : '備註 (c_fl_ly_notes)'}`} value={note} fullWidth subtle /> : null}
+                {note !== undefined ? (() => { const noteLabel = title.includes('始') ? '備註 (c_fl_ey_notes)' : '備註 (c_fl_ly_notes)'; return <ReadOnlyField label={noteLabel} value={note} fullWidth subtle onClickEdit={editableClickHandler(noteLabel, ek, onClickEdit)} />; })() : null}
             </div>
         </div>
     );
@@ -1163,6 +1250,7 @@ function ReadOnlyField({
     emphasis = false,
     derived = false,
     dirty = false,
+    onClickEdit,
 }: {
     label: string;
     value: FieldValue;
@@ -1172,6 +1260,7 @@ function ReadOnlyField({
     emphasis?: boolean;
     derived?: boolean;
     dirty?: boolean;
+    onClickEdit?: () => void;
 }) {
     return (
         <div
@@ -1189,7 +1278,12 @@ function ReadOnlyField({
                     ...(emphasis ? emphasisValueBoxStyle : {}),
                     ...(derived ? derivedValueBoxStyle : {}),
                     ...(dirty ? dirtyValueBoxStyle : {}),
+                    ...(onClickEdit ? clickableFieldStyle : {}),
                 }}
+                onClick={onClickEdit}
+                role={onClickEdit ? 'button' : undefined}
+                tabIndex={onClickEdit ? 0 : undefined}
+                onKeyDown={onClickEdit ? (e) => { if (e.key === 'Enter' || e.key === ' ') onClickEdit(); } : undefined}
             >
                 {displayValue(value)}
             </div>
@@ -1552,6 +1646,13 @@ const neutralButtonStyle: React.CSSProperties = {
     borderColor: '#cdd7e1',
 };
 
+const dangerButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: '#fff',
+    color: '#dc3545',
+    borderColor: '#dc3545',
+};
+
 const successMessageStyle: React.CSSProperties = {
     margin: '16px 20px 0',
     padding: '10px 12px',
@@ -1587,7 +1688,6 @@ const sectionWithDividerStyle: React.CSSProperties = {
 const sectionHeadingStyle: React.CSSProperties = {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
     gap: 12,
     marginBottom: 16,
     padding: '10px 14px',
@@ -1861,6 +1961,11 @@ const editorBottomBarStyle: React.CSSProperties = {
     backgroundColor: '#f9fbfe',
 };
 
+const editorBottomBarButtonsStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: 8,
+};
+
 const editorBottomBarHintStyle: React.CSSProperties = {
     fontSize: '0.82rem',
     color: '#62798f',
@@ -1926,6 +2031,11 @@ const notesLabelStyle: React.CSSProperties = {
     color: '#556677',
     marginBottom: 6,
     textAlign: 'left',
+};
+
+const clickableFieldStyle: React.CSSProperties = {
+    cursor: 'pointer',
+    transition: 'background-color 0.15s',
 };
 
 const emptyStyle: React.CSSProperties = {

--- a/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
+++ b/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import BasicInfoView from './BasicInfoView';
 import AltNamesTab from './tabs/AltNamesTab';
 import AddressesTab from './tabs/AddressesTab';
@@ -68,20 +68,28 @@ export default function TabContentLoader({
     onBasicInfoEditorStateChange,
     onRegisterBasicInfoSaveHandler,
 }: Props) {
-    const [cache, setCache] = useState<Record<string, TabState>>({});
-    const prevPersonRef = useRef<number | null>(null);
+    const [cacheState, setCacheState] = useState<{ personId: number | null; tabs: Record<string, TabState> }>({
+        personId,
+        tabs: {},
+    });
 
-    // 人物切換時清空快取
-    useEffect(() => {
-        if (prevPersonRef.current !== personId) {
-            setCache({});
-            prevPersonRef.current = personId;
-        }
-    }, [personId]);
+    // 人物切換時重設快取；本次渲染直接使用空快取，不等下一輪
+    const personChanged = cacheState.personId !== personId;
+    if (personChanged) {
+        setCacheState({ personId, tabs: {} });
+    }
+
+    const cache = personChanged ? {} : cacheState.tabs;
+    const setCache = (updater: Record<string, TabState> | ((prev: Record<string, TabState>) => Record<string, TabState>)) => {
+        setCacheState((prev) => ({
+            ...prev,
+            tabs: typeof updater === 'function' ? updater(prev.tabs) : updater,
+        }));
+    };
 
     // lazy load
     useEffect(() => {
-        if (!personId || !activeTab) return;
+        if (personId == null || !activeTab) return;
         if (cache[activeTab]) return;
 
         const url = tabEndpoint
@@ -92,7 +100,7 @@ export default function TabContentLoader({
 
         const controller = new AbortController();
 
-        fetch(url)
+        fetch(url, { signal: controller.signal })
             .then((res) => {
                 if (!res.ok) throw new Error(`HTTP ${res.status}`);
                 return res.json();
@@ -127,7 +135,7 @@ export default function TabContentLoader({
         });
     };
 
-    if (!personId) {
+    if (personId == null) {
         return null;
     }
 

--- a/resources/js/inertia/components/PersonBrowser/shared/CardActions.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/CardActions.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+    children: React.ReactNode;
+}
+
+/**
+ * 卡片右上角的操作按鈕容器（修改、刪除等）。
+ */
+export default function CardActions({ children }: Props) {
+    return <div style={containerStyle}>{children}</div>;
+}
+
+const containerStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: 10,
+    right: 14,
+    display: 'flex',
+    gap: 6,
+    zIndex: 1,
+};

--- a/resources/js/inertia/components/PersonBrowser/shared/LegacyDeleteButton.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/LegacyDeleteButton.tsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react';
+import { buildLegacyDeleteUrl, LegacyPk } from './legacyEditUrl';
+
+interface Props {
+    tabKey: string;
+    pk: LegacyPk;
+    canEdit: boolean;
+    fallbackPersonId?: number | null;
+}
+
+export default function LegacyDeleteButton({ tabKey, pk, canEdit, fallbackPersonId }: Props) {
+    if (!canEdit) {
+        return null;
+    }
+
+    const formRef = useRef<HTMLFormElement | null>(null);
+
+    const action = buildLegacyDeleteUrl(tabKey, pk, fallbackPersonId);
+    if (!action) {
+        return null;
+    }
+
+    const csrfToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content || '';
+
+    const handleClick = (event: React.MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!window.confirm('您真的確定要刪除嗎？\n\n請確認！')) {
+            return;
+        }
+
+        formRef.current?.submit();
+    };
+
+    return (
+        <>
+            <form ref={formRef} method="POST" action={action} style={hiddenFormStyle}>
+                <input type="hidden" name="_method" value="DELETE" />
+                <input type="hidden" name="_token" value={csrfToken} />
+            </form>
+            <button type="button" style={buttonStyle} title="刪除" onClick={handleClick}>
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <line x1="2" y1="2" x2="12" y2="12" />
+                    <line x1="12" y1="2" x2="2" y2="12" />
+                </svg>
+            </button>
+        </>
+    );
+}
+
+const hiddenFormStyle: React.CSSProperties = {
+    display: 'none',
+};
+
+const buttonStyle: React.CSSProperties = {
+    all: 'unset',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 30,
+    height: 30,
+    borderRadius: 6,
+    border: '1px solid #dc3545',
+    color: '#dc3545',
+    backgroundColor: '#fff',
+    fontSize: '0.85rem',
+    cursor: 'pointer',
+};

--- a/resources/js/inertia/components/PersonBrowser/shared/LegacyEditButton.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/LegacyEditButton.tsx
@@ -19,32 +19,23 @@ export default function LegacyEditButton({ tabKey, pk, canEdit, fallbackPersonId
     }
 
     return (
-        <div style={containerStyle}>
-            <a href={href} style={linkStyle}>
-                修改
-            </a>
-        </div>
+        <a href={href} style={linkStyle} title="修改">
+            ✎
+        </a>
     );
 }
-
-const containerStyle: React.CSSProperties = {
-    position: 'absolute',
-    top: 10,
-    right: 14,
-    zIndex: 1,
-};
 
 const linkStyle: React.CSSProperties = {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: 26,
-    padding: '0 10px',
-    borderRadius: 4,
+    width: 30,
+    height: 30,
+    borderRadius: 6,
     border: '1px solid #c4737e',
     color: '#7a2030',
     backgroundColor: '#fff',
     textDecoration: 'none',
-    fontSize: '0.8125rem',
-    fontWeight: 600,
+    fontSize: '0.95rem',
+    cursor: 'pointer',
 };

--- a/resources/js/inertia/components/PersonBrowser/shared/TabCard.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/TabCard.tsx
@@ -15,6 +15,6 @@ const cardStyle: React.CSSProperties = {
     position: 'relative',
     border: '1px solid #dee2e6',
     borderRadius: 6,
-    padding: '10px 88px 10px 14px',
+    padding: '10px 90px 10px 14px',
     backgroundColor: '#fff',
 };

--- a/resources/js/inertia/components/PersonBrowser/shared/legacyEditUrl.ts
+++ b/resources/js/inertia/components/PersonBrowser/shared/legacyEditUrl.ts
@@ -41,6 +41,32 @@ export function buildLegacyEditUrl(tabKey: string, pk: LegacyPk, fallbackPersonI
     return query ? `${path}?${query}` : path;
 }
 
+export function buildLegacyDeleteUrl(tabKey: string, pk: LegacyPk, fallbackPersonId?: number | null): string | null {
+    const segment = TAB_SEGMENTS[tabKey];
+    if (!segment) {
+        return null;
+    }
+
+    const personId = normalizePersonId(pk.c_personid, fallbackPersonId ?? getCurrentPersonIdFromLocation());
+    if (personId === null) {
+        return null;
+    }
+
+    const params = new URLSearchParams();
+    Object.entries(pk).forEach(([key, value]) => {
+        if (value === undefined) {
+            return;
+        }
+
+        params.set(key, value === null ? 'NULL' : String(value));
+    });
+
+    const query = params.toString();
+    const path = `/basicinformation/${personId}/${segment}/delete`;
+
+    return query ? `${path}?${query}` : path;
+}
+
 export function buildLegacyCreateUrl(tabKey: string, fallbackPersonId?: number | null): string | null {
     const segment = TAB_SEGMENTS[tabKey];
     if (!segment) {

--- a/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel, formatYearRange } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -66,7 +68,10 @@ export default function AddressesTab({ data, canEdit, postCE }: Props) {
                         }
                     />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="addresses" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="addresses" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="addresses" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -49,7 +51,10 @@ export default function AltNamesTab({ data, canEdit }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="alt_names" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="alt_names" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="alt_names" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel, formatYearRange } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -63,7 +65,10 @@ export default function AssociationsTab({ data, canEdit, postCE, onSelectPerson 
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="associations" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="associations" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="associations" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/EntriesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/EntriesTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -53,7 +55,10 @@ export default function EntriesTab({ data, canEdit }: Props) {
                     <MetaRow label="年份" value={item.year} />
                     <MetaRow label="親屬關聯" value={item.kin_summary} />
                     <MetaRow label="社會關聯" value={item.assoc_summary} />
-                    <LegacyEditButton tabKey="entries" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="entries" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="entries" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/EventsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/EventsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -52,7 +54,10 @@ export default function EventsTab({ data, canEdit }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="events" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="events" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="events" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/InstitutionsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/InstitutionsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -51,7 +53,10 @@ export default function InstitutionsTab({ data, canEdit }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="social_institutions" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="social_institutions" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="social_institutions" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -54,7 +56,10 @@ export default function KinshipTab({ data, canEdit, onSelectPerson }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="kinship" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="kinship" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="kinship" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/PossessionsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/PossessionsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -50,7 +52,10 @@ export default function PossessionsTab({ data, canEdit }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="possessions" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="possessions" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="possessions" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/PostingsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/PostingsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel, formatYearRange } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -56,7 +58,10 @@ export default function PostingsTab({ data, canEdit, postCE }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="postings" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="postings" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="postings" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -87,7 +89,10 @@ export default function SourcesTab({ data, canEdit }: Props) {
                             }
                         />
                         <MetaRow label="備註" value={item.notes} />
-                        <LegacyEditButton tabKey="sources" pk={item.pk} canEdit={canEdit} />
+                        <CardActions>
+                            <LegacyEditButton tabKey="sources" pk={item.pk} canEdit={canEdit} />
+                            <LegacyDeleteButton tabKey="sources" pk={item.pk} canEdit={canEdit} />
+                        </CardActions>
                     </TabCard>
                 );
             })}

--- a/resources/js/inertia/components/PersonBrowser/tabs/StatusesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/StatusesTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel, formatYearRange } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -51,7 +53,10 @@ export default function StatusesTab({ data, canEdit, postCE }: Props) {
                     <MetaRow label="出處" value={formatTextTitle(textRecords[item.source_id ?? 0], item.source_id)} />
                     <MetaRow label="頁碼" value={item.pages} />
                     <MetaRow label="備註" value={item.notes} />
-                    <LegacyEditButton tabKey="statuses" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="statuses" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="statuses" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />

--- a/resources/js/inertia/components/PersonBrowser/tabs/TextsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/TextsTab.tsx
@@ -5,6 +5,8 @@ import TabPager from '../shared/TabPager';
 import EmptyState from '../shared/EmptyState';
 import LegacyCreateButton from '../shared/LegacyCreateButton';
 import LegacyEditButton from '../shared/LegacyEditButton';
+import LegacyDeleteButton from '../shared/LegacyDeleteButton';
+import CardActions from '../shared/CardActions';
 import { useTabPager } from '../shared/useTabPager';
 import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
@@ -42,7 +44,10 @@ export default function TextsTab({ data, canEdit }: Props) {
                     <MetaRow label="著作" value={formatBilingualLabel(item.title_chn, item.title)} />
                     <MetaRow label="年份" value={item.year} />
                     <MetaRow label="角色" value={formatBilingualLabel(item.role_chn, item.role)} />
-                    <LegacyEditButton tabKey="texts" pk={item.pk} canEdit={canEdit} />
+                    <CardActions>
+                        <LegacyEditButton tabKey="texts" pk={item.pk} canEdit={canEdit} />
+                        <LegacyDeleteButton tabKey="texts" pk={item.pk} canEdit={canEdit} />
+                    </CardActions>
                 </TabCard>
             ))}
             <TabPager currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} showAll={showAll} onToggleShowAll={() => setShowAll(!showAll)} totalItems={totalItems} />


### PR DESCRIPTION
## Summary
- 基本信息：點擊可編輯欄位直接進入編輯模式（僅 `editable` 欄位可觸發），ESC 鍵退出編輯，編輯器底部新增取消按鈕
- 基本信息：新增「刪除人物」按鈕（使用既有 `DELETE /basicinformation/{id}` 路由），Person ID badge 改為左對齊
- 各頁籤（12 個）：新增刪除按鈕（SVG × 圖標），修改按鈕改為圖標風格，兩者橫排於 `CardActions` 容器
- 修復 `person_id=0`（未詳）無法顯示的問題（JS falsy-0 修正 + 後端 placeholder 資料）
- 修復 `TabContentLoader` 切換人物時快取 race condition（同步清快取 + fetch abort signal）
- 所有編輯/刪除按鈕僅對有權限使用者可見

🤖 Generated with [Claude Code](https://claude.com/claude-code)