### PR TITLE
Person Browser 配色統一為 Harvard Crimson 並修正 :visited 殘留

### DIFF
--- a/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
@@ -33,6 +33,8 @@ function buildPersonUrl(personId: number): string {
     return url.pathname + url.search;
 }
 
+const VISITED_RESET_CLASS = 'pb-person-link';
+
 export default function PeopleList({ people, pagination, selectedId, loading, onSelect, onPageChange }: Props) {
     const handleCardClick = (event: React.MouseEvent<HTMLAnchorElement>, personId: number) => {
         event.preventDefault();
@@ -55,11 +57,13 @@ export default function PeopleList({ people, pagination, selectedId, loading, on
 
     return (
         <div style={containerStyle}>
+            <style>{`.${VISITED_RESET_CLASS}:visited { color: inherit; }`}</style>
             <div style={listStyle}>
                 {people.map((p) => (
                     <a
                         key={p.c_personid}
                         href={buildPersonUrl(p.c_personid)}
+                        className={VISITED_RESET_CLASS}
                         style={{
                             ...itemStyle,
                             ...(p.c_personid === selectedId ? selectedItemStyle : {}),

--- a/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AddressesTab.tsx
@@ -86,7 +86,7 @@ const containerStyle: React.CSSProperties = {
 };
 
 const linkStyle: React.CSSProperties = {
-    color: '#007bff',
+    color: '#A51C30',
     textDecoration: 'none',
 };
 

--- a/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
@@ -107,7 +107,7 @@ const linkButtonStyle: React.CSSProperties = {
     border: 'none',
     background: 'none',
     padding: 0,
-    color: '#007bff',
+    color: '#A51C30',
     textDecoration: 'none',
     cursor: 'pointer',
     font: 'inherit',

--- a/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
@@ -98,7 +98,7 @@ const linkButtonStyle: React.CSSProperties = {
     border: 'none',
     background: 'none',
     padding: 0,
-    color: '#007bff',
+    color: '#A51C30',
     textDecoration: 'none',
     cursor: 'pointer',
     font: 'inherit',

--- a/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
@@ -115,7 +115,7 @@ const badgesStyle: React.CSSProperties = {
 };
 
 const linkStyle: React.CSSProperties = {
-    color: '#007bff',
+    color: '#A51C30',
     textDecoration: 'none',
 };
 
@@ -123,7 +123,7 @@ const badgeMainStyle: React.CSSProperties = {
     fontSize: '0.6875rem',
     padding: '1px 6px',
     borderRadius: 3,
-    backgroundColor: '#007bff',
+    backgroundColor: '#A51C30',
     color: '#fff',
 };
 
@@ -131,6 +131,7 @@ const badgeBioStyle: React.CSSProperties = {
     fontSize: '0.6875rem',
     padding: '1px 6px',
     borderRadius: 3,
-    backgroundColor: '#28a745',
-    color: '#fff',
+    backgroundColor: '#fff',
+    color: '#A51C30',
+    border: '1px solid #A51C30',
 };


### PR DESCRIPTION
## Summary
- 將 Person Browser 各頁籤連結色從藍色 (`#007bff`) 統一為 Harvard Crimson (`#A51C30`)
- 出處頁籤「主出處」與「本人傳記」badge 改用實底 vs 描邊區分（同色系、不同形式）
- 修正 PeopleList 人物卡片 `<a>` 的 `:visited` 顏色殘留問題，切換人物後不再保留已訪問色

## Test plan
- [x] 開啟 `/app/person-browser`，確認各頁籤連結為 Crimson 色
- [x] 切換至出處頁籤，確認「主出處」為實底紅、「本人傳記」為描邊紅
- [x] 在左側人物列表點選多位人物後，確認已訪問的卡片不會變色
- [x] 右鍵人物卡片可正常在新分頁開啟

🤖 Generated with [Claude Code](https://claude.com/claude-code)