### PR TITLE
SQLite 匯出器保留 MySQL COMMENT 為區塊註解

### DIFF
--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -425,6 +425,15 @@ class ExportMysqlToSqlite extends Command {
      */
     protected function convertCreateTableToSqlite($mysqlSql, $tableName) {
         $cleanSql = preg_replace('/`' . preg_quote($tableName, '/') . '`/i', '"' . $tableName . '"', $mysqlSql);
+
+        // 在拆掉 ENGINE=...$ 之前，先抽出表級 COMMENT='...'，否則 ENGINE=.*$ 的貪婪匹配會把它吃掉。
+        // 表級註解會以 SQL 區塊註解形式置於 CREATE TABLE 開頭，方便 AI agents 直接從 sqlite_master.sql 讀到。
+        // s 旗標保險起見也容許註解字面量內換行。
+        $tableComment = null;
+        if (preg_match('/\bCOMMENT\s*=\s*\'((?:[^\'\\\\]|\\\\.|\'\')*)\'/is', $cleanSql, $tableCommentMatch)) {
+            $tableComment = $this->decodeMysqlStringLiteral($tableCommentMatch[1]);
+        }
+
         $cleanSql = preg_replace('/ENGINE=.*$/is', '', $cleanSql);
         $cleanSql = preg_replace('/ROW_FORMAT=\w+/i', '', $cleanSql);
         $cleanSql = preg_replace('/AUTO_INCREMENT=\d+/i', '', $cleanSql);
@@ -547,7 +556,14 @@ class ExportMysqlToSqlite extends Command {
             throw new \RuntimeException(sprintf('无法生成 %s 的字段定义', $tableName));
         }
 
-        $tableSql = sprintf("CREATE TABLE \"%s\" (\n    %s\n);", $tableName, implode(",\n    ", $body));
+        // 表級註解必須放進括號內，否則 SQLite 解析時會丟掉位於 CREATE TABLE 之前
+        // 或分號之後的註解。放在第一個欄位前即可被原樣保存到 sqlite_master.sql。
+        $bodyText = implode(",\n    ", $body);
+        if ($tableComment !== null && $tableComment !== '') {
+            $bodyText = sprintf("/* %s */\n    %s", $this->escapeForBlockComment($tableComment), $bodyText);
+        }
+
+        $tableSql = sprintf("CREATE TABLE \"%s\" (\n    %s\n);", $tableName, $bodyText);
 
         // 根据 --with-indexes 选项决定是否包含索引
         $exportIndexes = $this->option('with-indexes') ? $indexes : [];
@@ -670,11 +686,19 @@ class ExportMysqlToSqlite extends Command {
         $rest = preg_replace('/\bZEROFILL\b/i', '', $rest);
         $rest = preg_replace('/\bCHARACTER SET\s+\w+/i', '', $rest);
         $rest = preg_replace('/\bCOLLATE\s+\w+/i', '', $rest);
-        // SQLite 不支援 COMMENT 子句，整段移除。
+        // SQLite 不支援 COMMENT 子句，但會保留 CREATE TABLE 原文於 sqlite_master.sql。
+        // 因此把 COMMENT 內容抽出後改以 SQL 區塊註解 /* ... */ 的形式接在欄位定義之後，
+        // AI agents 可直接從 schema 讀到欄位語意，毋須額外的說明文件。
         // 必須處理 MySQL 對單引號的兩種跳脫方式：'' (SQL 標準) 與 \' (MySQL 擴充)，
         // 否則 COMMENT 內含撇號時非貪婪 .*? 會在第一個內部單引號就提前結束，
         // 殘留字串字面量會破壞後續 SQLite DDL 解析。
-        $rest = preg_replace('/\bCOMMENT\s+\'(?:[^\'\\\\]|\\\\.|\'\')*\'/i', '', $rest);
+        // 用 s 旗標讓 . 也匹配換行（MySQL 雖罕見，但允許 COMMENT 字面量內含真實換行），
+        // 並用單一 regex + substr_replace 同時抽出與移除，避免兩條 regex 不同步。
+        $columnComment = null;
+        if (preg_match('/\bCOMMENT\s+\'((?:[^\'\\\\]|\\\\.|\'\')*)\'/is', $rest, $commentMatch, PREG_OFFSET_CAPTURE)) {
+            $columnComment = $this->decodeMysqlStringLiteral($commentMatch[1][0]);
+            $rest = substr_replace($rest, '', $commentMatch[0][1], strlen($commentMatch[0][0]));
+        }
         $rest = preg_replace('/\bON UPDATE\b[^,]+/i', '', $rest);
         $rest = preg_replace('/\s+DEFAULT\s+NULL/i', ' DEFAULT NULL', $rest);
         $rest = preg_replace('/\s+DEFAULT\s+\'0000-00-00 00:00:00\'/i', ' DEFAULT NULL', $rest);
@@ -687,11 +711,79 @@ class ExportMysqlToSqlite extends Command {
             $rest = 'INTEGER PRIMARY KEY AUTOINCREMENT';
         }
 
+        $definition = sprintf('"%s" %s', $columnName, trim($rest));
+
+        if ($columnComment !== null && $columnComment !== '') {
+            $definition .= sprintf(' /* %s */', $this->escapeForBlockComment($columnComment));
+        }
+
         return [
-            'definition' => sprintf('"%s" %s', $columnName, trim($rest)),
+            'definition' => $definition,
             'auto_increment' => $autoIncrement,
             'name' => $columnName,
         ];
+    }
+
+    /**
+     * 將 MySQL 字串字面量內容（去掉外圍單引號之後的字串）解碼為純文字。
+     * 處理 SQL 標準 '' 與 MySQL 擴充 \' \" \\ \n \r \t \0 \b \Z 等跳脫。
+     *
+     * 以位元組（strlen + index）迭代是 UTF-8 安全的：本函式只比對 ASCII 字元
+     * （'、\），UTF-8 多位元組續位 (0x80–0xBF) 的值不會與這些 ASCII 衝突，
+     * 因此不會把多位元組字元劈開。
+     */
+    protected function decodeMysqlStringLiteral($literal) {
+        $result = '';
+        $length = strlen($literal);
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $literal[$i];
+            if ($ch === "'" && $i + 1 < $length && $literal[$i + 1] === "'") {
+                $result .= "'";
+                $i++;
+
+                continue;
+            }
+            if ($ch === '\\' && $i + 1 < $length) {
+                $next = $literal[$i + 1];
+                $map = [
+                    "'" => "'",
+                    '"' => '"',
+                    '\\' => '\\',
+                    'n' => "\n",
+                    'r' => "\r",
+                    't' => "\t",
+                    '0' => "\0",
+                    'b' => "\x08",
+                    'Z' => "\x1a",
+                ];
+                if (isset($map[$next])) {
+                    $result .= $map[$next];
+                    $i++;
+
+                    continue;
+                }
+                // 其他跳脫直接保留 next 字元（MySQL 行為）
+                $result .= $next;
+                $i++;
+
+                continue;
+            }
+            $result .= $ch;
+        }
+
+        return $result;
+    }
+
+    /**
+     * 把字串轉義成可安全嵌入 /* ... *​/ 的內容：
+     * - 把所有 *​/ 變成 * /，避免提早結束區塊註解
+     * - 把控制字元（換行、tab 等）壓成空白，讓註解保持單行
+     */
+    protected function escapeForBlockComment($text) {
+        $text = preg_replace('/\*\//', '* /', $text);
+        $text = preg_replace('/[\x00-\x1f]+/', ' ', $text);
+
+        return trim($text);
     }
 
     /**

--- a/tests/Feature/SqliteExportPreservesCommentsTest.php
+++ b/tests/Feature/SqliteExportPreservesCommentsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\ExportMysqlToSqlite;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * 端到端驗證：把含 COMMENT 的 MySQL DDL 經過轉換後，餵給真實 SQLite，
+ * 再從 sqlite_master.sql 讀回原文，確認欄位／表級註解都被保留下來。
+ */
+class SqliteExportPreservesCommentsTest extends TestCase {
+    private function convert(string $mysqlSql, string $tableName): array {
+        $command = new class () extends ExportMysqlToSqlite {
+            public function option($key = null) {
+                return false;
+            }
+        };
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('convertCreateTableToSqlite');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $mysqlSql, $tableName);
+    }
+
+    public function test_sqlite_master_sql_retains_column_and_table_comments(): void {
+        $mysql = "CREATE TABLE `BIOG_MAIN_TEST` (\n"
+            . "  `c_personid` int(11) NOT NULL COMMENT '人物 ID（CBDB 主鍵）',\n"
+            . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person''s surname; auto-generated',\n"
+            . "  `c_chinese` varchar(255) DEFAULT NULL COMMENT '人物姓氏，由 c_surname_chn 自動生成',\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人物主表，CBDB 核心資料'";
+
+        $converted = $this->convert($mysql, 'BIOG_MAIN_TEST');
+
+        // 真正餵給 SQLite，再讀回 sqlite_master.sql
+        $connection = DB::connection();
+        if ($connection->getDriverName() !== 'sqlite') {
+            $this->markTestSkipped('此測試需要 SQLite 連線');
+        }
+
+        $connection->statement('DROP TABLE IF EXISTS BIOG_MAIN_TEST');
+        $connection->statement($converted['table']);
+
+        $stored = $connection->selectOne("SELECT sql FROM sqlite_master WHERE type='table' AND name='BIOG_MAIN_TEST'");
+        $this->assertNotNull($stored, 'CREATE TABLE 未被 SQLite 接受');
+
+        $sql = $stored->sql;
+        // 表級註解（放在括號內第一個欄位前）必須被 SQLite 保留
+        $this->assertStringContainsString('/* 人物主表，CBDB 核心資料 */', $sql);
+        // 欄位註解必須被 SQLite 保留，且 '' 已被解碼為單一撇號
+        $this->assertStringContainsString('/* 人物 ID（CBDB 主鍵） */', $sql);
+        $this->assertStringContainsString("/* person's surname; auto-generated */", $sql);
+        $this->assertStringContainsString('/* 人物姓氏，由 c_surname_chn 自動生成 */', $sql);
+
+        // 結構仍可正常運作
+        $connection->table('BIOG_MAIN_TEST')->insert([
+            'c_personid' => 1,
+            'c_surname' => 'Wang',
+            'c_chinese' => '王',
+        ]);
+        $row = $connection->table('BIOG_MAIN_TEST')->where('c_personid', 1)->first();
+        $this->assertSame('Wang', $row->c_surname);
+        $this->assertSame('王', $row->c_chinese);
+
+        $connection->statement('DROP TABLE IF EXISTS BIOG_MAIN_TEST');
+    }
+}

--- a/tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php
+++ b/tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php
@@ -24,10 +24,10 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
     /**
      * MySQL 以 SQL 標準雙寫單引號（''）跳脫 COMMENT 內的撇號時，
-     * 之前的非貪婪正則會在第一個內部單引號就提前結束，殘留字串字面量
-     * 會破壞 SQLite DDL 解析。回歸案例來自 BIOG_MAIN.c_surname。
+     * 解析必須能正確識別字串範圍，否則殘留字面量會破壞 SQLite DDL。
+     * COMMENT 內容應以區塊註解形式保留，並把 '' 還原為單一撇號。
      */
-    public function test_strips_comment_with_doubled_single_quote_escape(): void {
+    public function test_preserves_comment_with_doubled_single_quote_escape(): void {
         $sql = "CREATE TABLE `BIOG_MAIN` (\n"
             . "  `c_personid` int(11) NOT NULL,\n"
             . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person''s surname; auto-generated from c_surname_chn via pinyin lookup table',\n"
@@ -36,16 +36,18 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
         $result = $this->convert($sql);
 
-        $this->assertStringNotContainsString('COMMENT', $result['table']);
-        $this->assertStringNotContainsString("surname'", $result['table']);
-        $this->assertStringNotContainsString("'s surname", $result['table']);
-        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
+        // 不應殘留 MySQL 的 COMMENT 關鍵字
+        $this->assertStringNotContainsString('COMMENT ', $result['table']);
+        // '' 必須被解碼回單一撇號
+        $this->assertStringContainsString("/* person's surname; auto-generated from c_surname_chn via pinyin lookup table */", $result['table']);
+        // 欄位定義仍然合法
+        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL\s+\/\*/', $result['table']);
     }
 
     /**
-     * MySQL 反斜線跳脫風格（\'）也應該被正確處理。
+     * MySQL 反斜線跳脫風格（\'）也應被正確解碼。
      */
-    public function test_strips_comment_with_backslash_escape(): void {
+    public function test_preserves_comment_with_backslash_escape(): void {
         $sql = "CREATE TABLE `BIOG_MAIN` (\n"
             . "  `c_personid` int(11) NOT NULL,\n"
             . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person\\'s surname; auto-generated',\n"
@@ -54,15 +56,14 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
         $result = $this->convert($sql);
 
-        $this->assertStringNotContainsString('COMMENT', $result['table']);
-        $this->assertStringNotContainsString("'s surname", $result['table']);
-        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
+        $this->assertStringNotContainsString('COMMENT ', $result['table']);
+        $this->assertStringContainsString("/* person's surname; auto-generated */", $result['table']);
     }
 
     /**
-     * 同一張表上多個欄位都帶有含撇號的 COMMENT 時，每個都要正確去除。
+     * 同一張表上多個欄位都帶有 COMMENT 時，每一個都要被獨立保留。
      */
-    public function test_strips_multiple_comments_with_apostrophes(): void {
+    public function test_preserves_multiple_comments_with_apostrophes(): void {
         $sql = "CREATE TABLE `BIOG_MAIN` (\n"
             . "  `c_personid` int(11) NOT NULL,\n"
             . "  `c_surname` varchar(255) DEFAULT NULL COMMENT 'person''s surname',\n"
@@ -72,18 +73,15 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
         $result = $this->convert($sql);
 
-        $this->assertStringNotContainsString('COMMENT', $result['table']);
-        $this->assertStringNotContainsString("'s surname", $result['table']);
-        $this->assertStringNotContainsString("'t break", $result['table']);
-        $this->assertMatchesRegularExpression('/"c_surname"\s+\S+\s+DEFAULT NULL/', $result['table']);
-        $this->assertMatchesRegularExpression('/"c_mingzi"\s+\S+\s+DEFAULT NULL/', $result['table']);
+        $this->assertStringNotContainsString('COMMENT ', $result['table']);
+        $this->assertStringContainsString("/* person's surname */", $result['table']);
+        $this->assertStringContainsString("/* don't break me */", $result['table']);
     }
 
     /**
-     * COMMENT 內含逗號時，切分欄位定義的階段不能把字串字面量中的逗號當成欄位分隔符。
-     * 回歸案例如 BIOG_MAIN.c_surname_proper。
+     * COMMENT 內含逗號時，splitDefinitionItems 的字串感知必須保護它，否則會被誤切。
      */
-    public function test_strips_comment_with_comma_inside_string_literal(): void {
+    public function test_preserves_comment_with_comma_inside_string_literal(): void {
         $sql = "CREATE TABLE `BIOG_MAIN` (\n"
             . "  `c_personid` int(11) NOT NULL,\n"
             . "  `c_surname_proper` varchar(255) DEFAULT NULL COMMENT 'Surname in the person''s native language (non-Chinese), if applicable; user-editable',\n"
@@ -94,18 +92,26 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
         $result = $this->convert($sql);
 
-        $this->assertStringNotContainsString('COMMENT', $result['table']);
-        $this->assertStringNotContainsString('if applicable', $result['table']);
-        $this->assertStringNotContainsString("person''s native language", $result['table']);
-        $this->assertMatchesRegularExpression('/"c_surname_proper"\s+\S+\s+DEFAULT NULL/', $result['table']);
-        $this->assertMatchesRegularExpression('/"c_backslash_escape"\s+\S+\s+DEFAULT NULL/', $result['table']);
-        $this->assertMatchesRegularExpression('/"c_name"\s+\S+\s+DEFAULT NULL/', $result['table']);
+        $this->assertStringNotContainsString('COMMENT ', $result['table']);
+        $this->assertStringContainsString(
+            "/* Surname in the person's native language (non-Chinese), if applicable; user-editable */",
+            $result['table']
+        );
+        $this->assertStringContainsString(
+            "/* Surname in the person's native language, if applicable */",
+            $result['table']
+        );
+        $this->assertStringContainsString('/* Name after comma case */', $result['table']);
+        // 三個欄位都應該獨立存在，沒有被 COMMENT 內的逗號弄壞
+        $this->assertMatchesRegularExpression('/"c_surname_proper"/', $result['table']);
+        $this->assertMatchesRegularExpression('/"c_backslash_escape"/', $result['table']);
+        $this->assertMatchesRegularExpression('/"c_name"/', $result['table']);
     }
 
     /**
-     * 不含撇號的一般 COMMENT 仍要照常去除。
+     * 普通的純 ASCII COMMENT 也要被保留。
      */
-    public function test_strips_plain_comment(): void {
+    public function test_preserves_plain_comment(): void {
         $sql = "CREATE TABLE `T` (\n"
             . "  `id` int(11) NOT NULL COMMENT 'plain comment',\n"
             . "  PRIMARY KEY (`id`)\n"
@@ -113,7 +119,76 @@ class ExportMysqlToSqliteCommentEscapeTest extends TestCase {
 
         $result = $this->convert($sql, 'T');
 
-        $this->assertStringNotContainsString('COMMENT', $result['table']);
-        $this->assertStringNotContainsString('plain comment', $result['table']);
+        $this->assertStringNotContainsString('COMMENT ', $result['table']);
+        $this->assertStringContainsString('/* plain comment */', $result['table']);
+    }
+
+    /**
+     * 中日韓字元的 COMMENT 必須原樣保留，不能被字節級正則破壞。
+     */
+    public function test_preserves_chinese_comment(): void {
+        $sql = "CREATE TABLE `BIOG_MAIN` (\n"
+            . "  `c_personid` int(11) NOT NULL,\n"
+            . "  `c_surname` varchar(255) DEFAULT NULL COMMENT '人物姓氏，由 c_surname_chn 自動生成',\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        $result = $this->convert($sql);
+
+        $this->assertStringContainsString('/* 人物姓氏，由 c_surname_chn 自動生成 */', $result['table']);
+    }
+
+    /**
+     * COMMENT 內含 *​/ 必須被改寫，否則會把區塊註解提早關掉。
+     */
+    public function test_escapes_block_comment_terminator_inside_comment(): void {
+        $sql = "CREATE TABLE `T` (\n"
+            . "  `id` int(11) NOT NULL COMMENT 'tricky */ payload',\n"
+            . "  PRIMARY KEY (`id`)\n"
+            . ") ENGINE=InnoDB";
+
+        $result = $this->convert($sql, 'T');
+
+        $this->assertStringNotContainsString("'tricky */ payload'", $result['table']);
+        $this->assertStringContainsString('/* tricky * / payload */', $result['table']);
+        // 整段 CREATE TABLE 應該只有一個結束的 */（屬於該欄位的註解），且結構完整
+        $this->assertMatchesRegularExpression('/"id"\s+\S+(?:\s+NOT NULL)?\s+\/\* tricky \* \/ payload \*\//', $result['table']);
+    }
+
+    /**
+     * 表級 COMMENT='...' 應作為區塊註解，保留在 CREATE TABLE 括號內第一個欄位之前。
+     * 必須位於括號內才能被 SQLite 原樣保存到 sqlite_master.sql；位於 CREATE TABLE
+     * 之前或分號之後的註解都會被解析器丟棄。
+     */
+    public function test_preserves_table_level_comment(): void {
+        $sql = "CREATE TABLE `BIOG_MAIN` (\n"
+            . "  `c_personid` int(11) NOT NULL,\n"
+            . "  PRIMARY KEY (`c_personid`)\n"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='人物主表，CBDB 核心資料'";
+
+        $result = $this->convert($sql);
+
+        $this->assertStringContainsString('/* 人物主表，CBDB 核心資料 */', $result['table']);
+        // 表級註解必須出現在 CREATE TABLE ( 之後、第一個欄位之前
+        $this->assertMatchesRegularExpression(
+            '/CREATE TABLE\s+"BIOG_MAIN"\s*\(\s*\/\*\s*人物主表，CBDB 核心資料\s*\*\//s',
+            $result['table']
+        );
+    }
+
+    /**
+     * 沒有 COMMENT 的欄位不應被加上空 /* *​/。
+     */
+    public function test_does_not_add_empty_block_comment(): void {
+        $sql = "CREATE TABLE `T` (\n"
+            . "  `id` int(11) NOT NULL,\n"
+            . "  `name` varchar(255) DEFAULT NULL,\n"
+            . "  PRIMARY KEY (`id`)\n"
+            . ") ENGINE=InnoDB";
+
+        $result = $this->convert($sql, 'T');
+
+        $this->assertStringNotContainsString('/*', $result['table']);
+        $this->assertStringNotContainsString('*/', $result['table']);
     }
 }


### PR DESCRIPTION
## Summary
- MySQL 欄位級與表級 `COMMENT` 以 `/* ... */` 形式嵌入 SQLite `CREATE TABLE`，原樣寫進 `sqlite_master.sql`，AI agents 直接 `SELECT sql FROM sqlite_master` 即可讀到欄位語意，毋須額外維護說明文件。
- 表級 COMMENT 必須放在括號內第一個欄位前，否則 SQLite 解析時會丟掉位於語句之外的註解；ENGINE=...$ 貪婪刪除前先抽出表級 COMMENT 避免誤刪。
- 新增 `decodeMysqlStringLiteral`（處理 `''`、`\'`、`\n` 等 MySQL 跳脫，UTF-8 安全）與 `escapeForBlockComment`（將內文 `*/` 改寫為 `* /`，避免區塊註解提早關閉）。

## 為什麼可行
SQLite 雖然不支援 ALTER 維護欄位 COMMENT，但會原文保存 `CREATE TABLE` 並允許 `--`/`/* */` 注釋語法。CBDB 的 SQLite dump 是從頭重新生成，因此可以在建表時一次性把 MySQL 注釋寫進 schema。

## Test plan
- [x] `./vendor/bin/phpunit --filter ExportMysqlToSqliteCommentEscapeTest`（9 個 unit 用例：撇號 `''`/`\'` 兩種跳脫、含逗號、多欄位、CJK、嵌套 `*/`、表級 COMMENT、空註解不附加、純 ASCII）
- [x] `./vendor/bin/phpunit --filter SqliteExportPreservesCommentsTest`（Feature 級 round-trip：DDL 餵進真實 SQLite 後從 `sqlite_master.sql` 讀回，驗證表級＋欄位 COMMENT 都被引擎保留）
- [x] `./vendor/bin/php-cs-fixer fix`：無需修正
- [x] 本地實際匯出 `ADDRESSES` + `BIOG_MAIN`（schema-only 與帶 100 行資料各一次）：
  - `ADDRESSES`：1 個表級 COMMENT + 26 個欄位 COMMENT 全保留，`PRAGMA table_info` 26 欄位正常。
  - `BIOG_MAIN`：12 個欄位 COMMENT 全保留，含 7 個帶撇號（`person's surname`、`Wade-Giles, McCune-Reischauer` 等），無 `COMMENT '...'` 殘留進 SQLite DDL。
  - 100 行資料寫入＋讀回正確，CJK 字元無損。
- [x] 回歸：660f02a / a0a46d2 修過的撇號／逗號 COMMENT 解析路徑由「移除」翻為「保留」斷言，全部通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)