### PR TITLE
修正 AI 智能填充因 timeout 過短導致請求失敗

### DIFF
--- a/app/Http/Controllers/AiPostingAutofillController.php
+++ b/app/Http/Controllers/AiPostingAutofillController.php
@@ -40,6 +40,9 @@ class AiPostingAutofillController extends Controller {
         $sourceText = $request->input('source_text');
         $personId = $request->input('person_id');
 
+        // AI API 回應可能需要較長時間，延長 PHP 執行時間限制
+        set_time_limit(120);
+
         $startTime = microtime(true);
         $result = $this->autofillService->extractAndMatch($sourceText, $personId);
         $executionTimeMs = (int) round((microtime(true) - $startTime) * 1000);

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -121,8 +121,8 @@ class PostingAutofillService {
 
         $fullPrompt = $promptContent . "\n\n" . $sourceText;
 
-        // 調用 LLM API
-        $response = Http::timeout(30)
+        // 調用 LLM API（完整 prompt 約 12KB，模型處理需要較長時間）
+        $response = Http::connectTimeout(15)->timeout(90)
             ->withHeaders([
                 'Content-Type' => 'application/json',
                 'Authorization' => 'Bearer ' . $this->apiKey,


### PR DESCRIPTION
## Summary
- AI 智能填充的完整 prompt (~12KB) 搭配 `json_schema strict` 模式，Gemini API 處理時間常超過 30 秒
- 原先 `Http::timeout(30)` 加上 PHP `max_execution_time=30` 雙重限制導致請求必然失敗，前端顯示「請求失敗」
- 將 HTTP timeout 提高至 90s（含 connectTimeout 15s），並在控制器以 `set_time_limit(120)` 延長 PHP 執行限制

## Test plan
- [ ] 在 `/basicinformation/{id}/offices/create` 頁面使用 AI 智能填充，確認不再出現「請求失敗」
- [ ] 確認 AI 回應內容正確填入表單欄位

🤖 Generated with [Claude Code](https://claude.com/claude-code)