### PR TITLE
將 STATUS_CODES 描述欄位設為 NOT NULL

### DIFF
--- a/database/migrations/2026_04_20_000000_set_status_codes_desc_not_null.php
+++ b/database/migrations/2026_04_20_000000_set_status_codes_desc_not_null.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 將 STATUS_CODES.c_status_desc 與 c_status_desc_chn 設為 NOT NULL。
+ *
+ * 背景：
+ * - STATUS_CODES 主鍵為 c_status_code，這兩個描述欄位並非 PK 組成，
+ *   故不需要先 drop PK、alter、再 add PK。
+ * - 對齊 HOUSEHOLD_STATUS_CODES 等兄弟碼表慣例，描述欄位 NOT NULL 預設 ''。
+ */
+class SetStatusCodesDescNotNull extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('STATUS_CODES')) {
+            DB::statement("UPDATE STATUS_CODES SET c_status_desc = '' WHERE c_status_desc IS NULL");
+            DB::statement("UPDATE STATUS_CODES SET c_status_desc_chn = '' WHERE c_status_desc_chn IS NULL");
+
+            Schema::table('STATUS_CODES', function (Blueprint $table) {
+                $table->string('c_status_desc', 255)->nullable(false)->default('')->change();
+                $table->string('c_status_desc_chn', 255)->nullable(false)->default('')->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('STATUS_CODES')) {
+            Schema::table('STATUS_CODES', function (Blueprint $table) {
+                $table->string('c_status_desc', 255)->nullable()->default(null)->change();
+                $table->string('c_status_desc_chn', 255)->nullable()->default(null)->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+}

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,7 +1,7 @@
 # 數據庫 Schema 文檔
 
 > 本文檔由 `php artisan cbdb:generate-schema-docs` 自動生成
-> 生成時間：2026-04-17 16:41:16
+> 生成時間：2026-04-20 13:15:57
 
 ## 目錄
 
@@ -2013,8 +2013,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_status_code` | smallint(6) | NO | (NULL) |  |
-| `c_status_desc` | varchar(255) | YES | NULL |  |
-| `c_status_desc_chn` | varchar(255) | YES | NULL |  |
+| `c_status_desc` | varchar(255) | NO | '' |  |
+| `c_status_desc_chn` | varchar(255) | NO | '' |  |
 
 **索引**:
 
@@ -3925,8 +3925,8 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_status_code` | INTEGER | NO | (NULL) |  |
-| `c_status_desc` | varchar(255) | YES | NULL |  |
-| `c_status_desc_chn` | varchar(255) | YES | NULL |  |
+| `c_status_desc` | varchar | NO | '' |  |
+| `c_status_desc_chn` | varchar | NO | '' |  |
 
 ---
 


### PR DESCRIPTION
## Summary
- 新增 migration 將 `STATUS_CODES.c_status_desc` 與 `c_status_desc_chn` 的 NULL 回填為 `''` 並改為 `NOT NULL default ''`
- 兩欄非 PK 成員（主鍵為 `c_status_code`），直接 `ALTER` 即可，無需 drop / re-add primary key
- 對齊 `HOUSEHOLD_STATUS_CODES` 等兄弟碼表慣例
- 同步 `docs/DATABASE_SCHEMA.md`（MySQL 與 SQLite 兩份視圖）

## Test plan
- [x] `php artisan migrate --path=database/migrations/2026_04_20_000000_set_status_codes_desc_not_null.php --force` 在本機 MariaDB 10.11 執行成功
- [x] `DESCRIBE STATUS_CODES` 確認兩欄 `Null=NO`、`Default=''`
- [x] `php artisan cbdb:generate-schema-docs` 重新生成，diff 只有 STATUS_CODES 兩欄、其他表無意外變動

🤖 Generated with [Claude Code](https://claude.com/claude-code)