### PR TITLE
Person Browser 新增 ID 排序方向切換功能

### DIFF
--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -32,6 +32,7 @@ class PersonBrowserService {
         $page = (int) $request->input('page', 1);
         $perPage = max(1, min($perPage, 100));
         $page = max(1, $page);
+        $sortDirection = strtolower($request->input('sort', 'desc')) === 'asc' ? 'ASC' : 'DESC';
 
         $idQuery = DB::table('BIOG_MAIN')
             ->select('BIOG_MAIN.c_personid');
@@ -44,7 +45,7 @@ class PersonBrowserService {
             if (ctype_digit($q)) {
                 // 純數字：精確 personid 查詢
                 $idQuery->where('BIOG_MAIN.c_personid', '=', (int) $q)
-                    ->orderBy('BIOG_MAIN.c_personid', 'ASC');
+                    ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
             } else {
                 // 先嘗試倒排索引
                 $ftsIds = DB::table('CBDB__NAME_FTS')
@@ -69,7 +70,7 @@ class PersonBrowserService {
 
                 if (!empty($ftsIds)) {
                     $idQuery->whereIn('BIOG_MAIN.c_personid', $ftsIds)
-                        ->orderByRaw($this->buildIdOrderCase('BIOG_MAIN.c_personid', $ftsIds));
+                        ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
                 } else {
                     // 回退：多欄位 LIKE 搜尋
                     $idQuery->where(function ($sub) use ($q) {
@@ -80,11 +81,11 @@ class PersonBrowserService {
                             ->orWhere('BIOG_MAIN.c_name_proper', 'like', '%' . $q . '%')
                             ->orWhere('BIOG_MAIN.c_name_rm', 'like', '%' . $q . '%');
                     })
-                        ->orderBy('BIOG_MAIN.c_personid', 'ASC');
+                        ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
                 }
             }
         } else {
-            $idQuery->orderBy('BIOG_MAIN.c_personid', 'ASC');
+            $idQuery->orderBy('BIOG_MAIN.c_personid', $sortDirection);
         }
 
         // 取得朝代分布（基於當前搜尋條件，不含朝代篩選）
@@ -159,26 +160,6 @@ class PersonBrowserService {
             ],
             'dynasty_counts' => $dynastyCounts,
         ];
-    }
-
-    private function buildIdOrderCase(string $column, array $ids): string {
-        $normalized = array_values(array_map('intval', $ids));
-
-        if (empty($normalized)) {
-            return sprintf('%s ASC', $column);
-        }
-
-        $cases = [];
-        foreach ($normalized as $index => $id) {
-            $cases[] = sprintf('WHEN %d THEN %d', $id, $index);
-        }
-
-        return sprintf(
-            'CASE %s %s ELSE %d END',
-            $column,
-            implode(' ', $cases),
-            count($normalized)
-        );
     }
 
     /**

--- a/resources/js/inertia/Pages/PersonBrowser/Index.tsx
+++ b/resources/js/inertia/Pages/PersonBrowser/Index.tsx
@@ -2,13 +2,14 @@ import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { usePage } from '@inertiajs/react';
 import AppShell from '../../Layouts/AppShell';
 import PeopleSearchPanel from '../../components/PersonBrowser/PeopleSearchPanel';
-import PeopleList, { PersonListItem, Pagination } from '../../components/PersonBrowser/PeopleList';
+import PeopleList, { PersonListItem, Pagination, SortOrder } from '../../components/PersonBrowser/PeopleList';
 import PersonSummaryPanel, { PersonSummary } from '../../components/PersonBrowser/PersonSummaryPanel';
 import BrowserTabs, { TAB_DEFINITIONS } from '../../components/PersonBrowser/BrowserTabs';
 import TabContentLoader from '../../components/PersonBrowser/TabContentLoader';
 import SelectionDialog from '../../components/SelectionDialog';
 
 interface PageProps {
+    [key: string]: unknown;
     tabKeys: string[];
     searchEndpoint: string;
     summaryEndpoint: string;
@@ -29,6 +30,7 @@ interface BrowserLocationState {
     dynasty: string;
     tab: string;
     page: number;
+    sort: SortOrder;
 }
 
 export default function PersonBrowserIndex() {
@@ -51,6 +53,13 @@ export default function PersonBrowserIndex() {
     const [dynasty, setDynasty] = useState(initialDynasty || '');
     const [dynastyOptions, setDynastyOptions] = useState<Array<{ c_dy: number; label: string; count: number }>>([]);
     const [page, setPage] = useState(initialPage || 1);
+    const [sortOrder, setSortOrder] = useState<SortOrder>(() => {
+        if (typeof window !== 'undefined') {
+            const params = new URLSearchParams(window.location.search);
+            return params.get('sort') === 'asc' ? 'asc' : 'desc';
+        }
+        return 'desc';
+    });
     const [people, setPeople] = useState<PersonListItem[]>([]);
     const [pagination, setPagination] = useState<Pagination | null>(null);
     const [listLoading, setListLoading] = useState(false);
@@ -77,6 +86,7 @@ export default function PersonBrowserIndex() {
         dynasty: initialDynasty || '',
         tab: initialTab || 'basic_info',
         page: initialPage || 1,
+        sort: sortOrder,
     });
     const bypassNextPopGuardRef = useRef(false);
 
@@ -85,12 +95,15 @@ export default function PersonBrowserIndex() {
         const personId = params.get('person_id');
         const parsedPage = parseInt(params.get('page') || '1', 10);
 
+        const rawSort = params.get('sort');
+
         return {
             personId: personId ? parseInt(personId, 10) : null,
             keyword: params.get('keyword') || '',
             dynasty: params.get('c_dy') || '',
             tab: params.get('tab') || 'basic_info',
             page: Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
+            sort: rawSort === 'asc' ? 'asc' : 'desc',
         };
     }, []);
 
@@ -127,12 +140,18 @@ export default function PersonBrowserIndex() {
             url.searchParams.delete('page');
         }
 
+        if (state.sort === 'asc') {
+            url.searchParams.set('sort', 'asc');
+        } else {
+            url.searchParams.delete('sort');
+        }
+
         return url.toString();
     }, []);
 
     // ── URL sync ──
     const updateUrl = useCallback(
-        (params: { person_id?: number | null; keyword?: string; dynasty?: string; tab?: string; page?: number }) => {
+        (params: { person_id?: number | null; keyword?: string; dynasty?: string; tab?: string; page?: number; sort?: SortOrder }) => {
             const url = new URL(window.location.href);
             if (params.person_id != null) {
                 url.searchParams.set('person_id', String(params.person_id));
@@ -155,6 +174,10 @@ export default function PersonBrowserIndex() {
                 if (params.page > 1) url.searchParams.set('page', String(params.page));
                 else url.searchParams.delete('page');
             }
+            if (params.sort !== undefined) {
+                if (params.sort === 'asc') url.searchParams.set('sort', 'asc');
+                else url.searchParams.delete('sort');
+            }
 
             committedLocationRef.current = readLocationState(url.search);
             window.history.pushState({}, '', url.toString());
@@ -164,9 +187,9 @@ export default function PersonBrowserIndex() {
 
     // ── Search ──
     const doSearch = useCallback(
-        (q: string, p: number, dy: string = '') => {
+        (q: string, p: number, dy: string = '', sort: SortOrder = 'desc') => {
             setListLoading(true);
-            let url = `${searchEndpoint}?q=${encodeURIComponent(q)}&page=${p}&per_page=20`;
+            let url = `${searchEndpoint}?q=${encodeURIComponent(q)}&page=${p}&per_page=20&sort=${sort}`;
             if (dy) {
                 url += `&c_dy=${encodeURIComponent(dy)}`;
             }
@@ -192,9 +215,10 @@ export default function PersonBrowserIndex() {
         setKeyword(state.keyword);
         setDynasty(state.dynasty);
         setPage(state.page);
+        setSortOrder(state.sort);
         setActiveTab(state.tab);
         setSelectedId(state.personId);
-        doSearch(state.keyword, state.page, state.dynasty);
+        doSearch(state.keyword, state.page, state.dynasty, state.sort);
     }, [doSearch]);
 
     const handleSearch = useCallback(
@@ -202,27 +226,27 @@ export default function PersonBrowserIndex() {
             setKeyword(q);
             setDynasty(dy);
             setPage(1);
-            doSearch(q, 1, dy);
+            doSearch(q, 1, dy, sortOrder);
             updateUrl({ keyword: q, dynasty: dy, page: 1 });
         },
-        [doSearch, updateUrl],
+        [doSearch, sortOrder, updateUrl],
     );
 
     const handleClear = useCallback(() => {
         setKeyword('');
         setDynasty('');
         setPage(1);
-        doSearch('', 1, '');
+        doSearch('', 1, '', sortOrder);
         updateUrl({ keyword: '', dynasty: '', page: 1 });
-    }, [doSearch, updateUrl]);
+    }, [doSearch, sortOrder, updateUrl]);
 
     const handlePageChange = useCallback(
         (p: number) => {
             setPage(p);
-            doSearch(keyword, p, dynasty);
+            doSearch(keyword, p, dynasty, sortOrder);
             updateUrl({ keyword, dynasty, page: p });
         },
-        [keyword, dynasty, doSearch, updateUrl],
+        [keyword, dynasty, sortOrder, doSearch, updateUrl],
     );
 
     // ── Select person ──
@@ -237,10 +261,20 @@ export default function PersonBrowserIndex() {
         [activeTab, dynasty, isMobile, keyword, page, updateUrl],
     );
 
+    const handleSortChange = useCallback(
+        (sort: SortOrder) => {
+            setSortOrder(sort);
+            setPage(1);
+            doSearch(keyword, 1, dynasty, sort);
+            updateUrl({ keyword, dynasty, page: 1, sort });
+        },
+        [keyword, dynasty, doSearch, updateUrl],
+    );
+
     const handleBasicInfoSaved = useCallback(() => {
         setSummaryRefreshKey((prev) => prev + 1);
-        doSearch(keyword, page, dynasty);
-    }, [doSearch, keyword, page, dynasty]);
+        doSearch(keyword, page, dynasty, sortOrder);
+    }, [doSearch, keyword, page, dynasty, sortOrder]);
 
     const registerBasicInfoSaveHandler = useCallback((handler: (() => Promise<boolean>) | null) => {
         basicInfoSaveHandlerRef.current = handler;
@@ -296,7 +330,7 @@ export default function PersonBrowserIndex() {
     useEffect(() => {
         if (isInitialMount.current) {
             isInitialMount.current = false;
-            doSearch(initialKeyword || '', initialPage || 1, initialDynasty || '');
+            doSearch(initialKeyword || '', initialPage || 1, initialDynasty || '', sortOrder);
         }
     }, [doSearch, initialKeyword, initialDynasty, initialPage]);
 
@@ -440,8 +474,10 @@ export default function PersonBrowserIndex() {
                         pagination={pagination}
                         selectedId={selectedId}
                         loading={listLoading}
+                        sortOrder={sortOrder}
                         onSelect={guardedHandleSelect}
                         onPageChange={handlePageChange}
+                        onSortChange={handleSortChange}
                     />
                 </aside>
 

--- a/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+export type SortOrder = 'asc' | 'desc';
+
 export interface PersonListItem {
     c_personid: number;
     c_name_chn: string | null;
@@ -23,8 +25,10 @@ interface Props {
     pagination: Pagination | null;
     selectedId: number | null;
     loading: boolean;
+    sortOrder: SortOrder;
     onSelect: (personId: number) => void;
     onPageChange: (page: number) => void;
+    onSortChange: (sort: SortOrder) => void;
 }
 
 function buildPersonUrl(personId: number): string {
@@ -35,7 +39,7 @@ function buildPersonUrl(personId: number): string {
 
 const VISITED_RESET_CLASS = 'pb-person-link';
 
-export default function PeopleList({ people, pagination, selectedId, loading, onSelect, onPageChange }: Props) {
+export default function PeopleList({ people, pagination, selectedId, loading, sortOrder, onSelect, onPageChange, onSortChange }: Props) {
     const handleCardClick = (event: React.MouseEvent<HTMLAnchorElement>, personId: number) => {
         event.preventDefault();
         event.currentTarget.blur();
@@ -90,31 +94,46 @@ export default function PeopleList({ people, pagination, selectedId, loading, on
                 ))}
             </div>
 
-            {pagination && pagination.last_page > 1 && (
-                <div style={pagerStyle}>
+            <div style={footerStyle}>
+                <div style={sortAreaStyle}>
                     <button
-                        disabled={pagination.current_page <= 1}
-                        onPointerDown={(event) => event.preventDefault()}
-                        onMouseDown={(event) => event.preventDefault()}
-                        onClick={(event) => handlePagerClick(event, pagination.current_page - 1)}
-                        style={pagerBtnStyle}
+                        type="button"
+                        style={sortToggleBtnStyle}
+                        onClick={() => onSortChange(sortOrder === 'asc' ? 'desc' : 'asc')}
+                        title="Toggle ID sort order"
                     >
-                        ‹ 上頁
+                        ⇅ ID
                     </button>
-                    <span style={pagerInfoStyle}>
-                        {pagination.current_page} / {pagination.last_page}
+                    <span style={sortHintStyle}>
+                        {sortOrder === 'asc' ? 'ASC' : 'DESC'}
                     </span>
-                    <button
-                        disabled={pagination.current_page >= pagination.last_page}
-                        onPointerDown={(event) => event.preventDefault()}
-                        onMouseDown={(event) => event.preventDefault()}
-                        onClick={(event) => handlePagerClick(event, pagination.current_page + 1)}
-                        style={pagerBtnStyle}
-                    >
-                        下頁 ›
-                    </button>
                 </div>
-            )}
+                {pagination && pagination.last_page > 1 && (
+                    <div style={pagerStyle}>
+                        <button
+                            disabled={pagination.current_page <= 1}
+                            onPointerDown={(event) => event.preventDefault()}
+                            onMouseDown={(event) => event.preventDefault()}
+                            onClick={(event) => handlePagerClick(event, pagination.current_page - 1)}
+                            style={pagerBtnStyle}
+                        >
+                            ‹ 上頁
+                        </button>
+                        <span style={pagerInfoStyle}>
+                            {pagination.current_page} / {pagination.last_page}
+                        </span>
+                        <button
+                            disabled={pagination.current_page >= pagination.last_page}
+                            onPointerDown={(event) => event.preventDefault()}
+                            onMouseDown={(event) => event.preventDefault()}
+                            onClick={(event) => handlePagerClick(event, pagination.current_page + 1)}
+                            style={pagerBtnStyle}
+                        >
+                            下頁 ›
+                        </button>
+                    </div>
+                )}
+            </div>
         </div>
     );
 }
@@ -249,13 +268,47 @@ const miniTagValueStyle: React.CSSProperties = {
     textOverflow: 'ellipsis',
 };
 
+const footerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    padding: '6px 8px',
+    borderTop: '1px solid #dee2e6',
+    flexShrink: 0,
+};
+
+const sortAreaStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    flexShrink: 0,
+};
+
+const sortToggleBtnStyle: React.CSSProperties = {
+    padding: '6px 10px',
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    border: '1px solid #ced4da',
+    borderRadius: 6,
+    backgroundColor: '#fff',
+    color: '#495057',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    minHeight: 34,
+};
+
+const sortHintStyle: React.CSSProperties = {
+    fontSize: '0.75rem',
+    color: '#8a9bae',
+    whiteSpace: 'nowrap',
+};
+
 const pagerStyle: React.CSSProperties = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
-    padding: '6px 8px',
-    borderTop: '1px solid #dee2e6',
     fontSize: '0.8125rem',
 };
 

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -836,9 +836,10 @@ class PersonBrowserTest extends TestCase {
             'pagination' => ['current_page', 'last_page', 'per_page', 'total'],
         ]);
         $response->assertJsonPath('pagination.total', 3);
-        $response->assertJsonPath('data.0.c_personid', 1);
+        // 預設排序為降序（DESC）
+        $response->assertJsonPath('data.0.c_personid', 3);
         $response->assertJsonPath('data.1.c_personid', 2);
-        $response->assertJsonPath('data.2.c_personid', 3);
+        $response->assertJsonPath('data.2.c_personid', 1);
     }
 
     #[Test]
@@ -868,6 +869,30 @@ class PersonBrowserTest extends TestCase {
 
         $response->assertOk();
         $response->assertJsonPath('data.0.c_personid', 1);
+    }
+
+    #[Test]
+    public function test_search_by_fts_honors_sort_direction(): void {
+        DB::table('CBDB__NAME_FTS')->insert([
+            ['search_term' => '太守', 'c_personid' => 2],
+            ['search_term' => '太史', 'c_personid' => 3],
+        ]);
+
+        $ascendingResponse = $this->actingAs($this->user)
+            ->getJson(route('app.person-browser.search') . '?q=太&sort=asc');
+
+        $ascendingResponse->assertOk();
+        $ascendingResponse->assertJsonPath('data.0.c_personid', 1);
+        $ascendingResponse->assertJsonPath('data.1.c_personid', 2);
+        $ascendingResponse->assertJsonPath('data.2.c_personid', 3);
+
+        $descendingResponse = $this->actingAs($this->user)
+            ->getJson(route('app.person-browser.search') . '?q=太&sort=desc');
+
+        $descendingResponse->assertOk();
+        $descendingResponse->assertJsonPath('data.0.c_personid', 3);
+        $descendingResponse->assertJsonPath('data.1.c_personid', 2);
+        $descendingResponse->assertJsonPath('data.2.c_personid', 1);
     }
 
     // ───────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,8 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "baseUrl": ".",
         "paths": {
-            "@inertia/*": ["resources/js/inertia/*"]
+            "@inertia/*": ["./resources/js/inertia/*"]
         }
     },
     "include": ["resources/js/inertia/**/*"]


### PR DESCRIPTION
## Summary
- 後端所有搜尋路徑（FTS 全文索引、LIKE 回退、空搜尋、數字搜尋）統一支援 `sort=asc|desc` 參數，修正 FTS 路徑忽略排序方向的問題
- 前端新增 ID 排序切換按鈕（ASC / DESC），排序狀態正確同步至 URL 與 popstate 未儲存變更守衛
- 修正 `committedLocationRef` 硬編碼 `sort: 'desc'` 導致直接以 `?sort=asc` 開啟頁面時返回鍵行為異常
- 移除已無用的 `buildIdOrderCase()` 方法
- 修正 `PageProps` 缺少 index signature 的 TypeScript 類型錯誤
- 移除 `tsconfig.json` 已棄用的 `baseUrl`，改用 `./` 前綴路徑（面向 TS 7.0 相容）

## Test plan
- [x] `./vendor/bin/phpunit --filter PersonBrowser` 全部 40 個測試通過
- [x] 手動測試：空搜尋下切換排序，確認列表順序變化
- [x] 手動測試：名稱搜尋（FTS 路徑）下切換排序，確認列表順序變化
- [x] 手動測試：直接以 `?sort=asc` 開啟頁面，編輯基本資訊後按返回鍵，確認 URL 不被覆寫為 desc

🤖 Generated with [Claude Code](https://claude.com/claude-code)