### PR TITLE
自托管 Noto Sans TC，修正 zh-TW 字體偏細問題

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "cbdb-online-main-server",
       "dependencies": {
+        "@fontsource/noto-sans-tc": "^5.2.9",
         "@inertiajs/react": "^2.3.18",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
         "@vitejs/plugin-react": "^4.7.0",
@@ -769,6 +770,15 @@
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/noto-sans-tc": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-tc/-/noto-sans-tc-5.2.9.tgz",
+      "integrity": "sha512-Z+pXTvXYrip79lPV9X1lCYO3UTys55P25VqcifDStIzdZ86I4R6t8dz+NhGd09YdbvHWvOCB5Icw1m7glKHPNQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "5.15.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
+    "@fontsource/noto-sans-tc": "^5.2.9",
     "@inertiajs/react": "^2.3.18",
     "@ttskch/select2-bootstrap4-theme": "^1.5.2",
     "@vitejs/plugin-react": "^4.7.0",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,11 @@
 // Import AdminLTE v3 CSS from NPM
 import 'admin-lte/dist/css/adminlte.min.css';
 
+// Self-hosted Noto Sans TC (weights matching Source Sans Pro) — no Google CDN dependency
+import '@fontsource/noto-sans-tc/300.css';
+import '@fontsource/noto-sans-tc/400.css';
+import '@fontsource/noto-sans-tc/700.css';
+
 // Import jQuery and expose globally before any plugins run
 import $ from './jquery-global';
 

--- a/resources/views/layouts/dashboard-v3.blade.php
+++ b/resources/views/layouts/dashboard-v3.blade.php
@@ -61,7 +61,7 @@
         html, body {
             overscroll-behavior-x: none;
             touch-action: pan-y;
-            font-family: 'Source Sans Pro', sans-serif;
+            font-family: 'Source Sans Pro', 'Noto Sans TC', sans-serif;
         }
 
         .wrapper {


### PR DESCRIPTION
## 問題

`lang="zh-TW"` 時瀏覽器自動選用 PingFang TC（macOS 系統預設繁體中文字體），其 Regular 字重明顯比 Source Sans Pro 細，導致中文版閱讀吃力，且與英文版視覺落差大。

## 解法

自托管 Noto Sans TC（Google 為搭配 Source Sans Pro 設計的 CJK 字體，設計語言與字重一致），並明確加入 font-family stack。

- 不依賴 Google CDN，中國地區可用
- 瀏覽器依 unicode-range 按需下載子集，效能影響最小

## 改動

- `package.json` — 新增 `@fontsource/noto-sans-tc@5.2.9` 依賴
- `resources/js/app.js` — import 300/400/700 三個字重
- `resources/views/layouts/dashboard-v3.blade.php` — font-family 改為 `'Source Sans Pro', 'Noto Sans TC', sans-serif`

## 關聯

關閉 #1039（該 PR 的 fix 過淺，未能解決 PingFang TC fallback 問題）

## Test plan

- [ ] 切換至 zh-TW，確認中文字體粗細與英文版一致
- [ ] 確認歷史地圖頁不受影響
- [ ] `npm run build` 無錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)