### PR TITLE
修正：select-vue 下拉於選項非同步載入完成後重建 select2

### DIFF
--- a/resources/js/components/Select.vue
+++ b/resources/js/components/Select.vue
@@ -27,6 +27,16 @@
               dynastyEnd: null,
           }
         },
+        watch: {
+            // 選項以非同步方式（axios）載入，而 select2 是在 Blade 的 onViteReady
+            // 中先行初始化，此時原生 <select> 通常只有 placeholder。select2 只會在
+            // 每次按鍵時重新查詢目前的 <option>，因此使用者若在資料載入完成前展開並
+            // 輸入關鍵字，會看到「No results / 沒有結果」且不會自動恢復。
+            // 資料載入後重新整理 select2，確保選項與已選值同步。
+            data() {
+                this.$nextTick(() => this.syncSelect2());
+            },
+        },
         computed: {
             displayData() {
                 if (this.model !== 'nianhao' || !Array.isArray(this.data) || this.data.length === 0) {
@@ -69,6 +79,26 @@
             this.readDynastyYears();
         },
         methods: {
+            // 資料載入完成後重新整理 select2，使其反映最新的 <option> 與已選值。
+            // 若 Blade 尚未初始化 select2（無 select2-hidden-accessible），則略過，
+            // 由 Blade 之後初始化時即可帶入完整選項。
+            syncSelect2() {
+                const jq = window.jQuery || window.$;
+                if (!jq || !jq.fn || !jq.fn.select2) return;
+                const $el = jq(this.$el);
+                if (!$el.hasClass('select2-hidden-accessible')) return;
+
+                const wasOpen = $el.select2('isOpen');
+                const val = this.selectedid;
+                $el.select2('destroy').select2();
+                if (val !== undefined && val !== null && val !== '') {
+                    // change.select2 命名空間只通知 select2，避免誤觸表單 dirty 偵測
+                    $el.val(String(val)).trigger('change.select2');
+                }
+                if (wasOpen) {
+                    $el.select2('open');
+                }
+            },
             readDynastyYears() {
                 if (this.model !== 'nianhao') return;
                 const startEl = document.querySelector('.dynasty_start');


### PR DESCRIPTION
## 問題
英文介面下於 `/basicinformation/{id}/edit` 輸入朝代名稱（如 Tang/Song）過濾下拉時，會出現「No results found / 沒有結果」，看似過濾完全失效。

## 重現
以真實瀏覽器（Playwright）登入並切換至英文介面（`html lang="en"`）重現：
- 頁面剛載入、`/api/select/dynasty` 尚未回來時展開下拉並輸入「Tang」→ **No results found**
- 等選項載入完成後再輸入 → 正常過濾

## 原因（時序競態）
select2 在 Blade `onViteReady` 即以 `$(".select2").select2()` 初始化，但 `<select-vue>` 的選項是 axios **非同步**抓取，初始化當下原生 `<select>` 多半只有 placeholder。select2 僅在每次按鍵時重讀目前 `<option>` 過濾，因此在資料載入完成前展開輸入會查不到，且在下一次按鍵前不會自動恢復。

選項文字其實同時含中英（如 `6 唐 Tang 618 907`），故載入後中英皆可搜。英文使用者習慣打羅馬拼音搜尋（正好踩進競態），中文使用者多以肉眼辨識直接點選，造成「只有英文壞」的錯覺。

## 修改
於共用元件 `resources/js/components/Select.vue`：`watch: data` 後 `$nextTick` 重建 select2（destroy + 重新 init），使其反映完整選項與已選值；下拉開啟中則重新開啟以自癒。`change.select2` 命名空間僅通知 select2，不誤觸表單 dirty 偵測。

同一競態存在於所有使用 `select-vue` + `select2` 的表單（offices、addresses、altname、entries、events、kinship、statuses、possession、sources、socialinst、assoc、basicinformation），改於共用元件即一次涵蓋；並順帶修正初始已選值不顯示的問題。

## 驗證（`npm run build` 後，真實瀏覽器）
- ✅ 競態自癒：載入完成後**不需再按任何鍵**，下拉自動顯示全部 86 筆選項（修復前會卡在 No results）
- ✅ 已選朝代正確顯示為 `15 宋 Song 960 1279`
- ✅ 一般輸入 Tang/Song/Ming 仍正常，無 JS 錯誤
- ✅ `./vendor/bin/php-cs-fixer fix` 通過（本次為純前端變更）

## 後續建議（不在本 PR 範圍）
伺服器端 `api/select/search/*`（如 `searchOffice`、`socialinst`）的 `WHERE` 僅比對中文/拼音欄位，未含英文欄位，英文詞搜尋會穩定查不到；建議另開 issue 補上英文欄位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)