### PR TITLE
CHGIS 地圖：Place Name 可點擊連結與浮出地圖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ version.txt
 # SQLite DB for development with Docker
 db-data/database.sqlite3
 database/database.sqlite3
+
+# CHGIS 底圖（自 HuggingFace 下載，不入版控）
+/storage/app/chgis/*.mbtiles
+/storage/app/chgis/*.part.*
+/storage/app/chgis/*.bak.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@
 - Operations / Restore：
   - [app/Http/Controllers/OperationsController.php](./app/Http/Controllers/OperationsController.php)
   - [app/Repositories/OperationRepository.php](./app/Repositories/OperationRepository.php)
+- CHGIS 地圖（Place Name 連結與浮出地圖）：
+  - [app/Http/Controllers/ChgisMapController.php](./app/Http/Controllers/ChgisMapController.php)（tile/status/personPoints）
+  - [app/Services/PersonMapPointsService.php](./app/Services/PersonMapPointsService.php)、[app/Services/ChgisMapManager.php](./app/Services/ChgisMapManager.php)、[app/Support/CoordinateValidator.php](./app/Support/CoordinateValidator.php)
+  - [resources/js/chgis-map](./resources/js/chgis-map)、[config/chgis_map.php](./config/chgis_map.php)
+  - 底圖 `storage/app/chgis/chgis_map.mbtiles`（不入版控，`php artisan cbdb:fetch-chgis-map` 下載）；設計見 [docs/CHGIS_MAP_PLACE_LINK.md](./docs/CHGIS_MAP_PLACE_LINK.md)
 
 ## 常用命令
 
@@ -81,6 +86,7 @@ npm install
 npm run build
 php artisan cbdb:manage-user
 php artisan cbdb:import-trad-simp-map --truncate
+php artisan cbdb:fetch-chgis-map        # 下載 CHGIS 底圖（缺檔才下載）
 ```
 
 ## 提交前最低檢查

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 2026-06
 
+### CHGIS 地圖：Place Name 可點擊連結與浮出地圖
+- `/basicinformation/{id}/addresses` 與 `/offices` 列表頁的 **Place Name**，對「有有效經緯度」的地點渲染為可點擊連結；無效座標（0,0、單軸為 0、超出底圖範圍、經緯反掉等）維持純文字。
+- 點擊浮出以 `chgis_map.mbtiles` 為底圖的 Leaflet 地圖（無邊框、背景變暗模糊、Esc/遮罩/×關閉、手機近全螢幕、`prefers-reduced-motion`），標出該人物所有有效 addresses/offices 地點，當前點置中並以脈動標記突顯。
+- 底圖不入版控，部署時由 `php artisan cbdb:fetch-chgis-map` 自 HuggingFace（`cbdb/chgis-map`）下載至 `storage/app/chgis/`；缺檔時亦於首次存取地圖時背景下載並顯示提示。
+- 官職地點分組鍵改為 `(c_office_id, c_posting_id)`，前端點位 key 使用 `office:{office_id}:{posting_id}:{addr_id}`，避免 `c_posting_id` 非全域唯一時官名誤配與 key 碰撞。
+- lazy 下載加入 `Cache::lock()` 互斥、`ttl > timeout` 與 `started_at` stale 自癒，避免大型底圖下載時永久卡在 `downloading`。
+- 座標有效性判定集中於 `App\Support\CoordinateValidator`（設定見 `config/chgis_map.php`）。
+- 設計與實作細節見 [docs/CHGIS_MAP_PLACE_LINK.md](docs/CHGIS_MAP_PLACE_LINK.md)。
+- 前端新增 `leaflet` npm 依賴與 `resources/js/chgis-map` 入口（不使用 CDN）。
+
 ### 繁體中文 / 英文介面切換（i18n Phase 6）
 - 全站 Blade 視圖完成繁體中文／英文雙語化（約 91 個檔案、3,450 行字串）。
 - Navbar 新增語言切換按鈕（zh-TW ⇄ EN），使用者偏好儲存於 session。

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 * [稽核日誌提案](./docs/AUDIT_LOG_PROPOSAL.md)
 * [人物提案流程計畫](./docs/BIOGMAIN_APPROVAL_FLOWS_PLAN.md)
 * [BiogMain Repository 重構計畫](./docs/BIOGMAIN_REPOSITORY_REFACTOR_PLAN.md)
+* [CHGIS 地圖 Place Name 連結與浮出地圖](./docs/CHGIS_MAP_PLACE_LINK.md)
 * [複合主鍵 URL 設計](./docs/COMPOSITE_PRIMARY_KEY_URL_DESIGN.md)
 * [資料庫 Schema（MySQL/SQLite）](./docs/DATABASE_SCHEMA.md)
 * [Laravel Query 審查](./docs/LARAVEL_QUERY_REVIEW.md)
@@ -101,6 +102,7 @@ npm install
 ./vendor/bin/php-cs-fixer fix
 ./vendor/bin/phpunit
 npm run build
+php artisan cbdb:fetch-chgis-map
 ```
 
 ### 前端

--- a/app/Console/Commands/FetchChgisMap.php
+++ b/app/Console/Commands/FetchChgisMap.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\ChgisMapManager;
+use Illuminate\Console\Command;
+
+/**
+ * 下載 CHGIS 底圖（chgis_map.mbtiles）
+ *
+ * 部署時呼叫；冪等：若本地已有合格檔案則跳過。失敗回非零碼但不丟例外，
+ * 供 deploy.sh 以非致命方式處理（地圖功能會於首次存取時重試）。
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §4.4。
+ */
+class FetchChgisMap extends Command {
+    /**
+     * @var string
+     */
+    protected $signature = 'cbdb:fetch-chgis-map
+                            {--force : 強制重新下載，即使本地已有合格檔案}';
+
+    /**
+     * @var string
+     */
+    protected $description = '自 HuggingFace 下載 CHGIS 底圖 chgis_map.mbtiles（缺檔才下載）';
+
+    public function handle(ChgisMapManager $manager): int {
+        $path = $manager->path();
+
+        if (!$this->option('force') && $manager->isReady()) {
+            $this->info("CHGIS 底圖已存在，跳過下載：{$path}");
+
+            return self::SUCCESS;
+        }
+
+        $this->info('開始下載 CHGIS 底圖，來源：' . $manager->sourceUrl());
+        $this->line('目標路徑：' . $path);
+
+        $start = microtime(true);
+
+        try {
+            $manager->download();
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $seconds = round(microtime(true) - $start, 1);
+        $sizeMb = round(filesize($path) / 1048576, 1);
+        $this->info("下載完成：{$sizeMb} MB，耗時 {$seconds} 秒");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends ConsoleKernel {
         \App\Console\Commands\GenerateSchemaDocs::class,
         \App\Console\Commands\RebuildIndexYear::class,
         \App\Console\Commands\RebuildIndexAddress::class,
+        \App\Console\Commands\FetchChgisMap::class,
     ];
 
     /**

--- a/app/Http/Controllers/BasicInformationAddressesController.php
+++ b/app/Http/Controllers/BasicInformationAddressesController.php
@@ -7,6 +7,7 @@ use App\Models\AddrCode;
 use App\Models\AddressCode;
 use App\Models\TextCode;
 use App\Repositories\BiogMainRepository;
+use App\Services\PersonMapPointsService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -33,8 +34,11 @@ class BasicInformationAddressesController extends Controller {
      *
      * @return \Illuminate\Http\Response
      */
-    public function index($id) {
+    public function index(PersonMapPointsService $mapPoints, $id) {
         $biogbasicinformation = $this->biogMainRepository->byIdWithAddr($id);
+
+        // CHGIS 地圖：以 key 對應每列地址的座標與可連結狀態
+        $addressPointMap = collect($mapPoints->addressEntries($id))->keyBy('key');
 
         // 處理 basicinformation 可能為 null 或缺少字段的情況
         $personLabel = $id;
@@ -56,6 +60,7 @@ class BasicInformationAddressesController extends Controller {
 
         return view('biogmains.addresses.index', [
             'basicinformation' => $biogbasicinformation,
+            'addressPointMap' => $addressPointMap,
             'page_title' => __('person.addresses'),
             'page_description' => __('person.person_records') . ' – ' . __('person.addresses'),
             'breadcrumb_home' => __('person.person_records'),

--- a/app/Http/Controllers/BasicInformationOfficesController.php
+++ b/app/Http/Controllers/BasicInformationOfficesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
+use App\Services\PersonMapPointsService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -39,11 +40,14 @@ class BasicInformationOfficesController extends Controller {
      *
      * @return \Illuminate\Http\Response
      */
-    public function index($id) {
+    public function index(PersonMapPointsService $mapPoints, $id) {
         $biogbasicinformation = $this->biogMainRepository->byIdWithOff($id);
         //        dd($biogbasicinformation->offices_addr->toArray());
 
-        $serialAddr = $this->serialAddr($biogbasicinformation->offices_addr->toArray());
+        $serialAddr = $this->serialAddr($biogbasicinformation->offices_addr->toArray(), $mapPoints);
+
+        // CHGIS 地圖：依 (c_office_id, c_posting_id) 分組的官職地點，含可連結狀態
+        $officePlaces = $mapPoints->officePlacesByPosting($id);
 
         // 處理 basicinformation 可能為 null 或缺少字段的情況
         $personLabel = $id;
@@ -64,7 +68,7 @@ class BasicInformationOfficesController extends Controller {
         }
 
         //        dd($serialAddr);
-        return view('biogmains.offices.index', ['basicinformation' => $biogbasicinformation, 'post2addr' => $serialAddr,
+        return view('biogmains.offices.index', ['basicinformation' => $biogbasicinformation, 'post2addr' => $serialAddr, 'officePlaces' => $officePlaces,
             'page_title' => __('person.tab_postings'), 'page_description' => __('person.person_records') . ' – ' . __('person.tab_postings'), 'breadcrumb_home' => __('person.person_records'),
             'breadcrumbs' => [
                 ['label' => __('person.person_records'), 'url' => route('basicinformation.index')],
@@ -422,15 +426,28 @@ class BasicInformationOfficesController extends Controller {
      * @param array $array
      * @return null
      */
-    protected function serialAddr(array $array) {
+    protected function serialAddr(array $array, PersonMapPointsService $mapPoints) {
         $res = [];
         //        dd($array);
         foreach ($array as $item) {
-            $postingId = $item['pivot']['c_posting_id'];
-            if (Arr::has($res, $postingId)) {
-                $res[$postingId] = $res[$postingId].';'.$item['c_name_chn'];
+            $groupKey = $mapPoints->postingKey(
+                $item['pivot']['c_office_id'] ?? null,
+                $item['pivot']['c_posting_id'] ?? null
+            );
+            $placeName = $item['c_name_chn'] ?? null;
+
+            if ($placeName === null || $placeName === '') {
+                $placeName = $item['c_name'] ?? null;
+            }
+
+            if ($placeName === null || $placeName === '') {
+                continue;
+            }
+
+            if (Arr::has($res, $groupKey)) {
+                $res[$groupKey][] = $placeName;
             } else {
-                $res[$postingId] = $item['c_name_chn'];
+                $res[$groupKey] = [$placeName];
             }
         }
 

--- a/app/Http/Controllers/ChgisMapController.php
+++ b/app/Http/Controllers/ChgisMapController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\FetchChgisMapJob;
+use App\Services\ChgisMapManager;
+use App\Services\MbtilesReader;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * CHGIS 地圖：底圖 tile 服務與下載狀態
+ *
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §5.2。
+ */
+class ChgisMapController extends Controller {
+    /** 1×1 透明 PNG（圖磚未命中時回傳，避免 Leaflet 報錯）。 */
+    private const TRANSPARENT_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    public function __construct(private readonly ChgisMapManager $manager) {
+    }
+
+    /**
+     * 取出底圖圖磚（z/x/y，XYZ 慣例）。
+     */
+    public function tile(Request $request, int $z, int $x, int $y): Response {
+        if (!$this->manager->isReady()) {
+            abort(503, 'CHGIS 底圖尚未就緒');
+        }
+
+        $minZoom = (int) config('chgis_map.min_zoom', 3);
+        $maxZoom = (int) config('chgis_map.max_zoom', 8);
+
+        // 超出原生 zoom 或座標範圍 → 回透明磚（前端 overzoom 時亦安全）
+        if ($z < $minZoom || $z > $maxZoom || !$this->withinTileRange($z, $x, $y)) {
+            return $this->transparentTile();
+        }
+
+        try {
+            $data = (new MbtilesReader($this->manager->path()))->tile($z, $x, $y);
+        } catch (\Throwable $e) {
+            // 底圖暫時不可用（如下載 rename 競態）時降級為透明磚，避免 Leaflet 整面報錯
+            Log::warning('CHGIS 圖磚讀取失敗：' . $e->getMessage());
+
+            return $this->transparentTile();
+        }
+
+        if ($data === null) {
+            return $this->transparentTile();
+        }
+
+        // ETag 納入底圖檔 mtime，底圖更新後同 z/x/y 也會失效，避免回舊磚
+        $version = @filemtime($this->manager->path()) ?: 0;
+
+        $response = response($data, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Cache-Control', 'public, max-age=2592000')
+            ->setEtag(md5($z . '/' . $x . '/' . $y . '/' . $version))
+            ->setLastModified((new \DateTimeImmutable())->setTimestamp($version));
+
+        $response->isNotModified($request);
+
+        return $response;
+    }
+
+    /**
+     * 底圖狀態；缺檔時於回應後背景觸發下載。
+     */
+    public function status(Request $request): JsonResponse {
+        if ($this->manager->isReady()) {
+            return response()->json(['ready' => true, 'state' => 'ready']);
+        }
+
+        $state = Cache::get(FetchChgisMapJob::STATE_KEY);
+        $current = $state['state'] ?? null;
+
+        // 進行中且未逾時 → 回 downloading；逾時（程序疑似死亡）則視為 stale 往下重新觸發
+        if ($current === 'downloading' && !$this->isStale($state)) {
+            return response()->json([
+                'ready' => false,
+                'state' => 'downloading',
+                'started_at' => $state['started_at'] ?? null,
+            ]);
+        }
+
+        // 失敗狀態：除非前端要求重試，否則直接回報失敗
+        if ($current === 'failed' && !$request->boolean('retry')) {
+            return response()->json([
+                'ready' => false,
+                'state' => 'failed',
+                'message' => $state['message'] ?? null,
+            ]);
+        }
+
+        // 觸發下載（回應送出後才執行，不阻塞此請求）
+        $startedAt = time();
+
+        Cache::put(
+            FetchChgisMapJob::STATE_KEY,
+            ['state' => 'downloading', 'started_at' => $startedAt],
+            now()->addSeconds(FetchChgisMapJob::ttlSeconds())
+        );
+        FetchChgisMapJob::dispatchAfterResponse();
+
+        return response()->json([
+            'ready' => false,
+            'state' => 'downloading',
+            'started_at' => $startedAt,
+        ]);
+    }
+
+    /**
+     * downloading 狀態是否已逾時（疑似下載程序死亡）。
+     */
+    private function isStale(?array $state): bool {
+        $startedAt = $state['started_at'] ?? 0;
+
+        return (time() - (int) $startedAt) >= FetchChgisMapJob::ttlSeconds();
+    }
+
+    /**
+     * 回傳 1×1 透明 PNG。
+     */
+    private function transparentTile(): Response {
+        return response(base64_decode(self::TRANSPARENT_PNG), 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Cache-Control', 'public, max-age=86400');
+    }
+
+    /**
+     * x/y 是否落在該 zoom 的合法瓦片索引範圍 [0, 2^z - 1]。
+     */
+    private function withinTileRange(int $z, int $x, int $y): bool {
+        $max = (1 << $z) - 1;
+
+        return $x >= 0 && $x <= $max && $y >= 0 && $y <= $max;
+    }
+}

--- a/app/Http/Controllers/ChgisMapController.php
+++ b/app/Http/Controllers/ChgisMapController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Jobs\FetchChgisMapJob;
 use App\Services\ChgisMapManager;
 use App\Services\MbtilesReader;
+use App\Services\PersonMapPointsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -110,6 +111,13 @@ class ChgisMapController extends Controller {
             'state' => 'downloading',
             'started_at' => $startedAt,
         ]);
+    }
+
+    /**
+     * 某人物所有「有效座標」的地點（addresses + offices），供地圖 modal 繪製。
+     */
+    public function personPoints(PersonMapPointsService $service, int $id): JsonResponse {
+        return response()->json(['points' => $service->points($id)]);
     }
 
     /**

--- a/app/Jobs/FetchChgisMapJob.php
+++ b/app/Jobs/FetchChgisMapJob.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\ChgisMapManager;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 背景下載 CHGIS 底圖
+ *
+ * 由 status 端點於底圖缺檔時觸發（dispatchAfterResponse，不阻塞回應）。
+ * 以 cache lock 避免併發重複下載，並把進度狀態寫入 cache 供前端輪詢。
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §4.6。
+ */
+class FetchChgisMapJob implements ShouldQueue {
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** 下載狀態 cache 鍵。 */
+    public const STATE_KEY = 'chgis_map_download_state';
+
+    /** 互斥鎖鍵。 */
+    public const LOCK_KEY = 'chgis_map_download_lock';
+
+    /**
+     * 鎖／狀態的存活秒數。
+     *
+     * 必須嚴格大於下載逾時，否則長下載期間鎖會提前到期、引發重複下載；
+     * 狀態 TTL 與鎖一致，確保程序死亡後狀態能自然過期讓 status 重新觸發。
+     */
+    public static function ttlSeconds(): int {
+        return (int) config('chgis_map.source.timeout', 1800) + 600;
+    }
+
+    public function handle(ChgisMapManager $manager): void {
+        try {
+            if ($manager->isReady()) {
+                Cache::forget(self::STATE_KEY);
+
+                return;
+            }
+
+            // 互斥：同時只允許一個下載。搶不到鎖代表已有別的程序在下載。
+            $lock = Cache::lock(self::LOCK_KEY, self::ttlSeconds());
+            if (!$lock->get()) {
+                return;
+            }
+
+            try {
+                Cache::put(
+                    self::STATE_KEY,
+                    ['state' => 'downloading', 'started_at' => time()],
+                    now()->addSeconds(self::ttlSeconds())
+                );
+                $manager->download();
+                Cache::forget(self::STATE_KEY);
+                Log::info('CHGIS 底圖下載完成');
+            } finally {
+                $lock->release();
+            }
+        } catch (\Throwable $e) {
+            // 涵蓋 isReady／取鎖／下載各階段的例外，統一落為 failed，避免永久卡 downloading。
+            Cache::put(
+                self::STATE_KEY,
+                ['state' => 'failed', 'message' => $e->getMessage()],
+                now()->addMinutes(10)
+            );
+            Log::warning('CHGIS 底圖下載失敗：' . $e->getMessage());
+        }
+    }
+}

--- a/app/Models/BiogMain.php
+++ b/app/Models/BiogMain.php
@@ -96,11 +96,11 @@ class BiogMain extends Model {
     }
 
     public function offices() {
-        return $this->belongsToMany('App\Models\OfficeCode', 'POSTED_TO_OFFICE_DATA', 'c_personid', 'c_office_id')->withPivot('c_sequence', 'c_posting_id', 'c_firstyear', 'c_lastyear')->orderBy('c_sequence');
+        return $this->belongsToMany('App\Models\OfficeCode', 'POSTED_TO_OFFICE_DATA', 'c_personid', 'c_office_id')->withPivot('c_office_id', 'c_sequence', 'c_posting_id', 'c_firstyear', 'c_lastyear')->orderBy('c_sequence');
     }
 
     public function offices_addr() {
-        return $this->belongsToMany('App\Models\AddrCode', 'POSTED_TO_ADDR_DATA', 'c_personid', 'c_addr_id')->withPivot('c_posting_id')->where('c_office_id', '!=', -1);
+        return $this->belongsToMany('App\Models\AddrCode', 'POSTED_TO_ADDR_DATA', 'c_personid', 'c_addr_id')->withPivot('c_posting_id', 'c_office_id')->wherePivot('c_office_id', '!=', -1);
     }
 
     public function entries() {

--- a/app/Services/ChgisMapManager.php
+++ b/app/Services/ChgisMapManager.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * CHGIS 底圖（chgis_map.mbtiles）檔案管理
+ *
+ * 負責本地底圖檔的存在性判定與自 HuggingFace 串流下載。
+ * 由 cbdb:fetch-chgis-map 指令與 lazy 下載 Job 共用。
+ * 設定見 config/chgis_map.php，設計見 docs/CHGIS_MAP_PLACE_LINK.md §4。
+ */
+class ChgisMapManager {
+    /** SQLite/mbtiles 檔頭魔術位元組（16 bytes，含結尾 NUL）。 */
+    private const SQLITE_MAGIC = "SQLite format 3\0";
+
+    /** 本地底圖檔絕對路徑。 */
+    public function path(): string {
+        return (string) config('chgis_map.source.path');
+    }
+
+    /** 下載來源 URL（HuggingFace resolve raw）。 */
+    public function sourceUrl(): string {
+        return (string) config('chgis_map.source.url');
+    }
+
+    /** 視為有效檔案的體積下限（位元組）。 */
+    public function expectedMinBytes(): int {
+        return (int) config('chgis_map.source.expected_min_bytes', 5_000_000);
+    }
+
+    /**
+     * 底圖是否就緒（存在、體積達下限、且為合法 SQLite/mbtiles 格式）。
+     *
+     * 同時驗證魔術位元組，避免體積達標的 HTML 錯誤頁／LFS 指標／損壞檔
+     * 被誤判為就緒而永久跳過下載。
+     */
+    public function isReady(): bool {
+        $path = $this->path();
+
+        return is_file($path)
+            && filesize($path) >= $this->expectedMinBytes()
+            && $this->hasSqliteMagic($path);
+    }
+
+    /**
+     * 串流下載底圖到本地（原子寫入）。
+     *
+     * 下載到唯一命名的 *.part 暫存檔（與正式檔同目錄以保證 rename 原子性），
+     * 依序驗證 HTTP 狀態、體積下限、SQLite 魔術位元組後，才 rename 為正式檔，
+     * 避免半截檔或 HTML 錯誤頁被視為就緒。
+     *
+     * 注意：本方法非並發安全——唯一 .part 命名可避免並發互相寫壞同一暫存檔，
+     * 但仍可能重複下載。需要互斥時請由呼叫端加鎖（見 docs §4.6 P3）。
+     *
+     * @throws RuntimeException 下載失敗或檔案不完整／格式不符時
+     */
+    public function download(): void {
+        $path = $this->path();
+        $dir = dirname($path);
+
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new RuntimeException("無法建立目錄：{$dir}");
+        }
+
+        // 唯一暫存檔名，避免並發下載互相覆寫造成交錯壞檔。
+        $partPath = $path . '.part.' . getmypid() . '.' . bin2hex(random_bytes(4));
+
+        try {
+            try {
+                $response = Http::timeout((int) config('chgis_map.source.timeout', 1800))
+                    ->connectTimeout(30)
+                    ->sink($partPath)
+                    ->get($this->sourceUrl());
+            } catch (\Throwable $e) {
+                throw new RuntimeException('CHGIS 底圖下載失敗：' . $e->getMessage(), 0, $e);
+            }
+
+            if (!$response->successful()) {
+                throw new RuntimeException('CHGIS 底圖下載失敗，HTTP 狀態碼：' . $response->status());
+            }
+
+            clearstatcache(true, $partPath);
+            $size = is_file($partPath) ? filesize($partPath) : 0;
+            if ($size < $this->expectedMinBytes()) {
+                throw new RuntimeException(sprintf(
+                    'CHGIS 底圖下載不完整：實際 %d bytes，低於下限 %d bytes',
+                    $size,
+                    $this->expectedMinBytes()
+                ));
+            }
+
+            if (!$this->hasSqliteMagic($partPath)) {
+                throw new RuntimeException('CHGIS 底圖內容非 mbtiles（SQLite）格式，可能是錯誤頁或損壞檔');
+            }
+
+            // 原子替換，且不可在失敗時遺失既有可用底圖：
+            // Windows 的 rename 不覆蓋既存目標，故先把舊檔改名為備份，
+            // 新檔就位後才刪備份；任一步失敗則還原備份。
+            $backup = null;
+            if (is_file($path)) {
+                $backup = $path . '.bak.' . getmypid() . '.' . bin2hex(random_bytes(4));
+                if (!@rename($path, $backup)) {
+                    throw new RuntimeException("無法備份既有底圖：{$path}");
+                }
+            }
+
+            if (!@rename($partPath, $path)) {
+                $restoreFailed = false;
+                if ($backup !== null) {
+                    $restoreFailed = !@rename($backup, $path);
+                }
+
+                $message = "無法將暫存檔移動為正式檔：{$path}";
+                if ($restoreFailed) {
+                    $message .= '，且無法還原備份檔';
+                }
+
+                throw new RuntimeException($message);
+            }
+
+            if ($backup !== null) {
+                @unlink($backup);
+            }
+        } finally {
+            // 任一失敗路徑都清掉自己的暫存檔；成功 rename 後 partPath 已不存在。
+            if (is_file($partPath)) {
+                @unlink($partPath);
+            }
+        }
+    }
+
+    /**
+     * 檢查檔案開頭是否為 SQLite 魔術位元組。
+     */
+    private function hasSqliteMagic(string $file): bool {
+        $fh = @fopen($file, 'rb');
+        if ($fh === false) {
+            return false;
+        }
+
+        try {
+            $header = fread($fh, strlen(self::SQLITE_MAGIC));
+        } finally {
+            fclose($fh);
+        }
+
+        return $header === self::SQLITE_MAGIC;
+    }
+}

--- a/app/Services/MbtilesReader.php
+++ b/app/Services/MbtilesReader.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use PDO;
+
+/**
+ * MBTiles 讀取器
+ *
+ * 以唯讀方式開啟 mbtiles（SQLite 容器），依 z/x/y 取出 PNG 圖磚。
+ * MBTiles 採 TMS 排列，y 軸與 XYZ/Leaflet 相反，故需翻轉 tile_row。
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §5.2。
+ */
+class MbtilesReader {
+    private ?PDO $pdo = null;
+
+    public function __construct(private readonly string $path) {
+    }
+
+    /** mbtiles 檔是否存在。 */
+    public function isAvailable(): bool {
+        return is_file($this->path);
+    }
+
+    /**
+     * 取出 z/x/y（XYZ 慣例）對應的圖磚 PNG 位元組；不存在回 null。
+     */
+    public function tile(int $z, int $x, int $y): ?string {
+        // XYZ → TMS：翻轉 y 軸
+        $tmsY = (1 << $z) - 1 - $y;
+
+        $stmt = $this->pdo()->prepare(
+            'SELECT tile_data FROM tiles WHERE zoom_level = ? AND tile_column = ? AND tile_row = ? LIMIT 1'
+        );
+        $stmt->execute([$z, $x, $tmsY]);
+        $data = $stmt->fetchColumn();
+        $stmt->closeCursor();
+
+        return $data === false ? null : $data;
+    }
+
+    /**
+     * 延遲建立唯讀 PDO 連線（同一實例重用，降低逐磚開檔成本）。
+     */
+    private function pdo(): PDO {
+        if ($this->pdo === null) {
+            $options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
+            // 以唯讀模式開啟（若 PDO 版本支援），避免產生 wal/shm 或鎖檔。
+            if (defined('PDO::SQLITE_ATTR_OPEN_FLAGS') && defined('PDO::SQLITE_OPEN_READONLY')) {
+                $options[PDO::SQLITE_ATTR_OPEN_FLAGS] = PDO::SQLITE_OPEN_READONLY;
+            }
+
+            $this->pdo = new PDO('sqlite:' . $this->path, null, null, $options);
+        }
+
+        return $this->pdo;
+    }
+}

--- a/app/Services/PersonMapPointsService.php
+++ b/app/Services/PersonMapPointsService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\BiogAddr;
 use App\Models\BiogMain;
+use App\Support\CompositePrimaryKey;
 use App\Support\CoordinateValidator;
 use Illuminate\Support\Facades\DB;
 
@@ -74,7 +75,18 @@ class PersonMapPointsService {
                 'linkable' => $linkable,
                 'first_year' => $row->c_firstyear,
                 'last_year' => $row->c_lastyear,
-                'label' => $this->displayName($nameChn, $nameEn, ''),
+                'label' => $this->displayName($nameChn, $nameEn, 'addr_id:' . $row->c_addr_id),
+                // 該地址記錄頁（編輯查詢頁，相對 URL，供地圖 popup 開新分頁）
+                'url' => CompositePrimaryKey::buildUrl(
+                    'basicinformation.addresses.edit.query',
+                    ['id' => $personId],
+                    [
+                        'c_personid' => $personId,
+                        'c_addr_id' => (int) $row->c_addr_id,
+                        'c_addr_type' => (int) $row->c_addr_type,
+                        'c_sequence' => (int) $row->c_sequence,
+                    ]
+                ),
             ];
         }
 
@@ -119,12 +131,24 @@ class PersonMapPointsService {
                 'addr_id' => (int) $row->c_addr_id,
                 'name_chn' => $row->c_name_chn,
                 'name' => $row->c_name,
+                // 官名中／英（供 popup 並列顯示；可能為 null）
+                'office_name' => $info['office_chn'] ?? null,
+                'office_name_en' => $info['office_name'] ?? null,
                 'lon' => $linkable ? (float) $lon : null,
                 'lat' => $linkable ? (float) $lat : null,
                 'linkable' => $linkable,
                 'first_year' => $info['first_year'] ?? null,
                 'last_year' => $info['last_year'] ?? null,
                 'label' => $officeName ? ($officeName . ' · ' . $placeName) : $placeName,
+                // 該官職任命記錄頁（編輯查詢頁，相對 URL，供地圖 popup 開新分頁）
+                'url' => CompositePrimaryKey::buildUrl(
+                    'basicinformation.offices.edit.query',
+                    ['id' => $personId],
+                    [
+                        'c_office_id' => (int) $officeId,
+                        'c_posting_id' => (int) $postingId,
+                    ]
+                ),
             ];
         }
 

--- a/app/Services/PersonMapPointsService.php
+++ b/app/Services/PersonMapPointsService.php
@@ -74,7 +74,7 @@ class PersonMapPointsService {
                 'linkable' => $linkable,
                 'first_year' => $row->c_firstyear,
                 'last_year' => $row->c_lastyear,
-                'label' => $nameChn ?? ($nameEn ?? ''),
+                'label' => $this->displayName($nameChn, $nameEn, ''),
             ];
         }
 

--- a/app/Services/PersonMapPointsService.php
+++ b/app/Services/PersonMapPointsService.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\BiogAddr;
+use App\Models\BiogMain;
+use App\Support\CoordinateValidator;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 人物地圖點位服務
+ *
+ * 彙整某人物的所有地址（addresses）與官職地點（offices），標注每個地點是否
+ * 具有效座標（可連結／可在地圖顯示）。同一份資料同時供：
+ *  - personPoints 端點（只取 linkable 的點繪在地圖上）
+ *  - addresses／offices 列表頁（依 linkable 決定 Place Name 是否渲染為連結）
+ *
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §5.2、§5.3。
+ */
+class PersonMapPointsService {
+    /**
+     * 該人物所有「有效座標」的點位（addresses + offices），供地圖繪製。
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function points(int $personId): array {
+        $points = [];
+
+        foreach ($this->addressEntries($personId) as $entry) {
+            if ($entry['linkable']) {
+                $points[] = $entry;
+            }
+        }
+
+        foreach ($this->officePlacesByPosting($personId) as $places) {
+            foreach ($places as $entry) {
+                if ($entry['linkable']) {
+                    $points[] = $entry;
+                }
+            }
+        }
+
+        return $points;
+    }
+
+    /**
+     * 該人物所有地址列（含無效座標），每筆標注 linkable。
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function addressEntries(int $personId): array {
+        $rows = BiogAddr::where('c_personid', $personId)
+            ->with('addr')
+            ->orderBy('c_sequence')
+            ->get();
+
+        $entries = [];
+        foreach ($rows as $row) {
+            $addr = $row->addr; // 孤兒外鍵時可能為 null
+            $lon = $addr?->x_coord;
+            $lat = $addr?->y_coord;
+            $linkable = $addr !== null && CoordinateValidator::isValid($lon, $lat);
+            $nameChn = $addr?->c_name_chn;
+            $nameEn = $addr?->c_name;
+
+            $entries[] = [
+                'key' => 'addr:' . $row->c_addr_id . ':' . $row->c_addr_type . ':' . $row->c_sequence,
+                'source' => 'address',
+                'addr_id' => (int) $row->c_addr_id,
+                'name_chn' => $nameChn,
+                'name' => $nameEn,
+                'lon' => $linkable ? (float) $lon : null,
+                'lat' => $linkable ? (float) $lat : null,
+                'linkable' => $linkable,
+                'first_year' => $row->c_firstyear,
+                'last_year' => $row->c_lastyear,
+                'label' => $nameChn ?? ($nameEn ?? ''),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * 該人物官職地點，依官職任命（c_office_id + c_posting_id）分組（含無效座標）。
+     *
+     * 注意：c_posting_id 在 POSTED_TO_OFFICE_DATA 並非全域唯一（主鍵為
+     * (c_office_id, c_posting_id)），故分組鍵與點位 key 都必須帶 c_office_id，
+     * 避免不同官職誤合併或官名張冠李戴。分組鍵格式為 "{c_office_id}:{c_posting_id}"。
+     *
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    public function officePlacesByPosting(int $personId): array {
+        if (!BiogMain::whereKey($personId)->exists()) {
+            return [];
+        }
+
+        $officeByKey = $this->officeMetadataByPosting($personId);
+
+        $grouped = [];
+        foreach ($this->officeAddressRows($personId) as $row) {
+            $officeId = $row->c_office_id;
+            $postingId = $row->c_posting_id;
+            $groupKey = $this->postingKey($officeId, $postingId);
+            $lon = $row->x_coord;
+            $lat = $row->y_coord;
+            $linkable = CoordinateValidator::isValid($lon, $lat);
+            $info = $officeByKey[$groupKey] ?? [];
+            $officeName = $this->displayName(
+                $info['office_chn'] ?? null,
+                $info['office_name'] ?? null,
+                'office_id:' . $officeId
+            );
+            $placeName = $this->displayName($row->c_name_chn, $row->c_name, 'addr_id:' . $row->c_addr_id);
+
+            $grouped[$groupKey][] = [
+                'key' => 'office:' . $officeId . ':' . $postingId . ':' . $row->c_addr_id,
+                'source' => 'office',
+                'addr_id' => (int) $row->c_addr_id,
+                'name_chn' => $row->c_name_chn,
+                'name' => $row->c_name,
+                'lon' => $linkable ? (float) $lon : null,
+                'lat' => $linkable ? (float) $lat : null,
+                'linkable' => $linkable,
+                'first_year' => $info['first_year'] ?? null,
+                'last_year' => $info['last_year'] ?? null,
+                'label' => $officeName ? ($officeName . ' · ' . $placeName) : $placeName,
+            ];
+        }
+
+        // 每組內依 addr_id 穩定排序，確保多地點時輸出順序一致
+        foreach ($grouped as &$places) {
+            usort($places, static fn ($a, $b) => $a['addr_id'] <=> $b['addr_id']);
+        }
+        unset($places);
+
+        return $grouped;
+    }
+
+    /**
+     * 官職任命的複合分組鍵（"{c_office_id}:{c_posting_id}"）。
+     */
+    public function postingKey(int|string|null $officeId, int|string|null $postingId): string {
+        return $officeId . ':' . $postingId;
+    }
+
+    /**
+     * @return array<string, array{office_chn:?string, office_name:?string, first_year:mixed, last_year:mixed}>
+     */
+    private function officeMetadataByPosting(int $personId): array {
+        $rows = DB::table('POSTED_TO_OFFICE_DATA as posting')
+            ->leftJoin('OFFICE_CODES as office', 'office.c_office_id', '=', 'posting.c_office_id')
+            ->where('posting.c_personid', $personId)
+            ->orderByRaw('CASE WHEN posting.c_sequence IS NULL THEN 1 ELSE 0 END')
+            ->orderBy('posting.c_sequence')
+            ->select([
+                'posting.c_office_id',
+                'posting.c_posting_id',
+                'posting.c_firstyear',
+                'posting.c_lastyear',
+                'office.c_office_chn',
+                'office.c_office_trans',
+            ])
+            ->get();
+
+        $byKey = [];
+        foreach ($rows as $row) {
+            $key = $this->postingKey($row->c_office_id, $row->c_posting_id);
+            $byKey[$key] = [
+                'office_chn' => $row->c_office_chn,
+                'office_name' => $row->c_office_trans,
+                'first_year' => $row->c_firstyear,
+                'last_year' => $row->c_lastyear,
+            ];
+        }
+
+        return $byKey;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    private function officeAddressRows(int $personId) {
+        return DB::table('POSTED_TO_ADDR_DATA as posting_addr')
+            ->leftJoin('ADDR_CODES as addr', 'addr.c_addr_id', '=', 'posting_addr.c_addr_id')
+            ->where('posting_addr.c_personid', $personId)
+            ->where('posting_addr.c_office_id', '!=', -1)
+            ->orderBy('posting_addr.c_office_id')
+            ->orderBy('posting_addr.c_posting_id')
+            ->orderBy('posting_addr.c_addr_id')
+            ->select([
+                'posting_addr.c_office_id',
+                'posting_addr.c_posting_id',
+                'posting_addr.c_addr_id',
+                'addr.c_name_chn',
+                'addr.c_name',
+                'addr.x_coord',
+                'addr.y_coord',
+            ])
+            ->get();
+    }
+
+    private function displayName(?string $nameChn, ?string $name, string $fallback): string {
+        $nameChn = trim((string) ($nameChn ?? ''));
+        if ($nameChn !== '') {
+            return $nameChn;
+        }
+
+        $name = trim((string) ($name ?? ''));
+        if ($name !== '') {
+            return $name;
+        }
+
+        return $fallback;
+    }
+}

--- a/app/Support/CoordinateValidator.php
+++ b/app/Support/CoordinateValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * 座標有效性判定工具
+ *
+ * 判定一組 (x_coord, y_coord) = (經度, 緯度) 是否可在 CHGIS 底圖上連結／顯示。
+ * 規則詳見 docs/CHGIS_MAP_PLACE_LINK.md §3。
+ *
+ * 判定順序（任一不過即無效）：
+ *  1. 存在性：經緯度皆非 null、可轉為數值。
+ *  2. 非零：|lon| >= epsilon 且 |lat| >= epsilon（排除 0,0 與單軸為 0）。
+ *  3. 落在 mbtiles bounds 內，且（若啟用）落在 sane_bounds 內。
+ *  4. Web Mercator 可投影：|lat| <= mercator_lat_limit。
+ *
+ * 註：刻意不自動 swap 反掉的座標；反掉者多半因超出範圍而被判無效。
+ */
+class CoordinateValidator {
+    /**
+     * 判定座標是否有效（可連結）。
+     *
+     * @param float|int|string|null $lon 經度（x_coord）
+     * @param float|int|string|null $lat 緯度（y_coord）
+     */
+    public static function isValid($lon, $lat): bool {
+        return self::reason($lon, $lat) === null;
+    }
+
+    /**
+     * 回傳不通過的原因；通過時回 null（供 debug／測試）。
+     *
+     * @param float|int|string|null $lon 經度（x_coord）
+     * @param float|int|string|null $lat 緯度（y_coord）
+     */
+    public static function reason($lon, $lat): ?string {
+        // 1. 存在性 + 可數值化
+        if (!self::isNumeric($lon) || !self::isNumeric($lat)) {
+            return 'non_numeric';
+        }
+
+        $lon = (float) $lon;
+        $lat = (float) $lat;
+
+        // 2. 非零（含單軸為 0）
+        $epsilon = (float) config('chgis_map.epsilon', 1e-7);
+        if (abs($lon) < $epsilon || abs($lat) < $epsilon) {
+            return 'zero_axis';
+        }
+
+        // 3a. mbtiles bounds
+        $bounds = config('chgis_map.bounds', []);
+        if (!self::within($lon, $lat, $bounds)) {
+            return 'out_of_bounds';
+        }
+
+        // 3b. 合理東亞收斂框（可選）
+        $sane = config('chgis_map.sane_bounds', []);
+        if (!empty($sane['enabled']) && !self::within($lon, $lat, $sane)) {
+            return 'out_of_sane_bounds';
+        }
+
+        // 4. Web Mercator 緯度上限
+        $latLimit = (float) config('chgis_map.mercator_lat_limit', 85.0511);
+        if (abs($lat) > $latLimit) {
+            return 'mercator_unprojectable';
+        }
+
+        return null;
+    }
+
+    /**
+     * 判斷值是否為有效且有限的數值。
+     *
+     * 排除 null、空字串、布林、非數字字串，並排除 NAN/INF（如溢位的 '1e400'
+     * 或直接傳入的浮點 NAN/INF），避免後續比較靠副作用僥倖攔截。
+     *
+     * @param mixed $value
+     */
+    private static function isNumeric($value): bool {
+        if ($value === null || $value === '' || is_bool($value)) {
+            return false;
+        }
+
+        if (!is_numeric($value)) {
+            return false;
+        }
+
+        return is_finite((float) $value);
+    }
+
+    /**
+     * 判斷 (lon, lat) 是否落在指定範圍框內（含邊界）。
+     *
+     * @param array{west?:float,south?:float,east?:float,north?:float} $box
+     */
+    private static function within(float $lon, float $lat, array $box): bool {
+        if (!isset($box['west'], $box['south'], $box['east'], $box['north'])) {
+            return false;
+        }
+
+        return $lon >= (float) $box['west']
+            && $lon <= (float) $box['east']
+            && $lat >= (float) $box['south']
+            && $lat <= (float) $box['north'];
+    }
+}

--- a/config/chgis_map.php
+++ b/config/chgis_map.php
@@ -47,5 +47,7 @@ return [
         'path' => env('CHGIS_MAP_PATH', storage_path('app/chgis/chgis_map.mbtiles')),
         // 體積下限（位元組），低於此值視為半截/失敗檔。
         'expected_min_bytes' => (int) env('CHGIS_MAP_MIN_BYTES', 5_000_000),
+        // 整體下載逾時（秒）；數百 MB + 慢速連線需放寬。
+        'timeout' => (int) env('CHGIS_MAP_TIMEOUT', 1800),
     ],
 ];

--- a/config/chgis_map.php
+++ b/config/chgis_map.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| CHGIS 地圖設定
+|--------------------------------------------------------------------------
+|
+| 控制 Place Name 連結的有效座標判定、底圖（chgis_map.mbtiles）來源與
+| 下載行為。詳見 docs/CHGIS_MAP_PLACE_LINK.md。
+|
+*/
+
+return [
+    // mbtiles 底圖的 WGS84 範圍（取自 mbtiles metadata 的 bounds: W,S,E,N）。
+    // 座標需落在此範圍內才視為可連結。
+    'bounds' => [
+        'west' => (float) env('CHGIS_MAP_WEST', 58.5372),
+        'south' => (float) env('CHGIS_MAP_SOUTH', -62.6348),
+        'east' => (float) env('CHGIS_MAP_EAST', 152.24),
+        'north' => (float) env('CHGIS_MAP_NORTH', 82.7288),
+    ],
+
+    // 合理東亞收斂框：mbtiles bounds 南界（-62）明顯異常，啟用此框可過濾雜訊點。
+    // 有效座標需同時落在 bounds 與（啟用時）sane_bounds 內。
+    'sane_bounds' => [
+        'enabled' => (bool) env('CHGIS_MAP_SANE_ENABLED', true),
+        'west' => (float) env('CHGIS_MAP_SANE_WEST', 70.0),
+        'south' => (float) env('CHGIS_MAP_SANE_SOUTH', 15.0),
+        'east' => (float) env('CHGIS_MAP_SANE_EAST', 140.0),
+        'north' => (float) env('CHGIS_MAP_SANE_NORTH', 55.0),
+    ],
+
+    // 視為「等於 0」的容差，用於排除 0,0 與單軸為 0 的座標。
+    'epsilon' => (float) env('CHGIS_MAP_EPSILON', 1e-7),
+
+    // Web Mercator（EPSG:3857）可投影的緯度上限。
+    'mercator_lat_limit' => 85.0511,
+
+    'min_zoom' => (int) env('CHGIS_MAP_MIN_ZOOM', 3),
+    'max_zoom' => (int) env('CHGIS_MAP_MAX_ZOOM', 8),
+
+    // 底圖檔案來源與本地存放位置。
+    'source' => [
+        // HuggingFace dataset 的 resolve raw URL（公開 dataset，無需 token）。
+        'url' => env('CHGIS_MAP_URL', 'https://huggingface.co/datasets/cbdb/chgis-map/resolve/main/chgis_map.mbtiles'),
+        // 本地存放路徑（private disk，非 public）。
+        'path' => env('CHGIS_MAP_PATH', storage_path('app/chgis/chgis_map.mbtiles')),
+        // 體積下限（位元組），低於此值視為半截/失敗檔。
+        'expected_min_bytes' => (int) env('CHGIS_MAP_MIN_BYTES', 5_000_000),
+    ],
+];

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,7 +55,7 @@ php artisan route:cache
 php artisan view:cache
 
 # 5. 確認 CHGIS 底圖（缺檔則自 HuggingFace 下載；失敗不中斷部署）
-echo "检查 CHGIS 底图..."
-php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底图下载失败，地图功能将于首次访问时重试"
+echo "檢查 CHGIS 底圖..."
+php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底圖下載失敗，地圖功能將於首次訪問時重試"
 
 echo "部署完成！"

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,4 +54,8 @@ php artisan config:cache
 php artisan route:cache
 php artisan view:cache
 
+# 5. 確認 CHGIS 底圖（缺檔則自 HuggingFace 下載；失敗不中斷部署）
+echo "检查 CHGIS 底图..."
+php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底图下载失败，地图功能将于首次访问时重试"
+
 echo "部署完成！"

--- a/docs/CHGIS_MAP_PLACE_LINK.md
+++ b/docs/CHGIS_MAP_PLACE_LINK.md
@@ -1,10 +1,15 @@
 # CHGIS 地圖：Place Name 可點擊連結與浮出地圖（可行性設計）
 
-> 狀態：設計草案（尚未實作）
+> 狀態：**已實作**（分支 `feature/chgis-map-place-link`，分階段 P1–P7）。本文件為設計與實作對照說明。
 > 範圍：`/basicinformation/{id}/addresses` 與 `/basicinformation/{id}/offices` 兩個列表頁的 **Place Name** 欄位
 > 目標：為「有有效經緯度」的地點加上可點擊連結，點擊後浮出以 `chgis_map.mbtiles` 為底圖的地圖，標出該人物所有有效地點，並突顯當前點。
->
-> **開發方式：本功能請另開新分支進行（例如 `feature/chgis-map-place-link`），不要直接在 `develop` 上開發。**
+
+> **部署注意（lazy 下載）**：`/chgis-map/status` 缺檔時以 `FetchChgisMapJob::dispatchAfterResponse()` 在回應後背景下載。當 `QUEUE_CONNECTION=sync`（預設）時，下載在 web 程序內執行，受 PHP `max_execution_time` 限制——大型底圖可能在下載完成前被中止。**正式環境應以 `php artisan cbdb:fetch-chgis-map`（部署步驟，見 §4.5）預先抓好底圖**，lazy 下載僅為後備；若要倚賴 lazy 下載，請改用常駐 queue worker（database/redis）或確保該路徑的 `max_execution_time` ≥ `chgis_map.source.timeout`。
+
+> **實作備忘（與初版設計的差異）**：
+> - 官職分組鍵改用 `(c_office_id, c_posting_id)` 複合鍵（`c_posting_id` 在 `POSTED_TO_OFFICE_DATA` 非全域唯一），點位 key 為 `office:{office_id}:{posting_id}:{addr_id}`；避免官名張冠李戴與 key 碰撞。
+> - `ChgisMapManager` 下載額外驗證 SQLite 魔術位元組、原子替換含備份還原；lock TTL 嚴格大於下載逾時，狀態含 `started_at` 以 stale 自癒避免永久 `downloading`。
+> - 前端 Leaflet 改為 npm 依賴（非 CDN），當前點用 `divIcon` 脈動、一般點用 `circleMarker`，避開 Vite 下預設 marker 圖檔路徑問題。
 
 ---
 
@@ -131,6 +136,7 @@ return [
     'url' => env('CHGIS_MAP_URL', 'https://huggingface.co/datasets/cbdb/chgis-map/resolve/main/chgis_map.mbtiles'),
     'path' => storage_path('app/chgis/chgis_map.mbtiles'),
     'expected_min_bytes' => 5_000_000, // 體積下限，防半截檔
+    'timeout' => 1800,                  // 下載逾時（秒）；lock TTL = timeout + 600
 ],
 ```
 
@@ -144,7 +150,7 @@ return [
 ### 4.5 取得方式二：接到 `deploy.sh`
 在 `deploy.sh` 快取重建後追加（**非致命**）：
 ```bash
-# 6. 確認 CHGIS 底圖（缺檔則自 HuggingFace 下載；失敗不中斷部署）
+# 5. 確認 CHGIS 底圖（缺檔則自 HuggingFace 下載；失敗不中斷部署）
 echo "檢查 CHGIS 底圖..."
 php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底圖下載失敗，地圖功能將於首次存取時重試"
 ```
@@ -213,7 +219,7 @@ Route::get('/basicinformation/{id}/map-points', [ChgisMapController::class, 'per
 ```
 - 重用 `CoordinateValidator`：只回有效點。
 - address 與 office 都查（office 經 `offices_addr`）；同一頁觸發只需該頁資料，但為「顯示此人所有 addresses+offices」需**同時撈兩類**（不論從哪頁點進來）。
-- `key` 設計：addresses 用 `addr:{c_addr_id}:{c_addr_type}:{c_sequence}`；offices 用 `office:{c_posting_id}:{c_addr_id}`。供前端標記「當前點」。
+- `key` 設計：addresses 用 `addr:{c_addr_id}:{c_addr_type}:{c_sequence}`；offices **實作改為三鍵** `office:{c_office_id}:{c_posting_id}:{c_addr_id}`（因 `c_posting_id` 非全域唯一，見頂部「實作備忘」），供前端標記「當前點」。
 - 授權：與列表頁一致（公開可讀則公開；若有登入限制沿用）。
 
 ### 5.3 `serialAddr()` 調整（offices）

--- a/docs/CHGIS_MAP_PLACE_LINK.md
+++ b/docs/CHGIS_MAP_PLACE_LINK.md
@@ -1,0 +1,377 @@
+# CHGIS 地圖：Place Name 可點擊連結與浮出地圖（可行性設計）
+
+> 狀態：設計草案（尚未實作）
+> 範圍：`/basicinformation/{id}/addresses` 與 `/basicinformation/{id}/offices` 兩個列表頁的 **Place Name** 欄位
+> 目標：為「有有效經緯度」的地點加上可點擊連結，點擊後浮出以 `chgis_map.mbtiles` 為底圖的地圖，標出該人物所有有效地點，並突顯當前點。
+>
+> **開發方式：本功能請另開新分支進行（例如 `feature/chgis-map-place-link`），不要直接在 `develop` 上開發。**
+
+---
+
+## 1. 目標與範圍
+
+### 1.1 功能目標
+1. 在兩個列表頁的 Place Name 欄位，對「有效座標」的地點渲染為可點擊連結；無效座標維持純文字。
+2. 點擊後浮出 modal 地圖（無邊框、背景變暗、支援手機互動）。
+3. 地圖底圖來自 `chgis_map.mbtiles`；圖面標出該人物**所有**有效 addresses + offices 地點，**當前點**置中並以特殊標記突顯。
+4. `chgis_map.mbtiles` 不存放於 repo；部署與「首次存取地圖」時，若檔案不存在則自 HuggingFace 下載，並向使用者顯示提示。
+
+### 1.2 非目標（本期不做）
+- 不在 React/Inertia 版重做（這兩頁是 Blade 舊頁；本功能屬既有 Blade 頁的增強，按 AGENTS.md「相容期」原則僅做必要增強，不引入新框架）。
+- 不做歷史分期切換（沿用 `chgis_map.mbtiles` 單一底圖）。
+- 不做座標編輯／校正；僅做「能不能連結」的判定與展示。
+
+---
+
+## 2. 現況分析（依據程式碼）
+
+### 2.1 資料來源
+
+**Addresses** — `BasicInformationAddressesController::index()`（`byIdWithAddr` → `biog_addresses` hasMany `BiogAddr`）
+視圖 `resources/views/biogmains/addresses/index.blade.php:46`：
+```blade
+<td>{{ $basicinformation->biog_addresses[$i]->addr->c_name_chn }}</td>
+```
+- `BiogAddr->addr` 關聯指向 `AddrCode`，可取 `->addr->x_coord`、`->addr->y_coord`、`->addr->c_addr_id`、`->addr->c_name`。
+
+**Offices** — `BasicInformationOfficesController::index()`（`byIdWithOff` → `offices_addr` belongsToMany `AddrCode`，pivot `c_posting_id`，`BiogMain.php:102`）
+視圖 `resources/views/biogmains/offices/index.blade.php:46`：
+```blade
+<td>{{ $post2addr[$value->pivot->c_posting_id] ?? '' }}</td>
+```
+- `post2addr` 來自 `serialAddr()`（`BasicInformationOfficesController.php:425`），目前只把 `c_name_chn` 以 `;` 串接，**丟棄了座標與 addr_id**。
+
+> 結論：座標在兩頁都拿得到（皆經 `AddrCode`），但 offices 的 `serialAddr()` 需要改成保留 `x_coord/y_coord/c_addr_id`，而非只回傳字串。
+
+### 2.2 座標欄位
+- `ADDR_CODES.x_coord`（double，經度 longitude）、`ADDR_CODES.y_coord`（double，緯度 latitude）。
+- 全專案慣例一致（見 `ApiController2/4_2/5/6`、`ViewTableQueries`）：**x=經度、y=緯度**。
+
+### 2.3 既有地圖能力
+- `resources/js/historical-maps/app.js` 已用 **Leaflet**（透過 `window.L`），但所有 tile 來源是外部 CDN（OSM / CartoDB / Esri / `tiles.digitalhumanities.dev`）。
+- 全專案**沒有** mbtiles 讀取、沒有 tile server 路由（`routes/` 內 grep `tile/mbtiles` 無結果）。
+- `package.json` 未直接依賴 leaflet（以全域 `window.L` 提供）。
+
+### 2.4 mbtiles 檔案特性（實測 metadata）
+| 項目 | 值 |
+|------|----|
+| format | png |
+| type | overlay |
+| minzoom / maxzoom | 3 / 8 |
+| bounds (WGS84, W,S,E,N) | `58.5372, -62.6348, 152.24, 82.7288` |
+| tiles 數量 | 15,715 |
+
+- MBTiles 規格採 **TMS** 排列（y 軸與 XYZ/Leaflet 相反）：`tms_y = 2^z - 1 - y`。
+- 投影 EPSG:3857（Web Mercator），緯度有效範圍 ±85.0511°。
+
+---
+
+## 3. 「有效座標」判定規則（核心邏輯）
+
+集中為單一服務 `App\Support\CoordinateValidator`（純函式、無副作用、易測）。對任一 `(x_coord, y_coord)`：
+
+設 `lon = x_coord`、`lat = y_coord`，依序判定，任一不過即「無效（不加連結）」：
+
+1. **存在性**：`lon`、`lat` 皆非 `null`、可轉為數值。
+2. **非零**：`abs(lon) >= EPS` 且 `abs(lat) >= EPS`（`EPS = 1e-7`）。
+   - 同時排除 `0,0` 及「經度或緯度單軸為 0」的等價情形。
+3. **落在底圖範圍內**（EPSG:3857 / mbtiles bounds）：
+   - `WEST <= lon <= EAST` 且 `SOUTH <= lat <= NORTH`
+   - 預設取 mbtiles bounds：`WEST=58.5372, EAST=152.24, SOUTH=-62.6348, NORTH=82.7288`。
+   - 另設一組可選的「合理東亞收斂框」`SANE`（預設 `lon∈[70,140], lat∈[15,55]`，可由 config 關閉），用以過濾掉 mbtiles bounds 過寬（南界 −62 明顯異常）所放行的雜訊點。最終有效 = 落在 `mbtiles bounds` **且**（若啟用）落在 `SANE` 內。
+4. **Web Mercator 可投影**：`abs(lat) <= 85.0511`（理論保險；`SANE`/bounds 已涵蓋，但保留以防設定放寬）。
+
+### 3.1 關於「經緯度反掉」
+- 反掉的座標（把緯度值放進 `x_coord`）多半會被規則 3 自然濾掉：例如 `lon=110` 被當成 `lat` 時 `110 > 82.7288`、超出緯度上界即判無效。
+- **刻意不自動 swap**：CBDB 不該在展示層默默「猜測並修正」資料；若同時落在重疊區間（如兩值都在 70–82）而無法可靠判別，採「保守接受原值」並在文件標註此限制。資料層的反掉問題應另以資料清理處理，不在本功能範圍。
+
+### 3.2 設定集中化
+於 `config/chgis_map.php` 提供：
+```php
+return [
+    'bounds' => ['west' => 58.5372, 'south' => -62.6348, 'east' => 152.24, 'north' => 82.7288],
+    'sane_bounds' => ['enabled' => true, 'west' => 70, 'south' => 15, 'east' => 140, 'north' => 55],
+    'epsilon' => 1e-7,
+    'min_zoom' => 3,
+    'max_zoom' => 8,
+    // 下載相關見 §4
+];
+```
+> bounds 與 mbtiles metadata 應一致；若日後更換 mbtiles，僅需改 config（亦可寫一個 artisan 指令從 mbtiles metadata 讀回更新）。
+
+---
+
+## 4. mbtiles 資料來源與部署策略
+
+### 4.1 不放進 repo
+- `chgis_map.mbtiles` 為大型二進位（數十～數百 MB），**不入版控**。
+- `.gitignore` 增加：`/storage/app/chgis/*.mbtiles`。
+
+### 4.2 存放位置（決策）
+**放在 `storage/app/chgis/chgis_map.mbtiles`（private disk）。**
+
+理由：
+- mbtiles 是 SQLite 容器，**無法**像靜態檔目錄被 web server 直接當 `/{z}/{x}/{y}.png` 提供；必須由後端讀取 SQLite 再吐出 tile。故不需放 `public/`。
+- `storage/app` 已在 Docker volume 內持久化（`docker-compose.yml` 既有掛載），重啟不丟。
+- 走 `Storage::disk('local')` 存取，路徑統一、權限受控。
+
+> 不選 `public/`：會把整顆 SQLite 暴露為可下載檔，無意義且佔頻寬。
+> 不選 `db-data/`：該目錄語意是 SQLite 資料庫匯出，混放底圖會混淆。
+
+### 4.3 HuggingFace 來源
+- Dataset：`cbdb/chgis-map`
+- 檔案：`chgis_map.mbtiles`
+- 下載 URL（resolve raw）：
+  `https://huggingface.co/datasets/cbdb/chgis-map/resolve/main/chgis_map.mbtiles`
+- 與既有 `scripts/weekly-sqlite-sync.sh` 同生態系（HuggingFace datasets）。本功能為**只讀下載**，公開 dataset 無需 token。
+
+`config/chgis_map.php` 追加：
+```php
+'source' => [
+    'url' => env('CHGIS_MAP_URL', 'https://huggingface.co/datasets/cbdb/chgis-map/resolve/main/chgis_map.mbtiles'),
+    'path' => storage_path('app/chgis/chgis_map.mbtiles'),
+    'expected_min_bytes' => 5_000_000, // 體積下限，防半截檔
+],
+```
+
+### 4.4 取得方式一：artisan 指令（部署時）
+新增 `php artisan cbdb:fetch-chgis-map`：
+1. 若目標檔存在且大小 `>= expected_min_bytes` → 跳過（冪等）。
+2. 否則串流下載到 `*.mbtiles.part`，完成後驗證大小（可選 checksum）→ 原子改名為正式檔。
+3. 失敗不丟例外中止部署，僅 `warn` 並回非零旗標供腳本判斷（地圖功能會在執行期再嘗試，見 §4.6）。
+4. `--force` 可強制重新下載。
+
+### 4.5 取得方式二：接到 `deploy.sh`
+在 `deploy.sh` 快取重建後追加（**非致命**）：
+```bash
+# 6. 確認 CHGIS 底圖（缺檔則自 HuggingFace 下載；失敗不中斷部署）
+echo "檢查 CHGIS 底圖..."
+php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底圖下載失敗，地圖功能將於首次存取時重試"
+```
+> 放在最後且容錯：底圖缺失不應讓整個部署 `set -e` 失敗。
+
+### 4.6 取得方式三：執行期 lazy 下載（存取地圖時）
+依使用者要求「访问地图时若数据不在就去下载并给提示」：
+
+- 前端開 modal 時先呼叫 `GET /chgis-map/status`。
+- 後端 `status` 行為：
+  - 檔案就緒 → `{ ready: true }`。
+  - 檔案不存在且**未在下載** → 觸發背景下載（dispatch queued job `FetchChgisMapJob`，或在無 queue 環境下以 `cache lock + register_shutdown` 背景化），回 `{ ready: false, state: "downloading" }`。
+  - 下載中 → `{ ready: false, state: "downloading", progress: <0-100|null> }`。
+  - 下載失敗 → `{ ready: false, state: "failed", message: ... }`。
+- 前端在 `ready=false` 時顯示提示（見 §6.5），並輪詢 `status`（間隔 2–3s、上限約 60s）直到 `ready` 或 `failed`。
+- 以 cache lock（如 `Cache::lock('chgis_map_download', 600)`）避免併發重複下載。
+
+---
+
+## 5. 後端設計
+
+### 5.1 新增路由（`routes/web.php`）
+```php
+// 底圖 tile（讀 mbtiles 吐 PNG）
+Route::get('/chgis-map/tiles/{z}/{x}/{y}', [ChgisMapController::class, 'tile'])
+    ->where(['z' => '[0-9]+', 'x' => '[0-9]+', 'y' => '[0-9]+'])
+    ->name('chgis-map.tile');
+
+// 底圖狀態 / 觸發下載
+Route::get('/chgis-map/status', [ChgisMapController::class, 'status'])->name('chgis-map.status');
+
+// 某人物所有有效地點（給 modal 畫點）
+Route::get('/basicinformation/{id}/map-points', [ChgisMapController::class, 'personPoints'])
+    ->name('basicinformation.map-points');
+```
+> 路由置於 `web` middleware group，沿用既有授權上下文（與兩頁列表同等可見性）。
+
+### 5.2 `ChgisMapController`
+
+**`tile($z,$x,$y)`** — 從 mbtiles 取磚：
+- 開啟 `storage/app/chgis/chgis_map.mbtiles`（唯讀 SQLite，PDO/`new \PDO('sqlite:...')`，獨立連線，**不**走預設 DB 連線）。
+- MBTiles 為 TMS：`tms_y = (2 ** $z) - 1 - $y`。
+- `SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?`。
+- 命中 → `Response(png, 200)`，帶 `Content-Type: image/png`、`Cache-Control: public, max-age=...`、`ETag`。
+- 未命中 → 回 1×1 透明 PNG（`204` 會讓 Leaflet 報錯，回透明 PNG 較穩）。
+- 檔案不存在 → `503`（前端已先查 status，理論上不會走到）。
+- 連線快取：以 singleton/靜態持有 PDO，避免每磚重開檔。
+
+**`status()`** — 見 §4.6。
+
+**`personPoints($id)`** — 回該人物所有有效地點 GeoJSON/JSON：
+```jsonc
+{
+  "points": [
+    {
+      "key": "addr:12345:0:1",          // 穩定鍵（見下）
+      "source": "address",                // address | office
+      "addr_id": 12345,
+      "name_chn": "...", "name": "...",
+      "lon": 118.3, "lat": 35.1,
+      "first_year": 1023, "last_year": 1050,
+      "label": "知州 · 密州"               // 顯示用（office 帶官名）
+    }
+  ]
+}
+```
+- 重用 `CoordinateValidator`：只回有效點。
+- address 與 office 都查（office 經 `offices_addr`）；同一頁觸發只需該頁資料，但為「顯示此人所有 addresses+offices」需**同時撈兩類**（不論從哪頁點進來）。
+- `key` 設計：addresses 用 `addr:{c_addr_id}:{c_addr_type}:{c_sequence}`；offices 用 `office:{c_posting_id}:{c_addr_id}`。供前端標記「當前點」。
+- 授權：與列表頁一致（公開可讀則公開；若有登入限制沿用）。
+
+### 5.3 `serialAddr()` 調整（offices）
+`BasicInformationOfficesController::serialAddr()` 目前回 `posting_id => "名稱;名稱"`。
+- 新增一個並行方法（或擴充回傳結構），讓 view 能對每個 posting 的每個地點，知道 `name_chn / x_coord / y_coord / c_addr_id`，以判定是否連結。
+- 建議回傳：`posting_id => [ ['name'=>, 'lon'=>, 'lat'=>, 'addr_id'=>, 'linkable'=>bool], ... ]`，view 端逐一渲染（連結或純文字，多筆仍以 `;` 分隔）。
+- 保留舊 `serialAddr()` 給其他呼叫點（若有）以降風險。
+
+### 5.4 `CoordinateValidator`（§3）
+- `isValid(?float $lon, ?float $lat): bool`
+- `reason(?float $lon, ?float $lat): ?string`（debug/測試用，回不通過的原因）
+- 全部讀 `config('chgis_map.*')`。
+
+---
+
+## 6. 前端設計（UI/UX）
+
+### 6.1 連結渲染（兩頁 view）
+- Place Name 由純文字改為：`linkable` 時輸出
+  ```html
+  <a href="#" class="chgis-place-link"
+     data-person-id="{{ $id }}"
+     data-key="addr:12345:0:1"
+     data-lon="118.3" data-lat="35.1">地名</a>
+  ```
+  否則維持純文字（不可點）。
+- 不在 view 寫互動邏輯；用 `data-*` + 一支委派監聽的 JS（事件委派，避免逐列綁定）。
+
+### 6.2 資源載入（Vite，遵守 AGENTS.md：禁 CDN）
+- 新增 Vite entry：`resources/js/chgis-map/app.js`（modal + Leaflet 初始化）。
+- **Leaflet 改為 npm 依賴**（`npm i leaflet`）而非全域 CDN（符合「不要重新引入外部 CDN」原則）。`historical-maps` 既有的 `window.L` 用法可後續再收斂，本功能直接用 npm import。
+- 僅在這兩頁 `@vite` 載入該 entry（或全站載入但 lazy 初始化）。
+- 提交前需 `npm run build`。
+
+### 6.3 Modal 結構（無邊框、背景變暗）
+設計思路（依設計師慣例）：
+- **遮罩**：全螢幕 `position: fixed; inset:0;` 半透明深色 `rgba(0,0,0,.6)` + `backdrop-filter: blur(2px)`，網頁變暗。
+- **容器**：無邊框、大圓角、陰影；桌機約 `min(92vw, 1100px) × min(88vh, 760px)` 置中。
+- **地圖填滿**容器；右上角浮一個半透明圓形關閉鈕（`×`），不佔地圖邊。
+- **進出動畫**：遮罩 fade、容器 scale/translateY 輕微彈入（`prefers-reduced-motion` 時關閉）。
+- **關閉**：點遮罩、按 `×`、按 `Esc` 皆可關。
+- 開啟時鎖 `body` 捲動（`overflow:hidden`）。
+
+### 6.4 地圖內容
+- 底圖：`L.tileLayer('/chgis-map/tiles/{z}/{x}/{y}', { minZoom:3, maxZoom:10, maxNativeZoom:8, bounds: <mbtiles bounds>, noWrap:true })`（允許 overzoom 到 10，原生最大 8）。
+- 開啟後 `fetch(/basicinformation/{id}/map-points)` 取全部有效點。
+- **一般點**：標準 marker / circleMarker。
+- **當前點**（`data-key` 對應者）：特殊標記（較大、主題色、可加脈動光暈），`map.setView([lat,lon], zoom)` 置中。
+- 各 marker `bindPopup` 顯示地名、類型（地址/官職）、年代區間。
+- 多點時提供「縮放至全部」控制（`fitBounds`），但初始以當前點置中（符合需求）。
+- 圖例：區分「當前地點 / 其他地址 / 官職地點」。
+
+### 6.5 底圖未就緒的提示（§4.6）
+- 開 modal → 先查 status。
+- 未就緒：modal 內顯示置中提示卡：「**地圖底圖首次載入中，正在從資料庫下載，請稍候…**」+ spinner + 進度（若有）。
+- 輪詢 `ready` 後再初始化地圖；`failed` 顯示「底圖下載失敗，請稍後再試」+ 重試鈕。
+- i18n：所有字串走翻譯鍵（§7）。
+
+### 6.6 手機互動
+- 容器在手機改為近全螢幕（`100vw × 100dvh`，用 `dvh` 處理瀏覽器列高度）。
+- 觸控手勢：Leaflet `tap`/pinch zoom；`dragging` 啟用；避免與頁面捲動衝突（modal 開啟時 body 鎖捲動）。
+- 關閉鈕加大命中區（≥44px）；支援下滑關閉（可選）。
+- marker / popup 字級與點擊區放大。
+
+---
+
+## 7. i18n
+
+- 新增翻譯鍵於 `resources/lang/zh-TW/*.php` 與 `resources/lang/en/*.php`（兩者同步，AGENTS.md 規定）。
+- 建議群組 `chgis_map`（或併入 `biogmains`）：
+  - `map_modal_title`、`current_location`、`other_addresses`、`office_locations`
+  - `downloading_basemap`、`download_failed`、`retry`、`fit_all`、`close`
+  - popup：`address_type`、`posting`、`year_range`
+- Blade 中以 `__('chgis_map.key')`；JS 字串以 `{!! Js::from(__('chgis_map.key')) !!}` 注入（沿用專案慣例）。
+- 連結本身是地名（資料值），不翻譯；周邊 UI 文字一律翻譯。
+
+---
+
+## 8. 安全與授權
+
+- 三個新路由皆置於 `web` group，沿用兩列表頁相同的可見性（若列表公開可讀，地點與底圖亦同級公開）。
+- `tile`：路由以 `where` 限定 `z/x/y` 為整數；只 `SELECT` mbtiles，無寫入、無使用者輸入拼 SQL（PDO prepared）。
+- `personPoints`：只回該 `{id}` 的有效座標，無敏感欄位。
+- mbtiles 放 `storage/app`（非 public），只能透過 tile 控制器逐磚取得，無法整檔下載。
+- 下載來源 URL 由 config 固定（HuggingFace），不接受使用者參數，避免 SSRF。
+- 遵守 AGENTS.md：AJAX URL 用 `route('name', [], false)` 相對路徑，避免 HTTPS mixed content。
+
+---
+
+## 9. 測試計畫
+
+**Unit — `CoordinateValidator`**
+- null/null、0/0、單軸 0、`1e-9` 近零 → 無效。
+- 反掉（lat 值入 lon）落界外 → 無效。
+- 界內正常點 → 有效；`SANE` 開關行為；邊界值（恰等於 bounds）。
+- Web Mercator ±85.0511 邊界。
+
+**Feature — `ChgisMapController`**
+- `personPoints`：建測試人物，混入有效/無效座標，斷言只回有效點、`key`/`source` 正確、addresses 與 offices 都涵蓋。
+- `tile`：以小型測試 mbtiles fixture（少量磚）驗 TMS y-flip、命中回 PNG、未命中回透明 PNG、缺檔回 503。
+- `status`：缺檔回 `downloading` 並觸發 job（mock/fake queue）；就緒回 `ready`。
+
+**View / 整合**
+- addresses/offices index：有效座標渲染 `<a class="chgis-place-link">`、無效維持純文字（HTML 斷言）。
+- offices 多地點：部分可連結、部分不可，`;` 分隔仍正確。
+
+**前端**
+- 手動驗證 modal 開關、Esc/遮罩關閉、置中與突顯、手機尺寸、底圖下載提示流程。
+
+> 測試 mbtiles fixture 放 `tests/fixtures/`，數 KB 即可（手造一兩個 zoom 的磚）。
+
+---
+
+## 10. 實作階段拆分（建議 PR 切分）
+
+| 階段 | 內容 | 產出 |
+|------|------|------|
+| P1 | `config/chgis_map.php` + `CoordinateValidator` + 單元測試 | 判定邏輯可獨立合併 |
+| P2 | `cbdb:fetch-chgis-map` 指令 + `.gitignore` + 接 `deploy.sh` | 部署時能取得底圖 |
+| P3 | `ChgisMapController::tile` + `status` + 路由 + lazy 下載 job + 測試 | 底圖可服務 |
+| P4 | `personPoints` 端點 + offices `serialAddr` 重構 + 測試 | 點位資料可取得 |
+| P5 | 兩頁 view 連結渲染 + i18n | 後端連結出現 |
+| P6 | `chgis-map` 前端 entry（Leaflet npm、modal、UX、手機、下載提示）+ `npm run build` | 完整體驗 |
+| P7 | 文件（README/CHANGELOG）、回歸測試、收尾 | 上線 |
+
+---
+
+## 11. 風險與未決問題
+
+1. **mbtiles bounds 南界 −62 異常**：metadata 涵蓋範圍過寬，故引入可選 `SANE` 東亞收斂框；上線前宜以實際資料抽樣校準 `SANE` 數值。
+2. **體積與首次下載時間**：15,715 磚，檔案可能數十～數百 MB；lazy 下載期間使用者等待。建議部署階段（P2）就先抓好，lazy 下載僅作後備。
+3. **TMS y-flip**：最易出錯處；務必以 fixture 測試左上/右下磚對位。
+4. **Leaflet 來源**：本功能改用 npm import；`historical-maps` 仍用 `window.L`，短期並存、不強迫一次收斂（避免擴大改動面）。
+5. **offices 多地點連結**：同一 posting 可能串多個地名，需逐地名判定 linkable，UI 上避免把整串都變連結。
+6. **座標反掉無法 100% 偵測**（§3.1）：少數落在重疊區間者保守接受，屬已知限制。
+7. **HuggingFace 可用性**：下載失敗時功能優雅降級（顯示提示、可重試），不影響其他頁面。
+8. **快取**：tile 回應加 `ETag`/`Cache-Control`，降低 mbtiles 讀取壓力；PDO 連線重用。
+
+---
+
+## 12. 影響檔案一覽（預估）
+
+**新增**
+- `config/chgis_map.php`
+- `app/Support/CoordinateValidator.php`
+- `app/Http/Controllers/ChgisMapController.php`
+- `app/Console/Commands/FetchChgisMap.php`
+- `app/Jobs/FetchChgisMapJob.php`
+- `resources/js/chgis-map/app.js`（+ 樣式）
+- 翻譯鍵：`resources/lang/zh-TW/chgis_map.php`、`resources/lang/en/chgis_map.php`
+- 測試：`tests/Unit/CoordinateValidatorTest.php`、`tests/Feature/ChgisMapTest.php` + fixture
+
+**修改**
+- `routes/web.php`（3 路由）
+- `app/Http/Controllers/BasicInformationOfficesController.php`（`serialAddr` 重構 / 並行方法）
+- `resources/views/biogmains/addresses/index.blade.php:46`
+- `resources/views/biogmains/offices/index.blade.php:46`
+- `deploy.sh`（追加抓底圖步驟）
+- `.gitignore`（`/storage/app/chgis/*.mbtiles`）
+- `vite.config.js`（新 entry）
+- `README.md` / `CHANGELOG.md`（收尾）

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cn-era": "^0.4.1",
         "datatables.net": "^1.13.8",
         "datatables.net-bs4": "^2.3.5",
+        "leaflet": "^1.9.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "sql-formatter": "^15.6.12"
@@ -4058,6 +4059,12 @@
       "peerDependencies": {
         "vite": "^7.0.0"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lie": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cn-era": "^0.4.1",
     "datatables.net": "^1.13.8",
     "datatables.net-bs4": "^2.3.5",
+    "leaflet": "^1.9.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "sql-formatter": "^15.6.12"

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -458,30 +458,35 @@ function loadPoints(personId) {
 }
 
 function renderPoints(points, currentKey, fallbackCenter) {
-    if (!points.length) {
+    const valid = points.filter((p) => isFinite(p.lon) && isFinite(p.lat));
+    if (!valid.length) {
         setStatus({ message: t('no_points'), spinner: false, retry: false });
         return;
     }
 
+    // 依座標（四捨五入到 5 位小數）合併同地點的多個 node
+    const groups = groupByCoord(valid);
     const animate = !reducedMotion();
     const markers = [];
     let currentLatLng = null;
 
-    points.forEach((p) => {
-        if (!isFinite(p.lon) || !isFinite(p.lat)) {
-            return;
-        }
-        const latlng = [p.lat, p.lon];
-        const isCurrent = currentKey && p.key === currentKey;
-        const marker = isCurrent ? currentMarker(latlng) : normalMarker(latlng, p.source);
-        marker.addTo(mapInstance).bindPopup(popupHtml(p));
+    groups.forEach((entries) => {
+        const first = entries[0];
+        const latlng = [first.lat, first.lon];
+        const hasCurrent = currentKey && entries.some((e) => e.key === currentKey);
+        const marker = makeMarker(latlng, entries, hasCurrent);
+        marker.addTo(mapInstance).bindPopup(buildPopup(entries, currentKey), {
+            maxWidth: 300,
+            maxHeight: 320,
+        });
         markers.push(marker);
-        if (isCurrent) {
+        if (hasCurrent) {
             currentLatLng = latlng;
         }
     });
 
-    addLegend();
+    const hasCluster = Array.from(groups.values()).some((entries) => entries.length > 1);
+    addLegend(hasCluster);
 
     if (currentLatLng) {
         mapInstance.setView(currentLatLng, 7, { animate });
@@ -492,6 +497,33 @@ function renderPoints(points, currentKey, fallbackCenter) {
     } else {
         mapInstance.setView(fallbackCenter, 6, { animate });
     }
+}
+
+/** 依座標分組（同像素合併）。回傳 Map<coordKey, entries[]>。 */
+function groupByCoord(points) {
+    const groups = new Map();
+    points.forEach((p) => {
+        const lon = Number(p.lon);
+        const lat = Number(p.lat);
+        const key = lon.toFixed(5) + ',' + lat.toFixed(5);
+        if (!groups.has(key)) {
+            groups.set(key, []);
+        }
+        groups.get(key).push(p);
+    });
+    return groups;
+}
+
+/** 同組有地址→藍，純官職→綠。 */
+function groupColor(entries) {
+    return entries.some((e) => e.source === 'address') ? '#2563eb' : '#16a34a';
+}
+
+function makeMarker(latlng, entries, hasCurrent) {
+    if (entries.length === 1) {
+        return hasCurrent ? currentMarker(latlng) : normalMarker(latlng, entries[0].source);
+    }
+    return clusterMarker(latlng, entries.length, hasCurrent, groupColor(entries));
 }
 
 function normalMarker(latlng, source) {
@@ -516,28 +548,118 @@ function currentMarker(latlng) {
     return L.marker(latlng, { icon, zIndexOffset: 1000 });
 }
 
-function popupHtml(p) {
-    const typeLabel = p.source === 'office' ? t('type_office') : t('type_address');
-    const name = p.label || p.name_chn || p.name || '';
-    let html = `<strong>${escapeHtml(name)}</strong><br><span>${escapeHtml(typeLabel)}</span>`;
-    if (p.first_year || p.last_year) {
-        const years = `${p.first_year || '?'}–${p.last_year || '?'}`;
-        html += `<br><span>${escapeHtml(t('year_range'))}: ${escapeHtml(years)}</span>`;
+/** 多筆同座標：帶數字徽章的標記（含當前點脈動）。 */
+function clusterMarker(latlng, count, isCurrent, color) {
+    const n = Number(count) || 0;
+    const cls = 'chgis-cluster-marker' + (isCurrent ? ' chgis-cluster-marker--current' : '');
+    // n 為整數、color 為固定字面色，無使用者輸入，無 XSS
+    const style = isCurrent ? '' : ` style="background:${color}"`;
+    const html = `<div class="${cls}"${style}><span class="chgis-cluster-badge">${n}</span></div>`;
+    const icon = L.divIcon({
+        className: '',
+        html,
+        iconSize: [24, 24],
+        iconAnchor: [12, 12],
+        popupAnchor: [0, -12],
+    });
+    return L.marker(latlng, { icon, zIndexOffset: isCurrent ? 1000 : 0 });
+}
+
+function entryName(e) {
+    const label = firstNonEmpty(e.label, e.name_chn, e.name);
+    if (label !== '') {
+        return label;
     }
+    if (e.addr_id != null && e.addr_id !== '') {
+        return '#' + e.addr_id;
+    }
+
+    return t('unknown_place');
+}
+
+function firstNonEmpty(...values) {
+    for (const value of values) {
+        const text = value == null ? '' : String(value).trim();
+        if (text !== '') {
+            return text;
+        }
+    }
+
+    return '';
+}
+
+function formatYears(e) {
+    if (!e.first_year && !e.last_year) {
+        return '';
+    }
+
+    return String(e.first_year || '?') + '-' + String(e.last_year || '?');
+}
+
+function formatEntryLine(e, currentKey, showAddrId) {
+    const isCurrent = currentKey && e.key === currentKey;
+    let line = `<span class="chgis-pop__name">${escapeHtml(entryName(e))}</span>`;
+
+    if (showAddrId && e.addr_id != null && e.addr_id !== '') {
+        line += ` <span class="chgis-pop__meta">#${escapeHtml(e.addr_id)}</span>`;
+    }
+
+    const years = formatYears(e);
+    if (years) {
+        line += ` <span class="chgis-pop__yr">(${escapeHtml(years)})</span>`;
+    }
+
+    return `<div class="chgis-pop__item${isCurrent ? ' chgis-pop__item--current' : ''}">${line}</div>`;
+}
+
+/** 一組（同座標）的 popup：標頭 + 依類型分組的捲動清單，當前 node 標示。 */
+function buildPopup(entries, currentKey) {
+    const placeName = entryName(entries[0]);
+    const addresses = entries.filter((e) => e.source === 'address');
+    const offices = entries.filter((e) => e.source === 'office');
+
+    let head = `<strong>${escapeHtml(placeName)}</strong>`;
+    if (entries.length > 1) {
+        head += ` &middot; ${entries.length} ${escapeHtml(t('count_unit'))}`;
+    }
+
+    let html = `<div class="chgis-pop"><div class="chgis-pop__head">${head}</div>`;
+    html += popupSection(t('type_address'), addresses, currentKey);
+    html += popupSection(t('type_office'), offices, currentKey);
+    html += '</div>';
     return html;
 }
 
-function addLegend() {
+function popupSection(label, list, currentKey) {
+    if (!list.length) {
+        return '';
+    }
+
+    const showAddrId = new Set(list.map((e) => entryName(e))).size < list.length;
+    let html = `<div class="chgis-pop__section"><div class="chgis-pop__sectit">${escapeHtml(label)}</div>`;
+    list.forEach((e) => {
+        html += formatEntryLine(e, currentKey, showAddrId);
+    });
+    html += '</div>';
+    return html;
+}
+
+function addLegend(hasCluster) {
     if (legendControl) {
         legendControl.remove();
     }
     const legend = L.control({ position: 'bottomleft' });
     legend.onAdd = function () {
         const div = L.DomUtil.create('div', 'chgis-legend');
-        div.innerHTML = `
+        let html = `
             <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#ef4444"></span>${escapeHtml(t('current_location'))}</div>
             <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#2563eb"></span>${escapeHtml(t('other_addresses'))}</div>
             <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#16a34a"></span>${escapeHtml(t('office_locations'))}</div>`;
+        // 只有真的出現合併標記時才顯示徽章說明
+        if (hasCluster) {
+            html += `<div class="chgis-legend__row"><span class="chgis-legend__badge">N</span>${escapeHtml(t('legend_count_hint'))}</div>`;
+        }
+        div.innerHTML = html;
         return div;
     };
     legend.addTo(mapInstance);

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -565,18 +565,6 @@ function clusterMarker(latlng, count, isCurrent, color) {
     return L.marker(latlng, { icon, zIndexOffset: isCurrent ? 1000 : 0 });
 }
 
-function entryName(e) {
-    const label = firstNonEmpty(e.label, e.name_chn, e.name);
-    if (label !== '') {
-        return label;
-    }
-    if (e.addr_id != null && e.addr_id !== '') {
-        return '#' + e.addr_id;
-    }
-
-    return t('unknown_place');
-}
-
 function firstNonEmpty(...values) {
     for (const value of values) {
         const text = value == null ? '' : String(value).trim();
@@ -586,6 +574,57 @@ function firstNonEmpty(...values) {
     }
 
     return '';
+}
+
+/** 地點名稱（地名）：name_chn → name → #addr_id → 未知。 */
+function placeNameOf(e) {
+    const place = firstNonEmpty(e.name_chn, e.name);
+    if (place !== '') {
+        return place;
+    }
+    if (e.addr_id != null && e.addr_id !== '') {
+        return '#' + e.addr_id;
+    }
+
+    return t('unknown_place');
+}
+
+/** 官名中／英並列的 HTML（英文以較淡較小字呈現，避免擁擠）。 */
+function officeNameHtml(e) {
+    const chn = firstNonEmpty(e.office_name);
+    const en = firstNonEmpty(e.office_name_en);
+    if (chn && en) {
+        return escapeHtml(chn) + ` <span class="chgis-pop__en">${escapeHtml(en)}</span>`;
+    }
+    if (chn) {
+        return escapeHtml(chn);
+    }
+    if (en) {
+        return escapeHtml(en);
+    }
+
+    return '';
+}
+
+/** 一筆 entry 顯示的 HTML：官職為「官名(中 英) · 地名」，地址為「地名」。 */
+function entryDisplayHtml(e) {
+    const place = escapeHtml(placeNameOf(e));
+    if (e.source === 'office') {
+        const office = officeNameHtml(e);
+        return office ? `${office} &middot; ${place}` : place;
+    }
+
+    return place;
+}
+
+/** 純文字版（供同名碰撞偵測，不含標籤）。 */
+function entryDisplayText(e) {
+    if (e.source === 'office') {
+        const parts = [firstNonEmpty(e.office_name, e.office_name_en), placeNameOf(e)].filter(Boolean);
+        return parts.join(' · ');
+    }
+
+    return placeNameOf(e);
 }
 
 function formatYears(e) {
@@ -598,7 +637,12 @@ function formatYears(e) {
 
 function formatEntryLine(e, currentKey, showAddrId) {
     const isCurrent = currentKey && e.key === currentKey;
-    let line = `<span class="chgis-pop__name">${escapeHtml(entryName(e))}</span>`;
+    const inner = entryDisplayHtml(e);
+    // 有 url 時包成連結，於新分頁開啟該筆記錄頁；url 為相對路徑、經 escapeHtml
+    const nameHtml = e.url
+        ? `<a class="chgis-pop__link" href="${escapeHtml(e.url)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(t('open_record'))}">${inner}</a>`
+        : inner;
+    let line = `<span class="chgis-pop__name">${nameHtml}</span>`;
 
     if (showAddrId && e.addr_id != null && e.addr_id !== '') {
         line += ` <span class="chgis-pop__meta">#${escapeHtml(e.addr_id)}</span>`;
@@ -614,7 +658,7 @@ function formatEntryLine(e, currentKey, showAddrId) {
 
 /** 一組（同座標）的 popup：標頭 + 依類型分組的捲動清單，當前 node 標示。 */
 function buildPopup(entries, currentKey) {
-    const placeName = entryName(entries[0]);
+    const placeName = placeNameOf(entries[0]);
     const addresses = entries.filter((e) => e.source === 'address');
     const offices = entries.filter((e) => e.source === 'office');
 
@@ -635,7 +679,7 @@ function popupSection(label, list, currentKey) {
         return '';
     }
 
-    const showAddrId = new Set(list.map((e) => entryName(e))).size < list.length;
+    const showAddrId = new Set(list.map((e) => entryDisplayText(e))).size < list.length;
     let html = `<div class="chgis-pop__section"><div class="chgis-pop__sectit">${escapeHtml(label)}</div>`;
     list.forEach((e) => {
         html += formatEntryLine(e, currentKey, showAddrId);

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -265,6 +265,9 @@ function closeModal() {
     if (!overlayEl) {
         return;
     }
+    if (!overlayEl.classList.contains('is-open')) {
+        return;
+    }
     openToken++; // 使所有 pending 非同步 callback 失效
     stopPolling();
     abortPendingRequests();

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -1,0 +1,564 @@
+/**
+ * CHGIS 地圖 modal（addresses/offices 列表頁 Place Name 連結）
+ *
+ * 點擊 .chgis-place-link → 浮出以 chgis_map.mbtiles 為底圖的 Leaflet 地圖，
+ * 標出該人物所有有效地點，當前點置中並以脈動標記突顯。
+ * 設定與字串由後端注入 window.chgisMapConfig（見 _chgis_map_assets.blade.php）。
+ *
+ * 設計見 docs/CHGIS_MAP_PLACE_LINK.md §6。
+ */
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import './style.css';
+
+const cfg = () => window.chgisMapConfig || {};
+const t = (key) => (cfg().i18n && cfg().i18n[key]) || key;
+const reducedMotion = () =>
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+let overlayEl = null;
+let mapInstance = null;
+let legendControl = null;
+let pollTimer = null;
+let lastActiveElement = null;
+let savedOverflow = '';
+let pointerdownOnOverlay = false;
+let lastTabDirectionBackward = false;
+let basemapRequestController = null;
+let pointsRequestController = null;
+// 開啟世代：每次開啟/關閉遞增，非同步 callback 以此辨識自己是否已過期
+let openToken = 0;
+
+/** 建立 modal DOM（僅一次）。 */
+function buildOverlay() {
+    const overlay = document.createElement('div');
+    overlay.className = 'chgis-modal-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', t('modal_title'));
+    overlay.innerHTML = `
+        <div class="chgis-modal" tabindex="-1">
+            <button type="button" class="chgis-modal__close" aria-label="${escapeHtml(t('close'))}">&times;</button>
+            <div class="chgis-modal__map"></div>
+            <div class="chgis-modal__status" role="status" aria-live="polite" aria-atomic="true" hidden>
+                <div class="chgis-spinner" aria-hidden="true"></div>
+                <div class="chgis-status__message"></div>
+                <button type="button" class="chgis-status__retry" hidden></button>
+            </div>
+        </div>`;
+
+    // 僅當 pointer 起點與終點都落在遮罩本體（非地圖）才關閉，避免拖曳鬆手誤關
+    overlay.addEventListener('pointerdown', (e) => {
+        pointerdownOnOverlay = e.target === overlay;
+    });
+    overlay.addEventListener('pointerup', (e) => {
+        if (e.target === overlay && pointerdownOnOverlay) {
+            closeModal();
+        }
+        pointerdownOnOverlay = false;
+    });
+    overlay.querySelector('.chgis-modal__close').addEventListener('click', closeModal);
+    // modal 內 Tab focus trap
+    overlay.addEventListener('keydown', onTrapKeydown);
+    document.addEventListener('focusin', onDocumentFocusIn, true);
+
+    document.body.appendChild(overlay);
+    return overlay;
+}
+
+function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str == null ? '' : String(str);
+    return div.innerHTML;
+}
+
+function focusableEls() {
+    if (!overlayEl) {
+        return [];
+    }
+    return Array.from(
+        overlayEl.querySelectorAll(
+            'button:not([hidden]), a[href], [tabindex]:not([tabindex="-1"])'
+        )
+    ).filter((el) => el.offsetParent !== null && !el.disabled);
+}
+
+function onTrapKeydown(e) {
+    lastTabDirectionBackward = e.shiftKey;
+    if (e.key !== 'Tab') {
+        return;
+    }
+    const els = focusableEls();
+    if (!els.length) {
+        e.preventDefault();
+        return;
+    }
+    if (!overlayEl.contains(document.activeElement)) {
+        e.preventDefault();
+        (e.shiftKey ? els[els.length - 1] : els[0]).focus();
+        return;
+    }
+    const first = els[0];
+    const last = els[els.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+    }
+}
+
+function onDocumentFocusIn(e) {
+    if (!overlayEl || !overlayEl.classList.contains('is-open')) {
+        return;
+    }
+    if (overlayEl.contains(e.target)) {
+        return;
+    }
+    const els = focusableEls();
+    const fallback = els.length
+        ? (lastTabDirectionBackward ? els[els.length - 1] : els[0])
+        : overlayEl.querySelector('.chgis-modal');
+    if (fallback) {
+        fallback.focus();
+    }
+}
+
+function setStatus({ message, spinner = true, retry = false }) {
+    if (!overlayEl) {
+        return;
+    }
+    const statusEl = overlayEl.querySelector('.chgis-modal__status');
+    statusEl.querySelector('.chgis-status__message').textContent = message;
+    statusEl.querySelector('.chgis-spinner').style.display = spinner ? '' : 'none';
+    const retryBtn = statusEl.querySelector('.chgis-status__retry');
+    retryBtn.hidden = !retry;
+    statusEl.setAttribute('aria-busy', spinner ? 'true' : 'false');
+    statusEl.hidden = false;
+}
+
+function hideStatus() {
+    if (overlayEl) {
+        overlayEl.querySelector('.chgis-modal__status').hidden = true;
+    }
+}
+
+function resetRetry() {
+    if (!overlayEl) {
+        return;
+    }
+    const retryBtn = overlayEl.querySelector('.chgis-status__retry');
+    retryBtn.onclick = null;
+    retryBtn.hidden = true;
+}
+
+function cleanupMap() {
+    if (mapInstance) {
+        mapInstance.remove();
+        mapInstance = null;
+    }
+    legendControl = null;
+    if (overlayEl) {
+        overlayEl.querySelector('.chgis-modal__map').replaceChildren();
+    }
+}
+
+function abortPendingRequests() {
+    if (basemapRequestController) {
+        basemapRequestController.abort();
+        basemapRequestController = null;
+    }
+    if (pointsRequestController) {
+        pointsRequestController.abort();
+        pointsRequestController = null;
+    }
+}
+
+function isAbortError(error) {
+    return error && (error.name === 'AbortError' || error.code === 20);
+}
+
+function parseJsonResponse(response) {
+    if (!response.ok) {
+        return response
+            .json()
+            .catch(() => null)
+            .then((body) => {
+                const error = new Error('HTTP ' + response.status);
+                error.status = response.status;
+                error.body = body;
+                throw error;
+            });
+    }
+
+    return response.json();
+}
+
+function showRetryableStatus(message, onRetry) {
+    setStatus({ message, spinner: false, retry: true });
+    const retryBtn = overlayEl.querySelector('.chgis-status__retry');
+    retryBtn.textContent = t('retry');
+    retryBtn.onclick = () => {
+        setStatus({ message: t('loading') });
+        onRetry();
+    };
+}
+
+function openModal(trigger) {
+    const personId = trigger.dataset.personId;
+    const currentKey = trigger.dataset.key;
+    const lon = parseFloat(trigger.dataset.lon);
+    const lat = parseFloat(trigger.dataset.lat);
+    if (!personId) {
+        return;
+    }
+
+    const token = ++openToken;
+    lastActiveElement = trigger;
+    if (!overlayEl) {
+        overlayEl = buildOverlay();
+    }
+
+    // 重置狀態（避免沿用上一次的殘留）
+    stopPolling();
+    abortPendingRequests();
+    cleanupMap();
+    resetRetry();
+    hideStatus();
+
+    savedOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    requestAnimationFrame(() => {
+        overlayEl.classList.add('is-open');
+        overlayEl.querySelector('.chgis-modal__close').focus();
+    });
+
+    const start = () => startMap(token, personId, currentKey, lon, lat);
+
+    ensureBasemapReady(token)
+        .then(() => {
+            if (token === openToken) {
+                start();
+            }
+        })
+        .catch((err) => showFailure(err, start, token));
+}
+
+function showFailure(err, start, token) {
+    if (token !== openToken) {
+        return;
+    }
+    showRetryableStatus(err && err.userMessage ? err.userMessage : t('download_failed'), () => {
+        if (token !== openToken) {
+            return;
+        }
+        setStatus({ message: t('downloading_basemap') });
+        ensureBasemapReady(token, true)
+            .then(() => token === openToken && start())
+            .catch((e) => showFailure(e, start, token));
+    });
+}
+
+function closeModal() {
+    if (!overlayEl) {
+        return;
+    }
+    openToken++; // 使所有 pending 非同步 callback 失效
+    stopPolling();
+    abortPendingRequests();
+    overlayEl.classList.remove('is-open');
+    document.body.style.overflow = savedOverflow;
+    pointerdownOnOverlay = false;
+
+    cleanupMap();
+    hideStatus();
+    resetRetry();
+
+    if (lastActiveElement && typeof lastActiveElement.focus === 'function') {
+        lastActiveElement.focus();
+    }
+}
+
+function stopPolling() {
+    if (pollTimer) {
+        window.clearTimeout(pollTimer);
+        pollTimer = null;
+    }
+}
+
+/**
+ * 確認底圖就緒；缺檔時顯示下載提示並輪詢 status。
+ * @param {number} token 開啟世代
+ * @param {boolean} retry 失敗後重試（帶 ?retry=1）
+ */
+function ensureBasemapReady(token, retry = false) {
+    stopPolling();
+    if (basemapRequestController) {
+        basemapRequestController.abort();
+    }
+    const statusUrl = cfg().statusUrl;
+    const deadline = Date.now() + 60000; // 最多輪詢約 60 秒
+
+    return new Promise((resolve, reject) => {
+        const poll = (withRetry) => {
+            if (token !== openToken) {
+                return; // 已關閉或重新開啟，放棄
+            }
+            const url = withRetry ? `${statusUrl}?retry=1` : statusUrl;
+            basemapRequestController = new AbortController();
+            fetch(url, {
+                headers: { Accept: 'application/json' },
+                signal: basemapRequestController.signal,
+            })
+                .then(parseJsonResponse)
+                .then((data) => {
+                    basemapRequestController = null;
+                    if (token !== openToken) {
+                        return;
+                    }
+                    if (data.ready) {
+                        resolve();
+                        return;
+                    }
+                    if (data.state === 'failed') {
+                        reject({ userMessage: data.message || t('download_failed') });
+                        return;
+                    }
+                    setStatus({ message: t('downloading_basemap') });
+                    if (Date.now() > deadline) {
+                        reject({ userMessage: t('download_failed') });
+                        return;
+                    }
+                    pollTimer = window.setTimeout(() => poll(false), 2500);
+                })
+                .catch((error) => {
+                    basemapRequestController = null;
+                    if (isAbortError(error) || token !== openToken) {
+                        return;
+                    }
+                    const userMessage =
+                        error && error.body && typeof error.body.message === 'string'
+                            ? error.body.message
+                            : t('load_error');
+                    if (token === openToken) {
+                        reject({ userMessage });
+                    }
+                });
+        };
+        poll(retry);
+    });
+}
+
+function startMap(token, personId, currentKey, lon, lat) {
+    if (token !== openToken) {
+        return;
+    }
+    hideStatus();
+    const mapEl = overlayEl.querySelector('.chgis-modal__map');
+    const c = cfg();
+    const bounds = c.bounds || {};
+
+    cleanupMap();
+    mapInstance = L.map(mapEl, {
+        zoomControl: true,
+        attributionControl: false,
+        minZoom: c.minZoom || 3,
+        maxZoom: 10,
+    });
+
+    L.tileLayer(c.tileUrlTemplate, {
+        minZoom: c.minZoom || 3,
+        maxZoom: 10,
+        maxNativeZoom: c.maxZoom || 8,
+        noWrap: true,
+        bounds: boundsToLatLng(bounds),
+    }).addTo(mapInstance);
+
+    const fallbackCenter = isFinite(lon) && isFinite(lat) ? [lat, lon] : [35, 110];
+    mapInstance.setView(fallbackCenter, 6, { animate: false });
+
+    // modal 進場動畫結束後再重算尺寸，避免量到中間態
+    invalidateAfterTransition();
+
+    loadPoints(personId)
+        .then((points) => {
+            if (token === openToken) {
+                renderPoints(points, currentKey, fallbackCenter);
+            }
+        })
+        .catch((error) => {
+            if (isAbortError(error) || token !== openToken) {
+                return;
+            }
+            if (token === openToken) {
+                showRetryableStatus(t('load_error'), () => {
+                    if (token !== openToken) {
+                        return;
+                    }
+                    hideStatus();
+                    startMap(token, personId, currentKey, lon, lat);
+                });
+            }
+        });
+}
+
+function invalidateAfterTransition() {
+    const modal = overlayEl.querySelector('.chgis-modal');
+    let done = false;
+    const run = () => {
+        if (done || !mapInstance) {
+            return;
+        }
+        done = true;
+        mapInstance.invalidateSize({ animate: false });
+        modal.removeEventListener('transitionend', onEnd);
+    };
+    const onEnd = (e) => {
+        if (e.propertyName === 'transform') {
+            run();
+        }
+    };
+    modal.addEventListener('transitionend', onEnd);
+    // fallback：動畫被略過（reduced-motion）或 transitionend 未觸發時
+    window.setTimeout(run, reducedMotion() ? 30 : 240);
+}
+
+function boundsToLatLng(b) {
+    if (b.south == null) {
+        return undefined;
+    }
+    return [
+        [b.south, b.west],
+        [b.north, b.east],
+    ];
+}
+
+function loadPoints(personId) {
+    const base = cfg().pointsUrlBase || '/basicinformation';
+    const url = `${base}/${encodeURIComponent(personId)}/map-points`;
+    if (pointsRequestController) {
+        pointsRequestController.abort();
+    }
+    pointsRequestController = new AbortController();
+
+    return fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: pointsRequestController.signal,
+    })
+        .then(parseJsonResponse)
+        .finally(() => {
+            pointsRequestController = null;
+        })
+        .then((data) => (data && Array.isArray(data.points) ? data.points : []));
+}
+
+function renderPoints(points, currentKey, fallbackCenter) {
+    if (!points.length) {
+        setStatus({ message: t('no_points'), spinner: false, retry: false });
+        return;
+    }
+
+    const animate = !reducedMotion();
+    const markers = [];
+    let currentLatLng = null;
+
+    points.forEach((p) => {
+        if (!isFinite(p.lon) || !isFinite(p.lat)) {
+            return;
+        }
+        const latlng = [p.lat, p.lon];
+        const isCurrent = currentKey && p.key === currentKey;
+        const marker = isCurrent ? currentMarker(latlng) : normalMarker(latlng, p.source);
+        marker.addTo(mapInstance).bindPopup(popupHtml(p));
+        markers.push(marker);
+        if (isCurrent) {
+            currentLatLng = latlng;
+        }
+    });
+
+    addLegend();
+
+    if (currentLatLng) {
+        mapInstance.setView(currentLatLng, 7, { animate });
+    } else if (markers.length === 1) {
+        mapInstance.setView(markers[0].getLatLng(), 7, { animate });
+    } else if (markers.length > 1) {
+        mapInstance.fitBounds(L.featureGroup(markers).getBounds().pad(0.2), { animate });
+    } else {
+        mapInstance.setView(fallbackCenter, 6, { animate });
+    }
+}
+
+function normalMarker(latlng, source) {
+    const color = source === 'office' ? '#16a34a' : '#2563eb';
+    return L.circleMarker(latlng, {
+        radius: 7,
+        color: '#fff',
+        weight: 2,
+        fillColor: color,
+        fillOpacity: 0.9,
+    });
+}
+
+function currentMarker(latlng) {
+    const icon = L.divIcon({
+        className: '',
+        html: '<div class="chgis-current-marker"></div>',
+        iconSize: [20, 20],
+        iconAnchor: [10, 10],
+        popupAnchor: [0, -10],
+    });
+    return L.marker(latlng, { icon, zIndexOffset: 1000 });
+}
+
+function popupHtml(p) {
+    const typeLabel = p.source === 'office' ? t('type_office') : t('type_address');
+    const name = p.label || p.name_chn || p.name || '';
+    let html = `<strong>${escapeHtml(name)}</strong><br><span>${escapeHtml(typeLabel)}</span>`;
+    if (p.first_year || p.last_year) {
+        const years = `${p.first_year || '?'}–${p.last_year || '?'}`;
+        html += `<br><span>${escapeHtml(t('year_range'))}: ${escapeHtml(years)}</span>`;
+    }
+    return html;
+}
+
+function addLegend() {
+    if (legendControl) {
+        legendControl.remove();
+    }
+    const legend = L.control({ position: 'bottomleft' });
+    legend.onAdd = function () {
+        const div = L.DomUtil.create('div', 'chgis-legend');
+        div.innerHTML = `
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#ef4444"></span>${escapeHtml(t('current_location'))}</div>
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#2563eb"></span>${escapeHtml(t('other_addresses'))}</div>
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#16a34a"></span>${escapeHtml(t('office_locations'))}</div>`;
+        return div;
+    };
+    legend.addTo(mapInstance);
+    legendControl = legend;
+}
+
+/** 事件委派：點擊或鍵盤觸發 Place Name 連結。 */
+function onActivate(e) {
+    const trigger = e.target.closest('.chgis-place-link');
+    if (!trigger) {
+        return;
+    }
+    if (e.type === 'keydown' && e.key !== 'Enter' && e.key !== ' ') {
+        return;
+    }
+    e.preventDefault();
+    openModal(trigger);
+}
+
+document.addEventListener('click', onActivate);
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlayEl && overlayEl.classList.contains('is-open')) {
+        closeModal();
+        return;
+    }
+    onActivate(e);
+});

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -72,6 +72,27 @@ function escapeHtml(str) {
     return div.innerHTML;
 }
 
+function sanitizePopupUrl(url) {
+    const raw = url == null ? '' : String(url).trim();
+    if (raw === '') {
+        return '';
+    }
+
+    try {
+        const parsed = new URL(raw, window.location.origin);
+        const isSafeProtocol = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        if (!isSafeProtocol) {
+            return '';
+        }
+
+        return parsed.origin === window.location.origin
+            ? `${parsed.pathname}${parsed.search}${parsed.hash}`
+            : parsed.toString();
+    } catch (_error) {
+        return '';
+    }
+}
+
 function focusableEls() {
     if (!overlayEl) {
         return [];
@@ -485,8 +506,13 @@ function renderPoints(points, currentKey, fallbackCenter) {
         }
     });
 
-    const hasCluster = Array.from(groups.values()).some((entries) => entries.length > 1);
-    addLegend(hasCluster);
+    const groupList = Array.from(groups.values());
+    const hasCluster = groupList.some((entries) => entries.length > 1);
+    // 僅當地圖上真的出現「分割色」marker（mixed 且非 current，current 會被紅色覆蓋）才在圖例說明
+    const hasMixed = groupList.some(
+        (entries) => groupIsMixed(entries) && !(currentKey && entries.some((e) => e.key === currentKey))
+    );
+    addLegend(hasCluster, hasMixed);
 
     if (currentLatLng) {
         mapInstance.setView(currentLatLng, 7, { animate });
@@ -514,16 +540,28 @@ function groupByCoord(points) {
     return groups;
 }
 
-/** 同組有地址→藍，純官職→綠。 */
-function groupColor(entries) {
-    return entries.some((e) => e.source === 'address') ? '#2563eb' : '#16a34a';
+const COLOR_ADDRESS = '#2563eb';
+const COLOR_OFFICE = '#16a34a';
+const FILL_MIXED = `linear-gradient(90deg, ${COLOR_ADDRESS} 0 50%, ${COLOR_OFFICE} 50% 100%)`;
+
+/** 該組是否同時含地址與官職（同一地點既是傳記地址又是任官地）。 */
+function groupIsMixed(entries) {
+    return entries.some((e) => e.source === 'address') && entries.some((e) => e.source === 'office');
+}
+
+/** 標記填色：兼具兩類→左藍右綠分割；純地址→藍；純官職→綠。 */
+function groupFill(entries) {
+    if (groupIsMixed(entries)) {
+        return FILL_MIXED;
+    }
+    return entries.some((e) => e.source === 'address') ? COLOR_ADDRESS : COLOR_OFFICE;
 }
 
 function makeMarker(latlng, entries, hasCurrent) {
     if (entries.length === 1) {
         return hasCurrent ? currentMarker(latlng) : normalMarker(latlng, entries[0].source);
     }
-    return clusterMarker(latlng, entries.length, hasCurrent, groupColor(entries));
+    return clusterMarker(latlng, entries.length, hasCurrent, groupFill(entries));
 }
 
 function normalMarker(latlng, source) {
@@ -549,11 +587,11 @@ function currentMarker(latlng) {
 }
 
 /** 多筆同座標：帶數字徽章的標記（含當前點脈動）。 */
-function clusterMarker(latlng, count, isCurrent, color) {
+function clusterMarker(latlng, count, isCurrent, fill) {
     const n = Number(count) || 0;
     const cls = 'chgis-cluster-marker' + (isCurrent ? ' chgis-cluster-marker--current' : '');
-    // n 為整數、color 為固定字面色，無使用者輸入，無 XSS
-    const style = isCurrent ? '' : ` style="background:${color}"`;
+    // n 為整數、fill 為固定字面色／漸層，無使用者輸入，無 XSS
+    const style = isCurrent ? '' : ` style="background:${fill}"`;
     const html = `<div class="${cls}"${style}><span class="chgis-cluster-badge">${n}</span></div>`;
     const icon = L.divIcon({
         className: '',
@@ -637,23 +675,26 @@ function formatYears(e) {
 
 function formatEntryLine(e, currentKey, showAddrId) {
     const isCurrent = currentKey && e.key === currentKey;
-    const inner = entryDisplayHtml(e);
-    // 有 url 時包成連結，於新分頁開啟該筆記錄頁；url 為相對路徑、經 escapeHtml
-    const nameHtml = e.url
-        ? `<a class="chgis-pop__link" href="${escapeHtml(e.url)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(t('open_record'))}">${inner}</a>`
-        : inner;
-    let line = `<span class="chgis-pop__name">${nameHtml}</span>`;
+    const safeUrl = sanitizePopupUrl(e.url);
 
+    // 整列內容：地名/官名 + #id + 年代
+    let content = `<span class="chgis-pop__name">${entryDisplayHtml(e)}</span>`;
     if (showAddrId && e.addr_id != null && e.addr_id !== '') {
-        line += ` <span class="chgis-pop__meta">#${escapeHtml(e.addr_id)}</span>`;
+        content += ` <span class="chgis-pop__meta">#${escapeHtml(e.addr_id)}</span>`;
     }
-
     const years = formatYears(e);
     if (years) {
-        line += ` <span class="chgis-pop__yr">(${escapeHtml(years)})</span>`;
+        content += ` <span class="chgis-pop__yr">(${escapeHtml(years)})</span>`;
     }
 
-    return `<div class="chgis-pop__item${isCurrent ? ' chgis-pop__item--current' : ''}">${line}</div>`;
+    const currentCls = isCurrent ? ' chgis-pop__item--current' : '';
+
+    // 有 url 時「整列」即為連結（block，整列可點），於新分頁開啟該筆記錄頁
+    if (safeUrl) {
+        return `<a class="chgis-pop__item chgis-pop__item--link${currentCls}" href="${escapeHtml(safeUrl)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(t('open_record'))}">${content}</a>`;
+    }
+
+    return `<div class="chgis-pop__item${currentCls}">${content}</div>`;
 }
 
 /** 一組（同座標）的 popup：標頭 + 依類型分組的捲動清單，當前 node 標示。 */
@@ -688,7 +729,7 @@ function popupSection(label, list, currentKey) {
     return html;
 }
 
-function addLegend(hasCluster) {
+function addLegend(hasCluster, hasMixed) {
     if (legendControl) {
         legendControl.remove();
     }
@@ -696,12 +737,16 @@ function addLegend(hasCluster) {
     legend.onAdd = function () {
         const div = L.DomUtil.create('div', 'chgis-legend');
         let html = `
-            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#ef4444"></span>${escapeHtml(t('current_location'))}</div>
-            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#2563eb"></span>${escapeHtml(t('other_addresses'))}</div>
-            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#16a34a"></span>${escapeHtml(t('office_locations'))}</div>`;
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:#ef4444"></span><span class="chgis-legend__label">${escapeHtml(t('current_location'))}</span></div>
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:${COLOR_ADDRESS}"></span><span class="chgis-legend__label">${escapeHtml(t('biographical_addresses'))}</span></div>
+            <div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:${COLOR_OFFICE}"></span><span class="chgis-legend__label">${escapeHtml(t('office_locations'))}</span></div>`;
+        // 同一點兼具地址與官職時的分割標記說明
+        if (hasMixed) {
+            html += `<div class="chgis-legend__row"><span class="chgis-legend__dot" style="background:${FILL_MIXED}"></span><span class="chgis-legend__label">${escapeHtml(t('both_types'))}</span></div>`;
+        }
         // 只有真的出現合併標記時才顯示徽章說明
         if (hasCluster) {
-            html += `<div class="chgis-legend__row"><span class="chgis-legend__badge">N</span>${escapeHtml(t('legend_count_hint'))}</div>`;
+            html += `<div class="chgis-legend__row"><span class="chgis-legend__badge">N</span><span class="chgis-legend__label">${escapeHtml(t('legend_count_hint'))}</span></div>`;
         }
         div.innerHTML = html;
         return div;

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -156,11 +156,107 @@
 }
 .chgis-legend__dot {
     display: inline-block;
+    flex: 0 0 auto; /* 避免被 flex 壓扁成橢圓 */
     width: 12px;
     height: 12px;
     border-radius: 50%;
     border: 2px solid #fff;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+.chgis-legend__badge {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    box-sizing: border-box;
+    border-radius: 8px;
+    background: #111;
+    color: #fff;
+    font-size: 10px;
+    border: 1.5px solid #fff;
+}
+
+/* 多筆同座標：合併標記與數字徽章 */
+.chgis-cluster-marker {
+    position: relative;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 3px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    overflow: visible; /* 確保外溢的數字徽章不被裁切 */
+}
+.chgis-cluster-marker--current {
+    background: #ef4444;
+    box-shadow: 0 0 0 2px #ef4444;
+}
+.chgis-cluster-marker--current::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(239, 68, 68, 0.45);
+    transform: translate(-50%, -50%);
+    animation: chgis-pulse 1.6s ease-out infinite;
+}
+.chgis-cluster-badge {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    box-sizing: border-box;
+    border-radius: 8px;
+    background: #111;
+    color: #fff;
+    font-size: 11px;
+    line-height: 1;
+    border: 1.5px solid #fff;
+    white-space: nowrap;
+}
+
+/* 合併 popup 內容 */
+.chgis-pop {
+    max-height: 280px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+.chgis-pop__head {
+    font-size: 14px;
+    margin-bottom: 4px;
+}
+.chgis-pop__section {
+    margin-top: 6px;
+}
+.chgis-pop__sectit {
+    font-size: 11px;
+    color: #6b7280;
+    margin-bottom: 2px;
+}
+.chgis-pop__item {
+    font-size: 13px;
+    line-height: 1.6;
+    word-break: break-word;
+}
+.chgis-pop__item--current {
+    font-weight: 700;
+}
+.chgis-pop__name {
+    color: #111827;
+}
+.chgis-pop__meta,
+.chgis-pop__yr {
+    color: #6b7280;
 }
 
 /* 突出顯示「目前地點」的脈動標記 */
@@ -234,7 +330,8 @@
     .leaflet-zoom-anim .leaflet-zoom-animated {
         transition: none !important;
     }
-    .chgis-current-marker::after {
+    .chgis-current-marker::after,
+    .chgis-cluster-marker--current::after {
         animation: none;
     }
     /* spinner 改用較慢的不透明度脈動而非旋轉，仍傳達「進行中」 */

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -54,6 +54,8 @@
     border-radius: 12px;
     box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
     overflow: hidden;
+    /* modal 本身隔離成單一 stacking context，避免 transform 動畫期間與 Leaflet 內層 z-index 互相干擾。 */
+    isolation: isolate;
     transform: translateY(12px) scale(0.98);
     transition: transform 0.18s ease;
 }
@@ -64,6 +66,9 @@
 .chgis-modal__map {
     position: absolute;
     inset: 0;
+    /* 地圖固定在 modal 內最底層，Leaflet 的 marker/popup/control z-index 只能在這一層內排序，
+       不能跨出來蓋住 modal 其他兄弟層。 */
+    z-index: 0;
     background: #e8eef2;
     overscroll-behavior: contain;
 }
@@ -73,7 +78,8 @@
     position: absolute;
     top: 12px;
     right: 12px;
-    z-index: 10;
+    /* 永遠高於 status、legend 與 Leaflet controls，確保任何狀態下都能關閉。 */
+    z-index: 30;
     width: 44px;
     height: 44px;
     border: none;
@@ -99,7 +105,8 @@
 .chgis-modal__status {
     position: absolute;
     inset: 0;
-    z-index: 5;
+    /* 蓋住地圖內容，但保留右上角 close 可操作。 */
+    z-index: 20;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -142,30 +149,39 @@
     left: 12px;
     bottom: 12px;
     z-index: 10;
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.92);
     border-radius: 8px;
     padding: 8px 12px;
     font-size: 12px;
-    line-height: 1.7;
+    line-height: 1.45;
+    max-width: min(340px, 80vw); /* 容納最長標籤（Other biographical addresses）單行不溢出 */
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 .chgis-legend__row {
     display: flex;
-    align-items: center;
-    gap: 6px;
+    align-items: flex-start; /* 多行文字時與第一行對齊 */
+    gap: 7px;
+    white-space: nowrap; /* 桌機每列單行，圖例隨內容加寬 */
+}
+.chgis-legend__row + .chgis-legend__row {
+    margin-top: 4px;
+}
+.chgis-legend__label {
+    flex: 1 1 auto;
 }
 .chgis-legend__dot {
     display: inline-block;
     flex: 0 0 auto; /* 避免被 flex 壓扁成橢圓 */
-    width: 12px;
-    height: 12px;
+    margin-top: 2px; /* 與文字第一行對齊 */
+    width: 13px;
+    height: 13px;
     border-radius: 50%;
-    border: 2px solid #fff;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.28); /* 細深內框，分割色不被白環吃掉 */
 }
 .chgis-legend__badge {
     display: inline-flex;
     flex: 0 0 auto;
+    margin-top: 1px;
     align-items: center;
     justify-content: center;
     min-width: 16px;
@@ -243,13 +259,40 @@
     color: #6b7280;
     margin-bottom: 2px;
 }
+/* 清單項：地址與官職統一樣式，給足行距 + 細分隔線 + hover */
 .chgis-pop__item {
+    display: block;
     font-size: 13px;
-    line-height: 1.6;
+    line-height: 1.5;
+    padding: 5px 6px;
+    border-radius: 4px;
     word-break: break-word;
+}
+.chgis-pop__item + .chgis-pop__item {
+    border-top: 1px solid #eef1f4;
+}
+.chgis-pop__item:hover {
+    background: #f8fafc;
 }
 .chgis-pop__item--current {
     font-weight: 700;
+}
+/* 整列即連結（開新分頁檢視該筆記錄）：整列可點，名稱為連結色 */
+.chgis-pop__item--link {
+    color: inherit;
+    text-decoration: none;
+    cursor: pointer;
+}
+.chgis-pop__item--link .chgis-pop__name {
+    color: #2563eb;
+    text-decoration: underline;
+}
+.chgis-pop__item--link:hover .chgis-pop__name {
+    color: #1d4ed8;
+}
+.chgis-pop__item--link:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: -2px;
 }
 .chgis-pop__name {
     color: #111827;
@@ -257,20 +300,6 @@
 .chgis-pop__meta,
 .chgis-pop__yr {
     color: #6b7280;
-}
-/* popup 內連結（開新分頁檢視該筆記錄） */
-.chgis-pop__link {
-    color: #2563eb;
-    text-decoration: underline;
-}
-.chgis-pop__link:hover {
-    color: #1d4ed8;
-}
-.chgis-pop__link:focus-visible {
-    color: #1d4ed8;
-    outline: 2px solid #1d4ed8;
-    outline-offset: 2px;
-    border-radius: 2px;
 }
 /* 官名英文：較淡較小，避免與中文官名擁擠 */
 .chgis-pop__en {
@@ -333,12 +362,15 @@
         max-height: 100dvh;
         border-radius: 0;
     }
-    /* 圖例縮小避免擋住地圖 */
+    /* 圖例：手機放寬上限並允許換行，避免長標籤被擠壓 */
     .chgis-legend {
         font-size: 11px;
-        line-height: 1.5;
+        line-height: 1.4;
         padding: 6px 9px;
-        max-width: 45vw;
+        max-width: 62vw;
+    }
+    .chgis-legend__row {
+        white-space: normal; /* 手機允許標籤換行，縮排對齊由 align-items 處理 */
     }
 }
 

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -34,10 +34,14 @@
     transition: opacity 0.18s ease;
     padding: 16px;
     overscroll-behavior: contain;
-    touch-action: none;
+    /* 關閉時（無 .is-open）不攔截頁面操作；否則透明遮罩會蓋住整頁，需重整才能恢復 */
+    pointer-events: none;
+    touch-action: auto;
 }
 .chgis-modal-overlay.is-open {
     opacity: 1;
+    pointer-events: auto;
+    touch-action: none;
 }
 
 /* 容器：無邊框、圓角、陰影 */

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -1,0 +1,250 @@
+/* CHGIS 地圖 modal 樣式（設計見 docs/CHGIS_MAP_PLACE_LINK.md §6.3-§6.6） */
+
+/* Place Name 連結 */
+.chgis-place-link {
+    cursor: pointer;
+    color: #2563eb;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+.chgis-place-link:hover {
+    color: #1d4ed8;
+    text-decoration-style: solid;
+}
+.chgis-place-link:focus-visible {
+    color: #1d4ed8;
+    text-decoration-style: solid;
+    outline: 2px solid #1d4ed8;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* 遮罩：背景變暗 + 模糊 */
+.chgis-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 20000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    transition: opacity 0.18s ease;
+    padding: 16px;
+    overscroll-behavior: contain;
+    touch-action: none;
+}
+.chgis-modal-overlay.is-open {
+    opacity: 1;
+}
+
+/* 容器：無邊框、圓角、陰影 */
+.chgis-modal {
+    position: relative;
+    width: min(92vw, 1100px);
+    height: min(88vh, 760px);
+    max-height: min(88vh, 760px);
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    transform: translateY(12px) scale(0.98);
+    transition: transform 0.18s ease;
+}
+.chgis-modal-overlay.is-open .chgis-modal {
+    transform: translateY(0) scale(1);
+}
+
+.chgis-modal__map {
+    position: absolute;
+    inset: 0;
+    background: #e8eef2;
+    overscroll-behavior: contain;
+}
+
+/* 關閉鈕：右上角浮動半透明圓形，命中區 >= 44px */
+.chgis-modal__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 10;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.85);
+    color: #111;
+    font-size: 22px;
+    line-height: 44px;
+    text-align: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+.chgis-modal__close:hover {
+    background: #fff;
+}
+.chgis-modal__close:focus-visible,
+.chgis-status__retry:focus-visible {
+    outline: 3px solid #1d4ed8;
+    outline-offset: 2px;
+}
+
+/* 狀態提示（下載中／失敗） */
+.chgis-modal__status {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 24px;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.92);
+    color: #333;
+}
+.chgis-modal__status[hidden] {
+    display: none;
+}
+.chgis-spinner {
+    width: 36px;
+    height: 36px;
+    border: 4px solid #cbd5e1;
+    border-top-color: #2563eb;
+    border-radius: 50%;
+    animation: chgis-spin 0.9s linear infinite;
+}
+.chgis-status__message {
+    max-width: 28em;
+    font-size: 15px;
+    line-height: 1.6;
+}
+.chgis-status__retry {
+    padding: 8px 18px;
+    border: none;
+    border-radius: 6px;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+/* 圖例 */
+.chgis-legend {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 12px;
+    line-height: 1.7;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+.chgis-legend__row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.chgis-legend__dot {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+/* 突出顯示「目前地點」的脈動標記 */
+.chgis-current-marker {
+    position: relative;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #ef4444;
+    border: 3px solid #fff;
+    box-shadow: 0 0 0 2px #ef4444;
+}
+.chgis-current-marker::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: rgba(239, 68, 68, 0.45);
+    transform: translate(-50%, -50%);
+    animation: chgis-pulse 1.6s ease-out infinite;
+}
+
+@keyframes chgis-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+@keyframes chgis-pulse {
+    0% {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 0.7;
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(3);
+        opacity: 0;
+    }
+}
+
+/* 手機：近全螢幕、無圓角 */
+@media (max-width: 640px) {
+    .chgis-modal-overlay {
+        padding: 0;
+    }
+    .chgis-modal {
+        width: 100vw;
+        height: 100vh; /* 舊瀏覽器 fallback */
+        height: 100dvh; /* 支援者覆蓋，處理瀏覽器列高度 */
+        max-height: 100vh;
+        max-height: 100dvh;
+        border-radius: 0;
+    }
+    /* 圖例縮小避免擋住地圖 */
+    .chgis-legend {
+        font-size: 11px;
+        line-height: 1.5;
+        padding: 6px 9px;
+        max-width: 45vw;
+    }
+}
+
+/* 尊重減少動態偏好 */
+@media (prefers-reduced-motion: reduce) {
+    .chgis-modal-overlay,
+    .chgis-modal {
+        transition: none;
+    }
+    .leaflet-pan-anim .leaflet-tile,
+    .leaflet-zoom-anim .leaflet-zoom-animated {
+        transition: none !important;
+    }
+    .chgis-current-marker::after {
+        animation: none;
+    }
+    /* spinner 改用較慢的不透明度脈動而非旋轉，仍傳達「進行中」 */
+    .chgis-spinner {
+        animation: chgis-fade 1.4s ease-in-out infinite;
+    }
+}
+
+@keyframes chgis-fade {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.3;
+    }
+}

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -258,6 +258,28 @@
 .chgis-pop__yr {
     color: #6b7280;
 }
+/* popup 內連結（開新分頁檢視該筆記錄） */
+.chgis-pop__link {
+    color: #2563eb;
+    text-decoration: underline;
+}
+.chgis-pop__link:hover {
+    color: #1d4ed8;
+}
+.chgis-pop__link:focus-visible {
+    color: #1d4ed8;
+    outline: 2px solid #1d4ed8;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+/* 官名英文：較淡較小，避免與中文官名擁擠 */
+.chgis-pop__en {
+    color: #6b7280;
+    font-size: 0.85em;
+    margin-left: 3px;
+    font-weight: 400;
+    white-space: normal;
+}
 
 /* 突出顯示「目前地點」的脈動標記 */
 .chgis-current-marker {

--- a/resources/lang/en/chgis_map.php
+++ b/resources/lang/en/chgis_map.php
@@ -14,6 +14,8 @@ return [
     'office_locations' => 'Office locations',
     'fit_all' => 'Show all',
     'close' => 'Close',
+    'count_unit' => 'entries',
+    'legend_count_hint' => 'Number: entries at this place',
 
     // Status & hints
     'loading' => 'Loading…',

--- a/resources/lang/en/chgis_map.php
+++ b/resources/lang/en/chgis_map.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    // Link
+    'view_on_map' => 'View on map',
+    'open_place_on_map' => 'View :name on the map',
+    'unknown_place' => 'Unknown place',
+    'place_separator' => '; ',
+
+    // Modal title & legend
+    'modal_title' => 'Geographic location',
+    'current_location' => 'Current location',
+    'other_addresses' => 'Other addresses',
+    'office_locations' => 'Office locations',
+    'fit_all' => 'Show all',
+    'close' => 'Close',
+
+    // Status & hints
+    'loading' => 'Loading…',
+    'downloading_basemap' => 'Loading the base map for the first time, downloading from the database, please wait…',
+    'download_failed' => 'Failed to download the base map, please try again later',
+    'retry' => 'Retry',
+    'no_points' => 'This person has no locations with valid coordinates to display',
+    'load_error' => 'Failed to load location data',
+
+    // Popup fields
+    'type_address' => 'Address',
+    'type_office' => 'Office',
+    'year_range' => 'Years',
+];

--- a/resources/lang/en/chgis_map.php
+++ b/resources/lang/en/chgis_map.php
@@ -10,13 +10,14 @@ return [
     // Modal title & legend
     'modal_title' => 'Geographic location',
     'current_location' => 'Current location',
-    'other_addresses' => 'Other biographical addresses',
+    'biographical_addresses' => 'Biographical addresses',
     'office_locations' => 'Office locations',
     'fit_all' => 'Show all',
     'close' => 'Close',
     'count_unit' => 'entries',
     'legend_count_hint' => 'Number: entries at this place',
     'open_record' => 'Open this record in a new tab',
+    'both_types' => 'Both address and office',
 
     // Status & hints
     'loading' => 'Loading…',

--- a/resources/lang/en/chgis_map.php
+++ b/resources/lang/en/chgis_map.php
@@ -16,6 +16,7 @@ return [
     'close' => 'Close',
     'count_unit' => 'entries',
     'legend_count_hint' => 'Number: entries at this place',
+    'open_record' => 'Open this record in a new tab',
 
     // Status & hints
     'loading' => 'Loading…',

--- a/resources/lang/en/chgis_map.php
+++ b/resources/lang/en/chgis_map.php
@@ -10,7 +10,7 @@ return [
     // Modal title & legend
     'modal_title' => 'Geographic location',
     'current_location' => 'Current location',
-    'other_addresses' => 'Other addresses',
+    'other_addresses' => 'Other biographical addresses',
     'office_locations' => 'Office locations',
     'fit_all' => 'Show all',
     'close' => 'Close',

--- a/resources/lang/zh-TW/chgis_map.php
+++ b/resources/lang/zh-TW/chgis_map.php
@@ -14,6 +14,8 @@ return [
     'office_locations' => '官職地點',
     'fit_all' => '顯示全部',
     'close' => '關閉',
+    'count_unit' => '筆',
+    'legend_count_hint' => '數字：該地點筆數',
 
     // 狀態與提示
     'loading' => '載入中…',

--- a/resources/lang/zh-TW/chgis_map.php
+++ b/resources/lang/zh-TW/chgis_map.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    // 連結
+    'view_on_map' => '在地圖上查看',
+    'open_place_on_map' => '在地圖上查看 :name',
+    'unknown_place' => '地名不詳',
+    'place_separator' => '；',
+
+    // Modal 標題與圖例
+    'modal_title' => '地理位置',
+    'current_location' => '目前地點',
+    'other_addresses' => '其他地址',
+    'office_locations' => '官職地點',
+    'fit_all' => '顯示全部',
+    'close' => '關閉',
+
+    // 狀態與提示
+    'loading' => '載入中…',
+    'downloading_basemap' => '地圖底圖首次載入中，正在從資料庫下載，請稍候…',
+    'download_failed' => '底圖下載失敗，請稍後再試',
+    'retry' => '重試',
+    'no_points' => '此人物沒有可顯示的有效座標地點',
+    'load_error' => '地點資料載入失敗',
+
+    // Popup 欄位
+    'type_address' => '地址',
+    'type_office' => '官職',
+    'year_range' => '年代',
+];

--- a/resources/lang/zh-TW/chgis_map.php
+++ b/resources/lang/zh-TW/chgis_map.php
@@ -10,7 +10,7 @@ return [
     // Modal 標題與圖例
     'modal_title' => '地理位置',
     'current_location' => '目前地點',
-    'other_addresses' => '其他地址',
+    'other_addresses' => '其他傳記地址',
     'office_locations' => '官職地點',
     'fit_all' => '顯示全部',
     'close' => '關閉',

--- a/resources/lang/zh-TW/chgis_map.php
+++ b/resources/lang/zh-TW/chgis_map.php
@@ -16,6 +16,7 @@ return [
     'close' => '關閉',
     'count_unit' => '筆',
     'legend_count_hint' => '數字：該地點筆數',
+    'open_record' => '開新分頁檢視此記錄',
 
     // 狀態與提示
     'loading' => '載入中…',

--- a/resources/lang/zh-TW/chgis_map.php
+++ b/resources/lang/zh-TW/chgis_map.php
@@ -10,13 +10,14 @@ return [
     // Modal 標題與圖例
     'modal_title' => '地理位置',
     'current_location' => '目前地點',
-    'other_addresses' => '其他傳記地址',
+    'biographical_addresses' => '傳記地址',
     'office_locations' => '官職地點',
     'fit_all' => '顯示全部',
     'close' => '關閉',
     'count_unit' => '筆',
     'legend_count_hint' => '數字：該地點筆數',
     'open_record' => '開新分頁檢視此記錄',
+    'both_types' => '同時為地址與官職',
 
     // 狀態與提示
     'loading' => '載入中…',

--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -25,7 +25,7 @@
             i18n: {!! Js::from([
                 'modal_title' => __('chgis_map.modal_title'),
                 'current_location' => __('chgis_map.current_location'),
-                'other_addresses' => __('chgis_map.other_addresses'),
+                'biographical_addresses' => __('chgis_map.biographical_addresses'),
                 'office_locations' => __('chgis_map.office_locations'),
                 'close' => __('chgis_map.close'),
                 'loading' => __('chgis_map.loading'),
@@ -41,6 +41,7 @@
                 'count_unit' => __('chgis_map.count_unit'),
                 'legend_count_hint' => __('chgis_map.legend_count_hint'),
                 'open_record' => __('chgis_map.open_record'),
+                'both_types' => __('chgis_map.both_types'),
             ]) !!},
         };
     </script>

--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -34,9 +34,12 @@
                 'retry' => __('chgis_map.retry'),
                 'no_points' => __('chgis_map.no_points'),
                 'load_error' => __('chgis_map.load_error'),
+                'unknown_place' => __('chgis_map.unknown_place'),
                 'type_address' => __('chgis_map.type_address'),
                 'type_office' => __('chgis_map.type_office'),
                 'year_range' => __('chgis_map.year_range'),
+                'count_unit' => __('chgis_map.count_unit'),
+                'legend_count_hint' => __('chgis_map.legend_count_hint'),
             ]) !!},
         };
     </script>

--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -1,0 +1,44 @@
+{{--
+    CHGIS 地圖前端資源與設定注入
+    由 addresses/offices 列表頁 @include。注入 window.chgisMapConfig（路由、範圍、i18n），
+    並透過 @vite 載入 chgis-map 入口（含 Leaflet 與 modal 樣式）。
+    AGENTS.md：AJAX URL 使用相對路徑 route(name, [], false)，避免 HTTPS mixed content。
+--}}
+@php
+    // 以相對路徑（route(name, [], false)）產生 URL，避免 HTTPS mixed content（AGENTS.md §5），
+    // 並相容子目錄部署。tile 模板的 {z}/{x}/{y} 佔位符在 route 產生後再注入，避免被 URL 編碼。
+    $chgisTileTemplate = str_replace(
+        ['__Z__', '__X__', '__Y__'],
+        ['{z}', '{x}', '{y}'],
+        route('chgis-map.tile', ['z' => '__Z__', 'x' => '__X__', 'y' => '__Y__'], false)
+    );
+@endphp
+@push('scripts')
+    <script>
+        window.chgisMapConfig = {
+            statusUrl: {!! Js::from(route('chgis-map.status', [], false)) !!},
+            tileUrlTemplate: {!! Js::from($chgisTileTemplate) !!},
+            pointsUrlBase: {!! Js::from(route('basicinformation.index', [], false)) !!},
+            minZoom: {{ (int) config('chgis_map.min_zoom', 3) }},
+            maxZoom: {{ (int) config('chgis_map.max_zoom', 8) }},
+            bounds: {!! Js::from(config('chgis_map.bounds')) !!},
+            i18n: {!! Js::from([
+                'modal_title' => __('chgis_map.modal_title'),
+                'current_location' => __('chgis_map.current_location'),
+                'other_addresses' => __('chgis_map.other_addresses'),
+                'office_locations' => __('chgis_map.office_locations'),
+                'close' => __('chgis_map.close'),
+                'loading' => __('chgis_map.loading'),
+                'downloading_basemap' => __('chgis_map.downloading_basemap'),
+                'download_failed' => __('chgis_map.download_failed'),
+                'retry' => __('chgis_map.retry'),
+                'no_points' => __('chgis_map.no_points'),
+                'load_error' => __('chgis_map.load_error'),
+                'type_address' => __('chgis_map.type_address'),
+                'type_office' => __('chgis_map.type_office'),
+                'year_range' => __('chgis_map.year_range'),
+            ]) !!},
+        };
+    </script>
+    @vite(['resources/js/chgis-map/app.js'])
+@endpush

--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -40,6 +40,7 @@
                 'year_range' => __('chgis_map.year_range'),
                 'count_unit' => __('chgis_map.count_unit'),
                 'legend_count_hint' => __('chgis_map.legend_count_hint'),
+                'open_record' => __('chgis_map.open_record'),
             ]) !!},
         };
     </script>

--- a/resources/views/biogmains/_place_link.blade.php
+++ b/resources/views/biogmains/_place_link.blade.php
@@ -1,0 +1,45 @@
+{{--
+    Place Name 連結（CHGIS 地圖）
+    參數：
+      - $entry: PersonMapPointsService 的單筆點位陣列（含 name_chn/name/linkable/lon/lat/key/addr_id）
+      - $personId: 人物 c_personid
+    有效座標渲染為可點擊元素（點擊由 chgis-map 前端委派處理），否則為純文字。
+
+    安全：所有屬性值與文字一律以 {{ }}（自動 htmlspecialchars + ENT_QUOTES）輸出，
+    切勿改為 {!! !!} 或塞入 inline JS。不使用 href，避免未綁定 JS 時點擊污染 URL hash。
+--}}
+@php
+    $entry = array_merge([
+        'name_chn' => null,
+        'name' => null,
+        'addr_id' => null,
+        'key' => '',
+        'lon' => null,
+        'lat' => null,
+        'linkable' => false,
+    ], $entry ?? []);
+
+    // 顯示地名（非官名）：name_chn → name → #addr_id；以 null/空字串判斷，保留地名為 '0' 的邊界
+    $chgisName = $entry['name_chn'];
+    if ($chgisName === null || $chgisName === '') {
+        $chgisName = $entry['name'];
+    }
+    if ($chgisName === null || $chgisName === '') {
+        $chgisName = $entry['addr_id'] === null || $entry['addr_id'] === ''
+            ? __('chgis_map.unknown_place')
+            : '#' . $entry['addr_id'];
+    }
+@endphp
+@if(!empty($entry['linkable']))
+    <a class="chgis-place-link"
+       role="button"
+       tabindex="0"
+       data-person-id="{{ $personId }}"
+       data-key="{{ $entry['key'] }}"
+       data-lon="{{ $entry['lon'] }}"
+       data-lat="{{ $entry['lat'] }}"
+       aria-label="{{ __('chgis_map.open_place_on_map', ['name' => $chgisName]) }}"
+       title="{{ __('chgis_map.view_on_map') }}">{{ $chgisName }}</a>
+@else
+    {{ $chgisName }}
+@endif

--- a/resources/views/biogmains/addresses/index.blade.php
+++ b/resources/views/biogmains/addresses/index.blade.php
@@ -105,4 +105,5 @@ use App\Support\CompositePrimaryKey;
         </div>
     </div>
     @include('biogmains.history-button')
+    @include('biogmains._chgis_map_assets')
 @endsection

--- a/resources/views/biogmains/addresses/index.blade.php
+++ b/resources/views/biogmains/addresses/index.blade.php
@@ -43,7 +43,28 @@ use App\Support\CompositePrimaryKey;
                                 <br><span class="text-muted">{{ $basicinformation->biog_addresses[$i]->addr_type->c_addr_desc }}</span>
                             @endif
                         </td>
-                        <td>{{ $basicinformation->biog_addresses[$i]->addr->c_name_chn }}</td>
+                        <td>
+                            @php
+                                $addressRecord = $basicinformation->biog_addresses[$i];
+                                $chgisAddrKey = 'addr:' . $basicinformation->biog_addresses[$i]->c_addr_id . ':' . $basicinformation->biog_addresses[$i]->c_addr_type . ':' . $basicinformation->biog_addresses[$i]->c_sequence;
+                                $chgisAddrEntry = ($addressPointMap ?? collect())->get($chgisAddrKey);
+                                $fallbackAddr = $addressRecord->addr;
+                                $fallbackAddrName = $fallbackAddr?->c_name_chn;
+                                if ($fallbackAddrName === null || $fallbackAddrName === '') {
+                                    $fallbackAddrName = $fallbackAddr?->c_name;
+                                }
+                                if ($fallbackAddrName === null || $fallbackAddrName === '') {
+                                    $fallbackAddrName = $addressRecord->c_addr_id === null || $addressRecord->c_addr_id === ''
+                                        ? __('chgis_map.unknown_place')
+                                        : '#' . $addressRecord->c_addr_id;
+                                }
+                            @endphp
+                            @if($chgisAddrEntry)
+                                @include('biogmains._place_link', ['entry' => $chgisAddrEntry, 'personId' => $basicinformation->c_personid])
+                            @else
+                                {{ $fallbackAddrName }}
+                            @endif
+                        </td>
                         <td>{{ $basicinformation->biog_addresses[$i]->c_firstyear }}</td>
                         <td>{{ $basicinformation->biog_addresses[$i]->c_lastyear }}</td>
                         @auth

--- a/resources/views/biogmains/offices/index.blade.php
+++ b/resources/views/biogmains/offices/index.blade.php
@@ -43,7 +43,21 @@ use App\Support\CompositePrimaryKey;
                         <td>{{ $value->pivot->c_sequence }}</td>
                         <td>{{ $value->pivot->c_posting_id }}</td>
                         <td>{!! $value->c_office_pinyin. '<br>'. $value->c_office_chn . (!empty($value->c_office_trans) ? '<br><span class="text-muted">'. e($value->c_office_trans) .'</span>' : '') !!}</td>
-                        <td>{{ $post2addr[$value->pivot->c_posting_id] ?? '' }}</td>
+                        <td>
+                            @php
+                                $chgisOfficeKey = $value->pivot->c_office_id . ':' . $value->pivot->c_posting_id;
+                                $chgisPlaces = ($officePlaces ?? [])[$chgisOfficeKey] ?? [];
+                                $fallbackPlaces = collect($post2addr[$chgisOfficeKey] ?? []);
+                            @endphp
+                            {{-- 無地點的官職任命維持空白（沿用原行為），不顯示「地名不詳」 --}}
+                            @if(!empty($chgisPlaces))
+                                @foreach($chgisPlaces as $chgisPlace)
+                                    @include('biogmains._place_link', ['entry' => $chgisPlace, 'personId' => $basicinformation->c_personid])@if(!$loop->last){{ __('chgis_map.place_separator') }}@endif
+                                @endforeach
+                            @elseif($fallbackPlaces->isNotEmpty())
+                                {{ $fallbackPlaces->implode(__('chgis_map.place_separator')) }}
+                            @endif
+                        </td>
                         <td>{{ $value->pivot->c_firstyear }}</td>
                         <td>{{ $value->pivot->c_lastyear }}</td>
                         @auth

--- a/resources/views/biogmains/offices/index.blade.php
+++ b/resources/views/biogmains/offices/index.blade.php
@@ -98,4 +98,5 @@ use App\Support\CompositePrimaryKey;
         </div>
     </div>
     @include('biogmains.history-button')
+    @include('biogmains._chgis_map_assets')
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,12 @@ Route::middleware(['auth.optional'])->match(['get', 'post'], 'api/v2/get', 'Api\
 Route::get('view', 'ViewTableController@index')->middleware('auth')->name('view.index');
 Route::get('view/{key}', 'ViewTableController@show')->middleware('auth')->name('view.show');
 
+// CHGIS 地圖：底圖圖磚與下載狀態（與地址/官職列表頁同等公開）
+Route::get('chgis-map/tiles/{z}/{x}/{y}', 'ChgisMapController@tile')
+    ->where(['z' => '[0-9]+', 'x' => '[0-9]+', 'y' => '[0-9]+'])
+    ->name('chgis-map.tile');
+Route::get('chgis-map/status', 'ChgisMapController@status')->name('chgis-map.status');
+
 Route::resource('basicinformation', 'BasicInformationController', ['name' => [
     'show' => 'basicinformation.show',
     'create' => 'basicinformation.create',

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,9 @@ Route::get('chgis-map/tiles/{z}/{x}/{y}', 'ChgisMapController@tile')
     ->where(['z' => '[0-9]+', 'x' => '[0-9]+', 'y' => '[0-9]+'])
     ->name('chgis-map.tile');
 Route::get('chgis-map/status', 'ChgisMapController@status')->name('chgis-map.status');
+Route::get('basicinformation/{id}/map-points', 'ChgisMapController@personPoints')
+    ->where('id', '[0-9]+')
+    ->name('basicinformation.map-points');
 
 Route::resource('basicinformation', 'BasicInformationController', ['name' => [
     'show' => 'basicinformation.show',

--- a/tests/Feature/BasicInformationOfficesControllerTest.php
+++ b/tests/Feature/BasicInformationOfficesControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\BasicInformationOfficesController;
+use App\Repositories\BiogMainRepository;
+use App\Repositories\OperationRepository;
+use App\Repositories\ToolsRepository;
+use App\Services\PersonMapPointsService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BasicInformationOfficesControllerTest extends TestCase {
+    #[Test]
+    public function testSerialAddrFallsBackToEnglishAndUsesOfficePostingCompositeKey(): void {
+        $controller = new class (
+            $this->createMock(BiogMainRepository::class),
+            $this->createMock(OperationRepository::class),
+            $this->createMock(ToolsRepository::class)
+        ) extends BasicInformationOfficesController {
+            public function callSerialAddr(array $array, PersonMapPointsService $mapPoints): array {
+                return $this->serialAddr($array, $mapPoints);
+            }
+        };
+
+        $result = $controller->callSerialAddr([
+            [
+                'c_name_chn' => '',
+                'c_name' => 'English Place',
+                'pivot' => ['c_office_id' => 10, 'c_posting_id' => 20],
+            ],
+            [
+                'c_name_chn' => '中文地名',
+                'c_name' => 'Ignored English Name',
+                'pivot' => ['c_office_id' => 10, 'c_posting_id' => 20],
+            ],
+            [
+                'c_name_chn' => '另一地名',
+                'c_name' => 'Another Place',
+                'pivot' => ['c_office_id' => 11, 'c_posting_id' => 20],
+            ],
+            [
+                'c_name_chn' => '',
+                'c_name' => '',
+                'pivot' => ['c_office_id' => 12, 'c_posting_id' => 30],
+            ],
+        ], app(PersonMapPointsService::class));
+
+        $this->assertSame([
+            '10:20' => ['English Place', '中文地名'],
+            '11:20' => ['另一地名'],
+        ], $result);
+    }
+}

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -284,7 +284,10 @@ class BasicInformationPagesLoadTest extends TestCase {
         // 创建 ADDR_CODES 表（地址代码表）
         Schema::create('ADDR_CODES', function (Blueprint $table) {
             $table->integer('c_addr_id')->primary();
+            $table->string('c_name', 100)->nullable();
             $table->string('c_name_chn', 100)->nullable();
+            $table->double('x_coord')->nullable();
+            $table->double('y_coord')->nullable();
         });
 
         // 创建 BIOG_ADDR_CODES 表（地址类型代码表）
@@ -315,6 +318,8 @@ class BasicInformationPagesLoadTest extends TestCase {
         Schema::create('OFFICE_CODES', function (Blueprint $table) {
             $table->integer('c_office_id')->primary();
             $table->string('c_office_chn', 200)->nullable();
+            $table->string('c_office_pinyin', 200)->nullable();
+            $table->string('c_office_trans', 200)->nullable();
         });
 
         // 创建 ASSOC_CODES 表（社会关系代码表）
@@ -406,8 +411,10 @@ class BasicInformationPagesLoadTest extends TestCase {
         ]);
 
         \DB::table('ADDR_CODES')->insert([
-            'c_addr_id' => 1,
-            'c_name_chn' => '测试地址',
+            // addr 1：有效座標（落在 CHGIS sane_bounds 內）→ 應渲染為地圖連結
+            ['c_addr_id' => 1, 'c_name_chn' => '测试地址', 'c_name' => 'Test Addr', 'x_coord' => 114.3, 'y_coord' => 34.8],
+            // addr 2：官职地点，有效座標
+            ['c_addr_id' => 2, 'c_name_chn' => '官职地点', 'c_name' => 'Office Place', 'x_coord' => 119.4, 'y_coord' => 36.7],
         ]);
 
         \DB::table('BIOG_ADDR_CODES')->insert([
@@ -525,6 +532,14 @@ class BasicInformationPagesLoadTest extends TestCase {
             'c_sequence' => 1,
             'c_firstyear' => 1000,
             'c_lastyear' => 1010,
+        ]);
+
+        // 4b. 官职地点关联（CHGIS 地图：posting 1 → addr 2，有效座標）
+        \DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_posting_id' => 1,
+            'c_office_id' => 1,
+            'c_addr_id' => 2,
         ]);
 
         // 5. 社会关系数据 (assoc)
@@ -715,6 +730,46 @@ class BasicInformationPagesLoadTest extends TestCase {
     public function test_basicinformation_addresses_index_loads() {
         $response = $this->get("/basicinformation/{$this->testPersonId}/addresses");
         $response->assertStatus(200);
+
+        // CHGIS：有效座標的地址 Place Name 渲染為可點擊連結
+        $html = $response->getContent();
+        $this->assertStringContainsString('class="chgis-place-link"', $html);
+        $this->assertStringContainsString('data-key="addr:1:1:1"', $html);
+        $this->assertStringContainsString('data-lon="114.3"', $html);
+    }
+
+    /**
+     * 測試地址子頁面：孤兒地址與危險字元名稱不應導致 500 或 XSS
+     */
+    #[Test]
+    public function test_basicinformation_addresses_index_handles_orphan_and_escapes_place_name() {
+        \DB::table('ADDR_CODES')->insert([
+            'c_addr_id' => 3,
+            'c_name_chn' => '<script>alert("xss")</script>',
+            'c_name' => 'Escaped Addr',
+            'x_coord' => 116.3,
+            'y_coord' => 39.9,
+        ]);
+        \DB::table('BIOG_ADDR_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_addr_id' => 3,
+            'c_addr_type' => 1,
+            'c_sequence' => 2,
+        ]);
+        \DB::table('BIOG_ADDR_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_addr_id' => 999,
+            'c_addr_type' => 1,
+            'c_sequence' => 3,
+        ]);
+
+        $response = $this->get("/basicinformation/{$this->testPersonId}/addresses");
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+        $this->assertStringContainsString('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;', $html);
+        $this->assertStringNotContainsString('<script>alert("xss")</script>', $html);
+        $this->assertStringContainsString('#999', $html);
     }
 
     /**
@@ -757,6 +812,78 @@ class BasicInformationPagesLoadTest extends TestCase {
     public function test_basicinformation_offices_index_loads() {
         $response = $this->get("/basicinformation/{$this->testPersonId}/offices");
         $response->assertStatus(200);
+
+        // CHGIS：有效座標的官职地点 Place Name 渲染為可點擊連結，key 含 office_id
+        $html = $response->getContent();
+        $this->assertStringContainsString('class="chgis-place-link"', $html);
+        $this->assertStringContainsString('data-key="office:1:1:2"', $html);
+    }
+
+    /**
+     * 測試官職子頁面：多地點應使用 i18n 分隔符，且 Place Name 連結 key 含 office_id
+     */
+    #[Test]
+    public function test_basicinformation_offices_index_uses_localized_separator_for_multiple_places() {
+        \DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_posting_id' => 1,
+            'c_office_id' => 1,
+            'c_addr_id' => 1,
+        ]);
+
+        $response = $this->get("/basicinformation/{$this->testPersonId}/offices");
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+        $this->assertStringContainsString('data-key="office:1:1:1"', $html);
+        $this->assertStringContainsString('data-key="office:1:1:2"', $html);
+        $this->assertStringContainsString('；', $html);
+    }
+
+    /**
+     * 测试社会关系子页面：/basicinformation/{id}/assoc
+     */
+    /**
+     * 測試官職子頁面：Place Name 連結不應帶 href，且危險字元名稱需正確跳脫
+     */
+    #[Test]
+    public function test_basicinformation_offices_index_escapes_place_name_without_href_hash() {
+        \DB::table('ADDR_CODES')->where('c_addr_id', 2)->update([
+            'c_name_chn' => '<script>alert("office-xss")</script>',
+            'c_name' => 'Office Escaped Addr',
+        ]);
+
+        $response = $this->get("/basicinformation/{$this->testPersonId}/offices");
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+        $this->assertStringContainsString('&lt;script&gt;alert(&quot;office-xss&quot;)&lt;/script&gt;', $html);
+        $this->assertStringNotContainsString('<script>alert("office-xss")</script>', $html);
+
+        preg_match('/<a class="chgis-place-link"[^>]*>/', $html, $matches);
+        $this->assertNotEmpty($matches);
+        $this->assertStringNotContainsString('href=', $matches[0]);
+    }
+
+    /**
+     * 測試官職子頁面：英文語系下多地點分隔符應為 "; "
+     */
+    #[Test]
+    public function test_basicinformation_offices_index_uses_english_separator_when_locale_is_en() {
+        \DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => $this->testPersonId,
+            'c_posting_id' => 1,
+            'c_office_id' => 1,
+            'c_addr_id' => 1,
+        ]);
+
+        $response = $this->withSession(['locale' => 'en'])
+            ->get("/basicinformation/{$this->testPersonId}/offices");
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+        $this->assertStringContainsString('; ', $html);
+        $this->assertStringContainsString('View on map', $html);
     }
 
     /**

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -810,7 +810,8 @@ class BasicInformationPagesLoadTest extends TestCase {
      */
     #[Test]
     public function test_basicinformation_offices_index_loads() {
-        $response = $this->get("/basicinformation/{$this->testPersonId}/offices");
+        $response = $this->withSession(['locale' => 'zh-TW'])
+            ->get("/basicinformation/{$this->testPersonId}/offices");
         $response->assertStatus(200);
 
         // CHGIS：有效座標的官职地点 Place Name 渲染為可點擊連結，key 含 office_id
@@ -822,6 +823,9 @@ class BasicInformationPagesLoadTest extends TestCase {
         $this->assertStringContainsString('window.chgisMapConfig', $html);
         $this->assertStringContainsString('tileUrlTemplate', $html);
         $this->assertStringContainsString('\\/chgis-map\\/tiles\\/{z}\\/{x}\\/{y}', $html);
+        $this->assertStringContainsString('count_unit', $html);
+        $this->assertStringContainsString('legend_count_hint', $html);
+        $this->assertStringContainsString('unknown_place', $html);
     }
 
     /**
@@ -889,6 +893,12 @@ class BasicInformationPagesLoadTest extends TestCase {
         $html = $response->getContent();
         $this->assertStringContainsString('; ', $html);
         $this->assertStringContainsString('View on map', $html);
+        $this->assertStringContainsString('count_unit', $html);
+        $this->assertStringContainsString('entries', $html);
+        $this->assertStringContainsString('legend_count_hint', $html);
+        $this->assertStringContainsString('Number: entries at this place', $html);
+        $this->assertStringContainsString('unknown_place', $html);
+        $this->assertStringContainsString('Unknown place', $html);
     }
 
     /**

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -817,6 +817,11 @@ class BasicInformationPagesLoadTest extends TestCase {
         $html = $response->getContent();
         $this->assertStringContainsString('class="chgis-place-link"', $html);
         $this->assertStringContainsString('data-key="office:1:1:2"', $html);
+
+        // CHGIS：前端設定與資源已注入，且 tile URL 為相對路徑（JSON 中 / 轉義為 \/）
+        $this->assertStringContainsString('window.chgisMapConfig', $html);
+        $this->assertStringContainsString('tileUrlTemplate', $html);
+        $this->assertStringContainsString('\\/chgis-map\\/tiles\\/{z}\\/{x}\\/{y}', $html);
     }
 
     /**

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -826,6 +826,7 @@ class BasicInformationPagesLoadTest extends TestCase {
         $this->assertStringContainsString('count_unit', $html);
         $this->assertStringContainsString('legend_count_hint', $html);
         $this->assertStringContainsString('unknown_place', $html);
+        $this->assertStringContainsString('open_record', $html);
     }
 
     /**
@@ -899,6 +900,8 @@ class BasicInformationPagesLoadTest extends TestCase {
         $this->assertStringContainsString('Number: entries at this place', $html);
         $this->assertStringContainsString('unknown_place', $html);
         $this->assertStringContainsString('Unknown place', $html);
+        $this->assertStringContainsString('open_record', $html);
+        $this->assertStringContainsString('Open this record in a new tab', $html);
     }
 
     /**

--- a/tests/Feature/ChgisMapControllerTest.php
+++ b/tests/Feature/ChgisMapControllerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\FetchChgisMapJob;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use PDO;
+use Tests\TestCase;
+
+/**
+ * ChgisMapController（tile / status）測試
+ *
+ * 對應 docs/CHGIS_MAP_PLACE_LINK.md §5.2。
+ */
+class ChgisMapControllerTest extends TestCase {
+    private string $dir;
+    private string $path;
+
+    /** 兩塊內容不同的圖磚（用於驗證 TMS flip 方向與精確值）。 */
+    private string $tileAtRow6 = "\x89PNG\r\n\x1a\nTILE-AT-TMS-ROW-6";
+    private string $tileAtRow1 = "\x89PNG\r\n\x1a\nTILE-AT-TMS-ROW-1";
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->dir = storage_path('framework/testing/chgis-ctrl-' . getmypid());
+        $this->path = $this->dir . '/chgis_map.mbtiles';
+
+        config([
+            'chgis_map.source.path' => $this->path,
+            'chgis_map.source.expected_min_bytes' => 16,
+            'chgis_map.min_zoom' => 3,
+            'chgis_map.max_zoom' => 8,
+        ]);
+
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void {
+        $this->cleanup();
+        parent::tearDown();
+    }
+
+    private function cleanup(): void {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+        if (is_dir($this->dir)) {
+            @rmdir($this->dir);
+        }
+    }
+
+    /**
+     * 建立 mbtiles fixture，於指定 (zoom, column, tile_row) 寫入圖磚。
+     *
+     * 注意：tile_row 直接以 TMS 列號寫入（不經 XYZ 公式換算），讓測試獨立於
+     * controller 的 flip 公式，避免「寫入與讀取共用同一公式」的套套邏輯。
+     *
+     * @param array<int, array{z:int, col:int, row:int, data:string}> $tiles
+     */
+    private function makeFixture(array $tiles): void {
+        @mkdir($this->dir, 0775, true);
+
+        $pdo = new PDO('sqlite:' . $this->path);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE metadata (name TEXT, value TEXT)');
+        $pdo->exec('CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB)');
+        $pdo->prepare('INSERT INTO metadata(name, value) VALUES (?, ?)')->execute(['format', 'png']);
+
+        $stmt = $pdo->prepare('INSERT INTO tiles(zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)');
+        foreach ($tiles as $t) {
+            $stmt->bindValue(1, $t['z'], PDO::PARAM_INT);
+            $stmt->bindValue(2, $t['col'], PDO::PARAM_INT);
+            $stmt->bindValue(3, $t['row'], PDO::PARAM_INT);
+            $stmt->bindValue(4, $t['data'], PDO::PARAM_LOB);
+            $stmt->execute();
+        }
+        $pdo = null;
+    }
+
+    /**
+     * 預設 fixture：z=3, col=6，於 TMS row 6 與 row 1 放不同內容，
+     * 用於驗證 XYZ↔TMS 的 flip 方向與精確值。
+     */
+    private function makeDirectionalFixture(): void {
+        $this->makeFixture([
+            ['z' => 3, 'col' => 6, 'row' => 6, 'data' => $this->tileAtRow6],
+            ['z' => 3, 'col' => 6, 'row' => 1, 'data' => $this->tileAtRow1],
+        ]);
+    }
+
+    // ---- tile ----
+
+    public function testTileHitUsesCorrectTmsFlip(): void {
+        // MBTiles 規格：XYZ (z=3, y=1) → TMS tile_row = 2^3 - 1 - 1 = 6（獨立硬值）
+        // 故請求 /3/6/1 必須命中 TMS row 6 的內容，而非 row 1。
+        $this->makeDirectionalFixture();
+
+        $response = $this->get('/chgis-map/tiles/3/6/1');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $this->assertSame($this->tileAtRow6, $response->getContent());
+        $this->assertNotSame($this->tileAtRow1, $response->getContent());
+    }
+
+    public function testTileReturnsStableEtagAndSupportsNotModified(): void {
+        $this->makeDirectionalFixture();
+
+        $first = $this->get('/chgis-map/tiles/3/6/1');
+        $first->assertOk();
+        $etag = $first->headers->get('ETag');
+
+        $this->assertNotNull($etag);
+
+        $this->withHeader('If-None-Match', $etag)
+            ->get('/chgis-map/tiles/3/6/1')
+            ->assertStatus(304);
+    }
+
+    public function testTileEtagChangesWhenMbtilesFileMtimeChanges(): void {
+        $this->makeDirectionalFixture();
+
+        $first = $this->get('/chgis-map/tiles/3/6/1');
+        $first->assertOk();
+        $firstEtag = $first->headers->get('ETag');
+
+        clearstatcache(true, $this->path);
+        touch($this->path, filemtime($this->path) + 2);
+        clearstatcache(true, $this->path);
+
+        $second = $this->get('/chgis-map/tiles/3/6/1');
+        $second->assertOk();
+
+        $this->assertNotSame($firstEtag, $second->headers->get('ETag'));
+    }
+
+    public function testTileFlipDirectionIsConsistent(): void {
+        // 反向：XYZ (z=3, y=6) → TMS row = 2^3 - 1 - 6 = 1，應命中 row 1 內容。
+        $this->makeDirectionalFixture();
+
+        $response = $this->get('/chgis-map/tiles/3/6/6');
+
+        $response->assertOk();
+        $this->assertSame($this->tileAtRow1, $response->getContent());
+    }
+
+    public function testTileMissReturnsTransparentPng(): void {
+        $this->makeDirectionalFixture();
+
+        // 不存在的圖磚
+        $response = $this->get('/chgis-map/tiles/3/0/0');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $this->assertLessThan(200, strlen($response->getContent()));
+    }
+
+    public function testTileOutOfZoomReturnsTransparent(): void {
+        $this->makeDirectionalFixture();
+
+        // z=2 低於 min_zoom(3)
+        $response = $this->get('/chgis-map/tiles/2/1/1');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $this->assertLessThan(200, strlen($response->getContent()));
+    }
+
+    public function testTileOutOfRangeReturnsTransparent(): void {
+        $this->makeDirectionalFixture();
+
+        $response = $this->get('/chgis-map/tiles/3/8/1');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $this->assertLessThan(200, strlen($response->getContent()));
+    }
+
+    public function testTileWhenBasemapMissingReturns503(): void {
+        // 不建立 fixture → isReady false
+        $this->get('/chgis-map/tiles/3/6/1')->assertStatus(503);
+    }
+
+    // ---- status ----
+
+    public function testStatusReadyWhenFilePresent(): void {
+        $this->makeDirectionalFixture();
+
+        $this->get('/chgis-map/status')
+            ->assertOk()
+            ->assertJson(['ready' => true, 'state' => 'ready']);
+    }
+
+    public function testStatusTriggersDownloadWhenMissing(): void {
+        Bus::fake();
+
+        $response = $this->get('/chgis-map/status');
+
+        $response
+            ->assertOk()
+            ->assertJson(['ready' => false, 'state' => 'downloading']);
+
+        Bus::assertDispatchedAfterResponse(FetchChgisMapJob::class);
+        $state = Cache::get(FetchChgisMapJob::STATE_KEY);
+        $this->assertSame('downloading', $state['state'] ?? null);
+        $this->assertSame($state['started_at'] ?? null, $response->json('started_at'));
+    }
+
+    public function testStatusReturnsDownloadingWithoutRedispatch(): void {
+        Bus::fake();
+        Cache::put(
+            FetchChgisMapJob::STATE_KEY,
+            ['state' => 'downloading', 'started_at' => time()],
+            now()->addMinutes(10)
+        );
+
+        $this->get('/chgis-map/status')
+            ->assertOk()
+            ->assertJson([
+                'ready' => false,
+                'state' => 'downloading',
+                'started_at' => Cache::get(FetchChgisMapJob::STATE_KEY)['started_at'],
+            ]);
+
+        Bus::assertNothingDispatched();
+    }
+
+    public function testStatusRedispatchesWhenDownloadingIsStale(): void {
+        Bus::fake();
+        // started_at 遠早於 ttl，視為下載程序已死亡 → 應重新觸發，避免永久卡 downloading
+        Cache::put(
+            FetchChgisMapJob::STATE_KEY,
+            ['state' => 'downloading', 'started_at' => time() - FetchChgisMapJob::ttlSeconds() - 10],
+            now()->addMinutes(60)
+        );
+
+        $response = $this->get('/chgis-map/status');
+
+        $response
+            ->assertOk()
+            ->assertJson(['ready' => false, 'state' => 'downloading']);
+
+        Bus::assertDispatchedAfterResponse(FetchChgisMapJob::class);
+        $this->assertSame(
+            Cache::get(FetchChgisMapJob::STATE_KEY)['started_at'] ?? null,
+            $response->json('started_at')
+        );
+    }
+
+    public function testStatusReturnsFailedWithoutRetry(): void {
+        Bus::fake();
+        Cache::put(FetchChgisMapJob::STATE_KEY, ['state' => 'failed', 'message' => '網路錯誤'], now()->addMinutes(10));
+
+        $this->get('/chgis-map/status')
+            ->assertOk()
+            ->assertJson(['ready' => false, 'state' => 'failed', 'message' => '網路錯誤']);
+
+        Bus::assertNothingDispatched();
+    }
+
+    public function testStatusRetryRedispatchesAfterFailure(): void {
+        Bus::fake();
+        Cache::put(FetchChgisMapJob::STATE_KEY, ['state' => 'failed', 'message' => '網路錯誤'], now()->addMinutes(10));
+
+        $response = $this->get('/chgis-map/status?retry=1');
+
+        $response
+            ->assertOk()
+            ->assertJson(['ready' => false, 'state' => 'downloading']);
+
+        Bus::assertDispatchedAfterResponse(FetchChgisMapJob::class);
+        $this->assertNotNull($response->json('started_at'));
+    }
+}

--- a/tests/Feature/FetchChgisMapTest.php
+++ b/tests/Feature/FetchChgisMapTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use PDO;
+use Tests\TestCase;
+
+/**
+ * cbdb:fetch-chgis-map 指令測試
+ *
+ * 對應 docs/CHGIS_MAP_PLACE_LINK.md §4.4。
+ */
+class FetchChgisMapTest extends TestCase {
+    private string $dir;
+    private string $path;
+
+    /** 產生真正的 SQLite/mbtiles 測試 fixture，避免只模擬檔頭。 */
+    private function fakeMbtiles(int $minSize = 2048): string {
+        $tmp = tempnam(sys_get_temp_dir(), 'chgis-mbtiles-');
+        if ($tmp === false) {
+            throw new \RuntimeException('無法建立暫存 SQLite fixture');
+        }
+
+        try {
+            $pdo = new PDO('sqlite:' . $tmp);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $pdo->exec('CREATE TABLE metadata (name TEXT PRIMARY KEY, value TEXT)');
+            $pdo->exec('CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB)');
+            $pdo->prepare('INSERT INTO metadata(name, value) VALUES (?, ?)')
+                ->execute(['format', 'pbf']);
+
+            while (filesize($tmp) < $minSize) {
+                $pdo->prepare('INSERT INTO tiles(zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)')
+                    ->execute([0, random_int(0, PHP_INT_MAX), 0, random_bytes(512)]);
+            }
+
+            $pdo = null;
+
+            return (string) file_get_contents($tmp);
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->dir = storage_path('framework/testing/chgis-' . getmypid());
+        $this->path = $this->dir . '/chgis_map.mbtiles';
+
+        config([
+            'chgis_map.source.url' => 'https://huggingface.test/chgis_map.mbtiles',
+            'chgis_map.source.path' => $this->path,
+            'chgis_map.source.expected_min_bytes' => 16,
+        ]);
+
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void {
+        $this->cleanup();
+        parent::tearDown();
+    }
+
+    private function cleanup(): void {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+        if (is_dir($this->dir)) {
+            @rmdir($this->dir);
+        }
+    }
+
+    public function testDownloadsWhenMissing(): void {
+        $body = $this->fakeMbtiles();
+        Http::fake([
+            '*' => Http::response($body, 200),
+        ]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->path);
+        $this->assertSame($body, file_get_contents($this->path));
+        $this->assertCount(0, glob($this->dir . '/*.part*') ?: []);
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+
+    public function testSkipsWhenAlreadyPresent(): void {
+        @mkdir($this->dir, 0775, true);
+        file_put_contents($this->path, $this->fakeMbtiles());
+
+        Http::fake();
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->expectsOutputToContain('已存在')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    }
+
+    public function testRedownloadsWhenExistingFileIsCorrupt(): void {
+        // 既有檔體積達標但非 SQLite（壞檔）→ isReady 應回 false 而重新下載
+        @mkdir($this->dir, 0775, true);
+        file_put_contents($this->path, str_repeat('X', 2048));
+
+        $body = $this->fakeMbtiles();
+        Http::fake(['*' => Http::response($body, 200)]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->assertExitCode(0);
+
+        $this->assertSame($body, file_get_contents($this->path));
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+
+    public function testForceRedownloadsEvenIfPresent(): void {
+        @mkdir($this->dir, 0775, true);
+        file_put_contents($this->path, $this->fakeMbtiles(64));
+
+        $body = $this->fakeMbtiles(128);
+        Http::fake(['*' => Http::response($body, 200)]);
+
+        $this->artisan('cbdb:fetch-chgis-map', ['--force' => true])
+            ->assertExitCode(0);
+
+        $this->assertSame($body, file_get_contents($this->path));
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+
+    public function testFailsOnHttpError(): void {
+        Http::fake(['*' => Http::response('not found', 404)]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->expectsOutputToContain('HTTP 狀態碼')
+            ->assertExitCode(1);
+
+        $this->assertFileDoesNotExist($this->path);
+        $this->assertCount(0, glob($this->dir . '/*.part*') ?: []);
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+
+    public function testFailsOnIncompleteDownload(): void {
+        // 回傳體積低於 expected_min_bytes(16) 的內容
+        Http::fake(['*' => Http::response('tiny', 200)]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->expectsOutputToContain('不完整')
+            ->assertExitCode(1);
+
+        // 半截檔不應留下、也不應被視為就緒
+        $this->assertFileDoesNotExist($this->path);
+        $this->assertCount(0, glob($this->dir . '/*.part*') ?: []);
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+
+    public function testFailsOnNonMbtilesContent(): void {
+        // 體積達標(>=16)但非 SQLite 格式（例如 HTML 錯誤頁）→ 應被魔術位元組擋下
+        Http::fake(['*' => Http::response(str_repeat('<html>error</html>', 8), 200)]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->expectsOutputToContain('非 mbtiles')
+            ->assertExitCode(1);
+
+        $this->assertFileDoesNotExist($this->path);
+        $this->assertCount(0, glob($this->dir . '/*.part*') ?: []);
+        $this->assertCount(0, glob($this->dir . '/*.bak.*') ?: []);
+    }
+}

--- a/tests/Feature/PersonMapPointsTest.php
+++ b/tests/Feature/PersonMapPointsTest.php
@@ -216,6 +216,19 @@ class PersonMapPointsTest extends TestCase {
         $this->assertNotContains(88888, collect($points)->pluck('addr_id')->all());
     }
 
+    public function testAddressLabelFallsBackFromEmptyChineseToEnglish(): void {
+        DB::table('ADDR_CODES')->where('c_addr_id', 100)->update([
+            'c_name_chn' => '',
+            'c_name' => 'Kaifeng',
+        ]);
+
+        $entry = collect(app(PersonMapPointsService::class)->addressEntries(1001))
+            ->firstWhere('addr_id', 100);
+
+        $this->assertNotNull($entry);
+        $this->assertSame('Kaifeng', $entry['label']);
+    }
+
     public function testOfficeIdMinusOnePlaceholderIsExcluded(): void {
         // c_office_id = -1 為「無地點」佔位，應被 offices_addr 關聯排除
         DB::table('POSTED_TO_ADDR_DATA')->insert([

--- a/tests/Feature/PersonMapPointsTest.php
+++ b/tests/Feature/PersonMapPointsTest.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\PersonMapPointsService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * 人物地圖點位（personPoints 端點與 PersonMapPointsService）測試
+ *
+ * 對應 docs/CHGIS_MAP_PLACE_LINK.md §5.2、§5.3。
+ */
+class PersonMapPointsTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // 固定座標判定範圍，避免受 .env 影響
+        config([
+            'chgis_map.epsilon' => 1e-7,
+            'chgis_map.mercator_lat_limit' => 85.0511,
+            'chgis_map.bounds' => ['west' => 58.5372, 'south' => -62.6348, 'east' => 152.24, 'north' => 82.7288],
+            'chgis_map.sane_bounds' => ['enabled' => true, 'west' => 70.0, 'south' => 15.0, 'east' => 140.0, 'north' => 55.0],
+        ]);
+
+        $this->createSchema();
+        $this->seedData();
+    }
+
+    protected function tearDown(): void {
+        foreach (['BIOG_MAIN', 'BIOG_ADDR_DATA', 'ADDR_CODES', 'POSTED_TO_OFFICE_DATA', 'POSTED_TO_ADDR_DATA', 'OFFICE_CODES'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    private function createSchema(): void {
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+        });
+
+        Schema::create('BIOG_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_addr_id');
+            $table->integer('c_addr_type');
+            $table->integer('c_sequence');
+            $table->integer('c_firstyear')->nullable();
+            $table->integer('c_lastyear')->nullable();
+        });
+
+        Schema::create('ADDR_CODES', function (Blueprint $table) {
+            $table->integer('c_addr_id')->primary();
+            $table->string('c_name')->nullable();
+            $table->string('c_name_chn')->nullable();
+            $table->double('x_coord')->nullable();
+            $table->double('y_coord')->nullable();
+        });
+
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_office_id');
+            $table->integer('c_posting_id');
+            $table->integer('c_sequence')->nullable();
+            $table->integer('c_firstyear')->nullable();
+            $table->integer('c_lastyear')->nullable();
+        });
+
+        Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_office_id');
+            $table->integer('c_posting_id');
+            $table->integer('c_addr_id');
+        });
+
+        Schema::create('OFFICE_CODES', function (Blueprint $table) {
+            $table->integer('c_office_id')->primary();
+            $table->string('c_office_chn')->nullable();
+            $table->string('c_office_trans')->nullable();
+        });
+    }
+
+    private function seedData(): void {
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1001, 'c_name_chn' => '蘇軾', 'c_name' => 'Su Shi']);
+
+        // 地址：100 有效；101 為 0,0 無效；102 超界無效
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 100, 'c_name_chn' => '開封', 'c_name' => 'Kaifeng', 'x_coord' => 114.3, 'y_coord' => 34.8],
+            ['c_addr_id' => 101, 'c_name_chn' => '無座標地', 'c_name' => 'NoCoord', 'x_coord' => 0, 'y_coord' => 0],
+            ['c_addr_id' => 102, 'c_name_chn' => '超界地', 'c_name' => 'OutOfBounds', 'x_coord' => 200, 'y_coord' => 10],
+            // 官職地點：200 有效；201 為 0,0 無效
+            ['c_addr_id' => 200, 'c_name_chn' => '密州', 'c_name' => 'Mizhou', 'x_coord' => 119.4, 'y_coord' => 36.7],
+            ['c_addr_id' => 201, 'c_name_chn' => '無座標官地', 'c_name' => 'NoCoordOffice', 'x_coord' => 0, 'y_coord' => 0],
+        ]);
+
+        DB::table('BIOG_ADDR_DATA')->insert([
+            ['c_personid' => 1001, 'c_addr_id' => 100, 'c_addr_type' => 1, 'c_sequence' => 1, 'c_firstyear' => 1037, 'c_lastyear' => 1101],
+            ['c_personid' => 1001, 'c_addr_id' => 101, 'c_addr_type' => 1, 'c_sequence' => 2, 'c_firstyear' => null, 'c_lastyear' => null],
+            ['c_personid' => 1001, 'c_addr_id' => 102, 'c_addr_type' => 2, 'c_sequence' => 3, 'c_firstyear' => null, 'c_lastyear' => null],
+        ]);
+
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 9001, 'c_office_chn' => '知州'],
+            ['c_office_id' => 9002, 'c_office_chn' => '通判'],
+        ]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            ['c_personid' => 1001, 'c_office_id' => 9001, 'c_posting_id' => 5001, 'c_sequence' => 1, 'c_firstyear' => 1074, 'c_lastyear' => 1076],
+            ['c_personid' => 1001, 'c_office_id' => 9002, 'c_posting_id' => 5002, 'c_sequence' => 2, 'c_firstyear' => 1071, 'c_lastyear' => 1074],
+        ]);
+
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            ['c_personid' => 1001, 'c_office_id' => 9001, 'c_posting_id' => 5001, 'c_addr_id' => 200],
+            ['c_personid' => 1001, 'c_office_id' => 9002, 'c_posting_id' => 5002, 'c_addr_id' => 201],
+        ]);
+    }
+
+    // ---- endpoint ----
+
+    public function testEndpointReturnsOnlyValidPoints(): void {
+        $response = $this->getJson('/basicinformation/1001/map-points');
+
+        $response->assertOk();
+        $points = $response->json('points');
+
+        // 只有 1 個有效地址（100）+ 1 個有效官職地點（200）= 2
+        $this->assertCount(2, $points);
+
+        $byKey = collect($points)->keyBy('key');
+        $this->assertTrue($byKey->has('addr:100:1:1'));
+        // 點位 key 含 c_office_id，避免不同官職同 posting_id 碰撞
+        $this->assertTrue($byKey->has('office:9001:5001:200'));
+
+        $addr = $byKey['addr:100:1:1'];
+        $this->assertSame('address', $addr['source']);
+        $this->assertSame(100, $addr['addr_id']);
+        $this->assertEqualsWithDelta(114.3, $addr['lon'], 0.0001);
+        $this->assertEqualsWithDelta(34.8, $addr['lat'], 0.0001);
+
+        $office = $byKey['office:9001:5001:200'];
+        $this->assertSame('office', $office['source']);
+        $this->assertSame('知州 · 密州', $office['label']);
+    }
+
+    public function testEndpointExcludesInvalidCoordinates(): void {
+        $points = $this->getJson('/basicinformation/1001/map-points')->json('points');
+        $addrIds = collect($points)->pluck('addr_id')->all();
+
+        // 0,0 與超界座標不出現
+        $this->assertNotContains(101, $addrIds);
+        $this->assertNotContains(102, $addrIds);
+        $this->assertNotContains(201, $addrIds);
+    }
+
+    public function testEndpointReturnsEmptyForUnknownPerson(): void {
+        $this->getJson('/basicinformation/999999/map-points')
+            ->assertOk()
+            ->assertJson(['points' => []]);
+    }
+
+    // ---- service ----
+
+    public function testAddressEntriesFlagsLinkability(): void {
+        $entries = app(PersonMapPointsService::class)->addressEntries(1001);
+
+        $this->assertCount(3, $entries);
+        $byId = collect($entries)->keyBy('addr_id');
+        $this->assertTrue($byId[100]['linkable']);
+        $this->assertFalse($byId[101]['linkable']);
+        $this->assertFalse($byId[102]['linkable']);
+        // 無效座標不輸出 lon/lat
+        $this->assertNull($byId[101]['lon']);
+        $this->assertNull($byId[102]['lat']);
+    }
+
+    public function testOfficePlacesByPostingGroupsAndFlags(): void {
+        $byPosting = app(PersonMapPointsService::class)->officePlacesByPosting(1001);
+
+        // 分組鍵為 "{office_id}:{posting_id}"
+        $this->assertArrayHasKey('9001:5001', $byPosting);
+        $this->assertArrayHasKey('9002:5002', $byPosting);
+
+        $this->assertTrue($byPosting['9001:5001'][0]['linkable']);
+        $this->assertSame('知州 · 密州', $byPosting['9001:5001'][0]['label']);
+
+        $this->assertFalse($byPosting['9002:5002'][0]['linkable']);
+        $this->assertNull($byPosting['9002:5002'][0]['lon']);
+    }
+
+    public function testOrphanAddressDoesNotErrorAndIsNotLinkable(): void {
+        // BIOG_ADDR_DATA 指向不存在的 ADDR_CODES（孤兒外鍵）
+        DB::table('BIOG_ADDR_DATA')->insert([
+            'c_personid' => 1001, 'c_addr_id' => 88888, 'c_addr_type' => 9, 'c_sequence' => 9,
+            'c_firstyear' => null, 'c_lastyear' => null,
+        ]);
+
+        $entries = app(PersonMapPointsService::class)->addressEntries(1001);
+        $orphan = collect($entries)->firstWhere('addr_id', 88888);
+
+        $this->assertNotNull($orphan);
+        $this->assertFalse($orphan['linkable']);
+        $this->assertNull($orphan['name_chn']);
+        $this->assertSame('', $orphan['label']);
+        // 不應出現在地圖點位中
+        $points = app(PersonMapPointsService::class)->points(1001);
+        $this->assertNotContains(88888, collect($points)->pluck('addr_id')->all());
+    }
+
+    public function testOfficeIdMinusOnePlaceholderIsExcluded(): void {
+        // c_office_id = -1 為「無地點」佔位，應被 offices_addr 關聯排除
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1001, 'c_office_id' => -1, 'c_posting_id' => 5003, 'c_addr_id' => 200,
+        ]);
+
+        $byPosting = app(PersonMapPointsService::class)->officePlacesByPosting(1001);
+        $this->assertArrayNotHasKey('-1:5003', $byPosting);
+    }
+
+    public function testSamePostingIdDifferentOfficeDoesNotMisassignName(): void {
+        // 同 posting_id=5001 但不同 office（9003 縣令，地點 addr 100），不可取到 9001(知州) 的官名
+        DB::table('OFFICE_CODES')->insert(['c_office_id' => 9003, 'c_office_chn' => '縣令']);
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1001, 'c_office_id' => 9003, 'c_posting_id' => 5001, 'c_sequence' => 3, 'c_firstyear' => 1080, 'c_lastyear' => 1082,
+        ]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1001, 'c_office_id' => 9003, 'c_posting_id' => 5001, 'c_addr_id' => 100,
+        ]);
+
+        $byPosting = app(PersonMapPointsService::class)->officePlacesByPosting(1001);
+
+        // 兩個任命各自獨立分組，官名不互相覆蓋
+        $this->assertSame('知州 · 密州', $byPosting['9001:5001'][0]['label']);
+        $this->assertSame('縣令 · 開封', $byPosting['9003:5001'][0]['label']);
+    }
+
+    public function testMultipleAddressesUnderSamePostingAreGroupedAndSorted(): void {
+        // 同一任命（9001:5001）多個地點，應分在同組並依 addr_id 排序
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1001, 'c_office_id' => 9001, 'c_posting_id' => 5001, 'c_addr_id' => 100,
+        ]);
+
+        $places = app(PersonMapPointsService::class)->officePlacesByPosting(1001)['9001:5001'];
+
+        $this->assertCount(2, $places);
+        $this->assertSame(100, $places[0]['addr_id']);
+        $this->assertSame(200, $places[1]['addr_id']);
+    }
+
+    public function testOfficeOrphanAddressDoesNotErrorAndIsNotLinkable(): void {
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1001, 'c_office_id' => 9001, 'c_posting_id' => 5001, 'c_addr_id' => 88888,
+        ]);
+
+        $response = $this->getJson('/basicinformation/1001/map-points');
+        $response->assertOk();
+
+        $places = app(PersonMapPointsService::class)->officePlacesByPosting(1001)['9001:5001'];
+        $orphan = collect($places)->firstWhere('addr_id', 88888);
+
+        $this->assertNotNull($orphan);
+        $this->assertSame('office:9001:5001:88888', $orphan['key']);
+        $this->assertFalse($orphan['linkable']);
+        $this->assertNull($orphan['name_chn']);
+        $this->assertNull($orphan['name']);
+        $this->assertNull($orphan['lon']);
+        $this->assertNull($orphan['lat']);
+        $this->assertSame('知州 · addr_id:88888', $orphan['label']);
+        $this->assertNotContains(88888, collect($response->json('points'))->pluck('addr_id')->all());
+    }
+
+    public function testOfficeLabelFallsBackToEnglishAndAddrId(): void {
+        DB::table('OFFICE_CODES')->where('c_office_id', 9001)->update([
+            'c_office_chn' => null,
+            'c_office_trans' => 'Prefect',
+        ]);
+        DB::table('ADDR_CODES')->where('c_addr_id', 200)->update([
+            'c_name_chn' => null,
+            'c_name' => null,
+        ]);
+
+        $place = app(PersonMapPointsService::class)->officePlacesByPosting(1001)['9001:5001'][0];
+
+        $this->assertSame('Prefect · addr_id:200', $place['label']);
+    }
+}

--- a/tests/Feature/PersonMapPointsTest.php
+++ b/tests/Feature/PersonMapPointsTest.php
@@ -110,8 +110,8 @@ class PersonMapPointsTest extends TestCase {
         ]);
 
         DB::table('OFFICE_CODES')->insert([
-            ['c_office_id' => 9001, 'c_office_chn' => '知州'],
-            ['c_office_id' => 9002, 'c_office_chn' => '通判'],
+            ['c_office_id' => 9001, 'c_office_chn' => '知州', 'c_office_trans' => 'Prefect'],
+            ['c_office_id' => 9002, 'c_office_chn' => '通判', 'c_office_trans' => 'Vice Prefect'],
         ]);
 
         DB::table('POSTED_TO_OFFICE_DATA')->insert([
@@ -150,6 +150,18 @@ class PersonMapPointsTest extends TestCase {
         $office = $byKey['office:9001:5001:200'];
         $this->assertSame('office', $office['source']);
         $this->assertSame('知州 · 密州', $office['label']);
+
+        // 每筆帶記錄頁相對 URL（供 popup 開新分頁）與官名中英
+        $this->assertStringStartsWith('/basicinformation/1001/addresses/edit', $addr['url']);
+        $this->assertStringContainsString('c_personid=1001', $addr['url']);
+        $this->assertStringContainsString('c_addr_id=100', $addr['url']);
+        $this->assertStringContainsString('c_addr_type=1', $addr['url']);
+        $this->assertStringContainsString('c_sequence=1', $addr['url']);
+        $this->assertStringStartsWith('/basicinformation/1001/offices/edit', $office['url']);
+        $this->assertStringContainsString('c_office_id=9001', $office['url']);
+        $this->assertStringContainsString('c_posting_id=5001', $office['url']);
+        $this->assertSame('知州', $office['office_name']);
+        $this->assertSame('Prefect', $office['office_name_en']);
     }
 
     public function testEndpointExcludesInvalidCoordinates(): void {
@@ -210,7 +222,7 @@ class PersonMapPointsTest extends TestCase {
         $this->assertNotNull($orphan);
         $this->assertFalse($orphan['linkable']);
         $this->assertNull($orphan['name_chn']);
-        $this->assertSame('', $orphan['label']);
+        $this->assertSame('addr_id:88888', $orphan['label']);
         // 不應出現在地圖點位中
         $points = app(PersonMapPointsService::class)->points(1001);
         $this->assertNotContains(88888, collect($points)->pluck('addr_id')->all());

--- a/tests/Unit/CoordinateValidatorTest.php
+++ b/tests/Unit/CoordinateValidatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\CoordinateValidator;
+use Tests\TestCase;
+
+/**
+ * 座標有效性判定測試
+ *
+ * 對應 docs/CHGIS_MAP_PLACE_LINK.md §3 的判定規則。
+ */
+class CoordinateValidatorTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        // 固定測試用的範圍設定，避免受 .env 影響
+        config([
+            'chgis_map.epsilon' => 1e-7,
+            'chgis_map.mercator_lat_limit' => 85.0511,
+            'chgis_map.bounds' => ['west' => 58.5372, 'south' => -62.6348, 'east' => 152.24, 'north' => 82.7288],
+            'chgis_map.sane_bounds' => ['enabled' => true, 'west' => 70.0, 'south' => 15.0, 'east' => 140.0, 'north' => 55.0],
+        ]);
+    }
+
+    public function testValidEastAsiaPoint(): void {
+        // 開封一帶（lon ~114.3, lat ~34.8）
+        $this->assertTrue(CoordinateValidator::isValid(114.3, 34.8));
+    }
+
+    public function testNullCoordsAreInvalid(): void {
+        $this->assertFalse(CoordinateValidator::isValid(null, null));
+        $this->assertFalse(CoordinateValidator::isValid(114.3, null));
+        $this->assertFalse(CoordinateValidator::isValid(null, 34.8));
+        $this->assertSame('non_numeric', CoordinateValidator::reason(null, 34.8));
+    }
+
+    public function testEmptyStringIsInvalid(): void {
+        $this->assertFalse(CoordinateValidator::isValid('', ''));
+        $this->assertFalse(CoordinateValidator::isValid('abc', '34.8'));
+    }
+
+    public function testZeroZeroIsInvalid(): void {
+        $this->assertFalse(CoordinateValidator::isValid(0, 0));
+        $this->assertSame('zero_axis', CoordinateValidator::reason(0, 0));
+    }
+
+    public function testSingleAxisZeroIsInvalid(): void {
+        // 經度為 0
+        $this->assertFalse(CoordinateValidator::isValid(0, 34.8));
+        // 緯度為 0
+        $this->assertFalse(CoordinateValidator::isValid(114.3, 0));
+    }
+
+    public function testNearZeroIsInvalid(): void {
+        $this->assertFalse(CoordinateValidator::isValid(1e-9, 1e-9));
+        $this->assertFalse(CoordinateValidator::isValid(114.3, 1e-9));
+    }
+
+    public function testReversedCoordsFallOutOfBounds(): void {
+        // 反掉：把緯度 34.8 放進經度、經度 114.3 放進緯度
+        // 114.3 > north(82.7288) → 超界
+        $this->assertFalse(CoordinateValidator::isValid(34.8, 114.3));
+        $this->assertSame('out_of_bounds', CoordinateValidator::reason(34.8, 114.3));
+    }
+
+    public function testOutOfMbtilesBoundsIsInvalid(): void {
+        // 倫敦（lon ~-0.1, lat ~51.5）：經度 < west
+        $this->assertFalse(CoordinateValidator::isValid(-0.1276, 51.5072));
+        // 經度超過 east
+        $this->assertFalse(CoordinateValidator::isValid(160.0, 40.0));
+    }
+
+    public function testSaneBoundsFiltersWideMbtilesArea(): void {
+        // 南半球某點：在 mbtiles bounds（south=-62.6348）內，但被 sane_bounds（south=15）濾掉
+        $this->assertFalse(CoordinateValidator::isValid(100.0, -30.0));
+        $this->assertSame('out_of_sane_bounds', CoordinateValidator::reason(100.0, -30.0));
+    }
+
+    public function testSaneBoundsCanBeDisabled(): void {
+        config(['chgis_map.sane_bounds.enabled' => false]);
+        // 關閉 sane 後，南半球點只要落在 mbtiles bounds 即有效
+        $this->assertTrue(CoordinateValidator::isValid(100.0, -30.0));
+    }
+
+    public function testBoundaryValuesAreInclusive(): void {
+        config(['chgis_map.sane_bounds.enabled' => false]);
+        // 恰好等於 bounds 邊界
+        $this->assertTrue(CoordinateValidator::isValid(58.5372, 82.7288));
+        $this->assertTrue(CoordinateValidator::isValid(152.24, -62.6348));
+    }
+
+    public function testNumericStringsAreAccepted(): void {
+        // 資料庫 double 欄位有時以字串形式傳入
+        $this->assertTrue(CoordinateValidator::isValid('114.3', '34.8'));
+    }
+
+    public function testNanAndInfAreInvalid(): void {
+        // 直接傳入浮點 NAN/INF（is_numeric 會回 true，需靠 is_finite 攔截）
+        $this->assertFalse(CoordinateValidator::isValid(NAN, NAN));
+        $this->assertFalse(CoordinateValidator::isValid(INF, 34.8));
+        $this->assertFalse(CoordinateValidator::isValid(114.3, -INF));
+        $this->assertSame('non_numeric', CoordinateValidator::reason(NAN, 34.8));
+        // 溢位的科學記號字串 → (float) 後為 INF
+        $this->assertFalse(CoordinateValidator::isValid('1e400', '1e400'));
+    }
+
+    public function testBooleanIsInvalid(): void {
+        $this->assertFalse(CoordinateValidator::isValid(true, true));
+        $this->assertFalse(CoordinateValidator::isValid(114.3, false));
+    }
+
+    public function testScientificNotationStringParsesToNumber(): void {
+        // '1e2' = 100，為合法數值；落在 bounds/sane 內即有效（釘死行為）
+        $this->assertTrue(CoordinateValidator::isValid('1.143e2', '3.48e1'));
+    }
+
+    public function testWhitespacePaddedStringIsAccepted(): void {
+        // PHP is_numeric 接受前後空白，(float) 可正確轉換；釘死此行為
+        $this->assertTrue(CoordinateValidator::isValid(' 114.3 ', "34.8\t"));
+    }
+
+    public function testMercatorLatLimitTriggersWhenBoundsWidened(): void {
+        // 預設 bounds（north=82.7288）下第 4 關為死碼；放寬 north 後才可觸發
+        config([
+            'chgis_map.sane_bounds.enabled' => false,
+            'chgis_map.bounds' => ['west' => 58.5372, 'south' => -88.0, 'east' => 152.24, 'north' => 88.0],
+        ]);
+        // 緯度落在放寬後的 bounds 內，但超過 Web Mercator 上限 85.0511
+        $this->assertFalse(CoordinateValidator::isValid(100.0, 86.0));
+        $this->assertSame('mercator_unprojectable', CoordinateValidator::reason(100.0, 86.0));
+        // 恰好等於上限應通過（含界）
+        $this->assertTrue(CoordinateValidator::isValid(100.0, 85.0511));
+    }
+
+    public function testReversedCoordsStillInsideBoundsIsKnownLimitation(): void {
+        // 已知限制（§3.1）：兩值都落在彼此合法範圍時無法辨識反掉，保守接受。
+        // 注意：啟用 sane_bounds（lon 70-140, lat 15-55）時 lon/lat 範圍無交集，
+        // 反掉座標必被攔截；此限制僅在較寬的 mbtiles bounds 下才會出現。
+        config(['chgis_map.sane_bounds.enabled' => false]);
+        // mbtiles bounds 下 lon[58.5,152.24] 與 lat[-62.6,82.7] 交集為 [58.5,82.7]，
+        // 70 與 80 互換後仍都落在各自範圍 → 兩者皆有效（無法辨識反掉）。
+        $this->assertTrue(CoordinateValidator::isValid(70.0, 80.0));
+        $this->assertTrue(CoordinateValidator::isValid(80.0, 70.0));
+    }
+
+    public function testMissingBoundsKeysFailClosed(): void {
+        // config 缺 bounds 鍵 → 全部判無效（fail-closed）
+        config(['chgis_map.bounds' => []]);
+        $this->assertFalse(CoordinateValidator::isValid(114.3, 34.8));
+        $this->assertSame('out_of_bounds', CoordinateValidator::reason(114.3, 34.8));
+    }
+
+    public function testSaneBoundsEnabledButMissingKeysFailClosed(): void {
+        // sane_bounds 啟用但缺座標鍵 → 全部判無效（刻意 fail-closed，非疏漏）
+        config(['chgis_map.sane_bounds' => ['enabled' => true]]);
+        $this->assertFalse(CoordinateValidator::isValid(114.3, 34.8));
+        $this->assertSame('out_of_sane_bounds', CoordinateValidator::reason(114.3, 34.8));
+    }
+}

--- a/tests/Unit/FetchChgisMapJobTest.php
+++ b/tests/Unit/FetchChgisMapJobTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\FetchChgisMapJob;
+use App\Services\ChgisMapManager;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class FetchChgisMapJobTest extends TestCase {
+    protected function tearDown(): void {
+        Cache::forget(FetchChgisMapJob::STATE_KEY);
+        Cache::forget(FetchChgisMapJob::LOCK_KEY);
+
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testTtlSecondsIsLongerThanDownloadTimeout(): void {
+        config(['chgis_map.source.timeout' => 120]);
+
+        $this->assertSame(720, FetchChgisMapJob::ttlSeconds());
+        $this->assertGreaterThan((int) config('chgis_map.source.timeout'), FetchChgisMapJob::ttlSeconds());
+    }
+
+    public function testHandleClearsStateWhenBasemapAlreadyReady(): void {
+        Cache::put(FetchChgisMapJob::STATE_KEY, ['state' => 'downloading', 'started_at' => time()], now()->addMinute());
+
+        $manager = Mockery::mock(ChgisMapManager::class);
+        $manager->shouldReceive('isReady')->once()->andReturn(true);
+        $manager->shouldNotReceive('download');
+
+        (new FetchChgisMapJob())->handle($manager);
+
+        $this->assertNull(Cache::get(FetchChgisMapJob::STATE_KEY));
+    }
+
+    public function testHandleSkipsWhenAnotherWorkerHoldsLock(): void {
+        $manager = Mockery::mock(ChgisMapManager::class);
+        $manager->shouldReceive('isReady')->once()->andReturn(false);
+        $manager->shouldNotReceive('download');
+
+        $heldLock = Cache::lock(FetchChgisMapJob::LOCK_KEY, FetchChgisMapJob::ttlSeconds());
+        $this->assertTrue($heldLock->get());
+
+        try {
+            (new FetchChgisMapJob())->handle($manager);
+        } finally {
+            $heldLock->release();
+        }
+
+        $this->assertNull(Cache::get(FetchChgisMapJob::STATE_KEY));
+    }
+
+    public function testHandleClearsStateAfterSuccessfulDownload(): void {
+        $manager = Mockery::mock(ChgisMapManager::class);
+        $manager->shouldReceive('isReady')->once()->andReturn(false);
+        $manager->shouldReceive('download')->once();
+
+        (new FetchChgisMapJob())->handle($manager);
+
+        $this->assertNull(Cache::get(FetchChgisMapJob::STATE_KEY));
+    }
+
+    public function testHandleStoresFailedStateWhenDownloadThrows(): void {
+        $manager = Mockery::mock(ChgisMapManager::class);
+        $manager->shouldReceive('isReady')->once()->andReturn(false);
+        $manager->shouldReceive('download')->once()->andThrow(new RuntimeException('download failed'));
+
+        (new FetchChgisMapJob())->handle($manager);
+
+        $state = Cache::get(FetchChgisMapJob::STATE_KEY);
+
+        $this->assertSame('failed', $state['state'] ?? null);
+        $this->assertSame('download failed', $state['message'] ?? null);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
                 'resources/js/app.js',          // Main entry: AdminLTE v3 + base setup
                 'resources/js/datatables.js',   // DataTables plugin
                 'resources/js/historical-maps/app.js',
+                // CHGIS 地圖 modal（addresses/offices Place Name 連結）
+                'resources/js/chgis-map/app.js',
                 // Inertia + React entry (PoC)
                 'resources/js/inertia/app.tsx',
             ],


### PR DESCRIPTION
## 摘要

為 `/basicinformation/{id}/addresses` 與 `/offices` 列表頁的 **Place Name** 加上可點擊連結；點擊後浮出以 CHGIS 底圖（`chgis_map.mbtiles`）為底的 Leaflet 地圖，標出該人物**所有有效座標**的地址與官職地點，當前點置中並突顯。設計與實作對照見 [`docs/CHGIS_MAP_PLACE_LINK.md`](docs/CHGIS_MAP_PLACE_LINK.md)。

## 主要內容

**有效座標判定**（`App\Support\CoordinateValidator`，設定見 `config/chgis_map.php`）
- 依序：存在且有限數值 → 非零（含單軸為 0）→ 落在 mbtiles bounds 且東亞收斂框內 → Web Mercator 可投影。
- 反掉座標靠界外規則濾掉，不自動 swap；無效座標維持純文字。

**底圖取得**（不入版控）
- `php artisan cbdb:fetch-chgis-map`：自 HuggingFace `cbdb/chgis-map` 串流下載至 `storage/app/chgis/`，含 SQLite 魔術位元組驗證、原子替換含備份還原；接入 `deploy.sh`（非致命）。
- 缺檔時於首次開地圖背景下載並顯示提示（`FetchChgisMapJob`，lock TTL > 下載逾時、`started_at` stale 自癒）。

**後端**
- `ChgisMapController`：`tile`（讀 mbtiles、TMS y-flip、ETag/304、未命中/例外降級透明磚）、`status`、`personPoints`。
- `PersonMapPointsService`：彙整有效點；官職以 `(c_office_id, c_posting_id)` 複合鍵分組，避免 `c_posting_id` 非全域唯一造成官名誤配與 key 碰撞；每筆帶記錄頁相對 URL 與官名中英。

**前端**（`resources/js/chgis-map`，Leaflet 改 npm 依賴、非 CDN）
- 無邊框／背景變暗模糊、Esc/遮罩/×關閉、focus trap、aria-live、手機 100dvh、`prefers-reduced-motion`。
- 同座標多 node 合併為單一標記（數字徽章）；同點兼具地址與官職以左藍右綠分割標記區分。
- popup：依類型分組、整列即連結（新分頁開該筆記錄、`rel=noopener` + 來源協定過濾）、官名中英並列、Leaflet 原生捲動。
- 圖例：條件式顯示混合/數量說明；標籤以顏色為準（目前地點／傳記地址／官職地點）。

**i18n**：`resources/lang/{zh-TW,en}/chgis_map.php` 全程同步。

## 測試
- 新增單元與功能測試：`CoordinateValidatorTest`、`FetchChgisMapTest`、`FetchChgisMapJobTest`、`ChgisMapControllerTest`（含 TMS flip 方向性、stale 自癒）、`PersonMapPointsTest`（含複合鍵、孤兒外鍵、佔位排除、多地點）、`BasicInformationPagesLoadTest`（連結渲染與資源注入）。
- CHGIS 相關 88 測試全綠；完整套件 1361 測試全綠。
- `php-cs-fixer --dry-run`：本分支變更的 26 個 PHP 源檔 0 待修正。

## 部署注意
- 正式環境建議由 `cbdb:fetch-chgis-map`（部署步驟）預先抓底圖；lazy 下載僅為後備。`QUEUE_CONNECTION=sync` 時 lazy 下載受 `max_execution_time` 限制，詳見設計文件頂部部署備忘。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
