### PR TITLE
移除任官 AI 填充比較中的非 AI 欄位

### DIFF
--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -114,9 +114,7 @@ class AiFillLogController extends Controller {
             'c_ly_day_gz' => '終年干支日',
             'c_appt_code' => '除授類別',
             'c_assume_office_code' => '是否赴任',
-            'c_source' => '出處',
-            'c_inst_code' => '社會機構',
-            'c_sequence' => '次序',
+            // c_source、c_inst_code、c_sequence 不在 AI 生成範圍內，略過比較
             'c_notes' => '備註',
         ];
 
@@ -189,7 +187,6 @@ class AiFillLogController extends Controller {
             'c_ly_nh_code' => ['NIAN_HAO', 'c_nianhao_id', 'c_nianhao_chn'],
             'c_appt_code' => ['APPOINTMENT_CODES', 'c_appt_code', 'c_appt_desc_chn'],
             'c_assume_office_code' => ['ASSUME_OFFICE_CODES', 'c_assume_office_code', 'c_assume_office_desc_chn'],
-            'c_source' => ['TEXT_CODES', 'c_textid', 'c_title_chn'],
         ];
 
         foreach ($codeLookups as $field => [$table, $pk, $textCol]) {
@@ -217,22 +214,6 @@ class AiFillLogController extends Controller {
                     $names[] = $addrNames[$id] ?? (string) $id;
                 }
                 $labels['c_addr'] = implode(', ', $names);
-            }
-        }
-
-        // 社會機構特殊處理（需要透過 SOCIAL_INSTITUTION_NAME_CODES 取得名稱）
-        $instCode = $userSubmitted['c_inst_code'] ?? null;
-        if ($instCode !== null && $instCode !== '' && $instCode !== 0 && $instCode !== '0') {
-            $instNameCode = DB::table('SOCIAL_INSTITUTION_CODES')
-                ->where('c_inst_code', $instCode)
-                ->value('c_inst_name_code');
-            if ($instNameCode) {
-                $instName = DB::table('SOCIAL_INSTITUTION_NAME_CODES')
-                    ->where('c_inst_name_code', $instNameCode)
-                    ->value('c_inst_name_hz');
-                if ($instName !== null && $instName !== '') {
-                    $labels['c_inst_code'] = $instName;
-                }
             }
         }
 


### PR DESCRIPTION
## 摘要

- 從 `buildComparisonRows` 的欄位列表移除 `c_source`（出處）、`c_inst_code`（社會機構）、`c_sequence`（次序）
- 這三個欄位不在 `PostingAutofillService` 的生成範圍，AI 從不填入，放入比較只會讓「未匹配」數字虛高
- 同步移除 `resolveCodeLabels` 中對應的 `c_source` 代碼查詢與社會機構兩段資料庫查詢邏輯

`c_fy_intercalary`（始年閏月）與 `c_ly_intercalary`（終年閏月）確認在 AI tool schema 與 directMappings 中，保留比較。

## 測試計畫

- [x] 進入 `/admin/ai-fill-logs`，開啟任官記錄的 compare modal，確認出處、社會機構、次序不再出現在比較表
- [x] 確認其他欄位（官名、地名、始年、閏月等）仍正常顯示