### PR TITLE
移除 CodesController 未使用的 getIdName 輔助函式

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -740,13 +740,6 @@ class CodesController extends Controller {
         //當資料表等於SOCIAL_INSTITUTION_CODES，$id從表單取值。
         //$id = $data[$id_];
         //}
-        //20210323插入聯合主鍵的邏輯
-        $id_name = $this->getIdName($table);
-        $id_name_1 = $this->getIdName_1($table);
-        $id = $data[$id_name].'_._'.$data[$id_name_1];
-
-        //$id = $data[$id_name].'_._'.$data[$id_name_1].'_._'.$data[$id_name_2];
-        //修改結束
         try {
             DB::table($table)->insert($data);
         } catch (\Illuminate\Database\QueryException $e) {
@@ -849,19 +842,7 @@ class CodesController extends Controller {
         return redirect()->route('codes.show', ['table_name' => $table]);
     }
 
-    protected function getIdName($table_name) {
-        return $columns = Schema::getColumnListing($table_name)[0];
-    }
-
-    protected function getIdName_1($table_name) {
-        return $columns = Schema::getColumnListing($table_name)[1];
-    }
-
-    protected function getIdName_2($table_name) {
-        return $columns = Schema::getColumnListing($table_name)[2];
-    }
-
-    protected function buildTableHead(string $table, $sampleRow, ?array $joinConfig = null): array {
+protected function buildTableHead(string $table, $sampleRow, ?array $joinConfig = null): array {
         $thead = $this->getTableColumns($table);
 
         if (!empty($joinConfig)) {

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -730,6 +730,7 @@ class CodesController extends Controller {
                 ->withErrors(['missing_keys' => '新增失敗：請確認主鍵欄位已填寫完整。']);
         }
         $data = $this->enforceAuditFieldsForCreate($table, $data);
+
         //20210323遮除「第一欄預設隱藏」
         //$id_ = $this->getIdName($table_name);
         //if($table_name != 'SOCIAL_INSTITUTION_CODES') {
@@ -842,7 +843,7 @@ class CodesController extends Controller {
         return redirect()->route('codes.show', ['table_name' => $table]);
     }
 
-protected function buildTableHead(string $table, $sampleRow, ?array $joinConfig = null): array {
+    protected function buildTableHead(string $table, $sampleRow, ?array $joinConfig = null): array {
         $thead = $this->getTableColumns($table);
 
         if (!empty($joinConfig)) {


### PR DESCRIPTION
## Summary
- `CodesController::store()` 中用 `getIdName` / `getIdName_1` / `getIdName_2` 組出來的 `$id`，稍後會被 `buildCompositeId($keyColumns, $rowData)` 完全覆蓋，是一段死代碼。
- 三個 helper 除了這段死代碼外，整個專案再無其他使用者。
- 保留這段代碼還會對欄位少於 3 個的代碼表（例如 `OFFICE_CODE_TYPE_REL`）誤觸 `Undefined array key` — 緊接在 #993 之後徹底清掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)