### PR TITLE
移除 OFFICE_CODES 未使用的 c_category_1~4 欄位

### DIFF
--- a/database/migrations/2026_04_24_000000_drop_category_columns_from_office_codes.php
+++ b/database/migrations/2026_04_24_000000_drop_category_columns_from_office_codes.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * 要移除的類別欄位。
+     */
+    private const COLUMNS = [
+        'c_category_1',
+        'c_category_2',
+        'c_category_3',
+        'c_category_4',
+    ];
+
+    public function up(): void {
+        Schema::table('OFFICE_CODES', function (Blueprint $table) {
+            foreach (self::COLUMNS as $column) {
+                if (Schema::hasColumn('OFFICE_CODES', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+
+    public function down(): void {
+        Schema::table('OFFICE_CODES', function (Blueprint $table) {
+            foreach (self::COLUMNS as $column) {
+                $table->string($column, 255)->nullable()->default(null);
+            }
+        });
+    }
+};

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,7 +1,7 @@
 # 數據庫 Schema 文檔
 
 > 本文檔由 `php artisan cbdb:generate-schema-docs` 自動生成
-> 生成時間：2026-04-22 13:56:39
+> 生成時間：2026-04-24 16:52:43
 
 ## 目錄
 
@@ -1492,10 +1492,6 @@
 | `c_source` | int(11) | YES | NULL |  |
 | `c_pages` | varchar(255) | YES | NULL |  |
 | `c_notes` | longtext | YES | NULL |  |
-| `c_category_1` | varchar(255) | YES | NULL |  |
-| `c_category_2` | varchar(255) | YES | NULL |  |
-| `c_category_3` | varchar(255) | YES | NULL |  |
-| `c_category_4` | varchar(255) | YES | NULL |  |
 
 **索引**:
 
@@ -3588,10 +3584,6 @@
 | `c_source` | INTEGER | YES | NULL |  |
 | `c_pages` | varchar(255) | YES | NULL |  |
 | `c_notes` | longtext | YES | (NULL) |  |
-| `c_category_1` | varchar(255) | YES | NULL |  |
-| `c_category_2` | varchar(255) | YES | NULL |  |
-| `c_category_3` | varchar(255) | YES | NULL |  |
-| `c_category_4` | varchar(255) | YES | NULL |  |
 
 ---
 


### PR DESCRIPTION
## Summary
- 新增 migration `2026_04_24_000000_drop_category_columns_from_office_codes.php`，移除 `OFFICE_CODES` 表的 `c_category_1`、`c_category_2`、`c_category_3`、`c_category_4` 四個欄位。
- 四欄位皆為 nullable `varchar(255)`，無索引、無外鍵，且 `app/`、`resources/` 無任何引用，屬可安全清除的遺留欄位。
- 重新執行 `php artisan cbdb:generate-schema-docs` 同步更新 `docs/DATABASE_SCHEMA.md`。

## Test plan
- [x] `php artisan migrate` 成功
- [x] `Schema::getColumnListing('OFFICE_CODES')` 已確認四欄位消失
- [x] `php artisan cbdb:generate-schema-docs` 重新生成並 diff 符合預期
- [x] CI / phpunit

🤖 Generated with [Claude Code](https://claude.com/claude-code)