### PR TITLE
將 GET /api/v2/operations 改為公開端口（無需登入）

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,7 +60,7 @@ v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagin
 
 ### `GET /api/v2/operations`
 
-輸出操作記錄（對應 `/operations` 頁面），分頁輸出。**需要登入（session 或 Sanctum token）。**
+輸出操作記錄（對應 `/operations` 頁面），分頁輸出。**不需要登入。**
 
 ### 輸入參數
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,12 +24,6 @@ Route::group([
     Route::get('texts', 'Api\TextLookupController@index');
     Route::get('texts/{textId}', 'Api\TextLookupController@show')->where('textId', '[0-9]+');
     Route::get('persons', 'Api\PersonListController@index');
-});
-
-Route::group([
-    'prefix' => 'v2',
-    'middleware' => ['auth:sanctum,web'],
-], function () {
     Route::get('operations', 'Api\OperationListController@index');
 });
 

--- a/tests/Feature/ApiV2OperationListTest.php
+++ b/tests/Feature/ApiV2OperationListTest.php
@@ -85,9 +85,17 @@ class ApiV2OperationListTest extends TestCase {
     }
 
     public function test_accessible_without_authentication(): void {
+        $this->insertOperation();
+
         $response = $this->getJson('/api/v2/operations');
 
-        $response->assertOk()->assertJson(['ok' => true]);
+        $response->assertOk()->assertJsonStructure([
+            'ok',
+            'data' => [['id', 'user_id', 'c_personid', 'op_type', 'resource',
+                'resource_id', 'resource_data', 'crowdsourcing_status', 'created_at', 'updated_at']],
+            'pagination' => ['total', 'per_page', 'current_page', 'last_page', 'from', 'to'],
+        ]);
+        $this->assertEquals(1, $response->json('pagination.total'));
     }
 
     public function test_returns_paginated_response(): void {

--- a/tests/Feature/ApiV2OperationListTest.php
+++ b/tests/Feature/ApiV2OperationListTest.php
@@ -84,13 +84,13 @@ class ApiV2OperationListTest extends TestCase {
         ], $overrides));
     }
 
-    public function test_requires_authentication(): void {
+    public function test_accessible_without_authentication(): void {
         $response = $this->getJson('/api/v2/operations');
 
-        $response->assertStatus(401);
+        $response->assertOk()->assertJson(['ok' => true]);
     }
 
-    public function test_authenticated_user_receives_paginated_response(): void {
+    public function test_returns_paginated_response(): void {
         $user = $this->makeUser();
         $this->insertOperation();
 


### PR DESCRIPTION
## 摘要

將 `GET /api/v2/operations` 從需要登入改為公開端口，與 `GET /api/v2/persons` 一致。

## 變更內容

- 將 `operations` 路由移至 `auth.optional` 中間件群組
- 更新 `ApiV2OperationListTest`：移除 401 測試，改為確認匿名可存取
- 更新 `API.md` 文件說明

## 測試計畫

- [x] 19 個 Feature tests 全數通過
- [x] `GET /api/v2/operations` 無需登入可正常返回資料

🤖 Generated with [Claude Code](https://claude.ai/claude-code)