### PR TITLE
清除 ENTRY_DATA 流程中不存在的 c_secondary_source_author 欄位引用

### DIFF
--- a/app/Services/Mutations/EntryCreateHandler.php
+++ b/app/Services/Mutations/EntryCreateHandler.php
@@ -64,7 +64,6 @@ class EntryCreateHandler extends AbstractPersonSubresourceCreateHandler {
             'c_entry_nh_code',
             'c_entry_nh_year',
             'c_entry_range',
-            'c_secondary_source_author',
             'c_secondary_source_title',
         ];
     }

--- a/app/Services/Mutations/EntryMutationHandler.php
+++ b/app/Services/Mutations/EntryMutationHandler.php
@@ -63,7 +63,6 @@ class EntryMutationHandler extends AbstractPersonSubresourceMutationHandler {
             'c_entry_nh_code',
             'c_entry_nh_year',
             'c_entry_range',
-            'c_secondary_source_author',
             'c_secondary_source_title',
         ];
     }

--- a/tests/Feature/ApiV2CreateEntryTest.php
+++ b/tests/Feature/ApiV2CreateEntryTest.php
@@ -121,7 +121,6 @@ class ApiV2CreateEntryTest extends TestCase {
             $table->integer('c_entry_nh_code')->nullable();
             $table->integer('c_entry_nh_year')->nullable();
             $table->integer('c_entry_range')->nullable();
-            $table->string('c_secondary_source_author', 255)->nullable();
             $table->string('c_secondary_source_title', 255)->nullable();
             $table->string('c_created_by', 255)->nullable();
             $table->string('c_created_date', 255)->nullable();

--- a/tests/Feature/ApiV2DeleteEntryTest.php
+++ b/tests/Feature/ApiV2DeleteEntryTest.php
@@ -121,7 +121,6 @@ class ApiV2DeleteEntryTest extends TestCase {
             $table->integer('c_entry_nh_code')->nullable();
             $table->integer('c_entry_nh_year')->nullable();
             $table->integer('c_entry_range')->nullable();
-            $table->string('c_secondary_source_author', 255)->nullable();
             $table->string('c_secondary_source_title', 255)->nullable();
             $table->string('c_created_by', 255)->nullable();
             $table->string('c_created_date', 255)->nullable();

--- a/tests/Feature/ApiV2MutateEntryTest.php
+++ b/tests/Feature/ApiV2MutateEntryTest.php
@@ -121,7 +121,6 @@ class ApiV2MutateEntryTest extends TestCase {
             $table->integer('c_entry_nh_code')->nullable();
             $table->integer('c_entry_nh_year')->nullable();
             $table->integer('c_entry_range')->nullable();
-            $table->string('c_secondary_source_author', 255)->nullable();
             $table->string('c_secondary_source_title', 255)->nullable();
             $table->string('c_created_by', 255)->nullable();
             $table->string('c_created_date', 255)->nullable();


### PR DESCRIPTION
## Summary
- `ENTRY_DATA` 實際 schema **不含** `c_secondary_source_author`（見 `DATABASE_SCHEMA.md` 的 `ENTRY_DATA` 章節），但程式碼與測試仍保留此欄位的引用，形成幽靈欄位：寫入時靜默丟失資料，讀取時永遠拿不到值。
- 本 PR 將所有非 migration 的引用清除：
  - `app/Services/Mutations/EntryCreateHandler.php` — `allowedFields()`
  - `app/Services/Mutations/EntryMutationHandler.php` — `allowedFields()`
  - `tests/Feature/ApiV2CreateEntryTest.php` — 測試建表
  - `tests/Feature/ApiV2DeleteEntryTest.php` — 測試建表
  - `tests/Feature/ApiV2MutateEntryTest.php` — 測試建表
- Migration 檔案中的歷史引用（baseline import 與 #1005 drop migration）依專案慣例保留不動。

## 背景
- `SOCIAL_INSTITUTION_ALTNAME_DATA.c_secondary_source_author` 已在 PR #1005 移除。
- 本次清理發現 `ENTRY_DATA` 這張表**從一開始就沒有此欄位**（baseline `2025_01_01_000000_import_cbdb_schema.php` 的 CREATE TABLE 中沒有它），但 handler 與測試把它當作合法欄位處理。

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/ApiV2CreateEntryTest.php tests/Feature/ApiV2DeleteEntryTest.php tests/Feature/ApiV2MutateEntryTest.php` — 34 tests, 77 assertions, 全通過
- [x] `grep -r c_secondary_source_author` 確認剩餘引用僅在 migration 檔案與 `docs/DATABASE_SCHEMA.md`（PR #1006 處理中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)