### PR TITLE
修正 SQLite 匯出器無法處理 COMMENT 內單引號跳脫

### DIFF
--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -645,7 +645,11 @@ class ExportMysqlToSqlite extends Command {
         $rest = preg_replace('/\bZEROFILL\b/i', '', $rest);
         $rest = preg_replace('/\bCHARACTER SET\s+\w+/i', '', $rest);
         $rest = preg_replace('/\bCOLLATE\s+\w+/i', '', $rest);
-        $rest = preg_replace('/\bCOMMENT\s+\'.*?\'/i', '', $rest);
+        // SQLite 不支援 COMMENT 子句，整段移除。
+        // 必須處理 MySQL 對單引號的兩種跳脫方式：'' (SQL 標準) 與 \' (MySQL 擴充)，
+        // 否則 COMMENT 內含撇號時非貪婪 .*? 會在第一個內部單引號就提前結束，
+        // 殘留字串字面量會破壞後續 SQLite DDL 解析。
+        $rest = preg_replace('/\bCOMMENT\s+\'(?:[^\'\\\\]|\\\\.|\'\')*\'/i', '', $rest);
         $rest = preg_replace('/\bON UPDATE\b[^,]+/i', '', $rest);
         $rest = preg_replace('/\s+DEFAULT\s+NULL/i', ' DEFAULT NULL', $rest);
         $rest = preg_replace('/\s+DEFAULT\s+\'0000-00-00 00:00:00\'/i', ' DEFAULT NULL', $rest);

--- a/tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php
+++ b/tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\ExportMysqlToSqlite;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
+    private function convert(string $mysqlSql, string $tableName = 'BIOG_MAIN'): array {
+        // 匿名子類別覆寫 option()，讓我們可以脫離 Laravel console pipeline 直接呼叫
+        // 受保護的轉換方法。
+        $command = new class () extends ExportMysqlToSqlite {
+            public function option($key = null) {
+                return false;
+            }
+        };
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('convertCreateTableToSqlite');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $mysqlSql, $tableName);
+    }
+
+    /**
+     * MySQL 以 SQL 標準雙寫單引號（''）跳脫 COMMENT 內的撇號時，
+     * 之前的非貪婪正則會在第一個內部單引號就提前結束，殘留字串字面量
+     * 會破壞 SQLite DDL 解析。回歸案例來自 BIOG_MAIN.c_surname。
+     */
+    public function test_strips_comment_with_doubled_single_quote_escape(): void {
+        $sql = "CREATE TABLE `BIOG_MAIN` (\n"
+            . "  `c_personid` int(11) NOT NULL,\n"
+            . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person''s surname; auto-generated from c_surname_chn via pinyin lookup table',\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        $result = $this->convert($sql);
+
+        $this->assertStringNotContainsString('COMMENT', $result['table']);
+        $this->assertStringNotContainsString("surname'", $result['table']);
+        $this->assertStringNotContainsString("'s surname", $result['table']);
+        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
+    }
+
+    /**
+     * MySQL 反斜線跳脫風格（\'）也應該被正確處理。
+     */
+    public function test_strips_comment_with_backslash_escape(): void {
+        $sql = "CREATE TABLE `BIOG_MAIN` (\n"
+            . "  `c_personid` int(11) NOT NULL,\n"
+            . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person\\'s surname; auto-generated',\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        $result = $this->convert($sql);
+
+        $this->assertStringNotContainsString('COMMENT', $result['table']);
+        $this->assertStringNotContainsString("'s surname", $result['table']);
+        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
+    }
+
+    /**
+     * 同一張表上多個欄位都帶有含撇號的 COMMENT 時，每個都要正確去除。
+     */
+    public function test_strips_multiple_comments_with_apostrophes(): void {
+        $sql = "CREATE TABLE `BIOG_MAIN` (\n"
+            . "  `c_personid` int(11) NOT NULL,\n"
+            . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person''s surname',\n"
+            . "  `c_mingzi` varchar(255) DEFAULT NULL COMMENT 'don''t break me',\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB";
+
+        $result = $this->convert($sql);
+
+        $this->assertStringNotContainsString('COMMENT', $result['table']);
+        $this->assertStringNotContainsString("'s surname", $result['table']);
+        $this->assertStringNotContainsString("'t break", $result['table']);
+        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
+        $this->assertMatchesRegularExpression('/"c_mingzi"\s+\S+\s+DEFAULT NULL/', $result['table']);
+    }
+
+    /**
+     * 不含撇號的一般 COMMENT 仍要照常去除。
+     */
+    public function test_strips_plain_comment(): void {
+        $sql = "CREATE TABLE `T` (\n"
+            . "  `id` int(11) NOT NULL COMMENT 'plain comment',\n"
+            . "  PRIMARY KEY (`id`)\n"
+            . ") ENGINE=InnoDB";
+
+        $result = $this->convert($sql, 'T');
+
+        $this->assertStringNotContainsString('COMMENT', $result['table']);
+        $this->assertStringNotContainsString('plain comment', $result['table']);
+    }
+}


### PR DESCRIPTION
## Summary
- 修正 `App\Console\Commands\ExportMysqlToSqlite::convertColumnDefinition()` 中移除 MySQL `COMMENT` 的非貪婪正則 `'.*?'`：原版本在 COMMENT 內含撇號時會於第一個內部單引號提前結束，殘留字串字面量導致 SQLite DDL 解析失敗。
- 新正則同時處理 SQL 標準雙寫（`''`）與 MySQL 反斜線跳脫（`\'`）。
- 新增 `tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php`，4 個案例覆蓋兩種跳脫風格、多欄位 COMMENT 與純文字 COMMENT。

## 觸發背景
BIOG_MAIN 七個欄位（`c_surname`、`c_mingzi`、`c_surname_proper`、`c_mingzi_proper`、`c_name_proper`、`c_surname_rm`、`c_mingzi_rm`）於上游加入帶英文撇號的 COMMENT 後，每週同步從 2026-04-04 起連續四週在 BIOG_MAIN 環節失敗，HuggingFace `cbdb/cbdb-sqlite/latest.zip` 因此一個月未更新。

cron 端錯誤訊息範例：
```
导出表 BIOG_MAIN 失败: SQLSTATE[HY000]: General error: 1 near
"'s surname; auto-generated from c_surname_chn via pinyin lookup table'": syntax error
```

## Test plan
- [x] `./vendor/bin/phpunit --filter ExportMysqlToSqliteCommentEscapeTest` （4 tests, 14 assertions）
- [x] `./vendor/bin/php-cs-fixer fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)