### PR TITLE
修正 CHGIS tile 快取：no-cache 重新驗證，底圖更新即時生效

### DIFF
--- a/app/Http/Controllers/ChgisMapController.php
+++ b/app/Http/Controllers/ChgisMapController.php
@@ -37,7 +37,7 @@ class ChgisMapController extends Controller {
 
         // 超出原生 zoom 或座標範圍 → 回透明磚（前端 overzoom 時亦安全）
         if ($z < $minZoom || $z > $maxZoom || !$this->withinTileRange($z, $x, $y)) {
-            return $this->transparentTile();
+            return $this->transparentTile($request, $z, $x, $y);
         }
 
         try {
@@ -46,19 +46,22 @@ class ChgisMapController extends Controller {
             // 底圖暫時不可用（如下載 rename 競態）時降級為透明磚，避免 Leaflet 整面報錯
             Log::warning('CHGIS 圖磚讀取失敗：' . $e->getMessage());
 
-            return $this->transparentTile();
+            return $this->transparentTile($request, $z, $x, $y);
         }
 
         if ($data === null) {
-            return $this->transparentTile();
+            return $this->transparentTile($request, $z, $x, $y);
         }
 
         // ETag 納入底圖檔 mtime，底圖更新後同 z/x/y 也會失效，避免回舊磚
         $version = @filemtime($this->manager->path()) ?: 0;
 
+        // no-cache：瀏覽器仍快取磚體，但每次都帶 ETag 回來驗證；
+        // 底圖未變回 304（省頻寬），底圖更新（mtime 變→ETag 變）即拉新磚。
+        // 不可用長 max-age，否則 fresh 期內瀏覽器不驗證，會繼續用舊磚（造成換底圖後仍見舊河流色）。
         $response = response($data, 200)
             ->header('Content-Type', 'image/png')
-            ->header('Cache-Control', 'public, max-age=2592000')
+            ->header('Cache-Control', 'public, no-cache')
             ->setEtag(md5($z . '/' . $x . '/' . $y . '/' . $version))
             ->setLastModified((new \DateTimeImmutable())->setTimestamp($version));
 
@@ -132,10 +135,22 @@ class ChgisMapController extends Controller {
     /**
      * 回傳 1×1 透明 PNG。
      */
-    private function transparentTile(): Response {
-        return response(base64_decode(self::TRANSPARENT_PNG), 200)
+    private function transparentTile(Request $request, int $z, int $x, int $y): Response {
+        // tile() 已於未就緒時 abort(503)，故此處 isReady() 目前恆為真；
+        // 三元僅為防禦性，讓本方法在未來被其他入口重用時仍安全（不對缺檔 filemtime）。
+        $version = $this->manager->isReady() ? (@filemtime($this->manager->path()) ?: 0) : 0;
+
+        // 同樣用 no-cache：避免某 z/x/y 由「超出範圍→透明磚」轉為「底圖已覆蓋」後，
+        // 瀏覽器仍沿用快取的空白磚。透明磚也提供 ETag/304，避免每次都重送 200。
+        $response = response(base64_decode(self::TRANSPARENT_PNG), 200)
             ->header('Content-Type', 'image/png')
-            ->header('Cache-Control', 'public, max-age=86400');
+            ->header('Cache-Control', 'public, no-cache')
+            ->setEtag(md5('transparent/' . $z . '/' . $x . '/' . $y . '/' . $version))
+            ->setLastModified((new \DateTimeImmutable())->setTimestamp($version));
+
+        $response->isNotModified($request);
+
+        return $response;
     }
 
     /**

--- a/tests/Feature/ChgisMapControllerTest.php
+++ b/tests/Feature/ChgisMapControllerTest.php
@@ -92,6 +92,21 @@ class ChgisMapControllerTest extends TestCase {
         ]);
     }
 
+    /**
+     * 於既有 mbtiles 追加一塊圖磚（tile_row 直接以 TMS 列號寫入）。
+     */
+    private function insertTile(int $z, int $col, int $row, string $data): void {
+        $pdo = new PDO('sqlite:' . $this->path);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $stmt = $pdo->prepare('INSERT INTO tiles(zoom_level, tile_column, tile_row, tile_data) VALUES (?, ?, ?, ?)');
+        $stmt->bindValue(1, $z, PDO::PARAM_INT);
+        $stmt->bindValue(2, $col, PDO::PARAM_INT);
+        $stmt->bindValue(3, $row, PDO::PARAM_INT);
+        $stmt->bindValue(4, $data, PDO::PARAM_LOB);
+        $stmt->execute();
+        $pdo = null;
+    }
+
     // ---- tile ----
 
     public function testTileHitUsesCorrectTmsFlip(): void {
@@ -136,6 +151,90 @@ class ChgisMapControllerTest extends TestCase {
         $second->assertOk();
 
         $this->assertNotSame($firstEtag, $second->headers->get('ETag'));
+    }
+
+    public function testTileSendsRevalidatingCacheControl(): void {
+        $this->makeDirectionalFixture();
+
+        $response = $this->get('/chgis-map/tiles/3/6/1');
+
+        $response->assertOk();
+        // 必須每次帶 ETag 重新驗證（no-cache）；不可有長 fresh 期，
+        // 否則底圖更新後瀏覽器於 fresh 期內不驗證，會繼續顯示舊磚（舊河流色）。
+        $cacheControl = (string) $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-cache', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+    }
+
+    public function testTransparentTileSendsRevalidatingCacheControl(): void {
+        $this->makeDirectionalFixture();
+
+        // miss → 透明磚
+        $response = $this->get('/chgis-map/tiles/3/0/0');
+
+        $response->assertOk();
+        $this->assertLessThan(200, strlen($response->getContent()));
+        // 透明磚同樣需 no-cache：避免該格由「透明」轉為「底圖已覆蓋」後仍顯示快取空白磚。
+        $cacheControl = (string) $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-cache', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+    }
+
+    public function testTransparentTileSupportsNotModified(): void {
+        $this->makeDirectionalFixture();
+
+        $first = $this->get('/chgis-map/tiles/3/0/0');
+        $first->assertOk();
+        $etag = $first->headers->get('ETag');
+
+        $this->assertNotNull($etag);
+
+        $this->withHeader('If-None-Match', $etag)
+            ->get('/chgis-map/tiles/3/0/0')
+            ->assertStatus(304);
+    }
+
+    public function testTransparentTileEtagChangesWhenMbtilesFileMtimeChanges(): void {
+        $this->makeDirectionalFixture();
+
+        $first = $this->get('/chgis-map/tiles/3/0/0');
+        $first->assertOk();
+        $firstEtag = $first->headers->get('ETag');
+
+        clearstatcache(true, $this->path);
+        touch($this->path, filemtime($this->path) + 2);
+        clearstatcache(true, $this->path);
+
+        $second = $this->get('/chgis-map/tiles/3/0/0');
+        $second->assertOk();
+
+        $this->assertNotSame($firstEtag, $second->headers->get('ETag'));
+    }
+
+    public function testTransparentTileBecomingRealReturns200NotStale304(): void {
+        // 本次修復的核心情境：某格先是 miss（透明磚），底圖更新後該格已有實磚，
+        // 帶舊透明磚 ETag 重抓時必須回 200＋實磚內容，而非沿用快取的 304 空白磚。
+        $this->makeDirectionalFixture();
+
+        // 先 miss → 透明磚，取得其 ETag（XYZ 3/0/0 未在 fixture 中）
+        $first = $this->get('/chgis-map/tiles/3/0/0');
+        $first->assertOk();
+        $this->assertLessThan(200, strlen($first->getContent()));
+        $transparentEtag = $first->headers->get('ETag');
+        $this->assertNotNull($transparentEtag);
+
+        // 底圖更新：於該 z/x/y 寫入實磚（XYZ 3/0/0 → TMS row = 2^3-1-0 = 7）並推進 mtime
+        $realTile = "\x89PNG\r\n\x1a\nREAL-TILE-AT-3-0-0";
+        $this->insertTile(3, 0, 7, $realTile);
+        clearstatcache(true, $this->path);
+        touch($this->path, filemtime($this->path) + 2);
+        clearstatcache(true, $this->path);
+
+        // 帶舊透明磚 ETag 重抓 → 必須 200＋實磚內容，不可回 304
+        $second = $this->withHeader('If-None-Match', $transparentEtag)
+            ->get('/chgis-map/tiles/3/0/0');
+        $second->assertOk();
+        $this->assertSame($realTile, $second->getContent());
     }
 
     public function testTileFlipDirectionIsConsistent(): void {


### PR DESCRIPTION
## 問題
CHGIS tile 回應帶 `Cache-Control: public, max-age=2592000`（30 天）。雖已有含底圖 `mtime` 的 ETag，但 fresh 期內瀏覽器**不會重新驗證**，導致更新底圖（例如在 QGIS 改河流顏色後重新匯出 mbtiles）後，使用者仍持續看到舊磚——必須開隱私模式或等快取過期。

## 根因
`max-age` 的長 fresh 期讓 ETag 形同虛設：瀏覽器在 30 天內直接吃本機快取，根本不回伺服器帶 `If-None-Match` 驗證，所以 mtime 變更帶來的 ETag 失效永遠觸發不到。

## 修正
- `tile()` 與 `transparentTile()` 改為 `Cache-Control: public, no-cache`：瀏覽器仍快取磚體，但**每次帶 ETag 重新驗證**。底圖未變回 `304`（省頻寬），底圖一更新（mtime → ETag 變）即拉新磚。
- `transparentTile()` 補上 ETag（`transparent/` 前綴，避免與實磚在同 z/x/y、同 mtime 下誤撞 `304`）與 `304` 支援，消除「透明磚 → 底圖已覆蓋」後仍顯示快取空白磚的問題。

## 測試
`ChgisMapControllerTest` 19/19 全綠（含新增）：
- `no-cache` 標頭（實磚／透明磚）
- 透明磚 ETag 穩定 + `304`
- 透明磚 ETag 隨 mtime 變更失效
- **透明磚 → 實磚轉換必回 `200` 不回 `304`**（直接鎖定本次 bug）

php-cs-fixer 乾淨。

> 註：覆寫 `storage/app/chgis/chgis_map.mbtiles` 後即生效，使用者重新整理即可，不必再開隱私模式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)