### PR TITLE
新增「暫不公開」側邊欄選單，限管理員訪問

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,6 +65,7 @@ class Kernel extends HttpKernel {
         'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'auth.optional' => \App\Http\Middleware\OptionalAuthentication::class,
+        'superadmin' => \App\Http\Middleware\RequireSuperAdmin::class,
         'mcp.ability' => \App\Http\Middleware\EnsureMcpAbility::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,

--- a/app/Http/Middleware/RequireSuperAdmin.php
+++ b/app/Http/Middleware/RequireSuperAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireSuperAdmin {
+    public function handle(Request $request, Closure $next): Response {
+        abort_unless(
+            $request->user()?->isActive() && $request->user()?->isSuperAdmin(),
+            403,
+            '此頁面僅限管理員存取。'
+        );
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RequireSuperAdmin.php
+++ b/app/Http/Middleware/RequireSuperAdmin.php
@@ -8,8 +8,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RequireSuperAdmin {
     public function handle(Request $request, Closure $next): Response {
+        $user = $request->user();
         abort_unless(
-            $request->user()?->isActive() && $request->user()?->isSuperAdmin(),
+            $user?->isActive() && $user?->isSuperAdmin(),
             403,
             '此頁面僅限管理員存取。'
         );

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -379,7 +379,7 @@
                     </li>
                 @endif
 
-                @if(Auth::check() and Auth::user()->isSuperAdmin())
+                @if(Auth::check() and Auth::user()->isActive() and Auth::user()->isSuperAdmin())
                     @php
                         $adminPages = [
                             '用戶管理',

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -47,13 +47,6 @@
                 </li>
 
                 <li class="nav-item">
-                    <a href="{{ route('app.person-browser.index') }}" class="nav-link {{ request()->routeIs('app.person-browser.*') ? 'active' : '' }}">
-                        <i class="nav-icon fas fa-user-friends"></i>
-                        <p>人物瀏覽</p>
-                    </a>
-                </li>
-
-                <li class="nav-item">
                     <a href="{{ route('operations.index') }}" class="nav-link {{ $activePage == 'NewUpdate' ? 'active' : '' }}">
                         <i class="nav-icon fas fa-clipboard-list"></i>
                         <p>最近操作記錄</p>
@@ -337,6 +330,49 @@
                                 <a href="{{ route('app.query-playground.index') }}" class="nav-link {{ $activePage == 'Query Playground' || request()->routeIs('app.query-playground.*') ? 'active' : '' }}">
                                     <i class="nav-icon fas fa-terminal"></i>
                                     <p>SQL 查詢練習場</p>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                @endif
+
+                @if(Auth::check() and Auth::user()->isActive() and Auth::user()->isSuperAdmin())
+                    @php
+                        $notPublicPages = [
+                            '人物瀏覽',
+                            '按入仕查詢',
+                            '歷史地圖',
+                        ];
+                        $notPublicMenuOpen = in_array($activePage, $notPublicPages, true)
+                            || request()->routeIs('app.person-browser.*')
+                            || request()->routeIs('app.search-by.entry.*')
+                            || request()->routeIs('app.maps.*');
+                    @endphp
+                    <li class="nav-item {{ $notPublicMenuOpen ? 'menu-open' : '' }}">
+                        <a href="#" class="nav-link {{ $notPublicMenuOpen ? 'active' : '' }}">
+                            <i class="nav-icon fas fa-lock"></i>
+                            <p>
+                                暫不公開
+                                <i class="right fas fa-angle-left"></i>
+                            </p>
+                        </a>
+                        <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('app.person-browser.index') }}" class="nav-link {{ request()->routeIs('app.person-browser.*') ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-user-friends"></i>
+                                    <p>人物瀏覽</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('app.search-by.entry.index') }}" class="nav-link {{ request()->routeIs('app.search-by.entry.*') ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-search"></i>
+                                    <p>按入仕查詢</p>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('app.maps.index') }}" class="nav-link {{ request()->routeIs('app.maps.*') ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-map"></i>
+                                    <p>歷史地圖</p>
                                 </a>
                             </li>
                         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -227,15 +227,6 @@ Route::middleware('auth')->group(function () {
     Route::delete('api-tokens/{tokenId}', 'ApiTokenController@destroy')->name('api-tokens.destroy');
     Route::delete('api-tokens', 'ApiTokenController@destroyAll')->name('api-tokens.destroy-all');
 
-    // 按入仕查詢（Inertia + React）
-    Route::get('app/search-by/entry', 'SearchByEntryController@index')
-        ->middleware('inertia')
-        ->name('app.search-by.entry.index');
-    Route::get('app/search-by/entry/types', 'SearchByEntryController@getEntryTypes')->name('app.search-by.entry.types');
-    Route::get('app/search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('app.search-by.entry.codes');
-    Route::get('app/search-by/entry/places', 'SearchByEntryController@getPlaces')->name('app.search-by.entry.places');
-    Route::get('app/search-by/entry/query', 'SearchByEntryController@query')->name('app.search-by.entry.query');
-
     // 檢視表（Inertia + React）
     Route::get('app/view', 'ViewTableController@appIndex')
         ->middleware('inertia')
@@ -244,28 +235,41 @@ Route::middleware('auth')->group(function () {
         ->middleware('inertia')
         ->name('app.view.show');
 
-    // 人物瀏覽工作台（Inertia + React）
-    Route::get('app/person-browser', 'PersonBrowserController@index')
-        ->middleware('inertia')
-        ->name('app.person-browser.index');
-    Route::get('app/person-browser/search', 'PersonBrowserController@search')
-        ->name('app.person-browser.search');
-    Route::get('app/person-browser/people/{personId}/summary', 'PersonBrowserController@summary')
-        ->where('personId', '[0-9]+')
-        ->name('app.person-browser.summary');
-    Route::get('app/person-browser/people/{personId}/tabs/{tabKey}', 'PersonBrowserController@tab')
-        ->where('personId', '[0-9]+')
-        ->name('app.person-browser.tab');
+    // ── 暫不公開：僅管理員可訪問 ──────────────────────────────────────
+    Route::middleware('superadmin')->group(function () {
+        // 人物瀏覽工作台（Inertia + React）
+        Route::get('app/person-browser', 'PersonBrowserController@index')
+            ->middleware('inertia')
+            ->name('app.person-browser.index');
+        Route::get('app/person-browser/search', 'PersonBrowserController@search')
+            ->name('app.person-browser.search');
+        Route::get('app/person-browser/people/{personId}/summary', 'PersonBrowserController@summary')
+            ->where('personId', '[0-9]+')
+            ->name('app.person-browser.summary');
+        Route::get('app/person-browser/people/{personId}/tabs/{tabKey}', 'PersonBrowserController@tab')
+            ->where('personId', '[0-9]+')
+            ->name('app.person-browser.tab');
 
-    // 歷史地圖
-    Route::get('app/maps', 'HistoricalMapsController@index')
-        ->name('app.maps.index');
-    Route::get('maps', 'HistoricalMapsController@legacyRedirect')
-        ->name('maps.index');
+        // 按入仕查詢（Inertia + React）
+        Route::get('app/search-by/entry', 'SearchByEntryController@index')
+            ->middleware('inertia')
+            ->name('app.search-by.entry.index');
+        Route::get('app/search-by/entry/types', 'SearchByEntryController@getEntryTypes')->name('app.search-by.entry.types');
+        Route::get('app/search-by/entry/codes', 'SearchByEntryController@getEntryCodes')->name('app.search-by.entry.codes');
+        Route::get('app/search-by/entry/places', 'SearchByEntryController@getPlaces')->name('app.search-by.entry.places');
+        Route::get('app/search-by/entry/query', 'SearchByEntryController@query')->name('app.search-by.entry.query');
+
+        // 歷史地圖（需登入且為 superadmin）
+        Route::get('app/maps', 'HistoricalMapsController@index')
+            ->name('app.maps.index');
+    });
+    // ─────────────────────────────────────────────────────────────────
+
+    // Legacy maps 重定向（需登入，目標 /app/maps 本身已有 superadmin 保護）
+    Route::get('maps', 'HistoricalMapsController@legacyRedirect')->name('maps.index');
     Route::get('maps/index.html', 'HistoricalMapsController@legacyRedirect');
     Route::get('maps/tang', 'HistoricalMapsController@legacyRedirect');
-    Route::get('maps/tang/{path?}', 'HistoricalMapsController@legacyRedirect')
-        ->where('path', '.*');
+    Route::get('maps/tang/{path?}', 'HistoricalMapsController@legacyRedirect')->where('path', '.*');
 
     Route::get('admin/explainsql', 'AdminExplainSqlController@show')->name('admin.explainsql');
     Route::post('admin/explainsql', 'AdminExplainSqlController@explain');

--- a/tests/Feature/HistoricalMapsControllerTest.php
+++ b/tests/Feature/HistoricalMapsControllerTest.php
@@ -64,7 +64,7 @@ class HistoricalMapsControllerTest extends TestCase {
     }
 
     #[Test]
-    public function test_authenticated_user_can_access_historical_maps_page(): void {
+    public function test_superadmin_can_access_historical_maps_page(): void {
         $response = $this->actingAs($this->createUser())->get('/app/maps');
 
         $response->assertOk();

--- a/tests/Feature/HistoricalMapsControllerTest.php
+++ b/tests/Feature/HistoricalMapsControllerTest.php
@@ -52,6 +52,7 @@ class HistoricalMapsControllerTest extends TestCase {
             'institution' => 'Test Institute',
             'confirmation_token' => 'maps-test-token',
             'is_active' => 1,
+            'is_admin' => 3,
         ]);
     }
 
@@ -70,6 +71,22 @@ class HistoricalMapsControllerTest extends TestCase {
         $response->assertViewIs('maps.index');
         $response->assertSee('中國歷代行政區地圖');
         $response->assertSee('historical-layer-select', false);
+    }
+
+    #[Test]
+    public function test_non_superadmin_cannot_access_historical_maps_page(): void {
+        $regularUser = User::create([
+            'name' => 'Regular User',
+            'email' => 'regular@example.com',
+            'password' => Hash::make('password'),
+            'confirmation_token' => 'regular-token',
+            'is_active' => 1,
+            'is_admin' => 0,
+        ]);
+
+        $response = $this->actingAs($regularUser)->get('/app/maps');
+
+        $response->assertForbidden();
     }
 
     #[Test]

--- a/tests/Feature/InertiaSearchByEntryTest.php
+++ b/tests/Feature/InertiaSearchByEntryTest.php
@@ -17,6 +17,7 @@ class InertiaSearchByEntryTest extends TestCase {
         $this->createTestTables();
         $this->user = User::factory()->create([
             'is_active' => 1,
+            'is_admin' => 3,
         ]);
         $this->seedTestData();
     }

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -19,6 +19,7 @@ class PersonBrowserTest extends TestCase {
         $this->createTestTables();
         $this->user = User::factory()->create([
             'is_active' => 1,
+            'is_admin' => 3,
         ]);
         $this->seedTestData();
     }
@@ -745,6 +746,13 @@ class PersonBrowserTest extends TestCase {
     public function test_person_browser_requires_authentication(): void {
         $response = $this->get(route('app.person-browser.index'));
         $response->assertRedirect(route('login'));
+    }
+
+    #[Test]
+    public function test_person_browser_denies_non_superadmin_users(): void {
+        $regularUser = User::factory()->create(['is_active' => 1, 'is_admin' => 0]);
+        $response = $this->actingAs($regularUser)->get(route('app.person-browser.index'));
+        $response->assertForbidden();
     }
 
     #[Test]

--- a/tests/Feature/SearchByEntryControllerTest.php
+++ b/tests/Feature/SearchByEntryControllerTest.php
@@ -16,6 +16,7 @@ class SearchByEntryControllerTest extends TestCase {
         $this->createTestTables();
         $this->user = User::factory()->create([
             'is_active' => 1,
+            'is_admin' => 3,
         ]);
         $this->seedTestData();
     }


### PR DESCRIPTION
## 摘要

新增管理員專屬的「暫不公開」側邊欄選單，將三個尚未對外開放的功能頁面集中管理，並加上路由層的存取控制。

## 變更內容

### 新功能
- 側邊欄新增「暫不公開」treeview 選單（僅 superadmin 且帳號啟用中可見）
- 選單包含：**人物瀏覽**、**按入仕查詢**、**歷史地圖**

### 路由保護
- 新增 `RequireSuperAdmin` middleware：同時檢查 `isActive() && isSuperAdmin()`
- 三個功能的所有路由移入 `superadmin` middleware group
- Legacy maps 路由（`/maps`、`/maps/tang` 等）保留在 `auth` group，redirect 目標本身已受 superadmin 保護

### 側邊欄調整
- 移除原本公開的「人物瀏覽」選單項
- Sidebar 可見性條件與 middleware 一致（均要求 `isActive() && isSuperAdmin()`）

## 測試
- 各功能測試的 fixture 用戶更新為 superadmin（`is_admin=3`）
- 新增 403 測試：驗證非 superadmin 的認證用戶被正確拒絕
- 全套 1271 個測試通過

🤖 Generated with [Claude Code](https://claude.ai/claude-code)