### PR TITLE
fix(views): 修補 #app 內聯腳本因 Vue 重新掛載失效的監聽器

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 - 不要重新引入外部 CDN 的 jQuery、Bootstrap、DataTables。
 - 修改 `resources/js/**` 後，提交前需重新編譯前端。
 - React 列表不要使用 index 當 key；若資料有複合主鍵，請使用穩定 `pk`。
+- 頁面級內聯腳本若要對 `#app` 內的伺服器渲染節點綁定事件（`addEventListener`），必須包在 `onViteReady(function(){ ... })` 內。`app.js` 會在 DOM ready 時 `createApp(...).mount('#app')`，把整個 `#app`（layout 的 `<div class="wrapper" id="app">`）重新編譯並重建所有節點，掛載前直接綁定的監聽器會隨舊節點被丟棄而失效。`onViteReady` 的回呼在 mount 之後才執行，可確保綁在最終節點上。委託到 `document`/`window` 的監聽器與內聯 `onclick` 屬性不受影響。
 
 ### 6. i18n（繁體中文 / 英文切換）
 - 系統預設語言為繁體中文（`zh-TW`），使用者可透過 navbar 切換至英文（`en`）。

--- a/resources/views/admin/batch_load_book_titles.blade.php
+++ b/resources/views/admin/batch_load_book_titles.blade.php
@@ -91,7 +91,8 @@
             @endpush
             @push('scripts')
                 <script>
-                    (function () {
+                    // 監聽器須在 Vue 掛載（app.mount('#app')）後再綁定，否則會隨 #app 內節點重建被清除。
+                    onViteReady(function () {
                         var ta = document.getElementById('entries');
                         var gutter = document.getElementById('entries-line-numbers');
                         if (!ta || !gutter) return;
@@ -110,7 +111,7 @@
                         ta.addEventListener('input', render);
                         ta.addEventListener('scroll', function () { gutter.scrollTop = ta.scrollTop; });
                         render();
-                    })();
+                    });
                 </script>
             @endpush
 

--- a/resources/views/manage/edit.blade.php
+++ b/resources/views/manage/edit.blade.php
@@ -130,6 +130,8 @@
 </div>
 
 <script>
+// 監聽器須在 Vue 掛載（app.mount('#app')）後再綁定，否則會隨 #app 內節點重建被清除。
+onViteReady(function () {
 var _confirmDelete1 = {!! Js::from(__('admin.manage_confirm_delete_1')) !!};
 var _confirmDelete2 = {!! Js::from(__('admin.manage_confirm_delete_2')) !!};
 
@@ -141,7 +143,9 @@ document.getElementById('delete_user').addEventListener('change', function() {
     }
 });
 
-document.querySelector('form').addEventListener('submit', function(e) {
+// 限定為刪除核取方塊所在的編輯表單；document.querySelector('form') 會誤選到
+// 導覽列較前面的 #__locale-form，導致刪除二次確認綁錯表單而失效。
+document.getElementById('delete_user').closest('form').addEventListener('submit', function(e) {
     const deleteCheckbox = document.getElementById('delete_user');
     if (deleteCheckbox.checked) {
         if (!confirm(_confirmDelete2)) {
@@ -149,6 +153,7 @@ document.querySelector('form').addEventListener('submit', function(e) {
             return false;
         }
     }
+});
 });
 </script>
 @endsection


### PR DESCRIPTION
延續 #1065（/codes 搜尋失效）的同類問題清理。

## 根因
`resources/js/app.js` 在 DOM ready 時 `createApp({...}).mount('#app')`，`#app` 是整頁 wrapper。Vue 3 掛載到沒有 template/render 的元素會重新編譯 innerHTML 並**重建所有節點**，掛載前以 `addEventListener` 綁定的監聽器隨舊節點被丟棄。凡是在 `#app` 內以直接 `addEventListener` 綁定且未包 `onViteReady` 的頁面級內聯腳本都會靜默失效。

## 本 PR 修復（範圍：兩個確認會壞的頁面 + 規範）
- **`manage/edit.blade.php`**：
  - 刪除使用者核取方塊的 `change` 守衛、表單 `submit` 二次確認守衛改包在 `onViteReady(...)`。
  - 順帶修正既有選擇器缺陷：`document.querySelector('form')` 會誤選到導覽列較前的 `#__locale-form`（語言切換表單），導致刪除二次確認綁錯表單；改為 `document.getElementById('delete_user').closest('form')` 綁到編輯表單本身。
- **`admin/batch_load_book_titles.blade.php`**：行號欄位（`#entries`）的 IIFE 改為 `onViteReady(...)`，恢復行號同步。
- **`AGENTS.md`**：前端規範新增一條——`#app` 內頁面級內聯腳本綁定事件須包在 `onViteReady` 內。

## 不在本 PR 範圍
另有數個頁面（`profile/edit`、`biogmains` 數個）目前靠 `document` 捕獲委託兜底，未壞但脆弱；待後續單獨遷移。

## 驗證
- 3 輪 review agent（正向／對抗式／複核）+ codex 終端複審，皆無嚴重問題。
- 同類機理已於 #1065 以真實 Chrome + CDP 證實（監聽器先綁原始節點、隨後該節點被 Vue 重建移除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)