### PR TITLE
修正 UserProfileTest CI 失敗：profile_settings zh-TW 譯文

### DIFF
--- a/resources/lang/zh-TW/common.php
+++ b/resources/lang/zh-TW/common.php
@@ -18,7 +18,7 @@ return [
     'loading'           => '載入中…',
     'no_data'           => '無資料',
     'page_of'           => '第 :current 頁，共 :total 頁',
-    'profile_settings'  => '個人設定',
+    'profile_settings'  => '個人資料設定',
     'profile_settings_desc'   => '修改您的個人資料',
     'sign_out'          => '登出',
     'dark_mode_toggle'  => '切換深色模式',


### PR DESCRIPTION
## 問題

Phase 7 合併後 CI PHPUnit 1 個測試失敗：

```
Tests\Feature\UserProfileTest::testAuthenticatedUserCanAccessProfile
Failed asserting that '...' contains "個人資料設定"
```

## 根因

`UserProfileController` 原本寫死 `'page_title' => '個人資料設定'`。  
Phase 7 改為 `__('common.profile_settings')`，但 `resources/lang/zh-TW/common.php` 中該 key 的值是 `'個人設定'`（非 `'個人資料設定'`），導致 zh-TW 測試環境斷言失敗。

## 修正

將 `zh-TW/common.php` 的 `profile_settings` 值從 `'個人設定'` 改回 `'個人資料設定'`，與原始控制器字串一致。

## 測試

- 僅修改 1 行 lang 檔
- 不影響 `en/common.php`（`Profile Settings` 不變）
- CI 應恢復通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)