### PR TITLE
移除 Leaflet attribution 國旗 emoji

### DIFF
--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -392,6 +392,10 @@ function startMap(token, personId, currentKey, lon, lat) {
         maxZoom: 10,
     });
 
+    mapInstance.attributionControl.setPrefix(
+        '<a href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>'
+    );
+
     L.tileLayer(c.tileUrlTemplate, {
         minZoom: c.minZoom || 3,
         maxZoom: 10,


### PR DESCRIPTION
## Summary

- Leaflet 1.9.0 起 attribution prefix 預設含 🇺🇦，以 `setPrefix()` 改為純文字 Leaflet 連結

🤖 Generated with [Claude Code](https://claude.com/claude-code)