### PR TITLE
調整 SOCIAL_INSTITUTION 相關資料表結構

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -1,7 +1,7 @@
 # 數據庫 Schema 文檔
 
 > 本文檔由 `php artisan cbdb:generate-schema-docs` 自動生成
-> 生成時間：2026-04-16 16:23:42
+> 生成時間：2026-04-17 16:02:03
 
 ## 目錄
 
@@ -1922,7 +1922,6 @@
 | `c_source` | int(11) | YES | NULL |  |
 | `c_pages` | varchar(255) | YES | NULL |  |
 | `c_notes` | longtext | YES | NULL |  |
-| `c_secondary_source_author` | varchar(255) | YES | NULL |  |
 
 **索引**:
 
@@ -1980,8 +1979,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_inst_name_code` | smallint(6) | NO | (NULL) |  |
-| `c_inst_name_hz` | varchar(255) | YES | NULL |  |
-| `c_inst_name_py` | varchar(255) | YES | NULL |  |
+| `c_inst_name_hz` | varchar(255) | NO | '' |  |
+| `c_inst_name_py` | varchar(255) | NO | '' |  |
 
 **索引**:
 
@@ -2360,8 +2359,8 @@
 | `c_name_chn` | varchar(255) | YES | NULL | Chinese full name; auto-generated: c_surname_chn + c_mingzi_chn (no space) |
 | `c_inst_name_code` | smallint(6) | NO | (NULL) |  |
 | `c_inst_code` | smallint(6) | NO | (NULL) |  |
-| `c_inst_name_hz` | varchar(255) | YES | NULL |  |
-| `c_inst_name_py` | varchar(255) | YES | NULL |  |
+| `c_inst_name_hz` | varchar(255) | NO | '' |  |
+| `c_inst_name_py` | varchar(255) | NO | '' |  |
 | `c_bi_role_code` | smallint(6) | NO | (NULL) |  |
 | `c_bi_role_desc` | varchar(255) | YES | NULL |  |
 | `c_bi_role_chn` | varchar(255) | YES | NULL |  |
@@ -3860,7 +3859,6 @@
 | `c_source` | INTEGER | YES | NULL |  |
 | `c_pages` | varchar(255) | YES | NULL |  |
 | `c_notes` | longtext | YES | (NULL) |  |
-| `c_secondary_source_author` | varchar(255) | YES | NULL |  |
 
 ---
 
@@ -3903,8 +3901,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_inst_name_code` | INTEGER | NO | (NULL) |  |
-| `c_inst_name_hz` | varchar(255) | YES | NULL |  |
-| `c_inst_name_py` | varchar(255) | YES | NULL |  |
+| `c_inst_name_hz` | varchar | NO | '' |  |
+| `c_inst_name_py` | varchar | NO | '' |  |
 
 ---
 
@@ -4192,8 +4190,8 @@
 | `c_name_chn` | varchar(255) | YES | (NULL) |  |
 | `c_inst_name_code` | INTEGER | YES | (NULL) |  |
 | `c_inst_code` | INTEGER | YES | (NULL) |  |
-| `c_inst_name_hz` | varchar(255) | YES | (NULL) |  |
-| `c_inst_name_py` | varchar(255) | YES | (NULL) |  |
+| `c_inst_name_hz` | varchar | YES | (NULL) |  |
+| `c_inst_name_py` | varchar | YES | (NULL) |  |
 | `c_bi_role_code` | INTEGER | YES | (NULL) |  |
 | `c_bi_role_desc` | varchar(255) | YES | (NULL) |  |
 | `c_bi_role_chn` | varchar(255) | YES | (NULL) |  |

--- a/database/migrations/2026_04_17_000000_update_social_institution_schema.php
+++ b/database/migrations/2026_04_17_000000_update_social_institution_schema.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+require_once __DIR__.'/helpers.php';
+
+/**
+ * 1. 移除 SOCIAL_INSTITUTION_ALTNAME_DATA.c_secondary_source_author 欄位。
+ * 2. 將 SOCIAL_INSTITUTION_NAME_CODES 的 c_inst_name_hz 與 c_inst_name_py
+ *    由 nullable 改為 NOT NULL（既有 NULL 先補為空字串）。
+ *
+ * 備註：SQLite 執行 column->change() 時會重建整張資料表，會觸發引用
+ * SOCIAL_INSTITUTION_NAME_CODES 的 View_BiogInstData 校驗失敗，因此需先 DROP、
+ * 再重建該 view。
+ */
+return new class () extends Migration {
+    private const VIEW_BIOG_INST_DATA_SQL = <<<'SQL'
+CREATE VIEW View_BiogInstData AS
+SELECT
+    bi.c_personid,
+    person.c_name,
+    person.c_name_chn,
+    bi.c_inst_name_code,
+    bi.c_inst_code,
+    inst_names.c_inst_name_hz,
+    inst_names.c_inst_name_py,
+    bi.c_bi_role_code,
+    inst_codes.c_bi_role_desc,
+    inst_codes.c_bi_role_chn,
+    bi.c_bi_begin_year,
+    bi.c_bi_by_nh_code,
+    by_nh.c_nianhao_chn AS c_bi_by_nh_chn,
+    by_nh.c_nianhao_pin AS c_bi_by_nh_py,
+    bi.c_bi_by_nh_year,
+    bi.c_bi_by_range,
+    by_range.c_range AS c_bi_by_range_desc,
+    by_range.c_range_chn AS c_bi_by_range_chn,
+    bi.c_bi_end_year,
+    bi.c_bi_ey_nh_code,
+    ey_nh.c_nianhao_chn AS c_bi_ey_nh_chn,
+    ey_nh.c_nianhao_pin AS c_bi_ey_nh_py,
+    bi.c_bi_ey_nh_year,
+    bi.c_bi_ey_range,
+    ey_range.c_range AS c_bi_ey_range_desc,
+    ey_range.c_range_chn AS c_bi_ey_range_chn,
+    bi.c_source,
+    text_codes.c_title_chn AS c_source_chn,
+    text_codes.c_title AS c_source_py,
+    bi.c_pages,
+    bi.c_notes,
+    inst_addr.c_inst_addr_id,
+    inst_addr.c_inst_addr_type_code,
+    inst_addr.inst_xcoord,
+    inst_addr.inst_ycoord
+FROM BIOG_INST_DATA AS bi
+INNER JOIN BIOG_MAIN AS person
+    ON person.c_personid = bi.c_personid
+INNER JOIN SOCIAL_INSTITUTION_NAME_CODES AS inst_names
+    ON inst_names.c_inst_name_code = bi.c_inst_name_code
+INNER JOIN BIOG_INST_CODES AS inst_codes
+    ON inst_codes.c_bi_role_code = bi.c_bi_role_code
+LEFT JOIN NIAN_HAO AS by_nh
+    ON by_nh.c_nianhao_id = bi.c_bi_by_nh_code
+LEFT JOIN YEAR_RANGE_CODES AS by_range
+    ON by_range.c_range_code = bi.c_bi_by_range
+LEFT JOIN NIAN_HAO AS ey_nh
+    ON ey_nh.c_nianhao_id = bi.c_bi_ey_nh_code
+LEFT JOIN YEAR_RANGE_CODES AS ey_range
+    ON ey_range.c_range_code = bi.c_bi_ey_range
+LEFT JOIN TEXT_CODES AS text_codes
+    ON text_codes.c_textid = bi.c_source
+LEFT JOIN SOCIAL_INSTITUTION_ADDR AS inst_addr
+    ON inst_addr.c_inst_name_code = bi.c_inst_name_code
+   AND inst_addr.c_inst_code = bi.c_inst_code
+SQL;
+
+    public function up(): void {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('SOCIAL_INSTITUTION_ALTNAME_DATA')) {
+            Schema::table('SOCIAL_INSTITUTION_ALTNAME_DATA', function (Blueprint $table) {
+                $table->dropColumn('c_secondary_source_author');
+            });
+        }
+
+        if (Schema::hasTable('SOCIAL_INSTITUTION_NAME_CODES')) {
+            DB::statement("UPDATE SOCIAL_INSTITUTION_NAME_CODES SET c_inst_name_hz = '' WHERE c_inst_name_hz IS NULL");
+            DB::statement("UPDATE SOCIAL_INSTITUTION_NAME_CODES SET c_inst_name_py = '' WHERE c_inst_name_py IS NULL");
+
+            if (is_sqlite()) {
+                DB::statement('DROP VIEW IF EXISTS View_BiogInstData');
+            }
+
+            Schema::table('SOCIAL_INSTITUTION_NAME_CODES', function (Blueprint $table) {
+                $table->string('c_inst_name_hz', 255)->nullable(false)->default('')->change();
+                $table->string('c_inst_name_py', 255)->nullable(false)->default('')->change();
+            });
+
+            if (is_sqlite()) {
+                DB::statement(self::VIEW_BIOG_INST_DATA_SQL);
+            }
+        }
+
+        enable_foreign_keys();
+    }
+
+    public function down(): void {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('SOCIAL_INSTITUTION_NAME_CODES')) {
+            if (is_sqlite()) {
+                DB::statement('DROP VIEW IF EXISTS View_BiogInstData');
+            }
+
+            Schema::table('SOCIAL_INSTITUTION_NAME_CODES', function (Blueprint $table) {
+                $table->string('c_inst_name_hz', 255)->nullable()->default(null)->change();
+                $table->string('c_inst_name_py', 255)->nullable()->default(null)->change();
+            });
+
+            if (is_sqlite()) {
+                DB::statement(self::VIEW_BIOG_INST_DATA_SQL);
+            }
+        }
+
+        if (Schema::hasTable('SOCIAL_INSTITUTION_ALTNAME_DATA')) {
+            Schema::table('SOCIAL_INSTITUTION_ALTNAME_DATA', function (Blueprint $table) {
+                $table->string('c_secondary_source_author', 255)->nullable()->default(null);
+            });
+        }
+
+        enable_foreign_keys();
+    }
+};


### PR DESCRIPTION
## Summary
- 移除 `SOCIAL_INSTITUTION_ALTNAME_DATA.c_secondary_source_author` 欄位（未被任何程式碼引用）
- 將 `SOCIAL_INSTITUTION_NAME_CODES.c_inst_name_hz`、`c_inst_name_py` 由 nullable 改為 `NOT NULL DEFAULT ''`，既有 `NULL` 列先補為空字串
- SQLite 執行 `->change()` 會觸發整張表重建，會讓引用 `SOCIAL_INSTITUTION_NAME_CODES` 的 `View_BiogInstData` 校驗失敗；在 SQLite 分支先 `DROP VIEW` 再重建，MySQL 端 `ALTER COLUMN` 原地修改無此問題
- 同步以 `php artisan cbdb:generate-schema-docs` 更新 `DATABASE_SCHEMA.md`

## Test plan
- [x] `php artisan migrate` 在 MySQL 成功執行
- [x] `php artisan cbdb:generate-schema-docs` 在 SQLite in-memory 分支成功完成（先前會因 view 依賴失敗）
- [x] 於 CI 跑完整 `./vendor/bin/phpunit` 確認無回歸

🤖 Generated with [Claude Code](https://claude.com/claude-code)