### PR TITLE
fix(codes): 修復 /codes 表格搜尋與排序失效（Vue 重新掛載清除監聽器）

### DIFF
--- a/resources/views/codes/index.blade.php
+++ b/resources/views/codes/index.blade.php
@@ -53,7 +53,11 @@
 
 @section('js')
 <script>
-(function () {
+// 必須等 Vue 掛載（app.mount('#app')）後再綁定事件：
+// Vue 會把 #app 內的伺服器渲染節點整批重新建立，掛載前用 addEventListener
+// 綁定的監聽器會隨舊節點被丟棄，導致搜尋／排序失效。onViteReady 的回呼在
+// app.mount('#app') 之後才執行，可確保監聽器綁在最終節點上。
+onViteReady(function () {
     const tbody       = document.getElementById('codes-index-body');
     const searchInput = document.getElementById('table-search');
     const noMatchMsg  = document.getElementById('no-match-msg');
@@ -125,6 +129,6 @@
     searchInput.addEventListener('input', applyFilter);
 
     applyFilter();
-})();
+});
 </script>
 @endsection


### PR DESCRIPTION
## 問題
`/codes` 首頁的「搜尋表格」即時過濾與三態排序皆失效：在搜尋框輸入文字（如 `ASSOC`）列表不會過濾，點表頭也不會排序。

## 根因
`resources/js/app.js` 在 DOM ready 時執行 `createApp({...}).mount('#app')`，而 `#app` 是整頁 wrapper（`layouts/dashboard-v3.blade.php` 的 `<div class="wrapper" id="app">`）。Vue 3 掛載到沒有 `template`/`render` 選項的元素時，會把該元素現有的 `innerHTML` 重新編譯並**重建所有 DOM 節點**，導致掛載前以 `addEventListener` 綁定的監聽器隨舊節點被丟棄。

`/codes` 的內聯腳本以立即執行的 IIFE 在解析時就綁定監聽器，先於 Vue 掛載 → 監聽器被清除 → 搜尋／排序死掉。（jQuery `$(document).on` 委託與內聯 `onclick` 屬性不受影響，所以其他功能正常。）

以真實 Chrome + CDP 驗證：監聽器確實先綁到原始節點，隨後該節點被 Vue 重建移除，當前可見輸入框上 0 個監聽器。

## 修復
將 `resources/views/codes/index.blade.php` 的內聯腳本由 IIFE 改為 `onViteReady(function(){...})`。`onViteReady` 的回呼在 `app.mount('#app')` 之後才觸發（`app.js` 此時才設 `window.viteReady = true` 並 flush callbacks），確保監聽器綁在重建後的最終節點上。一併修好同段腳本的排序功能。

## 驗證
真實瀏覽器 before/after 對比（皆 0 page error）：
- 修復前：輸入 `ASSOC` 仍顯示全部 78 列（未過濾）
- 修復後：輸入 `ASSOC` 正確只剩 4 列（`ASSOC_CODES / ASSOC_CODE_TYPE_REL / ASSOC_DATA / ASSOC_TYPES`）

## 備註（不在本 PR 範圍）
另發現數個頁面有相同隱患（`manage/edit`、`admin/batch_load_book_titles`、`profile/edit` 等直接在 `#app` 內 `addEventListener` 未包 `onViteReady`），將另開分支統一處理並於 `AGENTS.md` 補上前端規範。

🤖 Generated with [Claude Code](https://claude.com/claude-code)