### PR TITLE
移除 Person Browser 點擊觸發編輯與 ESC 取消編輯功能

### DIFF
--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -158,14 +158,6 @@ export default function BasicInfoView({
         setError(null);
     }, [initialState]);
 
-    useEffect(() => {
-        if (!editing) return;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') cancelEdit();
-        };
-        window.addEventListener('keydown', onKeyDown);
-        return () => window.removeEventListener('keydown', onKeyDown);
-    }, [editing, cancelEdit]);
 
     const updateField = (key: string, value: string) => {
         setFormState((prev) => applyDerivedFields({
@@ -330,7 +322,7 @@ export default function BasicInfoView({
                 <div style={{ paddingBottom: 16 }}>
                     {sections.map((section, index) => (
                         <div key={section.title} style={index === 0 ? sectionStyle : sectionWithDividerStyle}>
-                            {renderReadOnlySection(section, canEdit ? beginEdit : undefined, editableKeys)}
+                            {renderReadOnlySection(section, undefined, editableKeys)}
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Summary
- 移除唯讀模式下點擊欄位自動進入編輯模式的功能，使用者需透過「編輯基本信息」按鈕進入編輯
- 移除 ESC 鍵全域監聽取消編輯的行為，避免意外退出編輯模式，需透過「取消」按鈕操作

## Test plan
- [x] 開啟 `/app/person-browser`，確認點擊唯讀欄位不再觸發編輯模式
- [x] 確認「編輯基本信息」按鈕仍可正常進入編輯模式
- [x] 進入編輯模式後按 ESC，確認不會取消編輯
- [x] 確認「取消」按鈕仍可正常退出編輯模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)