### PR TITLE
CHGIS 地圖：底圖版本自動偵測 + 來源標注

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ database/database.sqlite3
 
 # CHGIS 底圖（自 HuggingFace 下載，不入版控）
 /storage/app/chgis/*.mbtiles
+/storage/app/chgis/*.version
 /storage/app/chgis/*.part.*
 /storage/app/chgis/*.bak.*

--- a/app/Console/Commands/FetchChgisMap.php
+++ b/app/Console/Commands/FetchChgisMap.php
@@ -22,15 +22,31 @@ class FetchChgisMap extends Command {
     /**
      * @var string
      */
-    protected $description = '自 HuggingFace 下載 CHGIS 底圖 chgis_map.mbtiles（缺檔才下載）';
+    protected $description = '自 HuggingFace 下載 CHGIS 底圖 chgis_map.mbtiles（有更新才下載）';
 
     public function handle(ChgisMapManager $manager): int {
         $path = $manager->path();
 
+        // 本地已有合格檔案時，比對遠端 ETag 決定是否需要更新
+        $remoteEtag = null;
         if (!$this->option('force') && $manager->isReady()) {
-            $this->info("CHGIS 底圖已存在，跳過下載：{$path}");
+            $this->line('CHGIS 底圖已存在，檢查遠端版本...');
+            $remoteEtag = $manager->getRemoteEtag();
+            $localEtag = $manager->getLocalEtag();
 
-            return self::SUCCESS;
+            if ($remoteEtag === null) {
+                $this->warn('無法取得遠端版本資訊，保留現有底圖');
+
+                return self::SUCCESS;
+            }
+
+            if ($remoteEtag === $localEtag) {
+                $this->info("CHGIS 底圖已是最新（ETag：{$remoteEtag}），跳過下載");
+
+                return self::SUCCESS;
+            }
+
+            $this->info('偵測到新版本，開始更新底圖...');
         }
 
         $this->info('開始下載 CHGIS 底圖，來源：' . $manager->sourceUrl());
@@ -39,7 +55,7 @@ class FetchChgisMap extends Command {
         $start = microtime(true);
 
         try {
-            $manager->download();
+            $downloadedEtag = $manager->download();
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
 
@@ -49,6 +65,14 @@ class FetchChgisMap extends Command {
         $seconds = round(microtime(true) - $start, 1);
         $sizeMb = round(filesize($path) / 1048576, 1);
         $this->info("下載完成：{$sizeMb} MB，耗時 {$seconds} 秒");
+
+        // 優先用 download() 回傳的 ETag（與下載的檔案嚴格對應），
+        // 次選版本比對階段取到的 remoteEtag。
+        $etagToSave = $downloadedEtag ?? $remoteEtag;
+        if ($etagToSave !== null) {
+            $manager->saveEtag($etagToSave);
+            $this->line("版本標記已儲存（ETag：{$etagToSave}）");
+        }
 
         return self::SUCCESS;
     }

--- a/app/Services/ChgisMapManager.php
+++ b/app/Services/ChgisMapManager.php
@@ -21,6 +21,11 @@ class ChgisMapManager {
         return (string) config('chgis_map.source.path');
     }
 
+    /** 本地版本標記檔絕對路徑（存放上次下載時的遠端 ETag）。 */
+    public function versionPath(): string {
+        return dirname($this->path()) . '/chgis_map.version';
+    }
+
     /** 下載來源 URL（HuggingFace resolve raw）。 */
     public function sourceUrl(): string {
         return (string) config('chgis_map.source.url');
@@ -29,6 +34,61 @@ class ChgisMapManager {
     /** 視為有效檔案的體積下限（位元組）。 */
     public function expectedMinBytes(): int {
         return (int) config('chgis_map.source.expected_min_bytes', 5_000_000);
+    }
+
+    /**
+     * 取得遠端檔案的 ETag（透過 HTTP HEAD，自動追蹤 redirect）。
+     *
+     * 無法取得（網路錯誤、非 2xx）時回 null，呼叫端視為「無法判斷版本」。
+     */
+    public function getRemoteEtag(): ?string {
+        try {
+            $response = Http::timeout(30)
+                ->connectTimeout(10)
+                ->withOptions([
+                    'allow_redirects' => [
+                        'max' => 10,
+                        'strict' => false,
+                        'referer' => false,
+                        'protocols' => ['http', 'https'],
+                    ],
+                ])
+                ->head($this->sourceUrl());
+
+            if ($response->successful()) {
+                $etag = $response->header('ETag');
+
+                return ($etag !== '' && $etag !== null) ? $etag : null;
+            }
+        } catch (\Throwable) {
+            // 網路錯誤：無法判斷版本，回 null
+        }
+
+        return null;
+    }
+
+    /**
+     * 讀取本地版本標記（上次下載時儲存的 ETag），無記錄時回 null。
+     */
+    public function getLocalEtag(): ?string {
+        $path = $this->versionPath();
+        if (!is_file($path)) {
+            return null;
+        }
+        $content = trim((string) file_get_contents($path));
+
+        return $content !== '' ? $content : null;
+    }
+
+    /**
+     * 將 ETag 寫入版本標記檔，供下次啟動比對。
+     */
+    public function saveEtag(string $etag): void {
+        $dir = dirname($this->versionPath());
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            return;
+        }
+        file_put_contents($this->versionPath(), $etag);
     }
 
     /**
@@ -55,9 +115,11 @@ class ChgisMapManager {
      * 注意：本方法非並發安全——唯一 .part 命名可避免並發互相寫壞同一暫存檔，
      * 但仍可能重複下載。需要互斥時請由呼叫端加鎖（見 docs §4.6 P3）。
      *
+     * @return ?string 下載成功後回傳 ETag（若伺服器有回傳），否則 null
+     *
      * @throws RuntimeException 下載失敗或檔案不完整／格式不符時
      */
-    public function download(): void {
+    public function download(): ?string {
         $path = $this->path();
         $dir = dirname($path);
 
@@ -67,6 +129,8 @@ class ChgisMapManager {
 
         // 唯一暫存檔名，避免並發下載互相覆寫造成交錯壞檔。
         $partPath = $path . '.part.' . getmypid() . '.' . bin2hex(random_bytes(4));
+
+        $capturedEtag = null;
 
         try {
             try {
@@ -81,6 +145,10 @@ class ChgisMapManager {
             if (!$response->successful()) {
                 throw new RuntimeException('CHGIS 底圖下載失敗，HTTP 狀態碼：' . $response->status());
             }
+
+            // 從下載回應直接取 ETag，避免事後補一次 HEAD 造成版本不一致。
+            $etagHeader = $response->header('ETag');
+            $capturedEtag = ($etagHeader !== '' && $etagHeader !== null) ? $etagHeader : null;
 
             clearstatcache(true, $partPath);
             $size = is_file($partPath) ? filesize($partPath) : 0;
@@ -130,6 +198,8 @@ class ChgisMapManager {
                 @unlink($partPath);
             }
         }
+
+        return $capturedEtag;
     }
 
     /**

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -387,7 +387,7 @@ function startMap(token, personId, currentKey, lon, lat) {
     cleanupMap();
     mapInstance = L.map(mapEl, {
         zoomControl: true,
-        attributionControl: false,
+        attributionControl: true,
         minZoom: c.minZoom || 3,
         maxZoom: 10,
     });
@@ -398,6 +398,10 @@ function startMap(token, personId, currentKey, lon, lat) {
         maxNativeZoom: c.maxZoom || 8,
         noWrap: true,
         bounds: boundsToLatLng(bounds),
+        attribution:
+            '<a href="https://chgis.fas.harvard.edu/data/chgis/v6/" target="_blank" rel="noopener noreferrer">CHGIS v6</a>' +
+            ' © Harvard &amp; Fudan | Rivers &amp; coastlines: 1820 data |' +
+            ' <a href="https://huggingface.co/datasets/cbdb/chgis-map" target="_blank" rel="noopener noreferrer">Map data</a>',
     }).addTo(mapInstance);
 
     const fallbackCenter = isFinite(lon) && isFinite(lat) ? [lat, lon] : [35, 110];

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -73,6 +73,12 @@
     overscroll-behavior: contain;
 }
 
+/* Attribution bar：避免被 modal border-radius 裁切 */
+.chgis-modal__map .leaflet-control-attribution {
+    margin-bottom: 4px;
+    margin-right: 4px;
+}
+
 /* 關閉鈕：右上角浮動半透明圓形，命中區 >= 44px */
 .chgis-modal__close {
     position: absolute;

--- a/tests/Feature/FetchChgisMapTest.php
+++ b/tests/Feature/FetchChgisMapTest.php
@@ -93,13 +93,36 @@ class FetchChgisMapTest extends TestCase {
         @mkdir($this->dir, 0775, true);
         file_put_contents($this->path, $this->fakeMbtiles());
 
-        Http::fake();
+        $etag = '"test-etag-v1"';
+        file_put_contents($this->dir . '/chgis_map.version', $etag);
+
+        Http::fake(['*' => Http::response('', 200, ['ETag' => $etag])]);
 
         $this->artisan('cbdb:fetch-chgis-map')
-            ->expectsOutputToContain('已存在')
+            ->expectsOutputToContain('已是最新')
             ->assertExitCode(0);
 
-        Http::assertNothingSent();
+        // 只有一次 HEAD（版本比對），沒有 GET 下載
+        Http::assertSentCount(1);
+        Http::assertSent(fn ($req) => $req->method() === 'HEAD');
+    }
+
+    public function testDetectsUpdateAndRedownloads(): void {
+        @mkdir($this->dir, 0775, true);
+        file_put_contents($this->path, $this->fakeMbtiles(64));
+        file_put_contents($this->dir . '/chgis_map.version', '"old-etag"');
+
+        $newBody = $this->fakeMbtiles(128);
+        $newEtag = '"new-etag-v2"';
+
+        Http::fake(['*' => Http::response($newBody, 200, ['ETag' => $newEtag])]);
+
+        $this->artisan('cbdb:fetch-chgis-map')
+            ->expectsOutputToContain('新版本')
+            ->assertExitCode(0);
+
+        $this->assertSame($newBody, file_get_contents($this->path));
+        $this->assertSame($newEtag, file_get_contents($this->dir . '/chgis_map.version'));
     }
 
     public function testRedownloadsWhenExistingFileIsCorrupt(): void {


### PR DESCRIPTION
## Summary

- **版本自動偵測**：`cbdb:fetch-chgis-map` 指令新增 HTTP HEAD ETag 比對，本地有合格底圖時先向 HuggingFace 確認遠端版本，ETag 相同跳過下載，不同才重新取得；版本標記存於 `storage/app/chgis/chgis_map.version`（不入版控）
- **Attribution 標注**：啟用 Leaflet attribution control，tileLayer 加入 CHGIS v6 來源說明，含 Harvard & Fudan 版權與 Rivers & coastlines: 1820 data 注記（兩種語言介面均顯示英文）

## Test plan

- [x] `./vendor/bin/phpunit tests/Feature/FetchChgisMapTest.php` — 8/8 通過（含新增的 `testDetectsUpdateAndRedownloads`）
- [x] `npm run build` — 編譯成功
- [x] Review agent × 2 輪 + codex 確認無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)