### PR TITLE
修正官名搜索漏查特定朝代職名的問題

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -237,8 +237,16 @@ class ApiController extends Controller {
     }
 
     public function searchOffice(Request $request) {
-        $data = OfficeCode::where('c_office_chn', 'like', '%'.$request->q.'%')->orWhere('c_office_pinyin', 'like', '%'.$request->q.'%')->orWhere('c_office_id', $request->q)->paginate(20);
-        $data->appends(['q' => $request->q])->links();
+        $query = OfficeCode::where(function ($q) use ($request) {
+            $q->where('c_office_chn', 'like', '%'.$request->q.'%')
+                ->orWhere('c_office_pinyin', 'like', '%'.$request->q.'%')
+                ->orWhere('c_office_id', $request->q);
+        });
+        if ($request->filled('c_dy')) {
+            $query->where('c_dy', $request->c_dy);
+        }
+        $data = $query->paginate(20);
+        $data->appends(array_filter(['q' => $request->q, 'c_dy' => $request->c_dy]))->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_office_id;
             if ($item['id'] === 0) {

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -242,8 +242,8 @@ class ApiController extends Controller {
                 ->orWhere('c_office_pinyin', 'like', '%'.$request->q.'%')
                 ->orWhere('c_office_id', $request->q);
         });
-        if ($request->filled('c_dy')) {
-            $query->where('c_dy', $request->c_dy);
+        if ((int) $request->c_dy > 0) {
+            $query->where('c_dy', (int) $request->c_dy);
         }
         $data = $query->paginate(20);
         $data->appends(array_filter(['q' => $request->q, 'c_dy' => $request->c_dy]))->links();

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -237,16 +237,26 @@ class ApiController extends Controller {
     }
 
     public function searchOffice(Request $request) {
-        $query = OfficeCode::where(function ($q) use ($request) {
+        $baseQuery = OfficeCode::where(function ($q) use ($request) {
             $q->where('c_office_chn', 'like', '%'.$request->q.'%')
                 ->orWhere('c_office_pinyin', 'like', '%'.$request->q.'%')
                 ->orWhere('c_office_id', $request->q);
         });
+
         if ((int) $request->c_dy > 0) {
-            $query->where('c_dy', (int) $request->c_dy);
+            $data = (clone $baseQuery)->where('c_dy', (int) $request->c_dy)->paginate(20);
+            if ($data->total() === 0) {
+                $data = $baseQuery->paginate(20);
+            }
+        } else {
+            $data = $baseQuery->paginate(20);
         }
-        $data = $query->paginate(20);
-        $data->appends(array_filter(['q' => $request->q, 'c_dy' => $request->c_dy]))->links();
+
+        $appends = ['q' => $request->q];
+        if ((int) $request->c_dy > 0) {
+            $appends['c_dy'] = $request->c_dy;
+        }
+        $data->appends($appends)->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_office_id;
             if ($item['id'] === 0) {

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -83,6 +83,8 @@ class BasicInformationOfficesController extends Controller {
         // 處理 basicinformation 可能為 null 或缺少字段的情況
         $personLabel = $id;
 
+        $biogDy = null;
+
         try {
             $basicinformation = $this->biogMainRepository->byPersonId($id);
             if ($basicinformation) {
@@ -94,6 +96,7 @@ class BasicInformationOfficesController extends Controller {
                         $personLabel .= ' (' . $name . ')';
                     }
                 }
+                $biogDy = $basicinformation->c_dy ?? null;
             }
         } catch (\Exception $e) {
             // 如果 byPersonId 失敗（例如在測試環境中表結構不完整），只使用 ID
@@ -101,6 +104,7 @@ class BasicInformationOfficesController extends Controller {
 
         return view('biogmains.offices.create', [
             'id' => $id,
+            'biog_dy' => $biogDy,
             'page_title' => '官名', 'page_description' => '基本信息表 官名', 'page_url' => '/basicinformation/'.$id.'/offices', 'breadcrumb_home' => '人物基本資料', 'archer' => '<li>新增</li>',
             'breadcrumbs' => [
                 ['label' => '人物基本資料', 'url' => route('basicinformation.index')],
@@ -201,6 +205,7 @@ class BasicInformationOfficesController extends Controller {
 
         // 處理 basicinformation 可能為 null 或缺少字段的情況
         $personLabel = $id;
+        $biogDy = null;
 
         try {
             $basicinformation = $this->biogMainRepository->byPersonId($id);
@@ -213,12 +218,13 @@ class BasicInformationOfficesController extends Controller {
                         $personLabel .= ' (' . $name . ')';
                     }
                 }
+                $biogDy = $basicinformation->c_dy ?? null;
             }
         } catch (\Exception $e) {
             // 如果 byPersonId 失敗（例如在測試環境中表結構不完整），只使用 ID
         }
 
-        return view('biogmains.offices.edit', ['id' => $id, 'row' => $res['row'], 'res' => $res,
+        return view('biogmains.offices.edit', ['id' => $id, 'row' => $res['row'], 'res' => $res, 'biog_dy' => $biogDy,
             'page_title' => '官名', 'page_description' => '基本信息表 官名',
             'page_url' => '/basicinformation/'.$id.'/offices',
             'archer' => "<li>編輯</li>",
@@ -460,6 +466,7 @@ class BasicInformationOfficesController extends Controller {
 
         // 處理 personLabel
         $personLabel = $id;
+        $biogDy = null;
 
         try {
             $basicinformation = $this->biogMainRepository->byPersonId($id);
@@ -472,6 +479,7 @@ class BasicInformationOfficesController extends Controller {
                         $personLabel .= ' (' . $name . ')';
                     }
                 }
+                $biogDy = $basicinformation->c_dy ?? null;
             }
         } catch (\Exception $e) {
             // 忽略錯誤
@@ -482,6 +490,7 @@ class BasicInformationOfficesController extends Controller {
             'row' => $res['row'],
             'res' => $res,
             'pk' => $pk,
+            'biog_dy' => $biogDy,
             'page_title' => '官名',
             'page_description' => '基本信息表 官名',
             'page_url' => '/basicinformation/'.$id.'/offices',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -178,7 +178,7 @@ window.initAjaxSelect = function($el, model, options = {}) {
                 return {
                     results: data.data || [],
                     pagination: {
-                        more: (params.page * 30) < (data.total || 0)
+                        more: (params.page * 20) < (data.total || 0)
                     }
                 };
             },

--- a/resources/views/biogmains/offices/_form.blade.php
+++ b/resources/views/biogmains/offices/_form.blade.php
@@ -336,7 +336,17 @@
         textperson_pair_first_load();
 
         // 使用统一的 AJAX Select2 初始化助手函数
-        window.initAjaxSelect($(".c_office_id"), 'office');
+        window.initAjaxSelect($(".c_office_id"), 'office', {
+            ajax: {
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page || 1,
+                        c_dy: '{{ $biog_dy ?? '' }}',
+                    };
+                }
+            }
+        });
         window.initAjaxSelect($(".c_source"), 'text');
         window.initAjaxSelect($(".c_inst_code"), 'socialinstcode');
         window.initAjaxSelect($(".c_addr"), 'addr', {

--- a/tests/Feature/ApiSearchOfficeTest.php
+++ b/tests/Feature/ApiSearchOfficeTest.php
@@ -131,4 +131,20 @@ class ApiSearchOfficeTest extends TestCase {
         // 分页链接中应保留 q=0
         $this->assertStringContainsString('q=0', $response->getContent());
     }
+
+    #[Test]
+    public function search_office_page_two_request_with_zero_query_still_preserves_q_in_links(): void {
+        // 验证翻页请求（page=2）中 q=0 同样不被丢弃
+        DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 0, 'c_dy' => 15, 'c_office_pinyin' => 'unknown', 'c_office_chn' => '未知',
+        ]);
+
+        $response = $this->get('/api/select/search/office?q=0&page=2');
+
+        $response->assertOk();
+        // first_page_url 和 last_page_url 都必须带 q=0，确保翻页链接不丢参数
+        $firstPageUrl = $response->json('first_page_url');
+        $this->assertNotNull($firstPageUrl);
+        $this->assertStringContainsString('q=0', $firstPageUrl);
+    }
 }

--- a/tests/Feature/ApiSearchOfficeTest.php
+++ b/tests/Feature/ApiSearchOfficeTest.php
@@ -102,4 +102,33 @@ class ApiSearchOfficeTest extends TestCase {
         $this->assertContains(1001, $ids);
         $this->assertContains(1002, $ids);
     }
+
+    #[Test]
+    public function search_office_falls_back_to_all_dynasties_when_current_dynasty_has_no_match(): void {
+        // 朝代 99 在 OFFICE_CODES 中没有任何官职，应 fallback 到全朝代结果
+        DB::table('DYNASTIES')->insert(['c_dy' => 99, 'c_dynasty_chn' => '測試朝']);
+
+        $response = $this->get('/api/select/search/office?q=吏部侍郎&c_dy=99');
+
+        $response->assertOk();
+        $data = $response->json('data');
+
+        $ids = array_column($data, 'c_office_id');
+        $this->assertContains(1001, $ids);
+        $this->assertContains(1002, $ids);
+    }
+
+    #[Test]
+    public function search_office_with_numeric_zero_query_preserves_q_in_pagination_links(): void {
+        // q=0 是合法的 office_id 搜索，array_filter 不应丢掉它
+        DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 0, 'c_dy' => 15, 'c_office_pinyin' => 'unknown', 'c_office_chn' => '未知',
+        ]);
+
+        $response = $this->get('/api/select/search/office?q=0');
+
+        $response->assertOk();
+        // 分页链接中应保留 q=0
+        $this->assertStringContainsString('q=0', $response->getContent());
+    }
 }

--- a/tests/Feature/ApiSearchOfficeTest.php
+++ b/tests/Feature/ApiSearchOfficeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ApiSearchOfficeTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('OFFICE_CODES');
+        Schema::dropIfExists('DYNASTIES');
+
+        Schema::create('DYNASTIES', function (Blueprint $table) {
+            $table->smallInteger('c_dy')->primary();
+            $table->string('c_dynasty_chn')->nullable();
+            $table->integer('c_dynasty_firstyear')->nullable();
+            $table->integer('c_dynasty_lastyear')->nullable();
+        });
+
+        Schema::create('OFFICE_CODES', function (Blueprint $table) {
+            $table->integer('c_office_id')->primary();
+            $table->smallInteger('c_dy')->nullable();
+            $table->string('c_office_pinyin')->nullable();
+            $table->string('c_office_chn')->nullable();
+            $table->string('c_office_trans')->nullable();
+        });
+
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 15, 'c_dynasty_chn' => '宋'],
+            ['c_dy' => 17, 'c_dynasty_chn' => '金'],
+        ]);
+
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 1001, 'c_dy' => 15, 'c_office_pinyin' => 'li bu shi lang', 'c_office_chn' => '吏部侍郎'],
+            ['c_office_id' => 1002, 'c_dy' => 17, 'c_office_pinyin' => 'li bu shi lang', 'c_office_chn' => '吏部侍郎'],
+            ['c_office_id' => 1003, 'c_dy' => 15, 'c_office_pinyin' => 'li bu shang shu', 'c_office_chn' => '吏部尚書'],
+        ]);
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('OFFICE_CODES');
+        Schema::dropIfExists('DYNASTIES');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function search_office_with_positive_dynasty_returns_only_that_dynasty(): void {
+        $response = $this->get('/api/select/search/office?q=吏部侍郎&c_dy=17');
+
+        $response->assertOk();
+        $data = $response->json('data');
+
+        $ids = array_column($data, 'c_office_id');
+        $this->assertContains(1002, $ids);
+        $this->assertNotContains(1001, $ids);
+    }
+
+    #[Test]
+    public function search_office_with_zero_dynasty_returns_all_matching_offices(): void {
+        $response = $this->get('/api/select/search/office?q=吏部侍郎&c_dy=0');
+
+        $response->assertOk();
+        $data = $response->json('data');
+
+        $ids = array_column($data, 'c_office_id');
+        $this->assertContains(1001, $ids);
+        $this->assertContains(1002, $ids);
+    }
+
+    #[Test]
+    public function search_office_with_negative_dynasty_returns_all_matching_offices(): void {
+        $response = $this->get('/api/select/search/office?q=吏部侍郎&c_dy=-1');
+
+        $response->assertOk();
+        $data = $response->json('data');
+
+        $ids = array_column($data, 'c_office_id');
+        $this->assertContains(1001, $ids);
+        $this->assertContains(1002, $ids);
+    }
+
+    #[Test]
+    public function search_office_without_dynasty_returns_all_matching_offices(): void {
+        $response = $this->get('/api/select/search/office?q=吏部侍郎');
+
+        $response->assertOk();
+        $data = $response->json('data');
+
+        $ids = array_column($data, 'c_office_id');
+        $this->assertContains(1001, $ids);
+        $this->assertContains(1002, $ids);
+    }
+}


### PR DESCRIPTION
## 問題

在官名錄入頁（`/basicinformation/{id}/offices/create`）搜索「吏部侍郎」時，金朝（c_dy=17）的記錄（c_office_id=300629）不出現在結果中。

## 根本原因

1. `searchOffice()` 每頁只返回 20 條，無朝代過濾，按主鍵升序排列，金朝記錄 ID 較大被擠出首頁
2. 前端分頁「更多」判斷閾值用 `30` 但後端每頁 `20`，導致 21–30 條結果時第 2 頁永遠不顯示

## 修正內容

- 控制器（`create` / `edit` / `editQuery`）將人物朝代 `c_dy` 傳入視圖為 `biog_dy`
- 官名 Select2 以人物朝代過濾搜索，`c_dy ≤ 0`（未知朝代）時不套用過濾
- 當前朝代無匹配結果時自動 fallback 至全朝代（處理隋→唐、五代→唐/宋 等尚未建立朝代官職的情況）
- 修正 `array_filter` 導致 `q=0` 在翻頁時遺失的回歸
- 修正前端分頁閾值 30→20

## 測試

新增 `ApiSearchOfficeTest`，涵蓋 7 個 case：朝代過濾、sentinel 值回退、跨朝代 fallback、`q=0` 分頁保留。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)