### PR TITLE
限制 CHGIS 地圖顯示範圍並修正手機版面

### DIFF
--- a/config/chgis_map.php
+++ b/config/chgis_map.php
@@ -30,6 +30,16 @@ return [
         'north' => (float) env('CHGIS_MAP_SANE_NORTH', 55.0),
     ],
 
+    // 地圖顯示範圍（maxBounds）：限制使用者平移／縮放不要露出底圖內容以外的純黑／純白區。
+    // 取自實際彩色內容的外接框（分析 mbtiles 磚像素得 W60.8 S3.1 E150.0 N59.2），
+    // 略加邊距後使用。與點有效性無關（那由 bounds / sane_bounds 把關），僅控制可視範圍。
+    'display_bounds' => [
+        'west' => (float) env('CHGIS_MAP_DISPLAY_WEST', 60.5),
+        'south' => (float) env('CHGIS_MAP_DISPLAY_SOUTH', 3.0),
+        'east' => (float) env('CHGIS_MAP_DISPLAY_EAST', 150.5),
+        'north' => (float) env('CHGIS_MAP_DISPLAY_NORTH', 59.5),
+    ],
+
     // 視為「等於 0」的容差，用於排除 0,0 與單軸為 0 的座標。
     'epsilon' => (float) env('CHGIS_MAP_EPSILON', 1e-7),
 

--- a/docs/CHGIS_MAP_PLACE_LINK.md
+++ b/docs/CHGIS_MAP_PLACE_LINK.md
@@ -282,6 +282,7 @@ Route::get('/basicinformation/{id}/map-points', [ChgisMapController::class, 'per
 - 各 marker `bindPopup` 顯示地名、類型（地址/官職）、年代區間。
 - 多點時提供「縮放至全部」控制（`fitBounds`），但初始以當前點置中（符合需求）。
 - 圖例：區分「當前地點 / 其他地址 / 官職地點」。
+- **顯示範圍限制（maxBounds）**：地圖設 `maxBounds = config('chgis_map.display_bounds')` 且 `maxBoundsViscosity:1.0`，並在 `invalidateSize` 後以 `getBoundsZoom(displayBounds, true)` 把最小 zoom 設成「內容框蓋滿視窗」的值，避免平移／縮太遠露出底圖內容外的純黑／純白。`display_bounds` 取自實際彩色內容外接框（分析磚像素得約 `W60.8 S3.1 E150 N59.2`，加邊距後預設 `W60.5 S3 E150.5 N59.5`），與點有效性無關（後者仍由 `bounds`/`sane_bounds` 把關）。
 
 ### 6.5 底圖未就緒的提示（§4.6）
 - 開 modal → 先查 status。
@@ -294,6 +295,7 @@ Route::get('/basicinformation/{id}/map-points', [ChgisMapController::class, 'per
 - 觸控手勢：Leaflet `tap`/pinch zoom；`dragging` 啟用；避免與頁面捲動衝突（modal 開啟時 body 鎖捲動）。
 - 關閉鈕加大命中區（≥44px）；支援下滑關閉（可選）。
 - marker / popup 字級與點擊區放大。
+- **安全區與排版**：關閉鈕、attribution（資訊欄）、圖例皆以 `env(safe-area-inset-*)` 內推，避開瀏海／圓角螢幕邊緣遮蓋。圖例設 `width:max-content`（避免被 Leaflet 0 寬容器壓成一字一行的直排），並抬到 attribution 之上（多讓約兩行高），避免資訊欄與圖例層疊。
 
 ---
 

--- a/resources/js/chgis-map/app.js
+++ b/resources/js/chgis-map/app.js
@@ -383,6 +383,8 @@ function startMap(token, personId, currentKey, lon, lat) {
     const mapEl = overlayEl.querySelector('.chgis-modal__map');
     const c = cfg();
     const bounds = c.bounds || {};
+    // 顯示範圍（限制平移／縮放，不露出底圖內容外的純黑／純白）；缺設定時退回 tile bounds。
+    const displayLatLng = boundsToLatLng(c.displayBounds || bounds);
 
     cleanupMap();
     mapInstance = L.map(mapEl, {
@@ -390,6 +392,9 @@ function startMap(token, personId, currentKey, lon, lat) {
         attributionControl: true,
         minZoom: c.minZoom || 3,
         maxZoom: 10,
+        // 硬邊界：平移到界即回彈（maxBounds 延到 invalidateSize 後再設，
+        // 避免在 modal 進場、容器尺寸仍為 0 時夾擠出壞狀態導致底圖不顯示）。
+        maxBoundsViscosity: 1.0,
     });
 
     mapInstance.attributionControl.setPrefix(
@@ -401,7 +406,7 @@ function startMap(token, personId, currentKey, lon, lat) {
         maxZoom: 10,
         maxNativeZoom: c.maxZoom || 8,
         noWrap: true,
-        bounds: boundsToLatLng(bounds),
+        bounds: displayLatLng || boundsToLatLng(bounds),
         attribution:
             '<a href="https://chgis.fas.harvard.edu/data/chgis/v6/" target="_blank" rel="noopener noreferrer">CHGIS v6</a>' +
             ' © Harvard &amp; Fudan | Rivers &amp; coastlines: 1820 data |' +
@@ -445,6 +450,20 @@ function invalidateAfterTransition() {
         }
         done = true;
         mapInstance.invalidateSize({ animate: false });
+        // 容器有真實尺寸後才設 maxBounds 與最小 zoom（在 0×0 時設會夾擠出壞狀態、底圖不顯示）。
+        const disp = boundsToLatLng(cfg().displayBounds);
+        if (disp) {
+            const dispBounds = L.latLngBounds(disp);
+            // 最小 zoom = 「內容框剛好蓋滿視窗」的 zoom（inside=true：視窗需完全落在 bounds 內），
+            // 杜絕縮太遠露出內容外的純黑／純白。
+            const fitZoom = mapInstance.getBoundsZoom(dispBounds, true);
+            if (isFinite(fitZoom)) {
+                // 夾在 [設定 minZoom, maxZoom]：避免極小的 display_bounds 把 minZoom 推到超過 maxZoom 而鎖死地圖。
+                const floor = Math.max(cfg().minZoom || 3, fitZoom);
+                mapInstance.setMinZoom(Math.min(mapInstance.getMaxZoom(), floor));
+            }
+            mapInstance.setMaxBounds(dispBounds);
+        }
         modal.removeEventListener('transitionend', onEnd);
     };
     const onEnd = (e) => {
@@ -458,7 +477,7 @@ function invalidateAfterTransition() {
 }
 
 function boundsToLatLng(b) {
-    if (b.south == null) {
+    if (!b || b.south == null) {
         return undefined;
     }
     return [

--- a/resources/js/chgis-map/style.css
+++ b/resources/js/chgis-map/style.css
@@ -368,15 +368,41 @@
         max-height: 100dvh;
         border-radius: 0;
     }
-    /* 圖例：手機放寬上限並允許換行，避免長標籤被擠壓 */
+
+    /* 關閉鈕避開瀏海／圓角螢幕的安全區 */
+    .chgis-modal__close {
+        top: calc(12px + env(safe-area-inset-top));
+        right: calc(12px + env(safe-area-inset-right));
+    }
+
+    /* Attribution（資訊欄）：縮小字級、貼齊底部安全區，固定為畫面最底一條，
+       讓圖例可疊放在它「之上」而非與它層疊。 */
+    .chgis-modal__map .leaflet-control-attribution {
+        margin: 0;
+        max-width: 100%;
+        font-size: 10px;
+        line-height: 1.3;
+        padding: 2px 6px;
+        padding-right: calc(6px + env(safe-area-inset-right));
+        padding-bottom: calc(2px + env(safe-area-inset-bottom));
+        padding-left: calc(6px + env(safe-area-inset-left));
+    }
+
+    /* 圖例：
+       - width:max-content 定寬，杜絕被 Leaflet 0 寬容器壓成「一字一行」直排；
+       - 避開左／下安全區；
+       - 抬到 attribution 之上（多讓 ~34px ≈ 兩行 attribution 高），避免與資訊欄層疊。 */
     .chgis-legend {
         font-size: 11px;
         line-height: 1.4;
         padding: 6px 9px;
-        max-width: 62vw;
+        width: max-content;
+        max-width: calc(100vw - 24px - env(safe-area-inset-left) - env(safe-area-inset-right));
+        left: calc(12px + env(safe-area-inset-left));
+        bottom: calc(12px + env(safe-area-inset-bottom) + 34px);
     }
     .chgis-legend__row {
-        white-space: normal; /* 手機允許標籤換行，縮排對齊由 align-items 處理 */
+        white-space: normal; /* 標籤過長時仍可換行；有 max-content 兜底不會被壓成直排 */
     }
 }
 

--- a/resources/views/biogmains/_chgis_map_assets.blade.php
+++ b/resources/views/biogmains/_chgis_map_assets.blade.php
@@ -29,6 +29,7 @@
             minZoom: {{ (int) config('chgis_map.min_zoom', 3) }},
             maxZoom: {{ (int) config('chgis_map.max_zoom', 8) }},
             bounds: {!! Js::from(config('chgis_map.bounds')) !!},
+            displayBounds: {!! Js::from(config('chgis_map.display_bounds')) !!},
             i18n: {!! Js::from([
                 'modal_title' => __('chgis_map.modal_title'),
                 'current_location' => __('chgis_map.current_location'),


### PR DESCRIPTION
## 目的
解決 CHGIS 地圖兩個問題：
1. 可平移／縮放到底圖內容以外的純黑／純白空白區。
2. 手機版資訊欄（attribution）與圖例的版面問題。

## 變更
- **顯示範圍**：新增 `config/chgis_map.php` 的 `display_bounds`（取自底圖實際彩色內容外接框，約 W60.8 S3.1 E150 N59.2，加邊距後預設 W60.5 S3 E150.5 N59.5），注入前端。地圖設 `maxBounds` + `maxBoundsViscosity:1.0`，並以 `getBoundsZoom(bounds, true)` 自適應最小 zoom，杜絕露出內容外空白。與點有效性無關（仍由 `bounds`/`sane_bounds` 把關）。
- **Regression 修正**：`maxBounds` 延到 `invalidateSize`（容器已有真實尺寸）之後再設，修正在 modal 進場、容器 0×0 時夾擠導致「底圖載入延遲、要等很久才顯示」。
- **手機版面**：`env(safe-area-inset-*)` 避開瀏海／圓角遮蓋；圖例 `width:max-content` 杜絕被 Leaflet 0 寬容器壓成「一字一行」直排；圖例抬到 attribution 之上避免層疊。
- 文件：`docs/CHGIS_MAP_PLACE_LINK.md` 補述。

## 驗證
- `npm run build` 通過。
- Review agents（JS/後端、手機 CSS）與 codex CLI 複審皆「NO SERIOUS ISSUES」。
- 桌機：底圖立即顯示、四周拖曳被擋在內容框內。
- 手機：圖例不再直排／不被邊緣切／不與資訊欄層疊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)