### PR TITLE
強化任官 AI 填充：地址容錯、邊界滑窗與 UI 調整

### DIFF
--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -94,7 +94,8 @@ class AiFillLogController extends Controller {
         $fieldLabels = [
             'c_office_id' => '官名',
             'c_addr' => '地名',
-            'c_dy' => '朝代',
+            // 朝代（c_dy）刻意排除：實務上不是 AI 從原文提取，而是依人物或年份自動推得，
+            // 與用戶提交值比較容易讓比對結果失真。
             'c_firstyear' => '始年',
             'c_fy_nh_code' => '始年年號',
             'c_fy_nh_year' => '年號年數',
@@ -184,7 +185,6 @@ class AiFillLogController extends Controller {
         // 代碼欄位 → [table, pk_column, text_column]
         $codeLookups = [
             'c_office_id' => ['OFFICE_CODES', 'c_office_id', 'c_office_chn'],
-            'c_dy' => ['DYNASTIES', 'c_dy', 'c_dynasty_chn'],
             'c_fy_nh_code' => ['NIAN_HAO', 'c_nianhao_id', 'c_nianhao_chn'],
             'c_ly_nh_code' => ['NIAN_HAO', 'c_nianhao_id', 'c_nianhao_chn'],
             'c_appt_code' => ['APPOINTMENT_CODES', 'c_appt_code', 'c_appt_desc_chn'],

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -54,7 +54,7 @@ class PostingAutofillService {
             $aiData = $extractResult['data'];
 
             // 2. 對每個欄位進行模糊匹配
-            $matchResult = $this->matchFields($aiData, $personId);
+            $matchResult = $this->matchFields($aiData, $personId, $sourceText);
 
             return [
                 'success' => true,
@@ -264,7 +264,7 @@ class PostingAutofillService {
     /**
      * 對 AI 提取的數據進行模糊匹配
      */
-    protected function matchFields(array $aiData, int $personId): array {
+    protected function matchFields(array $aiData, int $personId, ?string $sourceText = null): array {
         $matched = [];
         $suggested = [];
         $empty = [];
@@ -393,49 +393,90 @@ class PostingAutofillService {
         if (!empty($aiData['addr_str']) && is_array($aiData['addr_str'])) {
             $addrData = $aiData['addr_str'];
             $addrData = $this->normalizeAddrName($addrData);
+            $fullText = $addrData['full_text'] ?? null;
             $searchName = $addrData['name'] ?? null;
             $parentName = $addrData['parent'] ?? null;
 
-            if (!empty($searchName)) {
-                $addrMatch = $this->fuzzyMatchAddress($searchName, $postingYear, $effectiveDynasty, $parentName);
+            // 候選查詢：優先用 full_text（避免 AI 對 parent/name 的錯誤再切分，例如將「江南東路」切成
+            // parent=「江南」、name=「東路」），失敗才退到 name + parent 的舊路徑。
+            //
+            // parent 的傳遞策略：
+            // - full_text == name：AI 沒有把字串再切到 name 之中，parent 是同層級補充的可信資訊，
+            //   保留它讓 fuzzyMatchAddress 在同名地名（如多個「永康」）時做歧義消解。
+            // - full_text != name：AI 把 full_text 拆成 parent + name，parent 可能本身就是 full_text
+            //   的前段（例如「江南東路」→ parent=「江南」），此時若用 full_text 還傳這個 parent，
+            //   可能反而讓 fuzzyMatchAddress 套錯歧義消解規則，故傳 null。
+            $candidates = [];
+            if (!empty($fullText)) {
+                $fullTextParent = ($fullText === $searchName) ? $parentName : null;
+                $candidates[] = ['query' => $fullText, 'parent' => $fullTextParent];
+            }
+            if (!empty($searchName) && $searchName !== $fullText) {
+                $candidates[] = ['query' => $searchName, 'parent' => $parentName];
+            }
 
+            $addrMatch = null;
+            $searchQuery = null;
+            foreach ($candidates as $candidate) {
+                $result = $this->fuzzyMatchAddress(
+                    $candidate['query'],
+                    $postingYear,
+                    $effectiveDynasty,
+                    $candidate['parent']
+                );
+
+                if ($result === null) {
+                    continue;
+                }
+                if ($addrMatch === null) {
+                    $addrMatch = $result;
+                    $searchQuery = $candidate['query'];
+                }
+                if ($result['match_type'] === 'exact') {
+                    $addrMatch = $result;
+                    $searchQuery = $candidate['query'];
+
+                    break;
+                }
+            }
+
+            // 顯示給前端的「建議搜尋字串」優先用 full_text（最完整，沒被 AI 二次切壞）
+            $displayQuery = $fullText ?: $searchName;
+
+            if (!empty($candidates)) {
                 if ($addrMatch) {
-                    $inputLength = mb_strlen($searchName);
+                    $inputLength = mb_strlen($searchQuery);
                     $matchedLength = $addrMatch['matched_length'];
 
                     // 判斷是否需要建議（黃色）：
                     // 1. 模糊匹配（前綴匹配，或有歧義但上層匹配失敗）
                     // 2. 輸入包含上層信息但只匹配到下層（輸入長度 > 匹配長度）
-                    // 注意：match_type 已經考慮了上層匹配的情況，不需要再檢查 parent 欄位
                     $needsConfirmation = (
                         $addrMatch['match_type'] === 'fuzzy' ||
                         $inputLength > $matchedLength
                     );
 
                     if ($needsConfirmation) {
-                        // 需要確認 → 黃色（建議）
                         $suggested['c_addr'] = [
                             'value' => [$addrMatch['id']],
                             'text' => [$addrMatch['text']],
-                            'ai_extracted' => $addrData['full_text'] ?? $searchName,
-                            'ai_structured' => $addrData, // 保留完整的結構化信息
-                            'search_query' => $searchName,
+                            'ai_extracted' => $displayQuery,
+                            'ai_structured' => $addrData,
+                            'search_query' => $displayQuery,
                         ];
                     } else {
-                        // 精確匹配且長度一致 → 綠色（確認）
                         $matched['c_addr'] = [
                             'value' => [$addrMatch['id']],
                             'text' => [$addrMatch['text']],
-                            'ai_extracted' => $addrData['full_text'] ?? $searchName,
-                            'ai_structured' => $addrData, // 保留完整的結構化信息
+                            'ai_extracted' => $displayQuery,
+                            'ai_structured' => $addrData,
                         ];
                     }
                 } else {
-                    // 完全找不到 → 黃色（建議）
                     $suggested['c_addr'] = [
-                        'ai_extracted' => $addrData['full_text'] ?? $searchName,
-                        'ai_structured' => $addrData, // 保留完整的結構化信息
-                        'search_query' => $searchName,
+                        'ai_extracted' => $displayQuery,
+                        'ai_structured' => $addrData,
+                        'search_query' => $displayQuery,
                     ];
                 }
             } else {
@@ -549,11 +590,253 @@ class PostingAutofillService {
             }
         }
 
+        // 單邊命中時嘗試邊界滑窗：例如「荊湖北路轉運司判官」AI 將其切成
+        // title=「判官」、addr=「荊湖北路轉運司」，導致 c_office_id 命中但 c_addr 找不到。
+        // 在保留兩邊「都精確命中」的前提下，沿原文切點滑窗找到更佳切法。
+        $this->refineTitleAddrBoundary(
+            $sourceText,
+            $aiData,
+            $matched,
+            $suggested,
+            $postingYear,
+            $effectiveDynasty,
+            $addrAdminType
+        );
+
         return [
             'matched' => $matched,
             'suggested' => $suggested,
             'empty' => $empty,
         ];
+    }
+
+    /**
+     * 邊界滑窗：在 title_str 與 addr_str.full_text 連起來的字串上滑切點，
+     * 嘗試找到「title 與 addr 同時 exact 命中字典」的更佳切法。
+     *
+     * 僅在單邊命中（office matched + addr 未匹配，或反之）時觸發，避免無謂計算。
+     * 命中時就地修改 $matched 與 $suggested。
+     */
+    protected function refineTitleAddrBoundary(
+        ?string $sourceText,
+        array $aiData,
+        array &$matched,
+        array &$suggested,
+        ?int $postingYear,
+        ?int $effectiveDynasty,
+        ?string $adminType
+    ): void {
+        $titleStr = $aiData['title_str'] ?? null;
+        $addrFull = $aiData['addr_str']['full_text'] ?? null;
+        if (empty($titleStr) || empty($addrFull)) {
+            return;
+        }
+
+        $officeMatched = isset($matched['c_office_id']);
+        $addrMatched = isset($matched['c_addr']);
+        $addrLost = isset($suggested['c_addr']) && empty($suggested['c_addr']['value']);
+        $officeLost = isset($suggested['c_office_id']) && empty($suggested['c_office_id']['value']);
+
+        $caseA = $officeMatched && !$addrMatched && $addrLost;
+        $caseB = $addrMatched && !$officeMatched && $officeLost;
+        if (!$caseA && !$caseB) {
+            return;
+        }
+
+        // 優先以 sourceText 為基準找 addr / title 的最近配對（取所有 occurrence 中
+        // union span 最短的那一對），這樣可：
+        //   - 正確處理 AI 把 title 吃進 addr.full_text 的情境（簡單拼接會產生重複）
+        //   - 即使 sourceText 中 addr/title 各出現多次也能收斂到實際相鄰那一組
+        //   - 順帶從 sourceText 推斷兩者順序
+        // 為避免在長 sourceText 中跨段落取一大塊（會讓 loop 內的 DB 查詢爆量），
+        // 後續以 MAX_COMBINED_LEN 硬性截斷，超過直接放棄滑窗。
+        $combined = null;
+        $addrFirst = true;
+        if (!empty($sourceText)) {
+            $best = $this->findClosestSpan($sourceText, $addrFull, $titleStr);
+            if ($best !== null) {
+                $combined = mb_substr($sourceText, $best['start'], $best['len']);
+                $addrFirst = $best['addr_first'];
+            }
+        }
+        if ($combined === null) {
+            // sourceText 缺失或 AI 與 sourceText 不一致時，退回直接拼接（addr-first 預設）。
+            $combined = $addrFull . $titleStr;
+        }
+
+        $totalLen = mb_strlen($combined);
+        if ($totalLen < 2) {
+            return;
+        }
+
+        // 硬性 cap：合併字串過長表示 AI 抽取的 addr/title 在 sourceText 中相距很遠，
+        // 多半不是同一個任官敘述，且字符數過大會讓滑窗 × DB 查詢量變得過重。
+        // 25 字對應最壞情況 24 個切點 × 2 次 DB 查詢 = 48 次，仍是可接受區間。
+        $MAX_COMBINED_LEN = 25;
+        if ($totalLen > $MAX_COMBINED_LEN) {
+            Log::info('[AI Autofill] 邊界滑窗略過：合併字串過長', [
+                'combined_len' => $totalLen,
+                'cap' => $MAX_COMBINED_LEN,
+                'ai_addr' => $addrFull,
+                'ai_title' => $titleStr,
+            ]);
+
+            return;
+        }
+
+        $aiSplit = [
+            'addr' => $addrFull,
+            'title' => $titleStr,
+        ];
+
+        // AI 原始邊界，作為「離 AI 切點越近越可信」的次要排序基準
+        $aiBoundary = $addrFirst ? mb_strlen($aiSplit['addr']) : mb_strlen($aiSplit['title']);
+
+        $bestSplit = null;
+        $validCount = 0;
+        // 排名以 tuple 比較：[地址命中字串長度, -|邊界距離|]
+        // 主排序：偏好較具體（較長）的地址，例如「荊湖北路」優於「荊湖」、「邶州」優於「邶」。
+        //         CBDB 領域中地址通常是穩定的行政單位名（路/府/州/縣），長越具體；
+        //         也對應「AI 把官名詞吃進地址」這個最常見的失誤方向 —— 只要存在
+        //         「更長地址 + 仍 exact 命中官名」的切法，就比「短地址 + 長複合官名」可靠。
+        // 次排序：與 AI 原邊界距離越小越可信（AI 通常接近正解，只是被個別字差打偏），
+        //         做為相同地址長度時的保守 tie-breaker。
+        $bestRank = [-1, PHP_INT_MIN];
+        for ($i = 1; $i < $totalLen; $i++) {
+            $part1 = mb_substr($combined, 0, $i);
+            $part2 = mb_substr($combined, $i);
+            $candidate = $addrFirst
+                ? ['addr' => $part1, 'title' => $part2]
+                : ['addr' => $part2, 'title' => $part1];
+
+            // 跳過 AI 原始切法（與目前狀態一致，沒必要再算）
+            if ($candidate['addr'] === $aiSplit['addr'] && $candidate['title'] === $aiSplit['title']) {
+                continue;
+            }
+
+            $addrM = $this->fuzzyMatchAddress($candidate['addr'], $postingYear, $effectiveDynasty, null);
+            if ($addrM === null || $addrM['match_type'] !== 'exact') {
+                continue;
+            }
+
+            $officeM = $this->fuzzyMatchOffice($candidate['title'], $effectiveDynasty, $adminType);
+            if ($officeM === null || $officeM['match_type'] !== 'exact') {
+                continue;
+            }
+
+            $validCount++;
+            $addrLen = mb_strlen($addrM['text']);
+            $boundaryDistance = abs($i - $aiBoundary);
+            $rank = [$addrLen, -$boundaryDistance];
+
+            if ($rank > $bestRank) {
+                $bestRank = $rank;
+                $bestSplit = [
+                    'addr' => $candidate['addr'],
+                    'title' => $candidate['title'],
+                    'addr_match' => $addrM,
+                    'office_match' => $officeM,
+                ];
+            }
+        }
+
+        if ($validCount > 1) {
+            Log::info('[AI Autofill] 邊界滑窗發現多個合法切法，依 (地址長, 距 AI 切點) 取最優', [
+                'combined' => $combined,
+                'valid_count' => $validCount,
+                'picked_addr' => $bestSplit['addr'] ?? null,
+                'picked_title' => $bestSplit['title'] ?? null,
+            ]);
+        }
+
+        if ($bestSplit === null) {
+            return;
+        }
+
+        Log::info('[AI Autofill] 邊界滑窗修正', [
+            'ai_addr' => $aiSplit['addr'],
+            'ai_title' => $aiSplit['title'],
+            'refined_addr' => $bestSplit['addr'],
+            'refined_title' => $bestSplit['title'],
+        ]);
+
+        $matched['c_office_id'] = [
+            'value' => $bestSplit['office_match']['id'],
+            'text' => $bestSplit['office_match']['text'],
+            'ai_extracted' => $titleStr,
+            'refined_from_boundary' => true,
+        ];
+        unset($suggested['c_office_id']);
+
+        $matched['c_addr'] = [
+            'value' => [$bestSplit['addr_match']['id']],
+            'text' => [$bestSplit['addr_match']['text']],
+            'ai_extracted' => $addrFull,
+            'ai_structured' => $aiData['addr_str'] ?? null,
+            'refined_from_boundary' => true,
+        ];
+        unset($suggested['c_addr']);
+    }
+
+    /**
+     * 在 $haystack 中找出 $needle1 與 $needle2 兩個子字串的所有出現位置，
+     * 回傳「union span 最短」的那一對。用於從可能很長的 sourceText 中
+     * 收斂出 addr / title 實際相鄰的那段。
+     *
+     * @return array|null ['start' => int, 'len' => int, 'addr_first' => bool] 或 null（任一找不到）
+     */
+    protected function findClosestSpan(string $haystack, string $needle1, string $needle2): ?array {
+        $positions1 = $this->findAllPositions($haystack, $needle1);
+        $positions2 = $this->findAllPositions($haystack, $needle2);
+        if (empty($positions1) || empty($positions2)) {
+            return null;
+        }
+
+        $len1 = mb_strlen($needle1);
+        $len2 = mb_strlen($needle2);
+
+        $best = null;
+        // 最壞情況下兩邊各 N 個 occurrence 會跑 N×N 次比較，但因為下游已經對總長度 cap，
+        // 且 needle 本身相對較長，N 通常極小（多半為 1），不會構成效能問題。
+        foreach ($positions1 as $p1) {
+            foreach ($positions2 as $p2) {
+                $start = min($p1, $p2);
+                $end = max($p1 + $len1, $p2 + $len2);
+                $spanLen = $end - $start;
+                if ($best === null || $spanLen < $best['len']) {
+                    $best = [
+                        'start' => $start,
+                        'len' => $spanLen,
+                        'addr_first' => ($p1 <= $p2),
+                    ];
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * 找出 $needle 在 $haystack 中所有起始位置（mb 安全）。
+     * 為避免極端輸入導致無限迴圈，限制最多回傳 16 個 occurrence。
+     */
+    protected function findAllPositions(string $haystack, string $needle): array {
+        if ($needle === '') {
+            return [];
+        }
+        $positions = [];
+        $offset = 0;
+        $maxOccurrences = 16;
+        while (count($positions) < $maxOccurrences) {
+            $pos = mb_strpos($haystack, $needle, $offset);
+            if ($pos === false) {
+                break;
+            }
+            $positions[] = $pos;
+            $offset = $pos + 1;
+        }
+
+        return $positions;
     }
 
     /**

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -69,13 +69,13 @@
         </div>
 
         {{-- 填充結果摘要（成功後顯示） --}}
-        <div class="alert alert-success" id="ai-result-summary" style="display:none;">
+        <div class="alert alert-light border" id="ai-result-summary" style="display:none;">
             <h5><i class="fas fa-check-circle"></i> AI 填充完成</h5>
             <ul class="mb-2">
                 <li>✅ <strong id="matched-count">0</strong> 個欄位成功匹配</li>
                 <li id="suggested-line" style="display:none;">⚠️ <strong id="suggested-count">0</strong> 個欄位需要確認（黃色標記，請檢查後直接提交）</li>
                 <li id="not-found-line" style="display:none;">🔍 <strong id="not-found-count">0</strong> 個欄位需要手動搜尋（AI 已提取關鍵字但未找到匹配）</li>
-                <li>❌ <strong id="empty-count">0</strong> 個欄位無法提取</li>
+                <li id="empty-line" style="display:none;">❌ <strong id="empty-count">0</strong> 個欄位無法提取</li>
             </ul>
         </div>
     @endif
@@ -417,6 +417,69 @@
                 }
             }
 
+            /**
+             * AI 提取了關鍵字但找不到匹配時，在欄位下方顯示提示
+             * 點擊「填入搜尋」會打開 Select2 並把 AI 關鍵字填到搜尋框
+             */
+            function showAiNotFoundHint($field, hintText) {
+                const $container = $field.closest('.col-sm-10, .col-sm-4, .col-sm-12').first();
+                if ($container.length === 0) return;
+                $container.find('.ai-not-found-hint').remove();
+
+                const safe = $('<div>').text(hintText).html();
+                const $hint = $(
+                    '<p class="ai-not-found-hint small mb-0 mt-1" ' +
+                        'style="color:#6c757d; background:#f6f8fa; padding:4px 10px; ' +
+                        'border-left:3px solid #adb5bd; border-radius:2px;">' +
+                        '<i class="fas fa-search" style="opacity:.6; margin-right:4px;"></i>' +
+                        'AI 提取「<strong style="color:#495057;">' + safe + '</strong>」未找到匹配 ' +
+                        '<button type="button" class="btn btn-link btn-sm p-0 ai-not-found-search" ' +
+                            'style="vertical-align:baseline;">填入搜尋</button>' +
+                    '</p>'
+                );
+                $container.append($hint);
+
+                $hint.find('.ai-not-found-search').on('click', function() {
+                    fillSelect2Search($field, hintText);
+                });
+            }
+
+            /**
+             * 把文字塞進 Select2 的搜尋輸入框並觸發搜尋。
+             * 處理 single / multi-select 的搜尋框位置差異，並在 multi-select 時
+             * 先清掉值為 0 的「未詳」placeholder，避免它與 search 並排擠壓視覺。
+             */
+            function fillSelect2Search($field, text) {
+                if (!$field.is('select') || !$field.hasClass('select2-hidden-accessible')) {
+                    $field.val(text).trigger('change').focus();
+                    return;
+                }
+
+                const isMulti = $field.prop('multiple');
+                if (isMulti) {
+                    const cleaned = ($field.val() || []).filter(function (v) {
+                        return String(v) !== '0';
+                    });
+                    $field.val(cleaned).trigger('change');
+                }
+
+                // 在 select2:open 之後再操作搜尋框，確保 DOM 已經就位
+                $field.one('select2:open', function () {
+                    // single-select：搜尋框在彈出 dropdown 內
+                    // multi-select：搜尋框在原本選擇容器內
+                    const $search = $('.select2-search__field:visible').last();
+                    if ($search.length > 0) {
+                        $search.val(text).trigger('input').trigger('keyup');
+                        $search.focus();
+                    }
+                });
+                $field.select2('open');
+            }
+
+            function clearAiNotFoundHints() {
+                $('.ai-not-found-hint').remove();
+            }
+
             // 點擊「AI 智能填充」按鈕
             $btnAiAutofill.on('click', function() {
                 const sourceText = $aiSourceText.val().trim();
@@ -482,6 +545,14 @@
                             } else {
                                 $('#not-found-line').hide();
                             }
+                            // 「無法提取」只在「完全沒匹配到任何欄位」時才提示，
+                            // 避免常規情況下出現「18 個欄位無法提取」這種誤導性訊息。
+                            var anyHit = stats.matched_count + stats.suggested_count + stats.not_found_count;
+                            if (anyHit === 0 && stats.empty_count > 0) {
+                                $('#empty-line').show();
+                            } else {
+                                $('#empty-line').hide();
+                            }
                             $aiResultSummary.show();
 
                             $btnClearAi.show();
@@ -519,6 +590,7 @@
                     removeAiClasses($(this));
                 });
                 $('.ai-field-label').removeClass('ai-field-label');
+                clearAiNotFoundHints();
 
                 // 1. 填充成功匹配的欄位（綠色）
                 for (const [fieldName, fieldData] of Object.entries(matched)) {
@@ -834,8 +906,12 @@
                                 }
                             }
                         } else {
-                            // 情況 2: 完全找不到匹配（只有 ai_extracted）→ 不修改欄位，跳過
-                            debugLog(`[AI Autofill] 欄位 ${fieldName} 未找到匹配，跳過填充`);
+                            // 情況 2: 完全找不到匹配（只有 ai_extracted）→ 顯示 AI 提取的關鍵字作為手動搜尋線索
+                            const hintText = fieldData.ai_extracted || fieldData.search_query || '';
+                            if (hintText) {
+                                showAiNotFoundHint($field, hintText);
+                            }
+                            debugLog(`[AI Autofill] 欄位 ${fieldName} 未找到匹配，顯示提示：${hintText}`);
                             continue;
                         }
                     } else {
@@ -869,6 +945,7 @@
                 });
 
                 $('.ai-field-label').removeClass('ai-field-label');
+                clearAiNotFoundHints();
                 $aiResultSummary.hide();
                 $btnClearAi.hide();
                 $aiStatus.empty();

--- a/tests/Feature/PostingAutofillBoundaryTest.php
+++ b/tests/Feature/PostingAutofillBoundaryTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * 回歸測試：保護兩個對 AI 切分錯誤的容錯機制。
+ *
+ * 1. 地址匹配優先用 addr_str.full_text，再退到 name + parent。
+ *    處理 AI 把「江南東路」誤切成 parent=「江南」、name=「東路」的情況。
+ * 2. title_str / addr_str 邊界滑窗：當其中一邊命中字典、另一邊找不到時，
+ *    沿原始字串切點滑窗找一個「兩邊都精確命中」的更佳切法。
+ *    處理「荊湖北路轉運司判官」AI 切成 title=「判官」、addr=「荊湖北路轉運司」的情況。
+ */
+class PostingAutofillBoundaryTest extends TestCase {
+    use RefreshDatabase;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config(['services.gemini.api_key' => 'test-api-key']);
+        config(['services.gemini.api_endpoint' => 'https://example.com/api']);
+        config(['services.gemini.model' => 'test-model']);
+
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 15, 'c_dynasty_chn' => '宋', 'c_dynasty' => 'Song', 'c_start' => 960, 'c_end' => 1279, 'c_sort' => 15],
+        ]);
+
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 2683, 'c_dy' => 15, 'c_office_chn' => '判官', 'c_office_chn_alt' => null],
+            ['c_office_id' => 1003, 'c_dy' => 15, 'c_office_chn' => '轉運司判官', 'c_office_chn_alt' => '轉運判官'],
+        ]);
+
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 12824, 'c_name' => 'Jiangnan Donglu', 'c_name_chn' => '江南東路', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 20001, 'c_name' => 'Jinghu Beilu', 'c_name_chn' => '荊湖北路', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            // 同名「永康」雙記錄，用於 parent 歧義消解測試
+            ['c_addr_id' => 30001, 'c_name' => 'Yongkang (Wuzhou)', 'c_name_chn' => '永康', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 30002, 'c_name' => 'Yongkang (Yongjiajun)', 'c_name_chn' => '永康', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 30100, 'c_name' => 'Wuzhou', 'c_name_chn' => '婺州', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 30200, 'c_name' => 'Yongjiajun', 'c_name_chn' => '永嘉軍', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+        ]);
+
+        DB::table('ADDR_BELONGS_DATA')->insert([
+            ['c_addr_id' => 30001, 'c_belongs_to' => 30100, 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 30002, 'c_belongs_to' => 30200, 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+        ]);
+    }
+
+    /**
+     * 建立宋代測試人物以驅動朝代過濾。
+     */
+    protected function makeSongPerson(int $personId = 88888): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => $personId, 'c_dy' => 15],
+        ]);
+    }
+
+    protected function makeUser(): User {
+        return User::factory()->create([
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+    }
+
+    protected function fakeAiResponse(array $posting): void {
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [[
+                    'message' => [
+                        'content' => json_encode(['postings' => [array_merge([
+                            'title_str' => null,
+                            'addr_str' => null,
+                            'c_firstyear' => null,
+                            'c_fy_nh_code' => null,
+                            'c_fy_nh_year' => null,
+                            'c_fy_range' => null,
+                            'c_fy_intercalary' => null,
+                            'c_fy_month' => null,
+                            'c_fy_day' => null,
+                            'c_fy_day_gz' => null,
+                            'c_lastyear' => null,
+                            'c_ly_nh_code' => null,
+                            'c_ly_nh_year' => null,
+                            'c_ly_range' => null,
+                            'c_ly_intercalary' => null,
+                            'c_ly_month' => null,
+                            'c_ly_day' => null,
+                            'c_ly_day_gz' => null,
+                            'c_appt_code' => null,
+                            'c_assume_office_code' => null,
+                        ], $posting)]]),
+                    ],
+                ]],
+            ], 200),
+        ]);
+    }
+
+    /**
+     * 案例 A：AI 把「江南東路」結構錯誤地切成 parent=「江南」、name=「東路」，
+     * 但 full_text 仍是正確的「江南東路」。改造後應優先用 full_text 直接命中字典。
+     */
+    public function test_full_text_takes_priority_when_ai_misparses_parent_name() {
+        $this->makeSongPerson();
+        $this->fakeAiResponse([
+            'title_str' => '轉運判官',
+            'addr_str' => [
+                'full_text' => '江南東路',
+                'parent' => '江南',
+                'name' => '東路',
+                'admin_type' => '路',
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => '江南東路轉運判官',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $matched = $response->json('data.matched_fields');
+        $this->assertArrayHasKey('c_addr', $matched, '地址應落在 matched（綠色），而非因為 name=「東路」匹配失敗而退到 suggested');
+        $this->assertSame([12824], $matched['c_addr']['value']);
+        $this->assertSame(['江南東路'], $matched['c_addr']['text']);
+
+        // c_office_id 走 c_office_chn_alt（轉運判官 → 1003）會被精確命中
+        $this->assertArrayHasKey('c_office_id', $matched);
+        $this->assertSame(1003, $matched['c_office_id']['value']);
+    }
+
+    /**
+     * 案例 B：AI 將「荊湖北路轉運司判官」切成 title=「判官」、addr=「荊湖北路轉運司」，
+     * title 命中但 addr 落空。邊界滑窗應修正為 title=「轉運司判官」、addr=「荊湖北路」。
+     */
+    public function test_boundary_refiner_recovers_when_addr_eats_office_suffix() {
+        $this->makeSongPerson();
+        $this->fakeAiResponse([
+            'title_str' => '判官',
+            'addr_str' => [
+                'full_text' => '荊湖北路轉運司',
+                'parent' => '荊湖北路',
+                'name' => '轉運司',
+                'admin_type' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => '荊湖北路轉運司判官',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $matched = $response->json('data.matched_fields');
+
+        // 邊界滑窗修正後：title 應升級到「轉運司判官」（id=1003），不再是「判官」（id=2683）
+        $this->assertArrayHasKey('c_office_id', $matched);
+        $this->assertSame(1003, $matched['c_office_id']['value'], '應修正為轉運司判官（1003），而非保留 AI 原本切到的判官（2683）');
+
+        // 地址應修正為「荊湖北路」（id=20001）
+        $this->assertArrayHasKey('c_addr', $matched);
+        $this->assertSame([20001], $matched['c_addr']['value']);
+        $this->assertSame(['荊湖北路'], $matched['c_addr']['text']);
+
+        // 應留下 refined_from_boundary 標記，方便日後審計
+        $this->assertTrue($matched['c_office_id']['refined_from_boundary'] ?? false);
+        $this->assertTrue($matched['c_addr']['refined_from_boundary'] ?? false);
+    }
+
+    /**
+     * 案例 C：full_text == name 但 parent 不為 null（最常見的 AI 輸出之一）。
+     * 字典中有兩筆「永康」分屬不同上層，必須靠 parent 消歧。
+     * 改造後若把 parent 強制設為 null（早期實作），會退化成第一筆命中或 fuzzy 結果。
+     */
+    public function test_full_text_path_preserves_parent_for_ambiguous_name() {
+        $this->makeSongPerson();
+        $this->fakeAiResponse([
+            'title_str' => '判官',
+            'addr_str' => [
+                'full_text' => '永康',
+                'parent' => '永嘉軍',
+                'name' => '永康',
+                'admin_type' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => '永嘉軍永康判官',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $matched = $response->json('data.matched_fields');
+        $this->assertArrayHasKey('c_addr', $matched, '同名地址應透過 parent 消歧後落入 matched');
+        $this->assertSame([30002], $matched['c_addr']['value'], 'parent=永嘉軍 應命中 30002，而非婺州下的 30001');
+    }
+
+    /**
+     * 案例 D：邊界滑窗 ranking metric。
+     * 構造一條兩個切法都「兩邊 exact 命中字典」的字串：
+     *   combined = "邶州刺史"
+     *     - (邶)(州刺史)：addr=「邶」(id=40001)、title=「州刺史」(id=40020)
+     *     - (邶州)(刺史)：addr=「邶州」(id=40002)、title=「刺史」(id=40021)
+     * 改造前 metric 為常數，會取 iteration 中最先出現的切法（addr-first 即最短地址）。
+     * 改造後應依「較長地址」為主排序，挑出 (邶州)(刺史)，避免地址被短切到不夠具體。
+     */
+    public function test_boundary_refiner_prefers_longer_address_among_multiple_valid_splits() {
+        $this->makeSongPerson();
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 40001, 'c_name' => 'Bei (short)', 'c_name_chn' => '邶', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+            ['c_addr_id' => 40002, 'c_name' => 'Beizhou', 'c_name_chn' => '邶州', 'c_firstyear' => 1000, 'c_lastyear' => 1200],
+        ]);
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 40020, 'c_dy' => 15, 'c_office_chn' => '州刺史', 'c_office_chn_alt' => null],
+            ['c_office_id' => 40021, 'c_dy' => 15, 'c_office_chn' => '刺史', 'c_office_chn_alt' => null],
+        ]);
+
+        // AI 把 title 命中為「刺史」，但 addr.full_text="邶州刺史" 不在字典 → 觸發 refiner
+        $this->fakeAiResponse([
+            'title_str' => '刺史',
+            'addr_str' => [
+                'full_text' => '邶州刺史',
+                'parent' => null,
+                'name' => '邶州刺史',
+                'admin_type' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => '邶州刺史',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+        $matched = $response->json('data.matched_fields');
+
+        $this->assertSame([40002], $matched['c_addr']['value'], 'ranking metric 應挑較長地址 邶州（40002），而非短地址 邶（40001）');
+        $this->assertSame(40021, $matched['c_office_id']['value'], '較長地址對應的官名應為「刺史」（40021）');
+        $this->assertTrue($matched['c_addr']['refined_from_boundary'] ?? false);
+    }
+
+    /**
+     * 案例 E：sourceText 中 addr 出現多次，refiner 應收斂到「離 title 最近」那一處，
+     * 而不是 mb_strpos 找到的第一個。
+     */
+    public function test_boundary_refiner_picks_closest_addr_occurrence_in_long_source() {
+        $this->makeSongPerson();
+        // sourceText: 「荊湖北路糧運記事 ... 荊湖北路轉運司判官」
+        // 第一次出現的「荊湖北路」距離「判官」較遠，第二次貼著「轉運司判官」。
+        $sourceText = '荊湖北路糧運記事，後遷荊湖北路轉運司判官';
+
+        $this->fakeAiResponse([
+            'title_str' => '判官',
+            'addr_str' => [
+                'full_text' => '荊湖北路轉運司',
+                'parent' => '荊湖北路',
+                'name' => '轉運司',
+                'admin_type' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => $sourceText,
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+        $matched = $response->json('data.matched_fields');
+
+        $this->assertSame(1003, $matched['c_office_id']['value'], 'refiner 應仍能修正為轉運司判官（1003）');
+        $this->assertSame([20001], $matched['c_addr']['value']);
+    }
+
+    /**
+     * 案例 F：sourceText 過長且 addr 與 title 距離過大時，refiner 應放棄，
+     * 不會在大段落上做 O(n) 滑窗導致 DB 查詢爆量。
+     */
+    public function test_boundary_refiner_aborts_when_span_exceeds_cap() {
+        $this->makeSongPerson();
+        // addr 只有官署前綴、office 可命中，觸發單邊命中的 refiner；
+        // 「荊湖北路轉運司」在開頭，「判官」相距 50+ 字，union span > 25 char cap。
+        $filler = str_repeat('某', 50);
+        $sourceText = '荊湖北路轉運司'.$filler.'判官';
+
+        $this->fakeAiResponse([
+            'title_str' => '判官',
+            'addr_str' => [
+                'full_text' => '荊湖北路轉運司',
+                'parent' => '荊湖北路',
+                'name' => '轉運司',
+                'admin_type' => null,
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => $sourceText,
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+        $matched = $response->json('data.matched_fields');
+        $suggested = $response->json('data.suggested_fields');
+
+        // refiner 跳過，AI 原本的 office 命中（判官，2683）保留
+        $this->assertSame(2683, $matched['c_office_id']['value']);
+        $this->assertArrayHasKey('c_addr', $suggested);
+        $this->assertArrayNotHasKey('value', $suggested['c_addr']);
+        // refiner 沒跑，所以不會留下 refined_from_boundary 標記
+        $this->assertArrayNotHasKey('refined_from_boundary', $matched['c_office_id']);
+    }
+
+    /**
+     * 邊界滑窗不得在 AI 已經切對時越權改動結果。
+     */
+    public function test_boundary_refiner_skipped_when_both_sides_already_matched() {
+        $this->makeSongPerson();
+        $this->fakeAiResponse([
+            'title_str' => '轉運判官',
+            'addr_str' => [
+                'full_text' => '江南東路',
+                'parent' => null,
+                'name' => '江南東路',
+                'admin_type' => '路',
+            ],
+        ]);
+
+        $response = $this->actingAs($this->makeUser())->postJson('/api/ai/posting/extract', [
+            'source_text' => '江南東路轉運判官',
+            'person_id' => 88888,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+        $matched = $response->json('data.matched_fields');
+
+        $this->assertSame([12824], $matched['c_addr']['value']);
+        $this->assertSame(1003, $matched['c_office_id']['value']);
+        // 兩邊原本就成功，不應觸發滑窗改寫
+        $this->assertArrayNotHasKey('refined_from_boundary', $matched['c_office_id']);
+        $this->assertArrayNotHasKey('refined_from_boundary', $matched['c_addr']);
+    }
+}


### PR DESCRIPTION
## Summary

針對 `/basicinformation/{id}/offices/create` 的 AI 智能填充，改善 AI 切分錯誤時的容錯能力，並調整結果 UI 與比較表。三個獨立 commit：

- **強化容錯（後端 + 測試）**：地址匹配優先用 `addr_str.full_text` 再退到 `name + parent`、新增 title/addr 邊界滑窗 refiner、加 ranking metric 與 span cap
- **UI 改善**：未匹配欄位顯示 AI 提取 hint、修「填入搜尋」、軟化結果摘要框顏色
- **比較表排除朝代**：朝代非 AI 從原文提取，避免比對失真

## 解決的具體案例

1. 「江南東路轉運判官」AI 將 `addr` 結構錯誤地切成 `parent=江南、name=東路`，但 `full_text` 仍是「江南東路」 → 改為先試 full_text，地址正確命中
2. 「荊湖北路轉運司判官」AI 切成 `title=判官、addr=荊湖北路轉運司`（addr 吃進 office 詞）→ 邊界滑窗修正為 `title=轉運司判官、addr=荊湖北路`
3. 同名地址（多個「永康」分屬不同上層州）full_text == name 時保留 parent 消歧
4. 多解時依「較長地址 + 離 AI 切點較近」挑最佳切法
5. 長 sourceText 中 addr/title 分散時走 25 字 cap 直接 abort 避免 query 爆量

## 涉及檔案

- `app/Services/PostingAutofillService.php`：matchFields / refineTitleAddrBoundary / findClosestSpan
- `app/Http/Controllers/AiFillLogController.php`：buildComparisonRows 移除 c_dy
- `resources/views/biogmains/offices/_form.blade.php`：showAiNotFoundHint / fillSelect2Search / 結果摘要框樣式
- `tests/Feature/PostingAutofillBoundaryTest.php`：新增 7 個回歸測試

## Test plan

- [x] 後端：`./vendor/bin/phpunit --filter "PostingAutofill|AiPostingAutofill|AiFillLog"`（37 tests / 137 assertions 全綠）
- [x] 前端手動驗證：
  - [x] 「江南東路轉運判官」應全綠匹配
  - [x] 「荊湖北路轉運司判官」應觸發邊界滑窗修正為 轉運司判官 + 荊湖北路
  - [x] AI 提取但未找到時顯示淡灰 hint，點「填入搜尋」官名（單選）正確帶入文字
  - [x] 點「填入搜尋」地名（多選）不再被「未詳」tag 擠壓、長文本不被遮
  - [x] 結果摘要框淡灰外觀、無「N 個欄位無法提取」雜訊
  - [x] `/admin/ai-fill-logs?category=posting` 比較表不再顯示朝代列

🤖 Generated with [Claude Code](https://claude.com/claude-code)