### PR TITLE
修正 OFFICE_CODE_TYPE_REL resource_id 解析導致 /operations 崩潰

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -171,12 +171,18 @@ class OperationsController extends Controller {
 
                             break;
                         case "OFFICE_CODE_TYPE_REL":
-                            $temp_l = explode("-", $resource_id);
-                            $relation = OfficeCodeTypeRel::where('c_office_id', $temp_l[0])
-                                ->where('c_office_tree_id', $temp_l[1])
-                                ->first();
-                            if ($relation) {
-                                $arr3 = $relation->toArray();
+                            if (strpos($resource_id, '_._') !== false) {
+                                $temp_l = explode('_._', $resource_id);
+                            } else {
+                                $temp_l = explode('-', $resource_id);
+                            }
+                            if (count($temp_l) >= 2) {
+                                $relation = OfficeCodeTypeRel::where('c_office_id', $temp_l[0])
+                                    ->where('c_office_tree_id', $temp_l[1])
+                                    ->first();
+                                if ($relation) {
+                                    $arr3 = $relation->toArray();
+                                }
                             }
 
                             break;


### PR DESCRIPTION
## 問題

透過 CodesController 編輯 `OFFICE_CODE_TYPE_REL` 記錄後，`/operations` 頁面報錯：

```
ErrorException: Undefined array key 1
OperationsController.php : 176
```

**根本原因**：`resource_id` 以 `_._` 分隔符儲存（如 `5_._10`），但 switch/case 只用 `explode("-", $resource_id)` 解析，導致陣列只有 1 個元素，`$temp_l[1]` 不存在。

## 修復

- `OFFICE_CODE_TYPE_REL` case 新增 `_._` 格式偵測，與 `ENTRY_DATA`、`STATUS_DATA`、`KIN_DATA` 一致
- 加上 `count($temp_l) >= 2` 邊界檢查

## 測試

- `./vendor/bin/phpunit --filter Operations`：64 tests, 267 assertions, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)