### PR TITLE
新增 LLM API 備援（fallback）機制

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -41,3 +41,13 @@ SEND_CLOUD_KEY=
 PUSHER_APP_ID=
 PUSHER_APP_KEY=
 PUSHER_APP_SECRET=
+
+# LLM API（主要）
+GEMINI_API_KEY=
+GEMINI_API_ENDPOINT=https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+GEMINI_MODEL=gemini-3-flash-preview
+
+# LLM API（備援，可選；主要 API 失敗時自動切換）
+GEMINI_API_KEY_1=
+GEMINI_API_ENDPOINT_1=
+GEMINI_MODEL_1=

--- a/app/Services/CodeLookupService.php
+++ b/app/Services/CodeLookupService.php
@@ -2,11 +2,14 @@
 
 namespace App\Services;
 
+use App\Support\LlmFallbackTrait;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class CodeLookupService {
+    use LlmFallbackTrait;
+
     protected string $apiKey;
     protected string $apiEndpoint;
     protected string $model;
@@ -15,6 +18,7 @@ class CodeLookupService {
         $this->apiKey = config('services.gemini.api_key', '');
         $this->apiEndpoint = config('services.gemini.api_endpoint');
         $this->model = config('services.gemini.model', 'gemini-2.0-flash');
+        $this->initLlmFallback();
     }
 
     /**
@@ -235,6 +239,23 @@ PROMPT;
     }
 
     protected function callLLM(array $messages): array {
+        $result = $this->doCallLLM($messages);
+
+        if (!$result['success'] && $this->hasFallback()) {
+            Log::warning('CodeLookup 主要 LLM 失敗，嘗試 fallback', ['primary_error' => $result['error']]);
+            $original = $this->switchToFallback();
+
+            try {
+                $result = $this->doCallLLM($messages);
+            } finally {
+                $this->restoreFromFallback($original);
+            }
+        }
+
+        return $result;
+    }
+
+    protected function doCallLLM(array $messages): array {
         try {
             $maxCompletionTokens = (int) config('services.gemini.max_completion_tokens', 8192);
             if ($maxCompletionTokens < 256) {

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -2,12 +2,15 @@
 
 namespace App\Services;
 
+use App\Support\LlmFallbackTrait;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class NaturalLanguageQueryService {
+    use LlmFallbackTrait;
+
     protected DatabaseSchemaService $schemaService;
     protected NlQueryToolsService $toolsService;
     protected string $apiKey;
@@ -20,6 +23,7 @@ class NaturalLanguageQueryService {
         $this->apiKey = config('services.gemini.api_key', '');
         $this->apiEndpoint = config('services.gemini.api_endpoint', 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
         $this->model = config('services.gemini.model', 'gemini-3-flash-preview');
+        $this->initLlmFallback();
     }
 
     /**
@@ -1295,6 +1299,34 @@ PROMPT;
      * @return array ['success' => bool, 'data' => array|null, 'error' => string|null]
      */
     protected function callLLM(
+        array $messages,
+        array $tools = [],
+        bool $allowToolCalls = false,
+        ?callable $heartbeatCallback = null,
+        ?callable $abortCheck = null,
+        bool $useStructuredOutput = true
+    ): array {
+        $result = $this->doCallLLM($messages, $tools, $allowToolCalls, $heartbeatCallback, $abortCheck, $useStructuredOutput);
+
+        if (!$result['success'] && $this->hasFallback() && !$this->isClientDisconnectError($result)) {
+            Log::warning('主要 LLM 失敗，嘗試 fallback', ['primary_error' => $result['error']]);
+            $original = $this->switchToFallback();
+
+            try {
+                $result = $this->doCallLLM($messages, $tools, $allowToolCalls, $heartbeatCallback, $abortCheck, $useStructuredOutput);
+            } finally {
+                $this->restoreFromFallback($original);
+            }
+        }
+
+        return $result;
+    }
+
+    private function isClientDisconnectError(array $result): bool {
+        return isset($result['error']) && str_contains($result['error'], '客戶端已中斷連線');
+    }
+
+    protected function doCallLLM(
         array $messages,
         array $tools = [],
         bool $allowToolCalls = false,

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -2,11 +2,14 @@
 
 namespace App\Services;
 
+use App\Support\LlmFallbackTrait;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class PostingAutofillService {
+    use LlmFallbackTrait;
+
     protected string $apiKey;
     protected string $apiEndpoint;
     protected string $model;
@@ -18,6 +21,7 @@ class PostingAutofillService {
         $this->apiKey = config('services.gemini.api_key', '');
         $this->apiEndpoint = config('services.gemini.api_endpoint');
         $this->model = config('services.gemini.model');
+        $this->initLlmFallback();
 
         // 讀取 prompt 模板（AI 任官信息提取 prompt）
         $this->promptTemplate = resource_path('prompts/ai-posting-extraction-prompt.txt');
@@ -102,9 +106,38 @@ class PostingAutofillService {
     }
 
     /**
-     * 調用 AI API 提取結構化數據
+     * 調用 AI API 提取結構化數據（含 fallback）
      */
     protected function callAI(string $sourceText): array {
+        try {
+            $result = $this->doCallAI($sourceText);
+        } catch (\Exception $e) {
+            Log::error('PostingAutofill 主要 LLM 連線異常', ['exception' => $e->getMessage()]);
+            $result = [
+                'success' => false,
+                'data' => null,
+                'error' => 'AI API 連線失敗：' . $e->getMessage(),
+            ];
+        }
+
+        if (!$result['success'] && $this->hasFallback()) {
+            Log::warning('PostingAutofill 主要 LLM 失敗，嘗試 fallback', ['primary_error' => $result['error']]);
+            $original = $this->switchToFallback();
+
+            try {
+                $result = $this->doCallAI($sourceText);
+            } finally {
+                $this->restoreFromFallback($original);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * 實際調用 AI API 的邏輯
+     */
+    protected function doCallAI(string $sourceText): array {
         // 讀取 prompt 模板
         if (!file_exists($this->promptTemplate)) {
             return [

--- a/app/Support/LlmFallbackTrait.php
+++ b/app/Support/LlmFallbackTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 為使用 LLM API 的服務提供備援（fallback）能力。
+ *
+ * 使用此 trait 的服務須擁有 $apiKey、$apiEndpoint、$model 三個屬性。
+ * 在建構子中呼叫 initLlmFallback() 即可載入備援設定。
+ */
+trait LlmFallbackTrait {
+    protected string $fallbackApiKey = '';
+    protected string $fallbackApiEndpoint = '';
+    protected string $fallbackModel = '';
+    protected bool $fallbackAvailable = false;
+
+    /**
+     * 從 config('services.gemini_fallback') 載入備援設定。
+     * 只要 api_key 非空即視為可用；endpoint 與 model 為空時沿用主要設定。
+     */
+    protected function initLlmFallback(): void {
+        $key = (string) config('services.gemini_fallback.api_key', '');
+        $endpoint = (string) config('services.gemini_fallback.api_endpoint', '');
+        $model = (string) config('services.gemini_fallback.model', '');
+
+        if ($key !== '') {
+            $this->fallbackApiKey = $key;
+            $this->fallbackApiEndpoint = $endpoint !== '' ? $endpoint : $this->apiEndpoint;
+            $this->fallbackModel = $model !== '' ? $model : $this->model;
+            $this->fallbackAvailable = true;
+        }
+    }
+
+    protected function hasFallback(): bool {
+        return $this->fallbackAvailable;
+    }
+
+    /**
+     * 將服務的 API 憑證切換到備援設定，並回傳原始憑證以便還原。
+     *
+     * @return array{apiKey: string, apiEndpoint: string, model: string}
+     */
+    protected function switchToFallback(): array {
+        $original = [
+            'apiKey' => $this->apiKey,
+            'apiEndpoint' => $this->apiEndpoint,
+            'model' => $this->model,
+        ];
+
+        $this->apiKey = $this->fallbackApiKey;
+        $this->apiEndpoint = $this->fallbackApiEndpoint;
+        $this->model = $this->fallbackModel;
+
+        Log::info('LLM fallback 已啟用', [
+            'service' => static::class,
+            'fallback_endpoint' => $this->fallbackApiEndpoint,
+            'fallback_model' => $this->fallbackModel,
+        ]);
+
+        return $original;
+    }
+
+    /**
+     * 還原至主要 API 憑證。
+     */
+    protected function restoreFromFallback(array $original): void {
+        $this->apiKey = $original['apiKey'];
+        $this->apiEndpoint = $original['apiEndpoint'];
+        $this->model = $original['model'];
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -42,4 +42,10 @@ return [
         'max_completion_tokens' => (int) env('GEMINI_MAX_COMPLETION_TOKENS', 8192),
     ],
 
+    'gemini_fallback' => [
+        'api_key' => env('GEMINI_API_KEY_1'),
+        'api_endpoint' => env('GEMINI_API_ENDPOINT_1'),
+        'model' => env('GEMINI_MODEL_1'),
+    ],
+
 ];

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -554,6 +554,139 @@ class AiPostingAutofillTest extends TestCase {
     }
 
     /**
+     * 測試主要 LLM 回傳 429 時自動 fallback 到備援 LLM
+     */
+    public function test_fallback_triggered_on_primary_api_error() {
+        config(['services.gemini_fallback.api_key' => 'fallback-key']);
+        config(['services.gemini_fallback.api_endpoint' => 'https://fallback.example.com/api']);
+        config(['services.gemini_fallback.model' => 'fallback-model']);
+
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        Http::fake([
+            // 主要 API 回 429
+            'https://example.com/api' => Http::response([
+                'error' => ['message' => 'Rate limit exceeded'],
+            ], 429),
+            // 備援 API 成功
+            'https://fallback.example.com/api' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => json_encode([
+                                'postings' => [
+                                    [
+                                        'title_str' => '知縣',
+                                        'addr_str' => null,
+                                        'c_firstyear' => null, 'c_fy_nh_code' => null, 'c_fy_nh_year' => null,
+                                        'c_fy_range' => null, 'c_fy_intercalary' => null, 'c_fy_month' => null,
+                                        'c_fy_day' => null, 'c_fy_day_gz' => null, 'c_lastyear' => null,
+                                        'c_ly_nh_code' => null, 'c_ly_nh_year' => null, 'c_ly_range' => null,
+                                        'c_ly_intercalary' => null, 'c_ly_month' => null, 'c_ly_day' => null,
+                                        'c_ly_day_gz' => null, 'c_appt_code' => null, 'c_assume_office_code' => null,
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '知某縣',
+            'person_id' => 1,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'fallback.example.com'));
+    }
+
+    /**
+     * 測試主要 LLM 連線異常（ConnectionException）時自動 fallback
+     */
+    public function test_fallback_triggered_on_primary_connection_exception() {
+        config(['services.gemini_fallback.api_key' => 'fallback-key']);
+        config(['services.gemini_fallback.api_endpoint' => 'https://fallback.example.com/api']);
+        config(['services.gemini_fallback.model' => 'fallback-model']);
+
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        $callCount = 0;
+        Http::fake(function ($request) use (&$callCount) {
+            $callCount++;
+            if (str_contains($request->url(), 'example.com/api') && !str_contains($request->url(), 'fallback')) {
+                // 模擬連線異常
+                throw new \Illuminate\Http\Client\ConnectionException('Connection timed out');
+            }
+
+            // 備援 API 成功
+            return Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => json_encode([
+                                'postings' => [
+                                    [
+                                        'title_str' => '知縣',
+                                        'addr_str' => null,
+                                        'c_firstyear' => null, 'c_fy_nh_code' => null, 'c_fy_nh_year' => null,
+                                        'c_fy_range' => null, 'c_fy_intercalary' => null, 'c_fy_month' => null,
+                                        'c_fy_day' => null, 'c_fy_day_gz' => null, 'c_lastyear' => null,
+                                        'c_ly_nh_code' => null, 'c_ly_nh_year' => null, 'c_ly_range' => null,
+                                        'c_ly_intercalary' => null, 'c_ly_month' => null, 'c_ly_day' => null,
+                                        'c_ly_day_gz' => null, 'c_appt_code' => null, 'c_assume_office_code' => null,
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ],
+                ],
+            ], 200);
+        });
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '知某縣',
+            'person_id' => 1,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+    }
+
+    /**
+     * 測試備援未設定時，主要 API 失敗直接報錯（不嘗試 fallback）
+     */
+    public function test_no_fallback_when_not_configured() {
+        // 確保備援未設定
+        config(['services.gemini_fallback.api_key' => '']);
+        config(['services.gemini_fallback.api_endpoint' => '']);
+
+        $user = User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'error' => ['message' => 'Unauthorized'],
+            ], 401),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '知某縣',
+            'person_id' => 1,
+        ]);
+
+        $response->assertStatus(400)->assertJson(['success' => false]);
+    }
+
+    /**
      * 測試並存朝代（宋/遼）地名消歧：利用 ADDRESSES 表的層級鏈區分同名地名
      */
     public function test_concurrent_dynasty_address_disambiguation_via_hierarchy() {

--- a/tests/Unit/LlmFallbackTraitTest.php
+++ b/tests/Unit/LlmFallbackTraitTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\LlmFallbackTrait;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class LlmFallbackTraitTest extends TestCase {
+    /**
+     * 備援未設定時，hasFallback() 回傳 false
+     */
+    public function test_fallback_unavailable_when_no_config() {
+        Config::set('services.gemini_fallback.api_key', '');
+        Config::set('services.gemini_fallback.api_endpoint', '');
+        Config::set('services.gemini_fallback.model', '');
+
+        $stub = $this->makeStub('primary-key', 'https://primary.example.com', 'primary-model');
+
+        $this->assertFalse($stub->hasFallback());
+    }
+
+    /**
+     * 只設定 api_key（無 endpoint）即可啟用備援，endpoint 自動沿用主要設定
+     */
+    public function test_fallback_enabled_with_key_only_inherits_endpoint() {
+        Config::set('services.gemini_fallback.api_key', 'fallback-key');
+        Config::set('services.gemini_fallback.api_endpoint', '');
+        Config::set('services.gemini_fallback.model', '');
+
+        $stub = $this->makeStub('primary-key', 'https://primary.example.com', 'primary-model');
+
+        $this->assertTrue($stub->hasFallback());
+
+        $original = $stub->switchToFallback();
+        $this->assertSame('fallback-key', $stub->apiKey);
+        $this->assertSame('https://primary.example.com', $stub->apiEndpoint);
+        $this->assertSame('primary-model', $stub->model);
+
+        $stub->restoreFromFallback($original);
+        $this->assertSame('primary-key', $stub->apiKey);
+    }
+
+    /**
+     * api_key 與 api_endpoint 都設定時，使用備援自己的 endpoint
+     */
+    public function test_fallback_uses_own_endpoint_when_provided() {
+        Config::set('services.gemini_fallback.api_key', 'fallback-key');
+        Config::set('services.gemini_fallback.api_endpoint', 'https://fallback.example.com');
+        Config::set('services.gemini_fallback.model', 'fallback-model');
+
+        $stub = $this->makeStub('primary-key', 'https://primary.example.com', 'primary-model');
+
+        $this->assertTrue($stub->hasFallback());
+
+        $stub->switchToFallback();
+        $this->assertSame('fallback-key', $stub->apiKey);
+        $this->assertSame('https://fallback.example.com', $stub->apiEndpoint);
+        $this->assertSame('fallback-model', $stub->model);
+    }
+
+    /**
+     * 備援 model 為空時沿用主要 model
+     */
+    public function test_fallback_inherits_primary_model_when_not_set() {
+        Config::set('services.gemini_fallback.api_key', 'fallback-key');
+        Config::set('services.gemini_fallback.api_endpoint', 'https://fallback.example.com');
+        Config::set('services.gemini_fallback.model', '');
+
+        $stub = $this->makeStub('primary-key', 'https://primary.example.com', 'primary-model');
+
+        $stub->switchToFallback();
+        $this->assertSame('primary-model', $stub->model);
+    }
+
+    /**
+     * switchToFallback() 回傳原始憑證，restoreFromFallback() 可完整還原
+     */
+    public function test_switch_and_restore_roundtrip() {
+        Config::set('services.gemini_fallback.api_key', 'fb-key');
+        Config::set('services.gemini_fallback.api_endpoint', 'https://fb.example.com');
+        Config::set('services.gemini_fallback.model', 'fb-model');
+
+        $stub = $this->makeStub('pk', 'https://p.example.com', 'pm');
+
+        $original = $stub->switchToFallback();
+        $this->assertSame('fb-key', $stub->apiKey);
+
+        $stub->restoreFromFallback($original);
+        $this->assertSame('pk', $stub->apiKey);
+        $this->assertSame('https://p.example.com', $stub->apiEndpoint);
+        $this->assertSame('pm', $stub->model);
+    }
+
+    private function makeStub(string $apiKey, string $apiEndpoint, string $model): object {
+        return new class ($apiKey, $apiEndpoint, $model) {
+            use LlmFallbackTrait {
+                initLlmFallback as public;
+                hasFallback as public;
+                switchToFallback as public;
+                restoreFromFallback as public;
+            }
+
+            public string $apiKey;
+            public string $apiEndpoint;
+            public string $model;
+
+            public function __construct(string $apiKey, string $apiEndpoint, string $model) {
+                $this->apiKey = $apiKey;
+                $this->apiEndpoint = $apiEndpoint;
+                $this->model = $model;
+                $this->initLlmFallback();
+            }
+        };
+    }
+}

--- a/tests/Unit/NaturalLanguageQueryServiceTest.php
+++ b/tests/Unit/NaturalLanguageQueryServiceTest.php
@@ -100,6 +100,47 @@ class NaturalLanguageQueryServiceTest extends TestCase {
     }
 
     #[Test]
+    public function it_falls_back_to_secondary_llm_on_primary_api_error() {
+        Config::set('services.gemini_fallback.api_key', 'fallback-key');
+        Config::set('services.gemini_fallback.api_endpoint', 'https://fallback.example.com/api');
+        Config::set('services.gemini_fallback.model', 'fallback-model');
+
+        $schemaService = $this->createMock(DatabaseSchemaService::class);
+        $schemaService->method('generateSchemaPrompt')->willReturn('Mock schema info');
+        $toolsService = $this->createMock(NlQueryToolsService::class);
+        $service = new NaturalLanguageQueryService($schemaService, $toolsService);
+
+        Http::fake([
+            // 主要 API 回 429（所有重試都會打到 * 或明確的 endpoint）
+            Config::get('services.gemini.api_endpoint', '*') => Http::response([
+                'error' => ['message' => 'Rate limit exceeded'],
+            ], 429),
+            // 備援 API 成功
+            'https://fallback.example.com/api' => Http::response([
+                'choices' => [
+                    [
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => json_encode([
+                                'sql' => 'SELECT 1',
+                                'explanation' => '備援回應',
+                                'error' => null,
+                            ]),
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $result = $service->generateSQL('test question');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('SELECT 1', $result['sql']);
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'fallback.example.com'));
+    }
+
+    #[Test]
     public function it_handles_invalid_json_response() {
         $this->schemaService->method('generateSchemaPrompt')
             ->willReturn('Mock schema info');


### PR DESCRIPTION
## Summary
- 當主要 `GEMINI_xxx` 遇到上游錯誤（429、401、500、連線逾時等）時，自動切換至 `GEMINI_xxx_1` 備援設定重試
- 備援未設定或為空時，行為與修改前完全一致（直接報錯給用戶）
- 只需在 `.env` 設定 `GEMINI_API_KEY_1` 即可啟用備援；`GEMINI_API_ENDPOINT_1` 和 `GEMINI_MODEL_1` 為空時自動沿用主要設定

## 變更內容
- 新增 `app/Support/LlmFallbackTrait.php`：共用備援邏輯（切換/還原憑證）
- `NaturalLanguageQueryService`、`CodeLookupService`、`PostingAutofillService` 皆引入 trait 支援 fallback
- `PostingAutofillService` 額外捕獲 `ConnectionException`，確保連線異常也觸發 fallback
- `config/services.php` 新增 `gemini_fallback` 設定區段
- `.env.docker.example` 新增備援變數範例

## Test plan
- [x] `LlmFallbackTraitTest`（5 個）：啟用條件、endpoint/model 繼承、switch/restore roundtrip
- [x] `AiPostingAutofillTest`（3 個新增）：429 fallback、ConnectionException fallback、備援未設定直接報錯
- [x] `NaturalLanguageQueryServiceTest`（1 個新增）：429 fallback
- [x] 全部 31 個相關測試通過（102 assertions）

🤖 Generated with [Claude Code](https://claude.com/claude-code)