### PR TITLE
補齊基本資訊複合主鍵空值哨兵與 ASSOC_DATA c_text_title 正規化

### DIFF
--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -127,10 +127,12 @@ class BasicInformationAddressesController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_ADDR_DATA 的 NOT NULL 複合主鍵欄位
         $request->merge([
-            'c_addr_id' => ($request->input('c_addr_id') == -999) ? '0' : ($request->input('c_addr_id') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_addr_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_id')),
+            'c_addr_type' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_type')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型
@@ -309,10 +311,12 @@ class BasicInformationAddressesController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_ADDR_DATA 的 NOT NULL 複合主鍵欄位
         $request->merge([
-            'c_addr_id' => ($request->input('c_addr_id') == -999) ? '0' : ($request->input('c_addr_id') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_addr_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_id')),
+            'c_addr_type' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_type')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型
@@ -508,6 +512,13 @@ class BasicInformationAddressesController extends Controller {
 
             return redirect()->back();
         }
+
+        // 數據預處理：補齊 BIOG_ADDR_DATA 的 NOT NULL 複合主鍵欄位
+        $request->merge([
+            'c_addr_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_id')),
+            'c_addr_type' => CompositePrimaryKey::emptyToSentinel($request->input('c_addr_type')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+        ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');

--- a/app/Http/Controllers/BasicInformationAssocController.php
+++ b/app/Http/Controllers/BasicInformationAssocController.php
@@ -166,21 +166,26 @@ class BasicInformationAssocController extends Controller {
             $c_inst_name_code = '0';
         }
 
+        // 數據預處理：補齊 ASSOC_DATA 的 NOT NULL 複合主鍵欄位
+        // c_text_title 以 '[n/a]' 為「未知出處」哨兵（DB 現行慣例）
+        // c_assoc_first_year 以 '-9999' 為「未知年份」哨兵
         $request->merge([
             'c_inst_code' => $c_inst_code,
             'c_inst_name_code' => $c_inst_name_code,
+            'c_assoc_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_code')),
+            'c_assoc_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_id')),
+            'c_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_code')),
+            'c_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_id')),
+            'c_assoc_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_code')),
+            'c_assoc_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_id')),
+            'c_text_title' => CompositePrimaryKey::emptyToSentinel($request->input('c_text_title'), '[n/a]'),
+            'c_assoc_first_year' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_first_year'), '-9999'),
         ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // 處理年份缺省值，確保符合複合主鍵要求
-            // 注意：c_text_title 允許為空字串，不需要強制填充 [n/a]，以免破壞現有空值資料的匹配
-            if ($request->input('c_assoc_first_year') === null || $request->input('c_assoc_first_year') === '') {
-                $request->merge(['c_assoc_first_year' => '-9999']);
-            }
-
             // 轉發到提案控制器
             return app(\App\Http\Controllers\BasicInformationProposalController::class)
                 ->proposalStore($request, $id, 'assoc');
@@ -291,7 +296,7 @@ class BasicInformationAssocController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理：分割 c_inst_code
+        // 數據預處理：分割 c_inst_code 並補齊 ASSOC_DATA 的 NOT NULL 複合主鍵欄位
         $temp = explode("-", $request->input('c_inst_code', ''));
         $c_inst_code = $temp[0] ?: '0';
         $c_inst_name_code = $temp[1] ?? '0';
@@ -304,6 +309,14 @@ class BasicInformationAssocController extends Controller {
         $request->merge([
             'c_inst_code' => $c_inst_code,
             'c_inst_name_code' => $c_inst_name_code,
+            'c_assoc_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_code')),
+            'c_assoc_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_id')),
+            'c_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_code')),
+            'c_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_id')),
+            'c_assoc_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_code')),
+            'c_assoc_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_id')),
+            'c_text_title' => CompositePrimaryKey::emptyToSentinel($request->input('c_text_title'), '[n/a]'),
+            'c_assoc_first_year' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_first_year'), '-9999'),
         ]);
 
         if (!Auth::user()->canWriteDirectly()) {
@@ -447,7 +460,7 @@ class BasicInformationAssocController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理：分割 c_inst_code
+        // 數據預處理：分割 c_inst_code 並補齊 ASSOC_DATA 的 NOT NULL 複合主鍵欄位
         $temp = explode("-", $request->input('c_inst_code', ''));
         $c_inst_code = $temp[0] ?: '0';
         $c_inst_name_code = $temp[1] ?? '0';
@@ -460,17 +473,20 @@ class BasicInformationAssocController extends Controller {
         $request->merge([
             'c_inst_code' => $c_inst_code,
             'c_inst_name_code' => $c_inst_name_code,
+            'c_assoc_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_code')),
+            'c_assoc_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_id')),
+            'c_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_code')),
+            'c_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_id')),
+            'c_assoc_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_code')),
+            'c_assoc_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_kin_id')),
+            'c_text_title' => CompositePrimaryKey::emptyToSentinel($request->input('c_text_title'), '[n/a]'),
+            'c_assoc_first_year' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_first_year'), '-9999'),
         ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');
 
         if ($action === 'proposal') {
-            // 處理年份缺省值
-            if ($request->input('c_assoc_first_year') === null || $request->input('c_assoc_first_year') === '') {
-                $request->merge(['c_assoc_first_year' => '-9999']);
-            }
-
             // 提案模式需要從 URL 查詢字串取得原始 PK（而非表單提交的新值）
             $schema = CompositePrimaryKey::SCHEMAS['ASSOC_DATA'];
             $originalPk = [];

--- a/app/Http/Controllers/BasicInformationEntriesController.php
+++ b/app/Http/Controllers/BasicInformationEntriesController.php
@@ -148,12 +148,17 @@ class BasicInformationEntriesController extends Controller {
         // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
         // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
         $data = $request->all();
-        $data['c_entry_code'] = ($data['c_entry_code'] ?? 0) == -999 ? '0' : ($data['c_entry_code'] ?? '0');
-        $data['c_entry_addr_id'] = ($data['c_entry_addr_id'] ?? 0) == -999 ? '0' : ($data['c_entry_addr_id'] ?? '0');
-        $data['c_kin_code'] = ($data['c_kin_code'] ?? 0) == -999 ? '0' : ($data['c_kin_code'] ?? '0');
-        $data['c_assoc_code'] = ($data['c_assoc_code'] ?? 0) == -999 ? '0' : ($data['c_assoc_code'] ?? '0');
-        $data['c_inst_code'] = ($data['c_inst_code'] ?? 0) == -999 ? '0' : ($data['c_inst_code'] ?? '0');
-        $data['c_source'] = ($data['c_source'] ?? 0) == -999 ? '0' : ($data['c_source'] ?? '0');
+        $data['c_entry_code'] = CompositePrimaryKey::emptyToSentinel($data['c_entry_code'] ?? null);
+        $data['c_entry_addr_id'] = CompositePrimaryKey::emptyToSentinel($data['c_entry_addr_id'] ?? null);
+        $data['c_kin_code'] = CompositePrimaryKey::emptyToSentinel($data['c_kin_code'] ?? null);
+        $data['c_assoc_code'] = CompositePrimaryKey::emptyToSentinel($data['c_assoc_code'] ?? null);
+        $data['c_inst_code'] = CompositePrimaryKey::emptyToSentinel($data['c_inst_code'] ?? null);
+        $data['c_source'] = CompositePrimaryKey::emptyToSentinel($data['c_source'] ?? null);
+        // 補齊其他 NOT NULL 複合主鍵欄位，避免清空後觸發 "缺少必要的複合主鍵參數" 錯誤
+        $data['c_year'] = CompositePrimaryKey::emptyToSentinel($data['c_year'] ?? null);
+        $data['c_kin_id'] = CompositePrimaryKey::emptyToSentinel($data['c_kin_id'] ?? null);
+        $data['c_assoc_id'] = CompositePrimaryKey::emptyToSentinel($data['c_assoc_id'] ?? null);
+        $data['c_sequence'] = CompositePrimaryKey::emptyToSentinel($data['c_sequence'] ?? null);
 
         $temp = explode("-", $data['c_inst_code']);
         $c_inst_code = $temp[0];
@@ -174,6 +179,10 @@ class BasicInformationEntriesController extends Controller {
             'c_inst_code' => $c_inst_code,
             'c_inst_name_code' => $c_inst_name_code,
             'c_source' => $data['c_source'],
+            'c_year' => $data['c_year'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_sequence' => $data['c_sequence'],
         ]);
 
         // 檢查動作類型
@@ -295,12 +304,17 @@ class BasicInformationEntriesController extends Controller {
         */
         // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
         $data = $request->all();
-        $data['c_entry_code'] = ($data['c_entry_code'] ?? 0) == -999 ? '0' : ($data['c_entry_code'] ?? '0');
-        $data['c_entry_addr_id'] = ($data['c_entry_addr_id'] ?? 0) == -999 ? '0' : ($data['c_entry_addr_id'] ?? '0');
-        $data['c_kin_code'] = ($data['c_kin_code'] ?? 0) == -999 ? '0' : ($data['c_kin_code'] ?? '0');
-        $data['c_assoc_code'] = ($data['c_assoc_code'] ?? 0) == -999 ? '0' : ($data['c_assoc_code'] ?? '0');
-        $data['c_inst_code'] = ($data['c_inst_code'] ?? 0) == -999 ? '0' : ($data['c_inst_code'] ?? '0');
-        $data['c_source'] = ($data['c_source'] ?? 0) == -999 ? '0' : ($data['c_source'] ?? '0');
+        $data['c_entry_code'] = CompositePrimaryKey::emptyToSentinel($data['c_entry_code'] ?? null);
+        $data['c_entry_addr_id'] = CompositePrimaryKey::emptyToSentinel($data['c_entry_addr_id'] ?? null);
+        $data['c_kin_code'] = CompositePrimaryKey::emptyToSentinel($data['c_kin_code'] ?? null);
+        $data['c_assoc_code'] = CompositePrimaryKey::emptyToSentinel($data['c_assoc_code'] ?? null);
+        $data['c_inst_code'] = CompositePrimaryKey::emptyToSentinel($data['c_inst_code'] ?? null);
+        $data['c_source'] = CompositePrimaryKey::emptyToSentinel($data['c_source'] ?? null);
+        // 補齊其他 NOT NULL 複合主鍵欄位，避免清空後觸發 "缺少必要的複合主鍵參數" 錯誤
+        $data['c_year'] = CompositePrimaryKey::emptyToSentinel($data['c_year'] ?? null);
+        $data['c_kin_id'] = CompositePrimaryKey::emptyToSentinel($data['c_kin_id'] ?? null);
+        $data['c_assoc_id'] = CompositePrimaryKey::emptyToSentinel($data['c_assoc_id'] ?? null);
+        $data['c_sequence'] = CompositePrimaryKey::emptyToSentinel($data['c_sequence'] ?? null);
 
         $temp = explode("-", $data['c_inst_code']);
         $c_inst_code = $temp[0];
@@ -319,6 +333,10 @@ class BasicInformationEntriesController extends Controller {
             'c_inst_code' => $c_inst_code,
             'c_inst_name_code' => $c_inst_name_code,
             'c_source' => $data['c_source'],
+            'c_year' => $data['c_year'],
+            'c_kin_id' => $data['c_kin_id'],
+            'c_assoc_id' => $data['c_assoc_id'],
+            'c_sequence' => $data['c_sequence'],
         ]);
 
         $data = $request->all();
@@ -526,11 +544,16 @@ class BasicInformationEntriesController extends Controller {
         // 數據預處理：處理 -999 轉為 0 並分割 c_inst_code
         // 這些預處理必須在提案 (proposal) 和直接儲存 (save) 之前完成
         $request->merge([
-            'c_entry_code' => ($request->input('c_entry_code') == -999) ? '0' : ($request->input('c_entry_code') ?? '0'),
-            'c_entry_addr_id' => ($request->input('c_entry_addr_id') == -999) ? '0' : ($request->input('c_entry_addr_id') ?? '0'),
-            'c_kin_code' => ($request->input('c_kin_code') == -999) ? '0' : ($request->input('c_kin_code') ?? '0'),
-            'c_assoc_code' => ($request->input('c_assoc_code') == -999) ? '0' : ($request->input('c_assoc_code') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_entry_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_entry_code')),
+            'c_entry_addr_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_entry_addr_id')),
+            'c_kin_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_code')),
+            'c_assoc_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_code')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
+            // 補齊其他 NOT NULL 複合主鍵欄位，避免清空後觸發 "缺少必要的複合主鍵參數" 錯誤
+            'c_year' => CompositePrimaryKey::emptyToSentinel($request->input('c_year')),
+            'c_kin_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_kin_id')),
+            'c_assoc_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_assoc_id')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
         ]);
 
         $temp = explode("-", $request->input('c_inst_code', ''));

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -488,14 +488,20 @@ class BasicInformationProposalController extends Controller {
     }
 
     protected function normalizePayloadForTable(string $table, array $payload): array {
-        if ($table !== 'BIOG_SOURCE_DATA') {
-            return $payload;
+        if ($table === 'BIOG_SOURCE_DATA') {
+            $payload['c_pages'] = (string) ($payload['c_pages'] ?? '');
+
+            if (array_key_exists('c_textid', $payload) && $payload['c_textid'] !== null && $payload['c_textid'] !== '') {
+                $payload['c_textid'] = (int) $payload['c_textid'] === -999 ? 0 : (int) $payload['c_textid'];
+            }
         }
 
-        $payload['c_pages'] = (string) ($payload['c_pages'] ?? '');
-
-        if (array_key_exists('c_textid', $payload) && $payload['c_textid'] !== null && $payload['c_textid'] !== '') {
-            $payload['c_textid'] = (int) $payload['c_textid'] === -999 ? 0 : (int) $payload['c_textid'];
+        // ASSOC_DATA 的 c_text_title 統一用 '[n/a]' 作為「未知出處」哨兵，
+        // c_assoc_first_year 統一用 '-9999' 作為「未知年份」哨兵。
+        // 兩者皆為 9-key 複合主鍵的一部分，提案與直接寫入需維持同一慣例。
+        if ($table === 'ASSOC_DATA') {
+            $payload['c_text_title'] = CompositePrimaryKey::emptyToSentinel($payload['c_text_title'] ?? null, '[n/a]');
+            $payload['c_assoc_first_year'] = CompositePrimaryKey::emptyToSentinel($payload['c_assoc_first_year'] ?? null, '-9999');
         }
 
         return $payload;

--- a/app/Http/Controllers/BasicInformationSourcesController.php
+++ b/app/Http/Controllers/BasicInformationSourcesController.php
@@ -129,9 +129,11 @@ class BasicInformationSourcesController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_SOURCE_DATA 的 NOT NULL 複合主鍵欄位
+        // c_pages 為 varchar NOT NULL，現行 DB 以空字串 '' 作為「未知頁數」哨兵
         $request->merge([
-            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_pages' => CompositePrimaryKey::emptyToSentinel($request->input('c_pages'), ''),
         ]);
 
         // 檢查動作類型
@@ -228,6 +230,13 @@ class BasicInformationSourcesController extends Controller {
 
             return redirect()->back();
         }
+
+        // 數據預處理：補齊 BIOG_SOURCE_DATA 的 NOT NULL 複合主鍵欄位
+        $request->merge([
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_pages' => CompositePrimaryKey::emptyToSentinel($request->input('c_pages'), ''),
+        ]);
+
         $data = $this->biogMainRepository->sourceUpdateById($request, $id, $id_);
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -338,9 +347,10 @@ class BasicInformationSourcesController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_SOURCE_DATA 的 NOT NULL 複合主鍵欄位
         $request->merge([
-            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_pages' => CompositePrimaryKey::emptyToSentinel($request->input('c_pages'), ''),
         ]);
 
         // 檢查動作類型

--- a/app/Http/Controllers/BasicInformationStatusesController.php
+++ b/app/Http/Controllers/BasicInformationStatusesController.php
@@ -118,8 +118,9 @@ class BasicInformationStatusesController extends Controller {
 
         // 數據預處理
         $request->merge([
-            'c_status_code' => ($request->input('c_status_code') == -999) ? '0' : ($request->input('c_status_code') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_status_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_status_code')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型
@@ -219,6 +220,13 @@ class BasicInformationStatusesController extends Controller {
 
             return redirect()->back();
         }
+
+        // 數據預處理：補齊 STATUS_DATA 的 NOT NULL 複合主鍵欄位
+        $request->merge([
+            'c_status_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_status_code')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+        ]);
+
         $data = $this->biogMainRepository->statuseUpdateById($request, $id_, $id);
         flash('Update success @ '.Carbon::now(), 'success');
 
@@ -370,8 +378,9 @@ class BasicInformationStatusesController extends Controller {
 
         // 數據預處理
         $request->merge([
-            'c_status_code' => ($request->input('c_status_code') == -999) ? '0' : ($request->input('c_status_code') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_status_code' => CompositePrimaryKey::emptyToSentinel($request->input('c_status_code')),
+            'c_sequence' => CompositePrimaryKey::emptyToSentinel($request->input('c_sequence')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型

--- a/app/Http/Controllers/BasicInformationTextsController.php
+++ b/app/Http/Controllers/BasicInformationTextsController.php
@@ -117,10 +117,11 @@ class BasicInformationTextsController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_TEXT_DATA 的 NOT NULL 複合主鍵欄位
         $request->merge([
-            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_role_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_role_id')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型
@@ -224,10 +225,11 @@ class BasicInformationTextsController extends Controller {
             return redirect()->back();
         }
 
-        // 數據預處理
+        // 數據預處理：補齊 BIOG_TEXT_DATA 的 NOT NULL 複合主鍵欄位
         $request->merge([
-            'c_textid' => ($request->input('c_textid') == -999) ? '0' : ($request->input('c_textid') ?? '0'),
-            'c_source' => ($request->input('c_source') == -999) ? '0' : ($request->input('c_source') ?? '0'),
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_role_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_role_id')),
+            'c_source' => CompositePrimaryKey::emptyToSentinel($request->input('c_source')),
         ]);
 
         // 檢查動作類型
@@ -368,6 +370,12 @@ class BasicInformationTextsController extends Controller {
 
             return redirect()->back();
         }
+
+        // 數據預處理：補齊 BIOG_TEXT_DATA 的 NOT NULL 複合主鍵欄位
+        $request->merge([
+            'c_textid' => CompositePrimaryKey::emptyToSentinel($request->input('c_textid')),
+            'c_role_id' => CompositePrimaryKey::emptyToSentinel($request->input('c_role_id')),
+        ]);
 
         // 檢查動作類型
         $action = $request->input('action', 'save');

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -190,6 +190,25 @@ class CompositePrimaryKey {
     }
 
     /**
+     * 將空值（null / 空字串 / '-999' / -999）正規化為指定哨兵值，
+     * 讓使用者清空表單欄位時仍能寫入 NOT NULL 複合主鍵欄位。
+     *
+     * 不同資料表的「未知」哨兵慣例不同：
+     * - 數字欄位（c_year, c_kin_id 等整數主鍵）：'0'
+     * - BIOG_SOURCE_DATA.c_pages（varchar）：''（現行 DB 已有 4823 筆以此為慣例）
+     * - ASSOC_DATA.c_text_title（varchar）：'[n/a]'（現行 DB 已有 68203 筆以此為慣例）
+     *
+     * 傳入非空值時原樣回傳（轉為字串），避免干擾合法內容。
+     */
+    public static function emptyToSentinel(mixed $value, string $sentinel = '0'): string {
+        if ($value === null || $value === '' || $value === -999 || $value === '-999') {
+            return $sentinel;
+        }
+
+        return (string) $value;
+    }
+
+    /**
      * 生成帶查詢參數的 URL
      *
      * @param string $route 路由名稱

--- a/database/migrations/2026_04_18_000000_normalize_assoc_data_empty_text_title.php
+++ b/database/migrations/2026_04_18_000000_normalize_assoc_data_empty_text_title.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 將 ASSOC_DATA 中 c_text_title 為空字串的資料正規化為 '[n/a]'。
+ *
+ * 背景：
+ * - ASSOC_DATA.c_text_title 是 9-key 複合主鍵的一部分，'[n/a]' 為現行主流慣例（68203+ 筆）
+ * - 歷史上有 294 筆空字串紀錄（2018 年 peter bol 早期建立），語意等同「未知出處」
+ * - 手動編輯表單現已統一 fallback 為 '[n/a]'，本 migration 補齊歷史資料
+ *
+ * 本 migration 是一次性資料清理，不寫 operations 審計紀錄。
+ * 若遇到 8-key 前綴相同但 c_text_title 分別為 '' 與 '[n/a]' 的衝突組，
+ * 直接刪除 '[n/a]' 版、保留較早的 '' 版，讓後續 UPDATE 不會撞 9-key 主鍵。
+ */
+class NormalizeAssocDataEmptyTextTitle extends Migration {
+    public function up(): void {
+        if (!Schema::hasTable('ASSOC_DATA')) {
+            return;
+        }
+
+        DB::transaction(function () {
+            $this->resolveDuplicatePkConflicts();
+            $normalized = DB::table('ASSOC_DATA')
+                ->where('c_text_title', '')
+                ->update(['c_text_title' => '[n/a]']);
+
+            if ($normalized > 0) {
+                echo "ASSOC_DATA: normalized {$normalized} rows (c_text_title '' -> '[n/a]')\n";
+            }
+        });
+    }
+
+    public function down(): void {
+        // 不還原：'[n/a]' 是 CBDB 的既有慣例，migration 前的空字串紀錄
+        // 無法和其他歷史上就寫入 '[n/a]' 的紀錄區分，down 會造成資料污染。
+    }
+
+    /**
+     * 找出 8-key 前綴相同、c_text_title 同時存在 '' 與 '[n/a]' 版的衝突組，
+     * 刪除 '[n/a]' 版以讓後續 UPDATE 不會違反 9-key 主鍵。
+     */
+    protected function resolveDuplicatePkConflicts(): void {
+        $prefixCols = ['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_assoc_first_year'];
+        $groupBy = implode(',', $prefixCols);
+
+        $conflicts = DB::select("
+            SELECT {$groupBy}
+            FROM ASSOC_DATA
+            WHERE c_text_title IN ('', '[n/a]')
+            GROUP BY {$groupBy}
+            HAVING COUNT(DISTINCT c_text_title) > 1
+        ");
+
+        foreach ($conflicts as $c) {
+            $conditions = [];
+            foreach ($prefixCols as $col) {
+                $conditions[] = [$col, '=', $c->$col];
+            }
+            DB::table('ASSOC_DATA')
+                ->where($conditions)
+                ->where('c_text_title', '[n/a]')
+                ->delete();
+        }
+    }
+}

--- a/tests/Feature/NormalizeAssocDataEmptyTextTitleMigrationTest.php
+++ b/tests/Feature/NormalizeAssocDataEmptyTextTitleMigrationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 針對 2026_04_18_000000_normalize_assoc_data_empty_text_title migration 的測試。
+ *
+ * 重點：驗證衝突解決路徑 —— 同 8-key 前綴同時存在 '' 與 '[n/a]' 時，
+ * 不會因 9-key 複合主鍵違例而中斷 migration。一般 migrate:fresh 跑的是空 DB，
+ * 跑不到這個分支，必須手動鋪資料模擬。
+ */
+class NormalizeAssocDataEmptyTextTitleMigrationTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('ASSOC_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code');
+            $table->integer('c_assoc_id');
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_assoc_kin_code')->default(0);
+            $table->integer('c_assoc_kin_id')->default(0);
+            $table->string('c_text_title')->default('');
+            $table->integer('c_assoc_first_year')->default(-9999);
+            $table->integer('c_source')->nullable();
+            $table->primary(['c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year']);
+        });
+    }
+
+    protected function runMigration(): void {
+        if (!class_exists('NormalizeAssocDataEmptyTextTitle', false)) {
+            require_once database_path('migrations/2026_04_18_000000_normalize_assoc_data_empty_text_title.php');
+        }
+        (new \NormalizeAssocDataEmptyTextTitle())->up();
+    }
+
+    #[Test]
+    public function migration_resolves_pk_conflict_and_normalizes_empty_text_title(): void {
+        DB::table('ASSOC_DATA')->insert([
+            // 衝突組：同 8-key 前綴下 '' 與 '[n/a]' 並存
+            ['c_personid' => 100, 'c_assoc_code' => 1, 'c_assoc_id' => 2, 'c_assoc_first_year' => -1, 'c_text_title' => '', 'c_source' => 0],
+            ['c_personid' => 100, 'c_assoc_code' => 1, 'c_assoc_id' => 2, 'c_assoc_first_year' => -1, 'c_text_title' => '[n/a]', 'c_source' => 9602],
+            // 單純的 '' 紀錄
+            ['c_personid' => 200, 'c_assoc_code' => 5, 'c_assoc_id' => 6, 'c_assoc_first_year' => 1000, 'c_text_title' => '', 'c_source' => 0],
+        ]);
+
+        $this->runMigration();
+
+        // 衝突組：'[n/a]' 版被刪、'' 版更名為 '[n/a]'，保留 peter bol 的較早版本（c_source=0）
+        $conflictRows = DB::table('ASSOC_DATA')
+            ->where(['c_personid' => 100, 'c_assoc_code' => 1, 'c_assoc_id' => 2, 'c_assoc_first_year' => -1])
+            ->get();
+        $this->assertCount(1, $conflictRows, '衝突組應合併為一筆');
+        $this->assertSame('[n/a]', $conflictRows->first()->c_text_title);
+        $this->assertSame(0, (int) $conflictRows->first()->c_source, '應保留較早的 c_source=0 版本');
+
+        // 單純紀錄：正常正規化
+        $normalRow = DB::table('ASSOC_DATA')
+            ->where(['c_personid' => 200, 'c_assoc_code' => 5])
+            ->first();
+        $this->assertSame('[n/a]', $normalRow->c_text_title);
+    }
+
+    #[Test]
+    public function migration_is_idempotent(): void {
+        DB::table('ASSOC_DATA')->insert([
+            ['c_personid' => 300, 'c_assoc_code' => 1, 'c_assoc_id' => 2, 'c_assoc_first_year' => -1, 'c_text_title' => '[n/a]'],
+        ]);
+
+        $this->runMigration();
+        $this->runMigration();
+
+        $this->assertSame(1, DB::table('ASSOC_DATA')->count());
+    }
+}

--- a/tests/Feature/ProposalNormalizationTest.php
+++ b/tests/Feature/ProposalNormalizationTest.php
@@ -100,24 +100,27 @@ class ProposalNormalizationTest extends TestCase {
     }
 
     /**
-     * 驗證 P2: ASSOC_DATA 提案正確處理空字串 c_text_title
+     * 驗證 ASSOC_DATA 修改提案把空字串 c_text_title 正規化為 '[n/a]' 哨兵。
+     *
+     * 歷史上曾以空字串作為「未知出處」的佔位值，2026 年後統一改用 '[n/a]'
+     * （見 migration 2026_04_18_000000_normalize_assoc_data_empty_text_title.php）。
+     * 控制器在送出提案時應將空輸入 fallback 為 '[n/a]'，確保 PK 匹配到遷移後的資料。
      */
     #[Test]
-    public function testAssocProposalWithEmptyTextTitle() {
+    public function testAssocProposalNormalizesEmptyTextTitleToNaSentinel() {
         $user = $this->makeActiveUser();
         $this->actingAs($user);
 
-        // 插入一條 c_text_title 為空字串的原始資料
+        // 原始資料以 '[n/a]' 為 c_text_title（反映遷移後的現況）
         DB::table('ASSOC_DATA')->insert([
             'c_personid' => 100,
             'c_assoc_code' => 1,
             'c_assoc_id' => 2,
-            'c_text_title' => '', // 空字串
+            'c_text_title' => '[n/a]',
             'c_assoc_first_year' => 1000,
         ]);
 
-        // 模擬修改提案
-        // URL 包含 c_text_title= (空字串)
+        // URL 故意送空字串 c_text_title，期望控制器把它正規化為 '[n/a]' 後比對到原始資料
         $response = $this->patch(route('basicinformation.assoc.update.query', [
             'id' => 100,
             'action' => 'proposal',
@@ -128,32 +131,31 @@ class ProposalNormalizationTest extends TestCase {
             'c_kin_id' => 0,
             'c_assoc_kin_code' => 0,
             'c_assoc_kin_id' => 0,
-            'c_text_title' => '', // 關鍵：空字串 PK 欄位
+            'c_text_title' => '',
             'c_assoc_first_year' => 1000,
         ]), [
             'c_notes' => '更新後的備註',
-            '__proposal_comment' => '測試空字串 PK',
+            '__proposal_comment' => '測試空字串 c_text_title 被正規化',
         ]);
 
         $response->assertRedirect();
 
-        // 驗證提案是否成功建立，且 c_text_title 被正確識別
         $operation = Operation::where('resource', 'ASSOC_DATA')->first();
         $this->assertNotNull($operation, '提案未建立，可能是 PK 匹配失敗');
 
         $payload = json_decode($operation->resource_data, true);
         $this->assertSame('更新後的備註', $payload['c_notes']);
 
-        // 驗證 resource_id 包含 c_text_title 的空字串 (應被編碼為 NULL 或空，取決於 buildCompositeId)
-        // 在 BasicInformationProposalController 中，'' 或 null 會被轉為 'NULL'
-        $this->assertStringContainsString('NULL', $operation->resource_id);
+        // resource_id 裡 c_text_title 應該是 URL 編碼後的 '[n/a]'（而非舊契約的 'NULL'）
+        $this->assertStringContainsString('c_text_title='.rawurlencode('[n/a]'), $operation->resource_id);
     }
 
     /**
-     * 驗證 ASSOC_DATA 新增提案允許空字串 c_text_title
+     * 驗證 ASSOC_DATA 新增提案即使送出空字串 c_text_title 仍可成功，
+     * 空值會被正規化為 '[n/a]' 寫入。
      */
     #[Test]
-    public function testAssocCreateProposalAllowsEmptyTextTitle() {
+    public function testAssocCreateProposalNormalizesEmptyTextTitleToNaSentinel() {
         $user = $this->makeActiveUser();
         $this->actingAs($user);
 
@@ -179,6 +181,9 @@ class ProposalNormalizationTest extends TestCase {
             ->latest('id')
             ->first();
         $this->assertNotNull($operation, 'ASSOC_DATA 空標題新增提案未建立');
+
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('[n/a]', $payload['c_text_title'], '空字串 c_text_title 應被正規化為 [n/a]');
     }
 
     /**

--- a/tests/Unit/CompositePrimaryKeyTest.php
+++ b/tests/Unit/CompositePrimaryKeyTest.php
@@ -83,6 +83,36 @@ class CompositePrimaryKeyTest extends TestCase {
     }
 
     #[Test]
+    public function empty_to_sentinel_normalizes_null_blank_and_minus_999_to_default_zero(): void {
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel(null));
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel(''));
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel(-999));
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel('-999'));
+    }
+
+    #[Test]
+    public function empty_to_sentinel_preserves_legitimate_values_as_string(): void {
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel('0'));
+        $this->assertSame('0', CompositePrimaryKey::emptyToSentinel(0));
+        $this->assertSame('1351', CompositePrimaryKey::emptyToSentinel(1351));
+        $this->assertSame('12345', CompositePrimaryKey::emptyToSentinel('12345'));
+        $this->assertSame('某書', CompositePrimaryKey::emptyToSentinel('某書'));
+    }
+
+    #[Test]
+    public function empty_to_sentinel_accepts_custom_sentinel_for_text_fields(): void {
+        // BIOG_SOURCE_DATA.c_pages 使用空字串作哨兵
+        $this->assertSame('', CompositePrimaryKey::emptyToSentinel(null, ''));
+        $this->assertSame('', CompositePrimaryKey::emptyToSentinel('', ''));
+        $this->assertSame('卷三', CompositePrimaryKey::emptyToSentinel('卷三', ''));
+
+        // ASSOC_DATA.c_text_title 使用 [n/a] 作哨兵
+        $this->assertSame('[n/a]', CompositePrimaryKey::emptyToSentinel(null, '[n/a]'));
+        $this->assertSame('[n/a]', CompositePrimaryKey::emptyToSentinel('', '[n/a]'));
+        $this->assertSame('論語', CompositePrimaryKey::emptyToSentinel('論語', '[n/a]'));
+    }
+
+    #[Test]
     public function it_decodes_null_sentinel_from_request(): void {
         $request = new Request([
             'c_personid' => 12345,


### PR DESCRIPTION
## Summary

修復入仕表單清空「入仕年」後無法保存的使用者回報，追根究柢為 Basic Information 系列控制器對 NOT NULL 複合主鍵欄位的空值哨兵處理不齊。本 PR 一併補齊所有受影響控制器，並處理 ASSOC_DATA 的歷史空字串紀錄。

- 抽取 `CompositePrimaryKey::emptyToSentinel()` 共用 helper，支援自訂哨兵字串（數字用 `'0'`、BIOG_SOURCE_DATA.c_pages 用 `''`、ASSOC_DATA.c_text_title 用 `'[n/a]'`、c_assoc_first_year 用 `'-9999'`）
- 6 個基本資訊控制器的 `store` / `update` / `updateQuery` 補齊缺漏的 PK 欄位預處理
- `BasicInformationProposalController::normalizePayloadForTable()` 加入 ASSOC_DATA 分支，讓提案流程與直接寫入走相同哨兵契約
- 新 migration：以 live DB 實測資料驗證過的 9-key 衝突解決 + 294 筆 `'' → '[n/a]'` 正規化（可重入）

## 受影響的資料表與欄位

| 資料表 | 原本漏掉的 NOT NULL PK 欄位 | 哨兵值 |
|---|---|---|
| ENTRY_DATA | c_year、c_kin_id、c_assoc_id、c_sequence | `'0'` |
| BIOG_ADDR_DATA | c_addr_type、c_sequence | `'0'` |
| BIOG_TEXT_DATA | c_role_id | `'0'` |
| STATUS_DATA | c_sequence | `'0'` |
| BIOG_SOURCE_DATA | c_pages (varchar) | `''` |
| ASSOC_DATA | 6 個 ID 欄位 + c_text_title + c_assoc_first_year | `'0'` / `'[n/a]'` / `'-9999'` |

已評估為安全、未動的控制器：Kinship、Events、Altnames、SocialInst、Offices、Possession。

## ASSOC_DATA migration

本機實測數據（live DB）：
- 9-key PK 衝突組：2 組（由維護者先行人工刪除 [n/a] 版；migration 本身亦可自動處理）
- `'' → '[n/a]'` 正規化：294 筆（[n/a] 總數 68203 → 68497）
- Migration 為純資料清理，不寫 operations 審計（一次性特殊修改）

## Test plan

- [x] `./vendor/bin/phpunit` 全綠：**1199 tests / 4687 assertions**
- [x] 新增 `CompositePrimaryKeyTest::empty_to_sentinel_*`（3 個單元測試）
- [x] 新增 `NormalizeAssocDataEmptyTextTitleMigrationTest`（衝突解決 + 冪等性）
- [x] 調整 `ProposalNormalizationTest` 對齊新契約（`'' → '[n/a]'`，不再是 `'NULL'`）
- [x] `php -l` 各修改檔語法檢查通過
- [x] `php-cs-fixer` 格式檢查通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)