### PR TITLE
將 POSTED_TO_OFFICE_DATA.c_appt_code 設為 NOT NULL 並重排欄位

### DIFF
--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -51,6 +51,11 @@ class OfficePostingRepository {
         $data['c_office_id'] = $data['c_office_id'] == -999 ? '0' : $data['c_office_id'];
         //$data['c_inst_code'] = $data['c_inst_code'] == -999 ? '0' : $data['c_inst_code'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
+        // c_appt_code 欄位為 NOT NULL；null／空字串／-999 統一回填 0（APPOINTMENT_CODES 的「未詳」哨兵）
+        if (array_key_exists('c_appt_code', $data)) {
+            $apptValue = $data['c_appt_code'];
+            $data['c_appt_code'] = ($apptValue === null || $apptValue === '' || $apptValue == -999) ? 0 : (int) $apptValue;
+        }
 
         $hasPostingChange = $this->hasMeaningfulChanges($data, $ori, ['c_modified_by', 'c_modified_date']);
 
@@ -368,6 +373,11 @@ class OfficePostingRepository {
 
             $data['c_fy_intercalary'] = (int)($data['c_fy_intercalary']);
             $data['c_ly_intercalary'] = (int)($data['c_ly_intercalary']);
+            // c_appt_code 欄位為 NOT NULL；null／空字串／-999 統一回填 0（APPOINTMENT_CODES 的「未詳」哨兵）
+            if (array_key_exists('c_appt_code', $data)) {
+                $apptValue = $data['c_appt_code'];
+                $data['c_appt_code'] = ($apptValue === null || $apptValue === '' || $apptValue == -999) ? 0 : (int) $apptValue;
+            }
 
             $lastPostingId = DB::table('POSTING_DATA')
                 ->lockForUpdate()

--- a/app/Services/Mutations/PostingMutationHandler.php
+++ b/app/Services/Mutations/PostingMutationHandler.php
@@ -81,6 +81,14 @@ class PostingMutationHandler extends AbstractPersonSubresourceMutationHandler {
             $data['c_ly_intercalary'] = (int) ($data['c_ly_intercalary'] ?? 0);
         }
 
+        // c_appt_code 欄位為 NOT NULL；null／空字串／-999 統一回填 0（APPOINTMENT_CODES 的「未詳」哨兵）
+        if (array_key_exists('c_appt_code', $data)) {
+            $value = $data['c_appt_code'];
+            if ($value === null || $value === '' || $value == -999) {
+                $data['c_appt_code'] = 0;
+            }
+        }
+
         return $data;
     }
 }

--- a/database/migrations/2026_04_22_000000_set_posted_to_office_data_c_appt_code_not_null.php
+++ b/database/migrations/2026_04_22_000000_set_posted_to_office_data_c_appt_code_not_null.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 將 POSTED_TO_OFFICE_DATA.c_appt_code 設為 NOT NULL，並把欄位移到 c_ly_range 之後。
+ *
+ * 背景：
+ * - 2026-04-16 已將 c_appt_code 從 varchar(255) 收斂為 smallint 並建立外鍵，
+ *   但歷史資料仍允許 NULL，導致介面與查詢需額外處理空值。
+ * - 對齊 c_appt_type_code 原欄位位置（介於 c_ly_range 與 c_assume_office_code 之間），
+ *   讓年份與任職相關欄位保持緊鄰，提升 schema 可讀性。
+ * - 空值回填 0，沿用 OFFICE_CODES.c_dy 等兄弟欄位的慣例。
+ */
+class SetPostedToOfficeDataCApptCodeNotNull extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        disable_foreign_keys();
+
+        // 1. 確保 APPOINTMENT_CODES 存在 0 號「未詳」哨兵，
+        //    否則後續 UPDATE 會造成 FK 孤兒、ApiController2 讀取時也會 NPE。
+        //    使用 insertOrIgnore 保持冪等，對已存在的 0 號不覆寫。
+        if (Schema::hasTable('APPOINTMENT_CODES')) {
+            DB::table('APPOINTMENT_CODES')->insertOrIgnore([
+                'c_appt_code' => 0,
+                'c_appt_desc_chn' => '未詳',
+                'c_appt_desc' => 'Unknown',
+            ]);
+        }
+
+        if (Schema::hasTable('POSTED_TO_OFFICE_DATA')) {
+            // 2. 填充空值：c_appt_code 在 2026-04-16 已轉為 smallint，
+            //    理論上不會再有空字串，但保留 '' 條件以防 SQLite 型別親和殘留。
+            DB::statement("UPDATE POSTED_TO_OFFICE_DATA SET c_appt_code = 0 WHERE c_appt_code IS NULL OR c_appt_code = ''");
+
+            // 3. MySQL：MODIFY COLUMN ... AFTER 同時完成 NOT NULL 與欄位重排。
+            //    SQLite：僅改 NOT NULL，欄位順序重排需重建整張表，對應用無實質影響。
+            if (is_mysql()) {
+                // MODIFY COLUMN ... AFTER 保留 c_appt_code_POSTED_TO_OFFICE_DATA_index 索引
+                // 與 POSTED_TO_OFFICE_DATA_ibfk_1 外鍵約束。
+                DB::statement('ALTER TABLE POSTED_TO_OFFICE_DATA MODIFY c_appt_code smallint NOT NULL DEFAULT 0 AFTER c_ly_range');
+            } else {
+                Schema::table('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+                    $table->smallInteger('c_appt_code')->nullable(false)->default(0)->change();
+                });
+            }
+        }
+
+        enable_foreign_keys();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        disable_foreign_keys();
+
+        if (Schema::hasTable('POSTED_TO_OFFICE_DATA')) {
+            if (is_mysql()) {
+                // 還原為 nullable；欄位保留在 c_ly_range 之後，不再搬回表尾，
+                // 因為舊位置僅是歷史遺留，沒有反向還原的價值。
+                DB::statement('ALTER TABLE POSTED_TO_OFFICE_DATA MODIFY c_appt_code smallint DEFAULT NULL');
+            } else {
+                Schema::table('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+                    $table->smallInteger('c_appt_code')->nullable()->default(null)->change();
+                });
+            }
+        }
+
+        enable_foreign_keys();
+    }
+}

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,7 +1,7 @@
 # 數據庫 Schema 文檔
 
 > 本文檔由 `php artisan cbdb:generate-schema-docs` 自動生成
-> 生成時間：2026-04-20 13:15:57
+> 生成時間：2026-04-22 13:56:39
 
 ## 目錄
 
@@ -1763,6 +1763,7 @@
 | `c_ly_nh_code` | smallint(6) | YES | NULL |  |
 | `c_ly_nh_year` | smallint(6) | YES | NULL |  |
 | `c_ly_range` | smallint(6) | YES | NULL |  |
+| `c_appt_code` | smallint(6) | NO | 0 |  |
 | `c_assume_office_code` | smallint(6) | YES | NULL |  |
 | `c_inst_code` | smallint(6) | YES | 0 |  |
 | `c_inst_name_code` | smallint(6) | YES | 0 |  |
@@ -1782,7 +1783,6 @@
 | `c_dy` | smallint(6) | YES | NULL |  |
 | `c_created_by` | varchar(255) | YES | NULL |  |
 | `c_modified_by` | varchar(255) | YES | NULL |  |
-| `c_appt_code` | smallint(6) | YES | NULL |  |
 | `c_created_date` | datetime | YES | NULL |  |
 | `c_modified_date` | datetime | YES | NULL |  |
 
@@ -3758,7 +3758,7 @@
 | `c_dy` | INTEGER | YES | NULL |  |
 | `c_created_by` | varchar(255) | YES | NULL |  |
 | `c_modified_by` | varchar(255) | YES | NULL |  |
-| `c_appt_code` | varchar(255) | YES | NULL |  |
+| `c_appt_code` | INTEGER | NO | '0' |  |
 | `c_created_date` | datetime | YES | (NULL) |  |
 | `c_modified_date` | datetime | YES | (NULL) |  |
 
@@ -4030,9 +4030,9 @@
 | 列名 | 類型 | 可空 | 默認值 | 備註 |
 |------|------|------|--------|------|
 | `c_text_cat_code` | INTEGER | NO | (NULL) |  |
-| `c_text_cat_desc` | varchar(255) | NO | '' |  |
-| `c_text_cat_desc_chn` | varchar(255) | NO | '' |  |
-| `c_text_cat_pinyin` | varchar(255) | NO | '' |  |
+| `c_text_cat_desc` | varchar | NO | '' |  |
+| `c_text_cat_desc_chn` | varchar | NO | '' |  |
+| `c_text_cat_pinyin` | varchar | NO | '' |  |
 | `c_text_cat_parent_id` | varchar(255) | YES | NULL |  |
 | `c_text_cat_level` | varchar(255) | YES | NULL |  |
 | `c_text_cat_sortorder` | INTEGER | YES | NULL |  |

--- a/tests/Feature/ApiV2MutatePostingTest.php
+++ b/tests/Feature/ApiV2MutatePostingTest.php
@@ -121,7 +121,7 @@ class ApiV2MutatePostingTest extends TestCase {
             $table->integer('c_ly_nh_year')->nullable();
             $table->integer('c_ly_range')->nullable();
             $table->integer('c_ly_intercalary')->default(0);
-            $table->integer('c_appt_code')->nullable();
+            $table->integer('c_appt_code')->default(0);
             $table->integer('c_assume_office_code')->nullable();
             $table->primary(['c_office_id', 'c_posting_id']);
         });

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -190,7 +190,7 @@ class CbdbApiPersonTest extends TestCase {
             $table->integer('c_ly_nh_code')->nullable();
             $table->integer('c_ly_nh_year')->nullable();
             $table->integer('c_ly_range')->nullable();
-            $table->integer('c_appt_code')->nullable();
+            $table->integer('c_appt_code')->default(0);
             $table->integer('c_assume_office_code')->nullable();
             $table->integer('c_source')->nullable();
             $table->string('c_pages')->nullable();
@@ -208,6 +208,12 @@ class CbdbApiPersonTest extends TestCase {
             $table->integer('c_appt_code')->primary();
             $table->string('c_appt_desc_chn')->nullable();
         });
+        // 對齊 migration 2026_04_22 建立的 0 號「未詳」哨兵，
+        // 避免日後擴測到 ApiController2 之類做 PHP 解參考的路徑時踩 NPE。
+        \DB::table('APPOINTMENT_CODES')->insert([
+            'c_appt_code' => 0,
+            'c_appt_desc_chn' => '未詳',
+        ]);
 
         Schema::create('ASSUME_OFFICE_CODES', function (Blueprint $table) {
             $table->integer('c_assume_office_code')->primary();


### PR DESCRIPTION
## Summary

- 新增 migration `2026_04_22_000000`：先 `insertOrIgnore` `APPOINTMENT_CODES` 的 0 號「未詳」哨兵，再把 `POSTED_TO_OFFICE_DATA.c_appt_code` 的 `NULL`／空字串回填為 0，最後於 MySQL 透過 `MODIFY COLUMN ... AFTER c_ly_range` 一次完成 NOT NULL default 0 與欄位重排（放到 `c_assume_office_code` 之前）。SQLite 路徑只改 NOT NULL 不重排。
- 寫入端補守門：`PostingMutationHandler::preprocessUpdateData` 與 `OfficePostingRepository` 的 `officeStoreById`／`officeUpdateById`，把 `c_appt_code` 的 `null`／空字串／`-999` 統一回填 0（沿用 APPOINTMENT_CODES 的 0 號哨兵）。
- 測試 fixture 對齊 prod：`ApiV2MutatePostingTest`、`CbdbApiPersonTest` 的 `c_appt_code` 由 `nullable()` 改成 `default(0)`；`CbdbApiPersonTest` 的 `APPOINTMENT_CODES` 補 0 號哨兵，避免未來擴測到 `ApiController2` 那類 PHP 解參考路徑時踩 NPE。
- `docs/DATABASE_SCHEMA.md` 重新生成。

## Test plan

- [x] `./vendor/bin/phpunit --filter 'CbdbApiPersonTest|ApiV2MutatePosting|OperationsOfficeRestore|AiPostingAutofill'` — 49 tests, 153 assertions 全綠
- [x] migration 已在本機 MySQL 跑過：363,318 NULL 回填為 0，欄位順序 `c_ly_range[11] → c_appt_code[12] → c_assume_office_code[13]`
- [x] `php -l` 全檔案語法通過
- [x] `./vendor/bin/php-cs-fixer fix` 無變動

🤖 Generated with [Claude Code](https://claude.com/claude-code)