### PR TITLE
避免 number 欄位被滑鼠滾輪意外改值

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -29,6 +29,9 @@ import '../css/mobile-responsive.css';
 import '../css/ai-autofill.css';
 
 import { formatTimestamp, getUserOffsetMinutes, getUserTimeZone } from './utils/datetime';
+import { installNumberInputWheelGuard } from './utils/disableNumberInputWheel';
+
+installNumberInputWheelGuard();
 
 // Set global defaults for all Select2 instances to use Bootstrap 4 theme
 $.fn.select2.defaults.set('theme', 'bootstrap4');

--- a/resources/js/inertia/app.tsx
+++ b/resources/js/inertia/app.tsx
@@ -1,5 +1,8 @@
 import { createInertiaApp } from '@inertiajs/react';
 import { createRoot } from 'react-dom/client';
+import { installNumberInputWheelGuard } from '../utils/disableNumberInputWheel';
+
+installNumberInputWheelGuard();
 
 createInertiaApp({
     resolve: (name) => {

--- a/resources/js/utils/disableNumberInputWheel.js
+++ b/resources/js/utils/disableNumberInputWheel.js
@@ -1,0 +1,34 @@
+/**
+ * 全域守衛：避免 <input type="number"> 在獲得焦點時被滑鼠滾輪改值。
+ *
+ * 瀏覽器原生行為下，當 number input 處於 focus，捲動滾輪每一格會 ±1 改變數值，
+ * 容易讓使用者在編輯後捲頁面時意外把值改掉（例如「享年」常見的 -1～-3 偏差）。
+ *
+ * 解法：在 document 層攔截 wheel 事件，若當前 active element 是
+ * type="number" 的 input，就 blur 它，讓默認行為改回頁面捲動。
+ *
+ * 一次安裝即可生效於整個頁面（Blade + React/Inertia 共用）。
+ */
+export function installNumberInputWheelGuard() {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+    }
+    if (window.__numberInputWheelGuardInstalled) {
+        return;
+    }
+    window.__numberInputWheelGuardInstalled = true;
+
+    document.addEventListener(
+        'wheel',
+        () => {
+            const active = document.activeElement;
+            if (
+                active instanceof HTMLInputElement &&
+                active.type === 'number'
+            ) {
+                active.blur();
+            }
+        },
+        { passive: true, capture: true },
+    );
+}


### PR DESCRIPTION
## Summary
- 新增全域 `wheel` 守衛 `resources/js/utils/disableNumberInputWheel.js`：當焦點在 `<input type="number">` 時自動 blur，讓滾輪改回頁面捲動，避免值被意外 ±1。
- 於 `resources/js/app.js`（Blade / dashboard-v3）與 `resources/js/inertia/app.tsx`（Inertia / Person Browser）兩支 entrypoint 同時接線，全站涵蓋。

## 背景
有使用者反映「人物基本信息錄入時，享年欄位提交後被隨機減 1～3 年」。追查後排除前後端任何對 `c_death_age` 的計算邏輯，根因為瀏覽器原生 `<input type="number">` 在 focus 時，每滾動一格滾輪會 ±1 改值，而使用者編輯完欄位後常會直接捲頁面到「儲存」按鈕，意外改到值。

本次修補一併涵蓋同類欄位：`c_birthyear`、`c_deathyear`、`c_*_nh_year`、`c_index_year`、`c_fl_*_year`，以及 QbeBuilder 的 LIMIT、SearchByEntry 的年份範圍等所有 `type="number"` 輸入。

## Test plan
- [x] 進入人物編輯，於享年輸入「75」後不點他處，直接用滾輪向下捲頁面，享年應保持 75
- [x] 同樣方式驗證生年、卒年、月、日、Index Year、活動年份等 number 欄位
- [x] 驗證在 React/Inertia 頁面與舊版 Blade 編輯頁皆生效
- [x] 鍵盤 ↑↓ 與輸入仍可正常使用
- [x] `npm run build` 無錯（已驗證）

🤖 Generated with [Claude Code](https://claude.com/claude-code)