### PR TITLE
fix(security): 升級 guzzlehttp/psr7 至 2.11.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -852,23 +852,25 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -876,8 +878,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -948,7 +951,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -964,7 +967,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",


### PR DESCRIPTION
## 摘要

修補 Dependabot 的 2 個 medium 安全警示（皆為 `guzzlehttp/psr7 < 2.10.2`）：

- **GHSA-hq7v-mx3g-29hw** — CRLF Injection via URI Host Component
- **GHSA-34xg-wgjx-8xph** — Host Confusion via Authority Reinterpretation

## 變更

- `guzzlehttp/psr7` `2.8.0` → `2.11.0`（傳遞依賴，`guzzlehttp/guzzle 7.10.0` 的 `^2.8` 約束相容）。
- 僅 `composer.lock` 變動（+12/−9）；`composer.json` 不需改。

## 驗證

- 全測試套件 **1412 全綠**。
- `composer audit` 已不再報 psr7 advisory。

## 備註

`composer audit` 另揪出 `laravel/framework` CVE-2026-48019（`<12.60.0`，CRLF in default email rule），**不在 Dependabot 清單**，將另起 PR 處理，不在本 PR 範圍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
