### PR TITLE
修正新增事件與地址時 c_sequence 為空導致插入失敗

### DIFF
--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -2836,6 +2836,9 @@ class BiogMainRepository {
         $data['c_personid'] = $id;
         $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary'] ?? 0);
         $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary'] ?? 0);
+        if (!isset($data['c_sequence']) || $data['c_sequence'] === '' || $data['c_sequence'] === null) {
+            $data['c_sequence'] = 0;
+        }
         $duplicate = DB::table('BIOG_ADDR_DATA')->where([
             ['c_personid', '=', $data['c_personid']],
             ['c_addr_id', '=', $data['c_addr_id']],

--- a/app/Repositories/EventStatusRepository.php
+++ b/app/Repositories/EventStatusRepository.php
@@ -255,6 +255,9 @@ class EventStatusRepository {
         $data = $request->all();
         $data = $this->formatSelect($data);
         $data['c_personid'] = $id;
+        if (!isset($data['c_sequence']) || $data['c_sequence'] === '' || $data['c_sequence'] === null) {
+            $data['c_sequence'] = 0;
+        }
         $this->insertAddrEvent($data['c_addr_id'], $id, $data['c_sequence'], $data['c_event_code']);
         $data = Arr::except($data, ['_token', 'action', '__proposal_comment', 'c_addr_id']);
         $data['c_intercalary'] = (int)($data['c_intercalary']);

--- a/resources/views/biogmains/addresses/_form.blade.php
+++ b/resources/views/biogmains/addresses/_form.blade.php
@@ -17,7 +17,7 @@
     <div class="form-group row">
         <label for="c_sequence" class="col-sm-2 col-form-label">遷徙次序</label>
         <div class="col-sm-10">
-            <input type="number" class="form-control" name="c_sequence" value="{{ $isEdit ? $row->c_sequence : '' }}" maxlength="4" {{ $isEdit ? '' : 'required' }}>
+            <input type="number" class="form-control" name="c_sequence" value="{{ $isEdit ? $row->c_sequence : '0' }}" maxlength="4" required>
         </div>
     </div>
 

--- a/resources/views/biogmains/events/_form.blade.php
+++ b/resources/views/biogmains/events/_form.blade.php
@@ -29,7 +29,7 @@
     <div class="form-group row">
         <label for="c_sequence" class="col-sm-2 col-form-label">次序(sequence)</label>
         <div class="col-sm-10">
-            <input type="text" class="form-control" name="c_sequence" value="{{ $isEdit ? $row->c_sequence : '' }}" maxlength="4">
+            <input type="text" class="form-control" name="c_sequence" value="{{ $isEdit ? $row->c_sequence : '0' }}" maxlength="4">
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- 新增事件 (`/basicinformation/{id}/events`) 時，表單未填 `c_sequence` 會傳入 NULL，`insertAddrEvent` 插入 `EVENTS_ADDR` 時觸發 `SQLSTATE[23000] Integrity constraint violation: Column 'c_sequence' cannot be null`
- 地址 (`BIOG_ADDR_DATA`) 新增路徑存在相同風險
- 依照使用者回饋：預設 `c_sequence = 0`（表示次序無意義，使用者如有需要再自行改）

## Changes
- `resources/views/biogmains/events/_form.blade.php`：新增時 `c_sequence` 預設 `0`
- `resources/views/biogmains/addresses/_form.blade.php`：新增時 `c_sequence` 預設 `0`
- `app/Repositories/EventStatusRepository.php::eventStoreById`：後端 fallback `0`
- `app/Repositories/BiogMainRepository.php::addrStoreById`：後端 fallback `0`

## Test plan
- [x] 於 `/basicinformation/{id}/events/create` 不填 `c_sequence` 直接儲存，應成功建立事件與 `EVENTS_ADDR` 關聯
- [x] 於 `/basicinformation/{id}/addresses/create` 同樣測試地址新增
- [x] 確認既有編輯流程不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)