### PR TITLE
將最近眾包錄入記錄移入暫不公開子選單

### DIFF
--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -63,13 +63,6 @@
                     </a>
                 </li>
 
-                <li class="nav-item">
-                    <a href="{{ route('crowdsourcing.index') }}" class="nav-link {{ $activePage == 'Crowdsourcing' ? 'active' : '' }}">
-                        <i class="nav-icon fas fa-users-cog"></i>
-                        <p>{{ __('nav.crowdsourcing_records') }}</p>
-                    </a>
-                </li>
-
                 @php
                     $codesPages = [
                         'Codes',
@@ -337,11 +330,13 @@
                 @if(Auth::check() and Auth::user()->isActive() and Auth::user()->isSuperAdmin())
                     @php
                         $notPublicPages = [
+                            'Crowdsourcing',
                             '人物瀏覽',
                             '按入仕查詢',
                             '歷史地圖',
                         ];
                         $notPublicMenuOpen = in_array($activePage, $notPublicPages, true)
+                            || request()->routeIs('crowdsourcing.*')
                             || request()->routeIs('app.person-browser.*')
                             || request()->routeIs('app.search-by.entry.*')
                             || request()->routeIs('app.maps.*');
@@ -355,6 +350,12 @@
                             </p>
                         </a>
                         <ul class="nav nav-treeview">
+                            <li class="nav-item">
+                                <a href="{{ route('crowdsourcing.index') }}" class="nav-link {{ $activePage == 'Crowdsourcing' ? 'active' : '' }}">
+                                    <i class="nav-icon fas fa-users-cog"></i>
+                                    <p>{{ __('nav.crowdsourcing_records') }}</p>
+                                </a>
+                            </li>
                             <li class="nav-item">
                                 <a href="{{ route('app.person-browser.index') }}" class="nav-link {{ request()->routeIs('app.person-browser.*') ? 'active' : '' }}">
                                     <i class="nav-icon fas fa-user-friends"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,8 +20,6 @@ Auth::routes();
 
 Route::get('email/verify/{token}', ['as' => 'email.verify', 'uses' => 'EmailController@verify']);
 Route::get('operations', ['as' => 'operations.index', 'uses' => 'OperationsController@index']);
-Route::get('crowdsourcing', ['as' => 'crowdsourcing.index', 'uses' => 'CrowdsourcingController@index']);
-
 Route::post('locale', 'LocaleController@switch')->name('locale.switch')->middleware('throttle:20,1');
 
 Route::get('home', 'HomeController@index')->name('home');
@@ -208,17 +206,6 @@ Route::resource('operations', 'OperationsController', ['name' => [
 ]]);
 Route::post('operations/{operation}/restore', 'OperationsController@restore')->name('operations.restore');
 
-Route::resource('crowdsourcing', 'CrowdsourcingController', ['name' => [
-    'show' => 'crowdsourcing.show',
-    'create' => 'crowdsourcing.create',
-    'edit' => 'crowdsourcing.edit',
-    'update' => 'crowdsourcing.update',
-]]);
-
-
-Route::get('crowdsourcing/{id}/confirm', 'CrowdsourcingController@confirm');
-Route::get('crowdsourcing/{id}/reject', 'CrowdsourcingController@reject');
-
 Route::middleware('auth')->group(function () {
     Route::get('profile', 'UserProfileController@edit')->name('profile.edit');
     Route::patch('profile', 'UserProfileController@update')->name('profile.update');
@@ -239,6 +226,17 @@ Route::middleware('auth')->group(function () {
 
     // ── 暫不公開：僅管理員可訪問 ──────────────────────────────────────
     Route::middleware('superadmin')->group(function () {
+        // 最近眾包錄入記錄
+        Route::get('crowdsourcing', ['as' => 'crowdsourcing.index', 'uses' => 'CrowdsourcingController@index']);
+        Route::resource('crowdsourcing', 'CrowdsourcingController', ['name' => [
+            'show' => 'crowdsourcing.show',
+            'create' => 'crowdsourcing.create',
+            'edit' => 'crowdsourcing.edit',
+            'update' => 'crowdsourcing.update',
+        ]]);
+        Route::get('crowdsourcing/{id}/confirm', 'CrowdsourcingController@confirm');
+        Route::get('crowdsourcing/{id}/reject', 'CrowdsourcingController@reject');
+
         // 人物瀏覽工作台（Inertia + React）
         Route::get('app/person-browser', 'PersonBrowserController@index')
             ->middleware('inertia')


### PR DESCRIPTION
## Summary

- 側邊欄移除頂層獨立的「最近眾包錄入記錄」入口，改放進「暫不公開」子選單首位
- 路由從無保護區段移入 `auth + superadmin` 雙層 middleware，直接存取 URL 也受後端保護
- `$notPublicPages` 及 `$notPublicMenuOpen` 補入 Crowdsourcing 相關條件，進入頁面時選單可正確展開

## Test plan

- [ ] 以 superadmin 帳號登入，確認側邊欄「暫不公開」展開後可見「最近眾包錄入記錄」
- [ ] 以一般 active 帳號登入，確認側邊欄不顯示「最近眾包錄入記錄」
- [ ] 以一般 active 帳號直接存取 `/crowdsourcing`，確認回傳 403
- [ ] `./vendor/bin/phpunit --filter Crowdsourcing` 全數通過（26/26）

🤖 Generated with [Claude Code](https://claude.com/claude-code)