### PR TITLE
修正 AI 任官自動填充對「同知」的官名匹配

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -317,9 +317,16 @@ class PostingAutofillService {
             ]);
         }
 
+        // 先取出 addr_str 的 admin_type，供官名消歧使用
+        // （例如「同知」在府、州、縣語境下應對應不同的官名）
+        $addrAdminType = null;
+        if (!empty($aiData['addr_str']) && is_array($aiData['addr_str'])) {
+            $addrAdminType = $aiData['addr_str']['admin_type'] ?? null;
+        }
+
         // 1. 官名匹配（title_str）
         if (!empty($aiData['title_str'])) {
-            $officeMatch = $this->fuzzyMatchOffice($aiData['title_str'], $effectiveDynasty);
+            $officeMatch = $this->fuzzyMatchOffice($aiData['title_str'], $effectiveDynasty, $addrAdminType);
             if ($officeMatch) {
                 // 根據匹配類型決定是確認匹配還是建議
                 if ($officeMatch['match_type'] === 'exact') {
@@ -521,9 +528,10 @@ class PostingAutofillService {
      *
      * @param string $officeName 官名
      * @param int|null $dynastyCode 朝代代碼（用於過濾）
+     * @param string|null $adminType 地址的行政層級（府/州/縣），用於消歧泛稱官名
      * @return array|null ['id' => int, 'text' => string, 'match_type' => 'exact'|'fuzzy']
      */
-    protected function fuzzyMatchOffice(string $officeName, ?int $dynastyCode = null): ?array {
+    protected function fuzzyMatchOffice(string $officeName, ?int $dynastyCode = null, ?string $adminType = null): ?array {
         // ========== Step 1: 精確匹配 c_office_chn ==========
         $query = DB::table('OFFICE_CODES')
             ->select('c_office_id as id', 'c_office_chn as text')
@@ -540,6 +548,17 @@ class PostingAutofillService {
                 'text' => $result->text,
                 'match_type' => 'exact',
             ];
+        }
+
+        // ========== Step 1.5: 根據 admin_type 消歧泛稱官名 ==========
+        // 僅在朝代專屬精確匹配（Step 1）落空時才觸發。
+        // 例如宋代 effectiveDynasty=15 時，OFFICE_CODES 沒有 c_dy=15 且 c_office_chn='同知' 的記錄，
+        // 若直接落入 Step 2 的 alt 匹配，會誤命中「同知樞密院事」等泛稱 alt 清單。
+        // 此處針對已知的泛稱（如同知）依 admin_type 對應抽象官名（如同知某府軍府事）。
+        // 放在 Step 1 之後可保留明清等朝代已有的「同知」專屬記錄，避免覆蓋朝代專屬精確匹配。
+        $disambiguated = $this->disambiguateOfficeByAdminType($officeName, $adminType);
+        if ($disambiguated !== null) {
+            return $disambiguated;
         }
 
         // ========== Step 2: 精確匹配 c_office_chn_alt（分號分割） ==========
@@ -658,6 +677,59 @@ class PostingAutofillService {
         }
 
         return null;
+    }
+
+    /**
+     * 根據地址 admin_type 對泛稱官名進行消歧。
+     *
+     * AI 有時只抽出泛稱（例如「同知」），需要結合地名的行政層級才能對應到正確的抽象官名：
+     *   - 府同知 → 同知某府軍府事（c_office_id = 6974）
+     *   - 州同知、縣同知 → 同知某州軍州事（c_office_id = 3301）
+     *
+     * 這類抽象官名在 OFFICE_CODES 中有固定的 c_office_chn，使用 where 精確查詢，
+     * 不受朝代過濾影響（抽象官名供各朝代檢索使用）。
+     *
+     * @return array|null ['id' => int, 'text' => string, 'match_type' => 'exact']
+     */
+    protected function disambiguateOfficeByAdminType(string $officeName, ?string $adminType): ?array {
+        if ($adminType === null || $adminType === '') {
+            return null;
+        }
+
+        $map = [
+            '同知' => [
+                '府' => '同知某府軍府事',
+                '州' => '同知某州軍州事',
+                '縣' => '同知某州軍州事',
+            ],
+        ];
+
+        if (!isset($map[$officeName][$adminType])) {
+            return null;
+        }
+
+        $targetName = $map[$officeName][$adminType];
+        $row = DB::table('OFFICE_CODES')
+            ->select('c_office_id as id', 'c_office_chn as text')
+            ->where('c_office_chn', '=', $targetName)
+            ->first();
+
+        if (!$row) {
+            return null;
+        }
+
+        Log::info('[AI Autofill] 官名消歧命中', [
+            'office_name' => $officeName,
+            'admin_type' => $adminType,
+            'resolved_to' => $targetName,
+            'office_id' => $row->id,
+        ]);
+
+        return [
+            'id' => $row->id,
+            'text' => $row->text,
+            'match_type' => 'exact',
+        ];
     }
 
     /**

--- a/tests/Feature/PostingAutofillOfficeMatchTest.php
+++ b/tests/Feature/PostingAutofillOfficeMatchTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\PostingAutofillService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * 回歸測試：fuzzyMatchOffice 對泛稱官名「同知」的消歧順序。
+ *
+ * 修正前的 bug：「同知」會被 Step 2 的 c_office_chn_alt 匹配誤命中「同知樞密院事」。
+ * 修正方式：在 Step 1（朝代專屬精確匹配）後、Step 2（alt 匹配）前加入
+ * admin_type 消歧，只在朝代專屬精確匹配落空時才將泛稱導向抽象官名。
+ *
+ * 這組測試同時保護兩個不變量：
+ * 1. 宋代等找不到朝代專屬「同知」記錄時，會根據地址 admin_type 導向
+ *    「同知某府軍府事」/「同知某州軍州事」。
+ * 2. 明清等已有朝代專屬「同知」記錄時，消歧不會蓋掉朝代專屬匹配
+ *    （避免 Step 1.5 被人提前到 Step 1 之前）。
+ */
+class PostingAutofillOfficeMatchTest extends TestCase {
+    use RefreshDatabase;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 15, 'c_dynasty_chn' => '宋', 'c_dynasty' => 'Song', 'c_start' => 960, 'c_end' => 1279, 'c_sort' => 15],
+            ['c_dy' => 19, 'c_dynasty_chn' => '明', 'c_dynasty' => 'Ming', 'c_start' => 1368, 'c_end' => 1644, 'c_sort' => 19],
+            ['c_dy' => 20, 'c_dynasty_chn' => '清', 'c_dynasty' => 'Qing', 'c_start' => 1644, 'c_end' => 1911, 'c_sort' => 20],
+        ]);
+
+        DB::table('OFFICE_CODES')->insert([
+            // 宋代：泛稱「同知」會出現在 107 的 alt 清單，用以重現舊版誤匹配。
+            ['c_office_id' => 107, 'c_dy' => 15, 'c_office_chn' => '同知樞密院事', 'c_office_chn_alt' => '同知院事;同知;同知樞'],
+            ['c_office_id' => 3301, 'c_dy' => 15, 'c_office_chn' => '同知某州軍州事', 'c_office_chn_alt' => '同知;郡副'],
+            ['c_office_id' => 6974, 'c_dy' => 15, 'c_office_chn' => '同知某府軍府事', 'c_office_chn_alt' => null],
+            // 明清：朝代專屬的「同知」精確記錄。
+            ['c_office_id' => 70974, 'c_dy' => 19, 'c_office_chn' => '同知', 'c_office_chn_alt' => null],
+            ['c_office_id' => 85485, 'c_dy' => 20, 'c_office_chn' => '同知', 'c_office_chn_alt' => '候補同知;候選同知'],
+        ]);
+    }
+
+    /**
+     * 呼叫 protected fuzzyMatchOffice，避免走完整 HTTP 流程。
+     */
+    protected function matchOffice(string $officeName, ?int $dynastyCode, ?string $adminType): ?array {
+        $service = app(PostingAutofillService::class);
+        $ref = new ReflectionClass($service);
+        $method = $ref->getMethod('fuzzyMatchOffice');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $officeName, $dynastyCode, $adminType);
+    }
+
+    public function test_song_tongzhi_with_fu_resolves_to_abstract_fu_office() {
+        $result = $this->matchOffice('同知', 15, '府');
+
+        $this->assertNotNull($result);
+        $this->assertSame(6974, $result['id']);
+        $this->assertSame('同知某府軍府事', $result['text']);
+        $this->assertSame('exact', $result['match_type']);
+    }
+
+    public function test_song_tongzhi_with_zhou_resolves_to_abstract_zhou_office() {
+        $result = $this->matchOffice('同知', 15, '州');
+
+        $this->assertNotNull($result);
+        $this->assertSame(3301, $result['id']);
+        $this->assertSame('同知某州軍州事', $result['text']);
+    }
+
+    public function test_song_tongzhi_with_xian_resolves_to_abstract_zhou_office() {
+        $result = $this->matchOffice('同知', 15, '縣');
+
+        $this->assertNotNull($result);
+        $this->assertSame(3301, $result['id']);
+    }
+
+    public function test_ming_tongzhi_with_fu_prefers_dynasty_specific_record() {
+        // 明代有朝代專屬「同知」（70974），Step 1 應優先命中，
+        // 不得因 admin_type=府 而退化到宋代 6974。
+        $result = $this->matchOffice('同知', 19, '府');
+
+        $this->assertNotNull($result);
+        $this->assertSame(70974, $result['id']);
+        $this->assertSame('同知', $result['text']);
+    }
+
+    public function test_qing_tongzhi_with_fu_prefers_dynasty_specific_record() {
+        $result = $this->matchOffice('同知', 20, '府');
+
+        $this->assertNotNull($result);
+        $this->assertSame(85485, $result['id']);
+    }
+
+    public function test_song_tongzhi_without_admin_type_does_not_hit_disambiguation() {
+        // 沒有 admin_type 時，消歧步驟不應觸發；維持既有（非此次修正範圍的）行為。
+        // 此處僅驗證不會回傳 6974/3301 抽象官名，不對具體命中做斷言。
+        $result = $this->matchOffice('同知', 15, null);
+
+        if ($result !== null) {
+            $this->assertNotContains($result['id'], [6974, 3301]);
+        }
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- 修正 AI 任官自動填充把「同知」誤比對成「同知樞密院事」(id 107) 的問題：舊版 `fuzzyMatchOffice` 的 Step 2（`c_office_chn_alt` 精確匹配）會在泛稱情境下誤命中 107 的 alt 清單。
- `PostingAutofillService::fuzzyMatchOffice` 新增 `admin_type` 參數，並在 Step 1 朝代專屬精確匹配落空後、Step 2 alt 匹配之前，依地址行政層級消歧：府 → 同知某府軍府事 (6974)、州/縣 → 同知某州軍州事 (3301)。
- 消歧刻意放在 Step 1 之後，保留明 (70974)、清 (85485) 等朝代專屬「同知」記錄不被宋代抽象官名覆蓋。

## Test plan
- [x] `./vendor/bin/phpunit --filter PostingAutofillOfficeMatchTest`（6 tests, 16 assertions，全綠）
- [x] 於 Query Playground / 任官編輯介面實測 AI 自動填充「同知 + 山東武定府」，確認回傳 `同知某府軍府事`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)