### PR TITLE
CHGIS tile URL 加底圖版本號做 cache-busting

### DIFF
--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -12,6 +12,13 @@
         ['{z}', '{x}', '{y}'],
         route('chgis-map.tile', ['z' => '__Z__', 'x' => '__X__', 'y' => '__Y__'], false)
     );
+
+    // 加底圖版本號做 cache-busting：以 mbtiles mtime 當版本（與 tile ETag 同源）。
+    // 底圖更新後版本號改變 → tile URL 改變（全新快取鍵），繞過瀏覽器既有的舊磚快取，
+    // 立即取得新磚；no-cache 僅能擋未來快取，無法淘汰使用者已存的舊磚，故另以 URL 版本根治。
+    $chgisManager = app(\App\Services\ChgisMapManager::class);
+    $chgisTileVersion = $chgisManager->isReady() ? (@filemtime($chgisManager->path()) ?: 0) : 0;
+    $chgisTileTemplate .= '?v=' . $chgisTileVersion;
 @endphp
 @push('scripts')
     <script>

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -822,7 +822,13 @@ class BasicInformationPagesLoadTest extends TestCase {
         // CHGIS：前端設定與資源已注入，且 tile URL 為相對路徑（JSON 中 / 轉義為 \/）
         $this->assertStringContainsString('window.chgisMapConfig', $html);
         $this->assertStringContainsString('tileUrlTemplate', $html);
-        $this->assertStringContainsString('\\/chgis-map\\/tiles\\/{z}\\/{x}\\/{y}', $html);
+        // tile 模板須帶 ?v= 底圖版本號做 cache-busting，版本來源需與 Blade 相同。
+        $chgisManager = app(\App\Services\ChgisMapManager::class);
+        $chgisTileVersion = $chgisManager->isReady() ? (@filemtime($chgisManager->path()) ?: 0) : 0;
+        $this->assertStringContainsString(
+            '\\/chgis-map\\/tiles\\/{z}\\/{x}\\/{y}?v=' . $chgisTileVersion,
+            $html
+        );
         $this->assertStringContainsString('count_unit', $html);
         $this->assertStringContainsString('legend_count_hint', $html);
         $this->assertStringContainsString('unknown_place', $html);


### PR DESCRIPTION
## 問題
延續 #1054（tile 改 `no-cache`）。實測正式機（`input.cbdb.fas.harvard.edu`）：底圖 mbtiles 已是修正後全淺藍版（prod/local/desktop 三檔 md5 相同）、程式已上 `no-cache`、無 CDN、無 Service Worker——伺服器每個 zoom 都吐淺藍。但使用者在某些 zoom 仍見舊深藍，且 `Ctrl+Shift+R`／清 storage 無效。

## 根因
`no-cache` 只能要求瀏覽器「之後」重新驗證，**無法淘汰使用者已用舊 `max-age=2592000` 快取的舊磚**。`Ctrl+Shift+R` 只 bypass 頁面載入當下的資源；Leaflet 在平移/縮放時才動態抓磚，那些請求又走回正常快取，於是早先快取過的 zoom 直接吃舊深藍磚。

## 修正
tile URL 模板末端加 `?v=<mbtiles mtime>`（與 tile ETag 同源）。底圖更新後 mtime 改變 → URL 改變（全新快取鍵）→ 瀏覽器舊磚快取自動失效，立即取得新磚。一次根治所有使用者的既有舊快取，並涵蓋未來每次底圖更新。

- `_chgis_map_assets.blade.php`：以 `ChgisMapManager` 取 mbtiles mtime 組版本號（`isReady()` false 時為 0）
- `BasicInformationPagesLoadTest`：斷言 `tileUrlTemplate` 帶 `?v=<同源版本>`

## 驗證
- `BasicInformationPagesLoadTest` 30/30 全綠
- route 僅以 path 比對，`?v=` 不影響路由/controller；Leaflet 對 `{z}/{x}/{y}` 後的 query 原樣保留

> 部署後請在正式機 `php artisan view:clear`（blade 已編譯），新頁面才會輸出帶 `?v=` 的模板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)