### PR TITLE
調整側邊欄全部表格項目依表名字母排序

### DIFF
--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -110,6 +110,18 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a href="/codes/ADDR_BELONGS_DATA" class="nav-link {{ in_array($activePage, ['ADDR_BELONGS_DATA'], true) ? 'active' : '' }}">
+                                <i class="nav-icon fas fa-sitemap"></i>
+                                <p>地址從屬表 <small>(ADDR_BELONGS_DATA)</small></p>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="/codes/ADDR_CODES" class="nav-link {{ in_array($activePage, ['ADDR_CODES'], true) ? 'active' : '' }}">
+                                <i class="nav-icon fas fa-map-marker-alt"></i>
+                                <p>地址編碼表 <small>(ADDR_CODES)</small></p>
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a href="/codes/ALTNAME_CODES" class="nav-link {{ in_array($activePage, ['ALTNAME_CODES'], true) ? 'active' : '' }}">
                                 <i class="nav-icon fas fa-user-tag"></i>
                                 <p>別名編碼表 <small>(ALTNAME_CODES)</small></p>
@@ -119,18 +131,6 @@
                             <a href="/codes/APPOINTMENT_CODES" class="nav-link {{ in_array($activePage, ['APPOINTMENT_CODES'], true) ? 'active' : '' }}">
                                 <i class="nav-icon fas fa-briefcase"></i>
                                 <p>任命類型編碼表 <small>(APPOINTMENT_CODES)</small></p>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a href="/codes/TEXT_CODES" class="nav-link {{ in_array($activePage, ['TEXT_CODES'], true) ? 'active' : '' }}">
-                                <i class="nav-icon fas fa-book"></i>
-                                <p>著作編碼表 <small>(TEXT_CODES)</small></p>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a href="/codes/ADDR_CODES" class="nav-link {{ in_array($activePage, ['ADDR_CODES'], true) ? 'active' : '' }}">
-                                <i class="nav-icon fas fa-map-marker-alt"></i>
-                                <p>地址編碼表 <small>(ADDR_CODES)</small></p>
                             </a>
                         </li>
                         <li class="nav-item">
@@ -146,9 +146,9 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a href="/codes/ADDR_BELONGS_DATA" class="nav-link {{ in_array($activePage, ['ADDR_BELONGS_DATA'], true) ? 'active' : '' }}">
-                                <i class="nav-icon fas fa-sitemap"></i>
-                                <p>地址從屬表 <small>(ADDR_BELONGS_DATA)</small></p>
+                            <a href="/codes/TEXT_CODES" class="nav-link {{ in_array($activePage, ['TEXT_CODES'], true) ? 'active' : '' }}">
+                                <i class="nav-icon fas fa-book"></i>
+                                <p>著作編碼表 <small>(TEXT_CODES)</small></p>
                             </a>
                         </li>
                         <li class="nav-item">


### PR DESCRIPTION
## Summary
- 將 `sidebar-v3.blade.php` 中「全部表格」選單項目（不含「全部表格首頁」）依括號內表名 A–Z 排序

## Test plan
- [x] 開啟任意頁面，確認左側「全部表格」展開後項目順序為 ADDR_BELONGS_DATA → ADDR_CODES → ALTNAME_CODES → APPOINTMENT_CODES → OFFICE_CODES → SOCIAL_INSTITUTION_CODES → TEXT_CODES → TEXT_INSTANCE_DATA

🤖 Generated with [Claude Code](https://claude.com/claude-code)