### PR TITLE
新增 ADDRESSES 至全部表格側邊欄

### DIFF
--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -4,6 +4,7 @@ return [
     'codes_home'               => 'Tables Home',
     'addr_belongs_data'        => 'Address Hierarchy Table',
     'addr_codes'               => 'Address Codes',
+    'addresses'                => 'Main Address Table',
     'altname_codes'            => 'Alternative Name Codes',
     'appointment_codes'        => 'Appointment Type Codes',
     'office_codes'             => 'Office Codes',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -4,6 +4,7 @@ return [
     'codes_home'               => '全部表格首頁',
     'addr_belongs_data'        => '地址從屬表',
     'addr_codes'               => '地址編碼表',
+    'addresses'                => '地址主表',
     'altname_codes'            => '別名編碼表',
     'appointment_codes'        => '任命類型編碼表',
     'office_codes'             => '任官編碼表',

--- a/resources/views/layouts/sidebar-v3.blade.php
+++ b/resources/views/layouts/sidebar-v3.blade.php
@@ -67,6 +67,7 @@
                     $codesPages = [
                         'Codes',
                         '全部表格',
+                        'ADDRESSES',
                         'ALTNAME_CODES',
                         'APPOINTMENT_CODES',
                         'TEXT_CODES',
@@ -103,6 +104,12 @@
                             <a href="/codes/ADDR_CODES" class="nav-link {{ in_array($activePage, ['ADDR_CODES'], true) ? 'active' : '' }}">
                                 <i class="nav-icon fas fa-map-marker-alt"></i>
                                 <p>{{ __('codes.addr_codes') }} <small>(ADDR_CODES)</small></p>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="/codes/ADDRESSES" class="nav-link {{ in_array($activePage, ['ADDRESSES'], true) ? 'active' : '' }}">
+                                <i class="nav-icon fas fa-map"></i>
+                                <p>{{ __('codes.addresses') }} <small>(ADDRESSES)</small></p>
                             </a>
                         </li>
                         <li class="nav-item">


### PR DESCRIPTION
## Summary

- 側邊欄「全部表格」依字母排序新增 ADDRESSES 項目（位於 ADDR_CODES 與 ALTNAME_CODES 之間）
- 圖示 `fa-map`，顯示名稱：地址主表 / Main Address Table
- 新增 zh-TW / en 翻譯鍵 `codes.addresses`

## Test plan

- [ ] 登入後確認側邊欄出現「地址主表 (ADDRESSES)」
- [ ] 點擊連結能正常導向 `/codes/ADDRESSES`
- [ ] 切換語言確認英文顯示為「Main Address Table」
- [ ] 確認 ADDRESSES 頁面 active state 正確高亮

🤖 Generated with [Claude Code](https://claude.com/claude-code)