### PR TITLE
主站明確指定 Source Sans Pro 字體，統一中英文顯示

### DIFF
--- a/resources/views/layouts/dashboard-v3.blade.php
+++ b/resources/views/layouts/dashboard-v3.blade.php
@@ -61,6 +61,7 @@
         html, body {
             overscroll-behavior-x: none;
             touch-action: pan-y;
+            font-family: 'Source Sans Pro', sans-serif;
         }
 
         .wrapper {


### PR DESCRIPTION
## Summary

- `dashboard-v3.blade.php` 的 `html, body` 規則加入 `font-family: 'Source Sans Pro', sans-serif`
- 防止瀏覽器在 `lang="zh-TW"` 時自動切換 OS 中文字體（如微軟正黑體、蘋方），使中英文版字體渲染一致
- 歷史地圖頁（`maps/index.blade.php`、`historical-maps/app.css`）維持原狀不動

## Test plan

- [ ] 切換語言至繁體中文，確認主站頁面字體與英文版視覺一致
- [ ] 確認歷史地圖頁字體未受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)