### PR TITLE
新增 API v2 人物清單與操作記錄端口

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,3 +1,137 @@
+# API v2（現行版本）
+
+v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagination` 結構。基底 URL：`https://input.cbdb.fas.harvard.edu/api/v2/...`
+
+---
+
+## 一、人物清單
+
+### `GET /api/v2/persons`
+
+輸出 BIOG_MAIN 所有人物的 `c_personid`，按主鍵升序，分頁輸出。**不需要登入。**
+
+### 輸入參數
+
+| 參數名 | 參數類型 | 預設值 | 說明 |
+| ------ | ------ | ------ | ------ |
+| per_page | 數字 | 100 | 每頁筆數，上限 1000 |
+| page | 數字 | 1 | 頁碼 |
+
+### 輸入示例
+
+`/api/v2/persons` 取第一頁（預設每頁 100 筆）  
+`/api/v2/persons?per_page=500&page=2` 取第二頁，每頁 500 筆
+
+### 輸出格式
+
+```json
+{
+  "ok": true,
+  "data": [
+    {"c_personid": 1},
+    {"c_personid": 2}
+  ],
+  "pagination": {
+    "total": 680000,
+    "per_page": 100,
+    "current_page": 1,
+    "last_page": 6800,
+    "from": 1,
+    "to": 100
+  }
+}
+```
+
+| 屬性名 | 屬性類型 | 說明 |
+| ------ | ------ | ------ |
+| ok | 布林 | 請求是否成功 |
+| data | 陣列 | 人物 ID 列表 |
+| data[i].c_personid | 數字 | 人物 ID |
+| pagination.total | 數字 | 資料總筆數 |
+| pagination.per_page | 數字 | 每頁筆數 |
+| pagination.current_page | 數字 | 當前頁碼 |
+| pagination.last_page | 數字 | 最後一頁頁碼 |
+| pagination.from | 數字 | 本頁第一筆的序號（空頁時為 0） |
+| pagination.to | 數字 | 本頁最後一筆的序號（空頁時為 0） |
+
+---
+
+## 二、操作記錄清單
+
+### `GET /api/v2/operations`
+
+輸出操作記錄（對應 `/operations` 頁面），分頁輸出。**需要登入（session 或 Sanctum token）。**
+
+### 輸入參數
+
+| 參數名 | 參數類型 | 預設值 | 說明 |
+| ------ | ------ | ------ | ------ |
+| per_page | 數字 | 20 | 每頁筆數，上限 100 |
+| page | 數字 | 1 | 頁碼 |
+| proposals_only | 布林 | false | `true` 只回傳提案（op_type 8/9）；`false` 只回傳一般操作 |
+| editor | 字串 | — | 依修改者篩選；純數字視為 user_id 精確比對，否則模糊匹配使用者名稱 |
+| op_type[] | 數字陣列 | — | 操作類型篩選（僅非提案模式有效）：1=新增、2=修改全部、3=修改部分、4=刪除 |
+| status[] | 字串陣列 | — | 提案審核狀態（僅 `proposals_only=true` 有效）：`pending`、`approved`、`rejected`、`cancelled` |
+
+### 輸入示例
+
+`/api/v2/operations` 取最近 20 筆一般操作記錄  
+`/api/v2/operations?proposals_only=true&status[]=pending` 取待審核提案  
+`/api/v2/operations?op_type[]=3&op_type[]=4` 只看修改與刪除操作  
+`/api/v2/operations?editor=10` 取 user_id=10 的操作記錄
+
+### 輸出格式
+
+```json
+{
+  "ok": true,
+  "data": [
+    {
+      "id": 12345,
+      "user_id": 7,
+      "c_personid": 10001,
+      "op_type": 3,
+      "resource": "BIOG_MAIN",
+      "resource_id": "c_personid=10001",
+      "resource_data": {"c_name_chn": "杜甫"},
+      "resource_original": {"c_name_chn": "杜甫（舊）"},
+      "crowdsourcing_status": 0,
+      "created_at": "2026-05-30T08:00:00.000000Z",
+      "updated_at": "2026-05-30T08:00:00.000000Z"
+    }
+  ],
+  "pagination": {
+    "total": 4200,
+    "per_page": 20,
+    "current_page": 1,
+    "last_page": 210,
+    "from": 1,
+    "to": 20
+  }
+}
+```
+
+| 屬性名 | 屬性類型 | 說明 |
+| ------ | ------ | ------ |
+| ok | 布林 | 請求是否成功 |
+| data | 陣列 | 操作記錄列表 |
+| data[i].id | 數字 | 操作 ID |
+| data[i].user_id | 數字 | 操作者的 user ID |
+| data[i].c_personid | 數字 | 相關人物 ID |
+| data[i].op_type | 數字 | 操作類型（1=新增、2=修改全部、3=修改部分、4=刪除、8=提案新增、9=提案修改） |
+| data[i].resource | 字串 | 被操作的資料表名稱 |
+| data[i].resource_id | 字串 | 被操作的資料列識別碼 |
+| data[i].resource_data | 物件 | 操作後的資料內容（JSON 已解碼） |
+| data[i].resource_original | 物件/null | 操作前的資料快照（JSON 已解碼；新增操作為 null） |
+| data[i].crowdsourcing_status | 數字 | 眾包狀態（0=正式操作） |
+| data[i].created_at | 字串 | 建立時間（ISO 8601） |
+| data[i].updated_at | 字串 | 更新時間（ISO 8601） |
+| pagination | 物件 | 分頁資訊（欄位同人物清單） |
+
+---
+
+# 舊版 API 文檔
+
 # 使用方法
 將下文輸入示例中 /api... 前接 input.cbdb.fas.harvard.edu
 

--- a/app/Http/Controllers/Api/OperationListController.php
+++ b/app/Http/Controllers/Api/OperationListController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Operation;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OperationListController extends Controller {
+    public function index(Request $request): JsonResponse {
+        $perPage = min((int) $request->input('per_page', 20), 100);
+        if ($perPage < 1) {
+            $perPage = 20;
+        }
+
+        $proposalsOnly = filter_var($request->input('proposals_only', false), FILTER_VALIDATE_BOOLEAN);
+
+        $query = Operation::where('crowdsourcing_status', 0);
+
+        if ($proposalsOnly) {
+            $query->whereIn('op_type', [
+                Operation::TYPE_PROPOSAL_CREATE,
+                Operation::TYPE_PROPOSAL_UPDATE,
+            ]);
+
+            $rawStatuses = $request->input('status', []);
+            if (!is_array($rawStatuses)) {
+                $rawStatuses = [$rawStatuses];
+            }
+            $allowedStatuses = ['pending', 'approved', 'rejected', 'cancelled'];
+            $statusFilters = array_values(array_intersect($rawStatuses, $allowedStatuses));
+
+            if (!empty($statusFilters)) {
+                $query->where(function ($sub) use ($statusFilters) {
+                    foreach ($statusFilters as $status) {
+                        $sub->orWhere('resource_data', 'like', '%"__review_status":"' . $status . '"%');
+                    }
+                });
+            }
+        } else {
+            $query->whereNotIn('op_type', [
+                Operation::TYPE_PROPOSAL_CREATE,
+                Operation::TYPE_PROPOSAL_UPDATE,
+            ]);
+
+            $rawOpTypes = $request->input('op_type', []);
+            if (!is_array($rawOpTypes)) {
+                $rawOpTypes = [$rawOpTypes];
+            }
+            $opTypeFilter = array_values(array_intersect(
+                array_filter(array_map('intval', $rawOpTypes)),
+                [
+                    Operation::TYPE_CREATE,
+                    Operation::TYPE_UPDATE_FULL,
+                    Operation::TYPE_UPDATE,
+                    Operation::TYPE_DELETE,
+                ]
+            ));
+            if (!empty($opTypeFilter)) {
+                $query->whereIn('op_type', $opTypeFilter);
+            }
+        }
+
+        $editorFilter = trim((string) $request->input('editor', ''));
+        if ($editorFilter !== '') {
+            $query->whereHas('user', function ($q) use ($editorFilter) {
+                if (ctype_digit($editorFilter)) {
+                    $q->where('id', (int) $editorFilter);
+                } else {
+                    $escaped = addcslashes($editorFilter, '%_');
+                    $q->where('name', 'like', '%' . $escaped . '%');
+                }
+            });
+        }
+
+        $paginator = $query->orderBy('updated_at', 'desc')->paginate($perPage);
+
+        $items = collect($paginator->items())->map(function (Operation $op) {
+            return [
+                'id' => $op->id,
+                'user_id' => $op->user_id,
+                'c_personid' => $op->c_personid,
+                'op_type' => $op->op_type,
+                'resource' => $op->resource,
+                'resource_id' => $op->resource_id,
+                'resource_data' => is_string($op->resource_data) ? json_decode($op->resource_data, true) : $op->resource_data,
+                'resource_original' => is_string($op->resource_original) ? json_decode($op->resource_original, true) : $op->resource_original,
+                'crowdsourcing_status' => $op->crowdsourcing_status,
+                'created_at' => $op->created_at,
+                'updated_at' => $op->updated_at,
+            ];
+        })->values()->all();
+
+        return response()->json([
+            'ok' => true,
+            'data' => $items,
+            'pagination' => [
+                'total' => $paginator->total(),
+                'per_page' => $paginator->perPage(),
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'from' => $paginator->firstItem() ?? 0,
+                'to' => $paginator->lastItem() ?? 0,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/PersonListController.php
+++ b/app/Http/Controllers/Api/PersonListController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\BiogMain;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PersonListController extends Controller {
+    public function index(Request $request): JsonResponse {
+        $perPage = min((int) $request->input('per_page', 100), 1000);
+        if ($perPage < 1) {
+            $perPage = 100;
+        }
+
+        $paginator = BiogMain::select(['c_personid'])
+            ->orderBy('c_personid', 'asc')
+            ->paginate($perPage);
+
+        return response()->json([
+            'ok' => true,
+            'data' => $paginator->items(),
+            'pagination' => [
+                'total' => $paginator->total(),
+                'per_page' => $paginator->perPage(),
+                'current_page' => $paginator->currentPage(),
+                'last_page' => $paginator->lastPage(),
+                'from' => $paginator->firstItem() ?? 0,
+                'to' => $paginator->lastItem() ?? 0,
+            ],
+        ]);
+    }
+}

--- a/docs/API_V2_PERSONS_AND_OPERATIONS_PLAN.md
+++ b/docs/API_V2_PERSONS_AND_OPERATIONS_PLAN.md
@@ -1,0 +1,192 @@
+# API v2：人物清單與操作記錄端口設計計畫
+
+## 背景
+
+需新增兩個分頁 API 端口：
+
+1. **人物清單**：輸出 `BIOG_MAIN` 中所有人物的 `c_personid`，分頁輸出。
+2. **操作記錄**：將 `/operations` 頁面的操作記錄清單做成 API，分頁輸出。
+
+---
+
+## 第一步：建立新分支
+
+```bash
+git checkout develop
+git pull
+git checkout -b feature/api-v2-persons-and-operations
+```
+
+---
+
+## 現行 API 架構摘要
+
+閱讀 `routes/api.php`、`app/Http/Controllers/Api/TextLookupController.php`
+及 `app/Http/Controllers/OperationsController.php` 後，整理現行慣例：
+
+| 面向 | 現行做法 |
+|------|---------|
+| 路由前綴 | 現代端口用 `v2`，舊端口直接放根層 |
+| 中間件 | `auth.optional`（允許未登入，不強制） |
+| 控制器位置 | `app/Http/Controllers/Api/` |
+| JSON 回應格式 | `{'ok': true, 'data': [...], 'meta': {...}}` |
+| 分頁 | Laravel `paginate()`；分頁資訊另外組成 `pagination` 物件 |
+| 錯誤格式 | `{'ok': false, 'message': '...', 'errors': {...}}` + HTTP 4xx |
+
+---
+
+## API 1：人物清單
+
+### 路由
+
+```
+GET /api/v2/persons
+```
+
+### Query 參數
+
+| 參數 | 預設值 | 說明 |
+|------|-------|------|
+| `per_page` | 100 | 每頁筆數，上限 1000 |
+| `page` | 1 | 頁碼（Laravel 自動處理） |
+
+### 實作位置
+
+- **路由**：`routes/api.php`，加入 `v2` prefix group 下
+- **控制器**：新建 `app/Http/Controllers/Api/PersonListController.php`
+
+### 查詢邏輯
+
+```php
+BiogMain::select(['c_personid'])
+    ->orderBy('c_personid', 'asc')
+    ->paginate($perPage);
+```
+
+只取 `c_personid`，按主鍵升序，確保結果穩定可分頁。
+
+### 回應格式
+
+```json
+{
+  "ok": true,
+  "data": [
+    {"c_personid": 1},
+    {"c_personid": 2},
+    ...
+  ],
+  "pagination": {
+    "total": 680000,
+    "per_page": 100,
+    "current_page": 1,
+    "last_page": 6800,
+    "from": 1,
+    "to": 100
+  }
+}
+```
+
+---
+
+## API 2：操作記錄
+
+### 路由
+
+```
+GET /api/v2/operations
+```
+
+### 設計決策
+
+現行 `OperationsController::index()` 包含大量 Blade 視圖邏輯：
+- 即時 diff 比對（從資料庫讀取現行資料列並比較）
+- audit log 載入
+- HTML 渲染用的輔助屬性
+
+**API 版本不複製這些邏輯**，原因：
+1. Diff 計算每筆需額外 DB query，分頁 20 筆就需 20+ 次，成本高
+2. `resource_data` / `resource_original` 已是完整 JSON，呼叫端可自行比對
+3. API 消費者需要的是乾淨的資料，不是渲染用的計算結果
+
+API 版只提供基本操作記錄欄位，`resource_data` / `resource_original` 解碼為 JSON 物件（不再是字串）。
+
+### Query 參數
+
+| 參數 | 預設值 | 說明 |
+|------|-------|------|
+| `per_page` | 20 | 每頁筆數，上限 100 |
+| `page` | 1 | 頁碼 |
+| `proposals_only` | false | `true` 只回傳提案（op_type 8/9） |
+| `editor` | — | 依修改者篩選（純數字=user_id，否則模糊匹配 name） |
+| `op_type` | — | 修改類型，多值陣列，例如 `op_type[]=1&op_type[]=3` |
+| `status` | — | 提案審核狀態，多值，`proposals_only=true` 時有效 |
+
+篩選邏輯與 `OperationsController::index()` 保持一致，直接重用，不重複實作。
+
+### 實作位置
+
+- **路由**：`routes/api.php`，加入 `v2` prefix group 下
+- **控制器**：新建 `app/Http/Controllers/Api/OperationListController.php`
+- **共用篩選邏輯**：直接在控制器內實作（邏輯簡單，不必抽 Service）
+
+### 回應格式
+
+```json
+{
+  "ok": true,
+  "data": [
+    {
+      "id": 12345,
+      "user_id": 7,
+      "c_personid": 10001,
+      "op_type": 3,
+      "resource": "BIOG_MAIN",
+      "resource_id": "c_personid=10001",
+      "resource_data": { ... },
+      "resource_original": { ... },
+      "crowdsourcing_status": 0,
+      "created_at": "2026-05-30T08:00:00.000000Z",
+      "updated_at": "2026-05-30T08:00:00.000000Z"
+    }
+  ],
+  "pagination": {
+    "total": 4200,
+    "per_page": 20,
+    "current_page": 1,
+    "last_page": 210,
+    "from": 1,
+    "to": 20
+  }
+}
+```
+
+---
+
+## 授權與安全
+
+兩個端口均使用 `auth.optional` 中間件（與現行 v2 端口一致）：
+- 未登入使用者可讀取
+- 不暴露任何寫入能力
+
+Operations API 只讀，且 `crowdsourcing_status = 0` 的記錄才是正式操作記錄，無隱私疑慮。
+
+---
+
+## 實作步驟
+
+1. **建分支**：`git checkout -b feature/api-v2-persons-and-operations`
+2. **新建** `app/Http/Controllers/Api/PersonListController.php`
+3. **新建** `app/Http/Controllers/Api/OperationListController.php`
+4. **修改** `routes/api.php`：在 `v2` + `auth.optional` group 下加入兩條路由
+5. **跑 CS Fixer**：`./vendor/bin/php-cs-fixer fix`
+6. **補測試**（Feature test，驗證分頁結構、篩選參數）
+7. **跑測試**：`./vendor/bin/phpunit`
+8. **更新** `API.md`：在文件最前面新增 `## API v2` heading，按現有文檔格式補上兩個端口的說明
+
+---
+
+## 不在本次範圍內
+
+- Operations API 的 diff 計算（視需求另行評估）
+- 寫入端口
+- 認證強制化（視後續政策決定）

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,14 @@ Route::group([
 ], function () {
     Route::get('texts', 'Api\TextLookupController@index');
     Route::get('texts/{textId}', 'Api\TextLookupController@show')->where('textId', '[0-9]+');
+    Route::get('persons', 'Api\PersonListController@index');
+});
+
+Route::group([
+    'prefix' => 'v2',
+    'middleware' => ['auth:sanctum,web'],
+], function () {
+    Route::get('operations', 'Api\OperationListController@index');
 });
 
 // Select APIs with optional authentication

--- a/tests/Feature/ApiV2OperationListTest.php
+++ b/tests/Feature/ApiV2OperationListTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ApiV2OperationListTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid')->default(0);
+            $table->smallInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->default('');
+            $table->longText('resource_data');
+            $table->longText('resource_original')->nullable();
+            $table->smallInteger('crowdsourcing_status')->default(0);
+            $table->smallInteger('rate')->default(0);
+            $table->timestamps();
+        });
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '甲']);
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('BIOG_MAIN');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    protected function makeUser(string $email = 'tester@example.com'): User {
+        return User::create([
+            'name' => 'tester',
+            'email' => $email,
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]);
+    }
+
+    protected function insertOperation(array $overrides = []): void {
+        DB::table('operations')->insert(array_merge([
+            'user_id' => 1,
+            'c_personid' => 1,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => 'c_personid=1',
+            'resource_data' => json_encode(['c_name_chn' => '甲']),
+            'resource_original' => null,
+            'crowdsourcing_status' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], $overrides));
+    }
+
+    public function test_requires_authentication(): void {
+        $response = $this->getJson('/api/v2/operations');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_receives_paginated_response(): void {
+        $user = $this->makeUser();
+        $this->insertOperation();
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk()->assertJsonStructure([
+            'ok',
+            'data' => [['id', 'user_id', 'c_personid', 'op_type', 'resource', 'resource_id',
+                'resource_data', 'resource_original', 'crowdsourcing_status', 'created_at', 'updated_at']],
+            'pagination' => ['total', 'per_page', 'current_page', 'last_page', 'from', 'to'],
+        ]);
+
+        $response->assertJson(['ok' => true]);
+        $this->assertEquals(1, $response->json('pagination.total'));
+    }
+
+    public function test_resource_data_is_decoded_as_json_object(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['resource_data' => json_encode(['c_name_chn' => '甲'])]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk();
+        $resourceData = $response->json('data.0.resource_data');
+        $this->assertIsArray($resourceData);
+        $this->assertEquals('甲', $resourceData['c_name_chn']);
+    }
+
+    public function test_excludes_proposal_create_and_update_by_default(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['op_type' => Operation::TYPE_UPDATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_PROPOSAL_CREATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_PROPOSAL_UPDATE]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('pagination.total'));
+        $this->assertEquals(Operation::TYPE_UPDATE, $response->json('data.0.op_type'));
+    }
+
+    public function test_proposal_delete_appears_in_normal_list_matching_blade_ui(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['op_type' => Operation::TYPE_UPDATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_PROPOSAL_DELETE]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk();
+        $this->assertEquals(2, $response->json('pagination.total'));
+        $opTypes = array_column($response->json('data'), 'op_type');
+        $this->assertContains(Operation::TYPE_UPDATE, $opTypes);
+        $this->assertContains(Operation::TYPE_PROPOSAL_DELETE, $opTypes);
+    }
+
+    public function test_proposals_only_returns_only_proposal_types(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['op_type' => Operation::TYPE_UPDATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_PROPOSAL_CREATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_PROPOSAL_UPDATE]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations?proposals_only=true');
+
+        $response->assertOk();
+        $this->assertEquals(2, $response->json('pagination.total'));
+        $opTypes = array_column($response->json('data'), 'op_type');
+        $this->assertContains(Operation::TYPE_PROPOSAL_CREATE, $opTypes);
+        $this->assertContains(Operation::TYPE_PROPOSAL_UPDATE, $opTypes);
+        $this->assertNotContains(Operation::TYPE_UPDATE, $opTypes);
+    }
+
+    public function test_op_type_filter_in_normal_mode(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['op_type' => Operation::TYPE_CREATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_UPDATE]);
+        $this->insertOperation(['op_type' => Operation::TYPE_DELETE]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations?op_type[]=' . Operation::TYPE_CREATE);
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('pagination.total'));
+        $this->assertEquals(Operation::TYPE_CREATE, $response->json('data.0.op_type'));
+    }
+
+    public function test_per_page_parameter_respected(): void {
+        $user = $this->makeUser();
+        for ($i = 0; $i < 5; $i++) {
+            $this->insertOperation();
+        }
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations?per_page=2');
+
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data'));
+        $this->assertEquals(5, $response->json('pagination.total'));
+        $this->assertEquals(2, $response->json('pagination.per_page'));
+        $this->assertEquals(3, $response->json('pagination.last_page'));
+    }
+
+    public function test_per_page_capped_at_100(): void {
+        $user = $this->makeUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations?per_page=9999');
+
+        $response->assertOk();
+        $this->assertEquals(100, $response->json('pagination.per_page'));
+    }
+
+    public function test_excludes_crowdsourcing_submissions(): void {
+        $user = $this->makeUser();
+        $this->insertOperation(['crowdsourcing_status' => 0]);
+        $this->insertOperation(['crowdsourcing_status' => 2]);
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('pagination.total'));
+    }
+
+    public function test_empty_result_has_zero_pagination(): void {
+        $user = $this->makeUser();
+
+        $response = $this->actingAs($user)->getJson('/api/v2/operations');
+
+        $response->assertOk()->assertJson(['ok' => true, 'data' => []]);
+        $this->assertEquals(0, $response->json('pagination.total'));
+        $this->assertEquals(0, $response->json('pagination.from'));
+        $this->assertEquals(0, $response->json('pagination.to'));
+    }
+}

--- a/tests/Feature/ApiV2PersonListTest.php
+++ b/tests/Feature/ApiV2PersonListTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ApiV2PersonListTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('BIOG_MAIN');
+        parent::tearDown();
+    }
+
+    public function test_returns_paginated_person_ids(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 10, 'c_name_chn' => '甲', 'c_name' => 'A'],
+            ['c_personid' => 20, 'c_name_chn' => '乙', 'c_name' => 'B'],
+            ['c_personid' => 30, 'c_name_chn' => '丙', 'c_name' => 'C'],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons');
+
+        $response->assertOk()->assertJson([
+            'ok' => true,
+        ]);
+
+        $data = $response->json('data');
+        $this->assertCount(3, $data);
+        $this->assertEquals(10, $data[0]['c_personid']);
+        $this->assertEquals(20, $data[1]['c_personid']);
+        $this->assertEquals(30, $data[2]['c_personid']);
+    }
+
+    public function test_returns_correct_pagination_structure(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '甲', 'c_name' => 'A'],
+            ['c_personid' => 2, 'c_name_chn' => '乙', 'c_name' => 'B'],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons?per_page=1&page=1');
+
+        $response->assertOk()->assertJsonStructure([
+            'ok',
+            'data',
+            'pagination' => ['total', 'per_page', 'current_page', 'last_page', 'from', 'to'],
+        ]);
+
+        $pagination = $response->json('pagination');
+        $this->assertEquals(2, $pagination['total']);
+        $this->assertEquals(1, $pagination['per_page']);
+        $this->assertEquals(1, $pagination['current_page']);
+        $this->assertEquals(2, $pagination['last_page']);
+        $this->assertEquals(1, $pagination['from']);
+        $this->assertEquals(1, $pagination['to']);
+    }
+
+    public function test_per_page_second_page(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '甲', 'c_name' => 'A'],
+            ['c_personid' => 2, 'c_name_chn' => '乙', 'c_name' => 'B'],
+            ['c_personid' => 3, 'c_name_chn' => '丙', 'c_name' => 'C'],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons?per_page=2&page=2');
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        $this->assertEquals(3, $data[0]['c_personid']);
+    }
+
+    public function test_per_page_capped_at_1000(): void {
+        $response = $this->getJson('/api/v2/persons?per_page=9999');
+
+        $response->assertOk();
+        $this->assertEquals(1000, $response->json('pagination.per_page'));
+    }
+
+    public function test_invalid_per_page_falls_back_to_default(): void {
+        $response = $this->getJson('/api/v2/persons?per_page=-5');
+
+        $response->assertOk();
+        $this->assertEquals(100, $response->json('pagination.per_page'));
+    }
+
+    public function test_empty_table_returns_zero_pagination(): void {
+        $response = $this->getJson('/api/v2/persons');
+
+        $response->assertOk()->assertJson([
+            'ok' => true,
+            'data' => [],
+        ]);
+
+        $pagination = $response->json('pagination');
+        $this->assertEquals(0, $pagination['total']);
+        $this->assertEquals(0, $pagination['from']);
+        $this->assertEquals(0, $pagination['to']);
+    }
+
+    public function test_results_ordered_by_personid_ascending(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 300, 'c_name_chn' => '丙', 'c_name' => 'C'],
+            ['c_personid' => 100, 'c_name_chn' => '甲', 'c_name' => 'A'],
+            ['c_personid' => 200, 'c_name_chn' => '乙', 'c_name' => 'B'],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons');
+
+        $response->assertOk();
+        $ids = array_column($response->json('data'), 'c_personid');
+        $this->assertEquals([100, 200, 300], $ids);
+    }
+
+    public function test_accessible_without_authentication(): void {
+        $response = $this->getJson('/api/v2/persons');
+
+        $response->assertOk()->assertJson(['ok' => true]);
+    }
+}


### PR DESCRIPTION
## 摘要

新增兩個分頁 API 端口（v2），見 [設計計畫](docs/API_V2_PERSONS_AND_OPERATIONS_PLAN.md)：

- **GET /api/v2/persons**：公開，分頁輸出 BIOG_MAIN 所有 `c_personid`，按主鍵升序排列
- **GET /api/v2/operations**：需登入（auth:sanctum,web），分頁輸出操作記錄，支援 `proposals_only`、`editor`、`op_type`、`status` 篩選，`resource_data` / `resource_original` 已解碼為 JSON 物件回傳

## 主要設計決策

- `operations` 端口不複製 Blade 的即時 diff 計算（每筆需額外 DB query），API 消費者可自行比對 JSON
- `proposals_only=false` 正確保留 op_type=10（TYPE_PROPOSAL_DELETE），與 Blade UI 一致
- `editor` 篩選加 `addcslashes` 逸脫 LIKE 萬用字元，防止 `%` / `_` 繞過篩選

## 修正的 Bug（code review 發現）

- `editor=%` 可讓 LIKE 篩選完全失效，已修正逸脫
- `TYPE_PROPOSAL_DELETE`（op_type=10）在非提案模式被錯誤排除，已修正

## 測試計畫

- [x] 新增 19 個 Feature tests（`ApiV2PersonListTest`、`ApiV2OperationListTest`）
- [x] 全套 1269 個測試通過（`./vendor/bin/phpunit`）
- [x] `GET /api/v2/persons` 可無需登入呼叫
- [x] `GET /api/v2/operations` 未登入返回 401
- [x] `per_page`、`proposals_only`、`editor`、`op_type` 篩選功能正常

🤖 Generated with [Claude Code](https://claude.ai/claude-code)