### PR TITLE
將 OFFICE_CODES.c_dy 調整為 NOT NULL

### DIFF
--- a/database/migrations/2026_04_13_000000_set_office_codes_c_dy_not_null.php
+++ b/database/migrations/2026_04_13_000000_set_office_codes_c_dy_not_null.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class SetOfficeCodesCDyNotNull extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('OFFICE_CODES')) {
+            DB::statement("UPDATE OFFICE_CODES SET c_dy = 0 WHERE c_dy IS NULL");
+
+            Schema::table('OFFICE_CODES', function (Blueprint $table) {
+                $table->smallInteger('c_dy')->nullable(false)->default(0)->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('OFFICE_CODES')) {
+            Schema::table('OFFICE_CODES', function (Blueprint $table) {
+                $table->smallInteger('c_dy')->nullable()->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+}


### PR DESCRIPTION
## Summary
- 沿用既有 migration 寫法，先把 `OFFICE_CODES.c_dy` 中 NULL 值補為 0
- 將欄位改為 `smallInteger NOT NULL DEFAULT 0`，`down()` 還原為 nullable
- 後台 MySQL 現況為 `smallint(6) NULL DEFAULT NULL`，本次調整使其與其他 *_CODES 表一致

## Test plan
- [x] `./vendor/bin/phpunit --filter AdminBatchLoadOfficesTest`
- [x] 自寫一次性測試驗證 sqlite 環境下 `c_dy` 為 NOT NULL、default 0（已刪除）