### PR TITLE
統一 AI 智能識別／填充區塊的版型與模型標示

### DIFF
--- a/resources/views/biogmains/assoc/_form.blade.php
+++ b/resources/views/biogmains/assoc/_form.blade.php
@@ -31,6 +31,57 @@
 
     <x-forms.person-id-display :personId="$id" />
 
+    {{-- AI 智能識別社會關係代碼（已啟用用戶 + Gemini API 已配置） --}}
+    @if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+        <div class="card card-info mb-3" id="ai-code-lookup-section">
+            <div class="card-header d-flex align-items-center">
+                <h3 class="card-title mb-0">
+                    <i class="fas fa-magic"></i> AI 智能識別社會關係代碼
+                </h3>
+                <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
+                   data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
+                    <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
+                </a>
+            </div>
+            <div class="collapse" id="ai-code-privacy-notice">
+                <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
+                    <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
+                    <ul class="mb-0">
+                        <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
+                        <li>您的文本將發送至第三方 AI 服務進行處理</li>
+                        <li>AI 識別結果僅供參考，請務必核實後再提交</li>
+                    </ul>
+                    <p class="mb-0 mt-2">當前使用模型：<code>{{ config('services.gemini.model') }}</code></p>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="form-group">
+                    <label for="ai-code-query">輸入描述（AI 將從 ASSOC_CODES 中識別相關代碼）</label>
+                    <textarea class="form-control" id="ai-code-query" rows="3"
+                              placeholder="例如：為釋顯達作塔記"></textarea>
+                    <small class="form-text text-muted">AI 會語義理解您的描述，從社會關係代碼表中找出最相關的代碼</small>
+                </div>
+                <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
+                    <i class="fas fa-bolt"></i> AI 智能識別
+                </button>
+                <span class="ml-3" id="ai-code-status"></span>
+
+                {{-- 候選結果區 --}}
+                <div id="ai-code-results" style="display:none;" class="mt-3">
+                    <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
+                    <div id="ai-code-candidates" class="mb-3"></div>
+
+                    <div id="ai-code-not-found" style="display:none;">
+                        <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
+                        <div id="ai-code-not-found-list"></div>
+                    </div>
+
+                    <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
+                </div>
+            </div>
+        </div>
+    @endif
+
     <div class="form-group row">
         <label for="c_sequence" class="col-sm-2 col-form-label">次序(sequence)</label>
         <div class="col-sm-10">
@@ -364,56 +415,6 @@
         </div>
     </div>
 </form>
-
-{{-- AI 智能識別社會關係代碼（已啟用用戶 + Gemini API 已配置） --}}
-@if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
-    <div class="card card-info mt-3" id="ai-code-lookup-section">
-        <div class="card-header d-flex align-items-center">
-            <h3 class="card-title mb-0">
-                <i class="fas fa-magic"></i> AI 智能識別社會關係代碼
-            </h3>
-            <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
-               data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
-                <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
-            </a>
-        </div>
-        <div class="collapse" id="ai-code-privacy-notice">
-            <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
-                <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
-                <ul class="mb-0">
-                    <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
-                    <li>您的文本將發送至第三方 AI 服務進行處理</li>
-                    <li>AI 識別結果僅供參考，請務必核實後再提交</li>
-                </ul>
-            </div>
-        </div>
-        <div class="card-body">
-            <div class="form-group">
-                <label for="ai-code-query">輸入描述（AI 將從 ASSOC_CODES 中識別相關代碼）</label>
-                <textarea class="form-control" id="ai-code-query" rows="3"
-                          placeholder="例如：為釋顯達作塔記"></textarea>
-                <small class="form-text text-muted">AI 會語義理解您的描述，從社會關係代碼表中找出最相關的代碼</small>
-            </div>
-            <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
-                <i class="fas fa-bolt"></i> AI 智能識別
-            </button>
-            <span class="ml-3" id="ai-code-status"></span>
-
-            {{-- 候選結果區 --}}
-            <div id="ai-code-results" style="display:none;" class="mt-3">
-                <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
-                <div id="ai-code-candidates" class="mb-3"></div>
-
-                <div id="ai-code-not-found" style="display:none;">
-                    <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
-                    <div id="ai-code-not-found-list"></div>
-                </div>
-
-                <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
-            </div>
-        </div>
-    </div>
-@endif
 
 @section('js')
     <script>

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -48,6 +48,7 @@
                         <li>您的文本將發送至第三方 AI 服務（Google Gemini API、OpenAI API 等，恕不另行通知）進行處理</li>
                         <li>AI 填充結果僅供參考，請務必核實後再提交</li>
                     </ul>
+                    <p class="mb-0 mt-2">當前使用模型：<code>{{ config('services.gemini.model') }}</code></p>
                 </div>
             </div>
             <div class="card-body">

--- a/resources/views/biogmains/statuses/_form.blade.php
+++ b/resources/views/biogmains/statuses/_form.blade.php
@@ -25,6 +25,57 @@
 
     <x-forms.person-id-display :personId="$id" />
 
+    {{-- AI 智能識別社會區分類別代碼（已啟用用戶 + Gemini API 已配置） --}}
+    @if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
+        <div class="card card-info mb-3" id="ai-code-lookup-section">
+            <div class="card-header d-flex align-items-center">
+                <h3 class="card-title mb-0">
+                    <i class="fas fa-magic"></i> AI 智能識別社會區分類別代碼
+                </h3>
+                <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
+                   data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
+                    <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
+                </a>
+            </div>
+            <div class="collapse" id="ai-code-privacy-notice">
+                <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
+                    <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
+                    <ul class="mb-0">
+                        <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
+                        <li>您的文本將發送至第三方 AI 服務進行處理</li>
+                        <li>AI 識別結果僅供參考，請務必核實後再提交</li>
+                    </ul>
+                    <p class="mb-0 mt-2">當前使用模型：<code>{{ config('services.gemini.model') }}</code></p>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="form-group">
+                    <label for="ai-code-query">輸入描述（AI 將從 STATUS_CODES 中識別相關代碼）</label>
+                    <textarea class="form-control" id="ai-code-query" rows="3"
+                              placeholder="例如：通醫學"></textarea>
+                    <small class="form-text text-muted">AI 會語義理解您的描述，從社會區分類別代碼表中找出最相關的代碼</small>
+                </div>
+                <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
+                    <i class="fas fa-bolt"></i> AI 智能識別
+                </button>
+                <span class="ml-3" id="ai-code-status"></span>
+
+                {{-- 候選結果區 --}}
+                <div id="ai-code-results" style="display:none;" class="mt-3">
+                    <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
+                    <div id="ai-code-candidates" class="mb-3"></div>
+
+                    <div id="ai-code-not-found" style="display:none;">
+                        <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
+                        <div id="ai-code-not-found-list"></div>
+                    </div>
+
+                    <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
+                </div>
+            </div>
+        </div>
+    @endif
+
     <div class="form-group row">
         <label for="c_sequence" class="col-sm-2 col-form-label">次序(c_sequence)</label>
         <div class="col-sm-10">
@@ -156,56 +207,6 @@
         </div>
     </div>
 </form>
-
-{{-- AI 智能識別社會區分類別代碼（已啟用用戶 + Gemini API 已配置） --}}
-@if(config('services.gemini.api_key') && auth()->check() && auth()->user()->isActive())
-    <div class="card card-info mt-3" id="ai-code-lookup-section">
-        <div class="card-header d-flex align-items-center">
-            <h3 class="card-title mb-0">
-                <i class="fas fa-magic"></i> AI 智能識別社會區分類別代碼
-            </h3>
-            <a class="ml-3 text-white" style="font-size: 0.85em; opacity: 0.85; cursor: pointer;"
-               data-toggle="collapse" href="#ai-code-privacy-notice" role="button" aria-expanded="false">
-                <i class="fas fa-exclamation-triangle"></i> 重要提示：數據收集與第三方服務
-            </a>
-        </div>
-        <div class="collapse" id="ai-code-privacy-notice">
-            <div class="alert alert-warning mb-0 rounded-0 border-left-0 border-right-0" style="font-size: 0.9em;">
-                <p class="mb-2">使用智能識別功能即表示您理解並同意：</p>
-                <ul class="mb-0">
-                    <li>您輸入的文本及 AI 識別結果將被記錄用於研究與改進</li>
-                    <li>您的文本將發送至第三方 AI 服務進行處理</li>
-                    <li>AI 識別結果僅供參考，請務必核實後再提交</li>
-                </ul>
-            </div>
-        </div>
-        <div class="card-body">
-            <div class="form-group">
-                <label for="ai-code-query">輸入描述（AI 將從 STATUS_CODES 中識別相關代碼）</label>
-                <textarea class="form-control" id="ai-code-query" rows="3"
-                          placeholder="例如：通醫學"></textarea>
-                <small class="form-text text-muted">AI 會語義理解您的描述，從社會區分類別代碼表中找出最相關的代碼</small>
-            </div>
-            <button type="button" class="btn btn-info" id="btn-ai-code-lookup">
-                <i class="fas fa-bolt"></i> AI 智能識別
-            </button>
-            <span class="ml-3" id="ai-code-status"></span>
-
-            {{-- 候選結果區 --}}
-            <div id="ai-code-results" style="display:none;" class="mt-3">
-                <h6><i class="fas fa-check-circle text-success"></i> 候選代碼（點擊填入表單）</h6>
-                <div id="ai-code-candidates" class="mb-3"></div>
-
-                <div id="ai-code-not-found" style="display:none;">
-                    <h6 class="text-warning"><i class="fas fa-exclamation-triangle"></i> 表中未找到對應的概念</h6>
-                    <div id="ai-code-not-found-list"></div>
-                </div>
-
-                <div id="ai-code-summary" class="alert alert-light mt-2" style="display:none;"></div>
-            </div>
-        </div>
-    </div>
-@endif
 
 @section('js')
     <script>


### PR DESCRIPTION
## Summary

- 將 `statuses`、`assoc` 表單的 AI 智能識別區塊從 `</form>` 之後搬到表頂（對齊 `offices` 的 AI 智能填充版型），`mt-3` → `mb-3`。
- 在 `offices`、`statuses`、`assoc` 三份表單的隱私提示 alert 內補上一行「當前使用模型：<code>{{ config('services.gemini.model') }}</code>」，與 `PostingAutofillService::__construct` 實際讀取的主模型一致，提升用戶透明度。
- 沒顯示 fallback 模型——fallback 僅在主模型觸發失敗才切換，不適合當作常態顯示。

## Test plan

- [x] `php artisan view:cache` — 全 Blade 模板編譯通過
- [x] `@if` / `@endif` 配對完整（statuses 7/7、assoc 21/21）
- [x] AI 區塊內所有按鈕維持 `type="button"`，搬進 `<form>` 內不會誤觸 submit
- [x] 於 `/basicinformation/:id/statuses/create`、`/basicinformation/:id/assoc/create` 實際載入，確認 AI 區塊位於 person-id-display 之後、表單欄位之前，且 collapse 展開可見模型名

🤖 Generated with [Claude Code](https://claude.com/claude-code)