### PR TITLE
重新命名側邊欄人物相關選項標籤

### DIFF
--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -42,14 +42,14 @@
                 <li class="nav-item">
                     <a href="{{ route('basicinformation.index') }}" class="nav-link {{ $activePage == 'Basicinformation' ? 'active' : '' }}">
                         <i class="nav-icon fas fa-landmark"></i>
-                        <p>人物基本資料</p>
+                        <p>人物編輯</p>
                     </a>
                 </li>
 
                 <li class="nav-item">
                     <a href="{{ route('app.person-browser.index') }}" class="nav-link {{ request()->routeIs('app.person-browser.*') ? 'active' : '' }}">
                         <i class="nav-icon fas fa-user-friends"></i>
-                        <p>人物瀏覽（新版）</p>
+                        <p>人物瀏覽</p>
                     </a>
                 </li>
 


### PR DESCRIPTION
## Summary
- 「人物基本資料」→「人物編輯」，更準確反映該頁面的編輯功能
- 「人物瀏覽（新版）」→「人物瀏覽」，移除已不需要的「新版」標記

## Test plan
- [x] 確認側邊欄顯示「人物編輯」與「人物瀏覽」
- [x] 確認連結指向正確頁面

🤖 Generated with [Claude Code](https://claude.com/claude-code)