### PR TITLE
將 Person Browser ID 排序預設方向改為升序

### DIFF
--- a/resources/js/inertia/Pages/PersonBrowser/Index.tsx
+++ b/resources/js/inertia/Pages/PersonBrowser/Index.tsx
@@ -56,9 +56,9 @@ export default function PersonBrowserIndex() {
     const [sortOrder, setSortOrder] = useState<SortOrder>(() => {
         if (typeof window !== 'undefined') {
             const params = new URLSearchParams(window.location.search);
-            return params.get('sort') === 'asc' ? 'asc' : 'desc';
+            return params.get('sort') === 'desc' ? 'desc' : 'asc';
         }
-        return 'desc';
+        return 'asc';
     });
     const [people, setPeople] = useState<PersonListItem[]>([]);
     const [pagination, setPagination] = useState<Pagination | null>(null);
@@ -187,7 +187,7 @@ export default function PersonBrowserIndex() {
 
     // ── Search ──
     const doSearch = useCallback(
-        (q: string, p: number, dy: string = '', sort: SortOrder = 'desc') => {
+        (q: string, p: number, dy: string = '', sort: SortOrder = 'asc') => {
             setListLoading(true);
             let url = `${searchEndpoint}?q=${encodeURIComponent(q)}&page=${p}&per_page=20&sort=${sort}`;
             if (dy) {


### PR DESCRIPTION
## Summary
- 將 Person Browser 的 ID 排序預設方向從降序（DESC）改為升序（ASC）
- URL 無 `sort` 參數時預設升序；僅當 `sort=desc` 時才使用降序

## Test plan
- [x] 開啟 `/app/person-browser`，確認列表預設以 ID 升序排列
- [x] 點擊排序按鈕切換為 DESC，確認功能正常
- [x] 帶 `?sort=desc` 參數進入頁面，確認為降序
- [x] 不帶 `sort` 參數進入頁面，確認為升序

🤖 Generated with [Claude Code](https://claude.com/claude-code)