### PR TITLE
調整新版 app 主題與 Person Browser 摘要介面 (WIP)

### DIFF
--- a/resources/js/inertia/Layouts/AppShell.tsx
+++ b/resources/js/inertia/Layouts/AppShell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { usePage } from '@inertiajs/react';
+import { APP_THEME } from '../theme';
 
 interface AppShellProps {
     children: React.ReactNode;
@@ -10,10 +11,10 @@ export default function AppShell({ children }: AppShellProps) {
     const version = app?.version || 'unknown';
 
     return (
-        <div style={{ minHeight: '100vh', backgroundColor: '#f4f6f9', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', display: 'flex', flexDirection: 'column' }}>
-            <header style={{ backgroundColor: '#A51C30', color: '#fff', padding: '12px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ minHeight: '100vh', backgroundColor: APP_THEME.canvas, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', display: 'flex', flexDirection: 'column' }}>
+            <header style={{ backgroundColor: APP_THEME.brand, color: '#fff', padding: '12px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>CBDB 中國歷代人物傳記資料庫</h1>
-                <a href="/" style={{ color: '#f2c4ca', textDecoration: 'none', fontSize: '0.875rem' }}>← 返回首頁</a>
+                <a href="/" style={{ color: APP_THEME.brandOnDark, textDecoration: 'none', fontSize: '0.875rem' }}>← 返回首頁</a>
             </header>
             <main style={{ padding: 0, margin: 0, flex: 1 }}>
                 {children}
@@ -41,6 +42,6 @@ export default function AppShell({ children }: AppShellProps) {
 }
 
 const footerLinkStyle: React.CSSProperties = {
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     textDecoration: 'none',
 };

--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { APP_THEME } from '../../theme';
 
 interface Props {
     sections: Section[];
@@ -276,9 +277,6 @@ export default function BasicInfoView({
                                     <input type="hidden" name="_method" value="DELETE" />
                                     <input type="hidden" name="_token" value={getCsrfToken()} />
                                 </form>
-                                <button type="button" style={dangerButtonStyle} onClick={handleDelete}>
-                                    刪除人物
-                                </button>
                             </>
                         ) : editing ? (
                             <>
@@ -325,6 +323,13 @@ export default function BasicInfoView({
                             {renderReadOnlySection(section, undefined, editableKeys)}
                         </div>
                     ))}
+                    {!editing && canEdit ? (
+                        <div style={dangerActionWrapStyle}>
+                            <button type="button" style={dangerButtonStyle} onClick={handleDelete}>
+                                刪除人物
+                            </button>
+                        </div>
+                    ) : null}
                 </div>
             )}
         </div>
@@ -346,7 +351,7 @@ function renderEditor(
     return (
         <>
             <div style={sectionStyle}>
-                <SectionHeading title="姓名資料" badge={badgeLabel('Person ID', values.c_personid)} />
+                <SectionHeading title="姓名資料" />
                 <div style={editorNameGroupGridStyle}>
                     <EditorGroup
                         title="中文"
@@ -991,7 +996,7 @@ function renderNameSection(section: Section, onClickEdit?: () => void, editableK
 
     return (
         <>
-            <SectionHeading title={section.title} badge={badgeLabel('Person ID', fields['Person ID'])} />
+            <SectionHeading title={section.title} />
             <div style={nameGroupGridStyle}>
                 {groups.map((group) => (
                     <div key={group.title} style={nameGroupCardStyle}>
@@ -1520,14 +1525,6 @@ function displayValue(value: FieldValue) {
     return String(value);
 }
 
-function badgeLabel(prefix: string, value: FieldValue) {
-    if (value == null || value === '') {
-        return null;
-    }
-
-    return `${prefix} ${value}`;
-}
-
 function joinDisplayValues(left: FieldValue, right: FieldValue) {
     const parts = [left, right]
         .map((value) => (value == null ? '' : String(value).trim()))
@@ -1620,7 +1617,7 @@ const buttonBaseStyle: React.CSSProperties = {
 
 const primaryButtonStyle: React.CSSProperties = {
     ...buttonBaseStyle,
-    backgroundColor: '#A51C30',
+    backgroundColor: APP_THEME.brand,
     color: '#fff',
 };
 
@@ -1636,6 +1633,12 @@ const neutralButtonStyle: React.CSSProperties = {
     backgroundColor: '#fff',
     color: '#4f6274',
     borderColor: '#cdd7e1',
+};
+
+const dangerActionWrapStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '8px 16px 0',
 };
 
 const dangerButtonStyle: React.CSSProperties = {
@@ -1683,9 +1686,9 @@ const sectionHeadingStyle: React.CSSProperties = {
     gap: 12,
     marginBottom: 16,
     padding: '10px 14px',
-    backgroundColor: '#f9eced',
+    backgroundColor: APP_THEME.brandSurface,
     borderRadius: 6,
-    borderLeft: '3px solid #A51C30',
+    borderLeft: `3px solid ${APP_THEME.brand}`,
     flexWrap: 'wrap',
 };
 
@@ -1693,7 +1696,7 @@ const sectionTitleStyle: React.CSSProperties = {
     margin: 0,
     fontSize: '1.08rem',
     fontWeight: 700,
-    color: '#3d1019',
+    color: APP_THEME.brandTextStrong,
     letterSpacing: '0.01em',
 };
 
@@ -1702,8 +1705,8 @@ const sectionBadgeStyle: React.CSSProperties = {
     alignItems: 'center',
     padding: '5px 10px',
     borderRadius: 999,
-    backgroundColor: '#fbeef0',
-    color: '#7a2030',
+    backgroundColor: APP_THEME.brandSurfaceStrong,
+    color: APP_THEME.brandText,
     fontSize: '0.78rem',
     fontWeight: 700,
 };

--- a/resources/js/inertia/components/PersonBrowser/BrowserTabs.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BrowserTabs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { APP_THEME } from '../../theme';
 
 interface TabDef {
     key: string;
@@ -80,19 +81,19 @@ const tabStyle: React.CSSProperties = {
 
 const activeTabStyle: React.CSSProperties = {
     backgroundColor: '#fff',
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     fontWeight: 700,
     border: '1px solid #e0e0e0',
     borderBottom: '2px solid #fff',
 };
 
 const badgeStyle: React.CSSProperties = {
-    backgroundColor: '#f9eced',
+    backgroundColor: APP_THEME.brandSurface,
     borderRadius: 8,
     padding: '1px 6px',
     fontSize: '0.72rem',
     fontWeight: 600,
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     minWidth: 16,
     textAlign: 'center',
 };

--- a/resources/js/inertia/components/PersonBrowser/PeopleSearchPanel.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PeopleSearchPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { APP_THEME } from '../../theme';
 
 interface DynastyOption {
     c_dy: number;
@@ -129,7 +130,7 @@ const searchBtnStyle: React.CSSProperties = {
     fontSize: '0.8125rem',
     border: 'none',
     borderRadius: 4,
-    backgroundColor: '#A51C30',
+    backgroundColor: APP_THEME.brand,
     color: '#fff',
     cursor: 'pointer',
 };

--- a/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AddressDisplayWithMap from './shared/AddressDisplayWithMap';
+import { APP_THEME } from '../../theme';
 
 export interface PersonSummary {
     c_personid: number;
@@ -78,7 +79,7 @@ export default function PersonSummaryPanel({ summary, loading, error }: Props) {
                 <Tag label="朝代" value={summary.dynasty_chn} />
                 <Tag
                     label="籍貫"
-                    value={(
+                    value={summary.index_addr_chn || summary.index_addr ? (
                         <AddressDisplayWithMap
                             labelChn={summary.index_addr_chn}
                             labelEng={summary.index_addr}
@@ -88,7 +89,7 @@ export default function PersonSummaryPanel({ summary, loading, error }: Props) {
                             longitude={summary.index_addr_longitude}
                             year={summary.c_index_year}
                         />
-                    )}
+                    ) : '(未詳)'}
                 />
                 <Tag label="生卒" value={lifespan} />
                 <Tag label="Index Year" value={summary.c_index_year != null ? String(summary.c_index_year) : null} />
@@ -161,21 +162,25 @@ const tagStyle: React.CSSProperties = {
     overflow: 'hidden',
     fontSize: '0.9rem',
     lineHeight: 1,
-    border: '1px solid #e0d5d7',
+    border: `1px solid ${APP_THEME.brandBorder}`,
 };
 
 const tagLabelStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
     padding: '6px 10px',
-    backgroundColor: '#f9eced',
-    color: '#7a2030',
+    backgroundColor: APP_THEME.brandSurfaceStrong,
+    color: APP_THEME.brandTextStrong,
     fontWeight: 600,
     whiteSpace: 'nowrap',
 };
 
 const tagValueStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
     padding: '6px 11px',
     backgroundColor: '#fff',
-    color: '#2a1015',
+    color: APP_THEME.brandTextStrong,
     fontWeight: 700,
     whiteSpace: 'nowrap',
 };

--- a/resources/js/inertia/components/PersonBrowser/shared/AddressDisplayWithMap.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/AddressDisplayWithMap.tsx
@@ -50,6 +50,7 @@ export default function AddressDisplayWithMap({
 const wrapStyle: React.CSSProperties = {
     display: 'inline-flex',
     alignItems: 'center',
-    flexWrap: 'wrap',
+    flexWrap: 'nowrap',
     gap: 4,
+    lineHeight: 1,
 };

--- a/resources/js/inertia/components/PersonBrowser/shared/LegacyCreateButton.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/LegacyCreateButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { buildLegacyCreateUrl } from './legacyEditUrl';
+import { APP_THEME } from '../../../theme';
 
 interface Props {
     tabKey: string;
@@ -39,8 +40,8 @@ const linkStyle: React.CSSProperties = {
     minHeight: 30,
     padding: '0 12px',
     borderRadius: 4,
-    border: '1px solid #A51C30',
-    color: '#A51C30',
+    border: `1px solid ${APP_THEME.brandBorder}`,
+    color: APP_THEME.brandText,
     backgroundColor: '#fff',
     textDecoration: 'none',
     fontSize: '0.875rem',

--- a/resources/js/inertia/components/PersonBrowser/shared/MapPreviewTrigger.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/MapPreviewTrigger.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import SelectionDialog from '../../../components/SelectionDialog';
+import { APP_THEME } from '../../../theme';
 
 interface Props {
     latitude: number;
@@ -20,7 +21,7 @@ export default function MapPreviewTrigger({
     adminCatLabel = null,
     year = null,
     mapId = null,
-    buttonLabel = '看地圖',
+    buttonLabel = '地圖',
 }: Props) {
     const [open, setOpen] = useState(false);
     const mapUrl = useMemo(
@@ -147,20 +148,24 @@ const buttonStyle: React.CSSProperties = {
     display: 'inline-flex',
     alignItems: 'center',
     gap: 4,
-    marginLeft: 8,
-    padding: '2px 7px',
-    borderRadius: 999,
-    border: '1px solid #A51C30',
-    backgroundColor: '#fff',
-    color: '#A51C30',
+    padding: 0,
+    border: 'none',
+    backgroundColor: 'transparent',
+    color: APP_THEME.brandText,
     cursor: 'pointer',
-    fontSize: '0.8rem',
-    lineHeight: 1.2,
-    verticalAlign: 'middle',
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    fontWeight: 600,
+    lineHeight: 1,
+    whiteSpace: 'nowrap',
+    appearance: 'none',
+    WebkitAppearance: 'none',
 };
 
 const iconStyle: React.CSSProperties = {
     display: 'block',
+    width: 13,
+    height: 13,
 };
 
 const frameWrapStyle: React.CSSProperties = {
@@ -195,8 +200,8 @@ const closeButtonStyle: React.CSSProperties = {
     height: 36,
     padding: '0 14px',
     borderRadius: 4,
-    border: '1px solid #A51C30',
-    backgroundColor: '#A51C30',
+    border: `1px solid ${APP_THEME.brand}`,
+    backgroundColor: APP_THEME.brand,
     color: '#fff',
     cursor: 'pointer',
     fontSize: '0.9rem',

--- a/resources/js/inertia/components/PersonBrowser/shared/MetaRow.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/MetaRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { APP_THEME } from '../../../theme';
 
 interface Props {
     label: string;
@@ -29,7 +30,7 @@ const rowStyle: React.CSSProperties = {
 };
 
 const labelStyle: React.CSSProperties = {
-    color: '#6c757d',
+    color: APP_THEME.brandText,
     minWidth: 80,
     flexShrink: 0,
     fontWeight: 500,

--- a/resources/js/inertia/components/PersonBrowser/shared/TabPager.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/TabPager.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { APP_THEME } from '../../../theme';
 
 interface Props {
     currentPage: number;
@@ -115,7 +116,7 @@ const btnStyle: React.CSSProperties = {
 };
 
 const activeStyle: React.CSSProperties = {
-    backgroundColor: '#A51C30',
+    backgroundColor: APP_THEME.brand,
     color: '#fff',
     fontWeight: 600,
 };

--- a/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AssociationsTab.tsx
@@ -12,6 +12,7 @@ import { formatBilingualLabel, formatYearRange } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
 import { formatTextTitle } from '../shared/textLookup';
 import { useTextCodes } from '../shared/useTextCodes';
+import { APP_THEME } from '../../../theme';
 
 interface AssociationItem {
     pk: {
@@ -107,7 +108,7 @@ const linkButtonStyle: React.CSSProperties = {
     border: 'none',
     background: 'none',
     padding: 0,
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     textDecoration: 'none',
     cursor: 'pointer',
     font: 'inherit',

--- a/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/KinshipTab.tsx
@@ -12,6 +12,7 @@ import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
 import { formatTextTitle } from '../shared/textLookup';
 import { useTextCodes } from '../shared/useTextCodes';
+import { APP_THEME } from '../../../theme';
 
 interface KinshipItem {
     pk: {
@@ -98,7 +99,7 @@ const linkButtonStyle: React.CSSProperties = {
     border: 'none',
     background: 'none',
     padding: 0,
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     textDecoration: 'none',
     cursor: 'pointer',
     font: 'inherit',

--- a/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
@@ -12,6 +12,7 @@ import { formatBilingualLabel } from '../shared/formatters';
 import { stableKey } from '../shared/stableKey';
 import { buildTextUrl, formatTextTitle } from '../shared/textLookup';
 import { useTextCodes } from '../shared/useTextCodes';
+import { APP_THEME } from '../../../theme';
 
 interface SourceItem {
     pk: {
@@ -115,7 +116,7 @@ const badgesStyle: React.CSSProperties = {
 };
 
 const linkStyle: React.CSSProperties = {
-    color: '#A51C30',
+    color: APP_THEME.brandText,
     textDecoration: 'none',
 };
 
@@ -123,7 +124,7 @@ const badgeMainStyle: React.CSSProperties = {
     fontSize: '0.6875rem',
     padding: '1px 6px',
     borderRadius: 3,
-    backgroundColor: '#A51C30',
+    backgroundColor: APP_THEME.brand,
     color: '#fff',
 };
 
@@ -132,6 +133,6 @@ const badgeBioStyle: React.CSSProperties = {
     padding: '1px 6px',
     borderRadius: 3,
     backgroundColor: '#fff',
-    color: '#A51C30',
-    border: '1px solid #A51C30',
+    color: APP_THEME.brandText,
+    border: `1px solid ${APP_THEME.brandBorder}`,
 };

--- a/resources/js/inertia/theme.ts
+++ b/resources/js/inertia/theme.ts
@@ -1,0 +1,12 @@
+export const APP_THEME = {
+    canvas: '#FFFFFF',
+    brand: '#4E88C7',
+    brandStrong: '#000000',
+    brandAccent: '#A51C30',
+    brandSurface: '#FFFFFF',
+    brandSurfaceStrong: '#95B5DF',
+    brandBorder: '#93A1AD',
+    brandText: '#4E88C7',
+    brandTextStrong: '#000000',
+    brandOnDark: '#FFFFFF',
+} as const;


### PR DESCRIPTION
- 將 Inertia 新版 app 的品牌色集中到共用 theme token，改用較中性的 Harvard 藍系主視覺，降低 crimson 的 danger 感
- 同步調整 AppShell、Person Browser 的標籤、badge、tab、按鈕與連結色彩，讓摘要與內容區塊的 accent 一致
- 修正籍貫摘要在有地圖入口時高度被撐高的問題，並將按鈕文案改為「地圖」
- 籍貫空值時顯示為「(未詳)」，移除姓名資料區塊重複顯示的 Person ID
- 將人物刪除操作移到基本資訊頁底部，保留刪除前的確認提示

驗證：npm run build

<img width="1692" height="944" alt="IMG_7420" src="https://github.com/user-attachments/assets/92965aa4-3578-4bb5-a8a1-76e84ed185cc" />
