### PR TITLE
修正新增代碼表時因欄位數不足導致 Undefined array key 2

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -743,7 +743,6 @@ class CodesController extends Controller {
         //20210323插入聯合主鍵的邏輯
         $id_name = $this->getIdName($table);
         $id_name_1 = $this->getIdName_1($table);
-        $id_name_2 = $this->getIdName_2($table);
         $id = $data[$id_name].'_._'.$data[$id_name_1];
 
         //$id = $data[$id_name].'_._'.$data[$id_name_1].'_._'.$data[$id_name_2];


### PR DESCRIPTION
## Summary
- `CodesController::store()` 呼叫 `getIdName_2($table)` 取第三個欄位，但像 `OFFICE_CODE_TYPE_REL` 這類只有兩個欄位（`c_office_id`、`c_office_tree_id`）的代碼表會拋出 `Undefined array key 2`。
- `$id_name_2` 取到後並未被使用（`$id` 僅由前兩個欄位組合），直接移除該呼叫即可修正。

## Repro
1. 登入後前往 `/codes/OFFICE_CODE_TYPE_REL/create`。
2. 填寫 `c_office_id=803811`、`c_office_tree_id=2009` 後送出。
3. 修正前會顯示 Ignition `Undefined array key 2`（`CodesController.php:862` → `store()` 第 746 行）。

## Test plan
- [x] 於 `OFFICE_CODE_TYPE_REL` 新增一筆資料，確認不再出現 `Undefined array key 2`。
- [x] 於其他多欄位代碼表（如 `SOCIAL_INSTITUTION_CODES`）新增資料，確認仍可正常建立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)