### PR TITLE
修正 AI 自動填充官職的 fallback 邏輯

### DIFF
--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -120,12 +120,19 @@ class PostingAutofillService {
             ];
         }
 
-        if (!$result['success'] && $this->hasFallback()) {
+        if (!$result['success'] && !($result['no_content'] ?? false) && $this->hasFallback()) {
             Log::warning('PostingAutofill 主要 LLM 失敗，嘗試 fallback', ['primary_error' => $result['error']]);
             $original = $this->switchToFallback();
 
             try {
                 $result = $this->doCallAI($sourceText);
+            } catch (\Exception $e) {
+                Log::error('PostingAutofill fallback LLM 連線異常', ['exception' => $e->getMessage()]);
+                $result = [
+                    'success' => false,
+                    'data' => null,
+                    'error' => 'AI API 連線失敗：' . $e->getMessage(),
+                ];
             } finally {
                 $this->restoreFromFallback($original);
             }
@@ -144,6 +151,7 @@ class PostingAutofillService {
                 'success' => false,
                 'data' => null,
                 'error' => 'Prompt 模板檔案不存在',
+                'no_content' => true,
             ];
         }
 
@@ -216,6 +224,7 @@ class PostingAutofillService {
                 'success' => false,
                 'data' => null,
                 'error' => '未能從文本中提取任官信息',
+                'no_content' => true,
             ];
         }
 


### PR DESCRIPTION
## 問題

主 LLM 正常執行、成功解析 AI 回應，但文本中無任官信息（`postings[]` 為空）時，系統仍會觸發 fallback 呼叫 Gemini。這導致：

- 不必要的 Gemini API 呼叫
- 若 Gemini 本身出錯（如近日的 500 Internal Error），用戶會看到誤導性的技術錯誤，而非「文本無任官信息」的正確提示

## 修正內容

- 在 `doCallAI()` 的「空 postings」與「Prompt 不存在」回傳中加入 `no_content: true` 旗標
- `callAI()` 的 fallback 條件改為 `!$result['success'] && !($result['no_content'] ?? false)`，只對技術錯誤（HTTP 失敗、超時、連線異常）觸發 fallback
- 為 fallback 呼叫補上 `catch`，避免 Gemini 連線異常未處理而往上冒泡

## 測試

- Review agent + Codex 均確認邏輯正確，無嚴重問題
- Gemini fallback 端點測試正常（同步更新了過期 API key 與 model 版本至 gemini-flash-latest）

🤖 Generated with [Claude Code](https://claude.com/claude-code)