### PR TITLE
將 TEXT_BIBLCAT_CODES 描述欄位設為 NOT NULL

### DIFF
--- a/database/migrations/2026_04_21_000000_set_text_biblcat_codes_desc_not_null.php
+++ b/database/migrations/2026_04_21_000000_set_text_biblcat_codes_desc_not_null.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 將 TEXT_BIBLCAT_CODES 的 c_text_cat_desc、c_text_cat_desc_chn、c_text_cat_pinyin 設為 NOT NULL。
+ *
+ * 背景：
+ * - TEXT_BIBLCAT_CODES 主鍵為 c_text_cat_code，這三個描述欄位並非 PK 組成，
+ *   故不需要先 drop PK、alter、再 add PK。
+ * - 對齊 STATUS_CODES 等兄弟碼表慣例，描述欄位 NOT NULL 預設 ''。
+ */
+class SetTextBiblcatCodesDescNotNull extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('TEXT_BIBLCAT_CODES')) {
+            DB::statement("UPDATE TEXT_BIBLCAT_CODES SET c_text_cat_desc = '' WHERE c_text_cat_desc IS NULL");
+            DB::statement("UPDATE TEXT_BIBLCAT_CODES SET c_text_cat_desc_chn = '' WHERE c_text_cat_desc_chn IS NULL");
+            DB::statement("UPDATE TEXT_BIBLCAT_CODES SET c_text_cat_pinyin = '' WHERE c_text_cat_pinyin IS NULL");
+
+            Schema::table('TEXT_BIBLCAT_CODES', function (Blueprint $table) {
+                $table->string('c_text_cat_desc', 255)->nullable(false)->default('')->change();
+                $table->string('c_text_cat_desc_chn', 255)->nullable(false)->default('')->change();
+                $table->string('c_text_cat_pinyin', 255)->nullable(false)->default('')->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('TEXT_BIBLCAT_CODES')) {
+            Schema::table('TEXT_BIBLCAT_CODES', function (Blueprint $table) {
+                $table->string('c_text_cat_desc', 255)->nullable()->default(null)->change();
+                $table->string('c_text_cat_desc_chn', 255)->nullable()->default(null)->change();
+                $table->string('c_text_cat_pinyin', 255)->nullable()->default(null)->change();
+            });
+        }
+
+        enable_foreign_keys();
+    }
+}

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -2134,9 +2134,9 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_text_cat_code` | smallint(6) | NO | (NULL) |  |
-| `c_text_cat_desc` | varchar(255) | YES | NULL |  |
-| `c_text_cat_desc_chn` | varchar(255) | YES | NULL |  |
-| `c_text_cat_pinyin` | varchar(255) | YES | NULL |  |
+| `c_text_cat_desc` | varchar(255) | NO | '' |  |
+| `c_text_cat_desc_chn` | varchar(255) | NO | '' |  |
+| `c_text_cat_pinyin` | varchar(255) | NO | '' |  |
 | `c_text_cat_parent_id` | varchar(255) | YES | NULL |  |
 | `c_text_cat_level` | varchar(255) | YES | NULL |  |
 | `c_text_cat_sortorder` | smallint(6) | YES | NULL |  |
@@ -4030,9 +4030,9 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_text_cat_code` | INTEGER | NO | (NULL) |  |
-| `c_text_cat_desc` | varchar(255) | YES | NULL |  |
-| `c_text_cat_desc_chn` | varchar(255) | YES | NULL |  |
-| `c_text_cat_pinyin` | varchar(255) | YES | NULL |  |
+| `c_text_cat_desc` | varchar(255) | NO | '' |  |
+| `c_text_cat_desc_chn` | varchar(255) | NO | '' |  |
+| `c_text_cat_pinyin` | varchar(255) | NO | '' |  |
 | `c_text_cat_parent_id` | varchar(255) | YES | NULL |  |
 | `c_text_cat_level` | varchar(255) | YES | NULL |  |
 | `c_text_cat_sortorder` | INTEGER | YES | NULL |  |


### PR DESCRIPTION
## Summary
- 將 `TEXT_BIBLCAT_CODES` 的 `c_text_cat_desc`、`c_text_cat_desc_chn`、`c_text_cat_pinyin` 設為 `NOT NULL`，預設 `''`
- 新增 migration：先把既有 NULL 回填為 `''`，再 `ALTER` 改為 `NOT NULL DEFAULT ''`
- 三欄皆非 PK 組成，無需 drop/re-add primary key
- 對齊 STATUS_CODES 等兄弟碼表慣例
- 同步 `docs/DATABASE_SCHEMA.md`（MariaDB 與 SQLite 兩區塊）

## Test plan
- [x] 本地 `php artisan migrate` 執行成功
- [x] `INFORMATION_SCHEMA` 驗證三欄 `IS_NULLABLE=NO`、`COLUMN_DEFAULT=''`
- [x] CI 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)