### PR TITLE
feat(api): /api/v2/persons 新增 c_created_date 與 c_modified_date（人物層級修改水位線）

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,6 @@
-# API v2（現行版本）
+# API v2
+
+v1 與 v2 並行提供：v1 為舊版端口，v2 為較新端口；兩者目前同時可用。本文件描述 v2。
 
 v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagination` 結構。基底 URL：`https://input.cbdb.fas.harvard.edu/api/v2/...`
 
@@ -8,7 +10,11 @@ v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagin
 
 ### `GET /api/v2/persons`
 
-輸出 BIOG_MAIN 所有人物的 `c_personid`，按主鍵升序，分頁輸出。**不需要登入。**
+輸出 BIOG_MAIN 所有人物的 `c_personid` 與時間資訊，按主鍵升序，分頁輸出。**不需要登入。**
+
+每筆人物附帶兩個時間欄位：
+- `c_created_date`：該人物的建檔時間（取自 BIOG_MAIN）。
+- `c_modified_date`：該人物**任何**資訊（本體 BIOG_MAIN 或其子資源：地址、別名、官職、親屬、事件、社會地位、入仕、著作、財產、社會機構、關係等）最後一次被修改的時間。此為人物聚合層級的水位線，與 BIOG_MAIN 本表的 `c_modified_date`（僅反映本列修改）語意不同。日常由系統即時維護，並可由 `php artisan cbdb:rebuild-person-change-index` 全量校正。
 
 ### 輸入參數
 
@@ -28,8 +34,8 @@ v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagin
 {
   "ok": true,
   "data": [
-    {"c_personid": 1},
-    {"c_personid": 2}
+    {"c_personid": 1, "c_created_date": "2007-05-01 00:00:00", "c_modified_date": "2026-03-12 09:21:00"},
+    {"c_personid": 2, "c_created_date": "2008-01-01 00:00:00", "c_modified_date": null}
   ],
   "pagination": {
     "total": 680000,
@@ -45,8 +51,10 @@ v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagin
 | 屬性名 | 屬性類型 | 說明 |
 | ------ | ------ | ------ |
 | ok | 布林 | 請求是否成功 |
-| data | 陣列 | 人物 ID 列表 |
+| data | 陣列 | 人物列表 |
 | data[i].c_personid | 數字 | 人物 ID |
+| data[i].c_created_date | 字串/null | 人物建檔時間（`YYYY-MM-DD HH:MM:SS`），無則為 null |
+| data[i].c_modified_date | 字串/null | 人物（含所有子資源）最後修改時間；尚未回填時為 null |
 | pagination.total | 數字 | 資料總筆數 |
 | pagination.per_page | 數字 | 每頁筆數 |
 | pagination.current_page | 數字 | 當前頁碼 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 2026-06
 
+### `/api/v2/persons` 新增 c_created_date / c_modified_date（人物層級修改水位線）
+- `/api/v2/persons` 每筆人物新增輸出 `c_created_date`（建檔時間，取自 BIOG_MAIN）與 `c_modified_date`（人物**任何**資訊——本體或子資源——最後修改時間）。
+- `c_modified_date` 為人物聚合層級水位線，存於新 sidecar 表 `person_change_index`，與 BIOG_MAIN 本表 `c_modified_date`（僅本列語意）分離互不污染。
+- 日常由 `AuditLogService::logChange()` 收斂點即時維護（`DB::afterCommit` 交易外 best-effort，失敗由 rebuild 補回）；新增 `php artisan cbdb:rebuild-person-change-index` 供初始全量回填、定期校正、手動刷新（NULL-safe GREATEST upsert、c_personid 範圍分段、named lock、省資源；支援 `--since/--id-from/--id-to/--person/--prune/--chunk/--commit-interval`）。
+- ⚠ **部署注意**：migration 只建表不回填，部署後須**手動執行一次** `php artisan cbdb:rebuild-person-change-index`，否則 `c_modified_date` 全為 null。
+- 為 audit_log 補 `(table_name, occurred_at, id)` 複合索引以支撐 rebuild 的 keyset 掃描。
+- 設計與細節見 [docs/PERSON_CHANGE_INDEX_DESIGN.md](docs/PERSON_CHANGE_INDEX_DESIGN.md)。
+
 ### CHGIS 地圖：Place Name 可點擊連結與浮出地圖
 - `/basicinformation/{id}/addresses` 與 `/offices` 列表頁的 **Place Name**，對「有有效經緯度」的地點渲染為可點擊連結；無效座標（0,0、單軸為 0、超出底圖範圍、經緯反掉等）維持純文字。
 - 點擊浮出以 `chgis_map.mbtiles` 為底圖的 Leaflet 地圖（無邊框、背景變暗模糊、Esc/遮罩/×關閉、手機近全螢幕、`prefers-reduced-motion`），標出該人物所有有效 addresses/offices 地點，當前點置中並以脈動標記突顯。

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ npm install
 ./vendor/bin/phpunit
 npm run build
 php artisan cbdb:fetch-chgis-map
+php artisan cbdb:rebuild-person-change-index   # 部署後須跑一次：回填人物層級修改水位線（否則 /api/v2/persons 的 c_modified_date 全為 null）
 ```
+
+> 部署提醒：`person_change_index`（供 `/api/v2/persons` 的 `c_created_date` / `c_modified_date`）的 migration 只建表不回填。部署到任何環境後須**手動執行一次** `php artisan cbdb:rebuild-person-change-index` 做初始全量回填；之後日常由系統即時維護，並可定期以 `--since` 增量校正。詳見 [docs/PERSON_CHANGE_INDEX_DESIGN.md](docs/PERSON_CHANGE_INDEX_DESIGN.md)。
 
 ### 前端
 - React/Inertia 版 Query Playground 是現行主路徑：`/app/query-playground`

--- a/app/Console/Commands/RebuildPersonChangeIndex.php
+++ b/app/Console/Commands/RebuildPersonChangeIndex.php
@@ -1,0 +1,514 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\PersonChangeIndexService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * 重建 / 刷新 person_change_index（人物層級建檔／最後修改水位線）。
+ *
+ * 設計見 docs/PERSON_CHANGE_INDEX_DESIGN.md。重點：
+ * - 日常增量由 AuditLogService 即時維護；此命令供初始化全量回填、定期校正、手動刷新
+ *   （有些歷史記錄不在 audit_log 裡，必須從來源表完整重算）。
+ * - 無鎖刷新：分批 NULL-safe GREATEST upsert，水位線單調不回退，可與線上流量並行；
+ *   不使用 LOCK TABLES、不開單一巨大交易。
+ * - 低配伺服器省資源：c_personid 範圍分段（不用 OFFSET、不對複合主鍵亂用 chunkById）、
+ *   分段提交、disableQueryLog、gc、named lock 防併發。
+ */
+class RebuildPersonChangeIndex extends Command {
+    protected $signature = 'cbdb:rebuild-person-change-index
+                            {--chunk=2000 : 每段處理的 c_personid 區間寬度（低配機建議偏小）}
+                            {--commit-interval=5000 : 每處理多少筆 c_personid 提交一次並開新交易}
+                            {--since= : 只重算此時間（YYYY-MM-DD HH:MM:SS）後有變更的人物}
+                            {--id-from= : 只重算 c_personid >= 此值}
+                            {--id-to= : 只重算 c_personid <= 此值}
+                            {--person= : 只重算單一 c_personid（除錯）}
+                            {--prune : 額外清除孤兒列（BIOG_MAIN 已不存在的 c_personid）}
+                            {--sleep=0 : 每段提交後 usleep 毫秒，降載讓出 CPU}';
+
+    protected $description = '重建／刷新 person_change_index 人物層級修改水位線';
+
+    /**
+     * 14 張人物相關來源表，全部具 datetime 的 c_created_date / c_modified_date。
+     * 其中 c_personid 可能為 nullable（POSTED_TO_ADDR_DATA / POSTED_TO_OFFICE_DATA /
+     * POSSESSION_DATA），聚合時一律 WHERE c_personid IS NOT NULL。
+     */
+    protected const SOURCE_TABLES = [
+        'ALTNAME_DATA',
+        'ASSOC_DATA',
+        'BIOG_ADDR_DATA',
+        'BIOG_INST_DATA',
+        'BIOG_MAIN',
+        'BIOG_SOURCE_DATA',
+        'BIOG_TEXT_DATA',
+        'ENTRY_DATA',
+        'EVENTS_DATA',
+        'KIN_DATA',
+        'POSSESSION_DATA',
+        'POSTED_TO_ADDR_DATA',
+        'POSTED_TO_OFFICE_DATA',
+        'STATUS_DATA',
+    ];
+
+    /**
+     * audit_log.table_name 可能出現的別名（BIOG_TEXT_DATA 在部分路徑記為 TEXT_DATA）。
+     */
+    protected const AUDIT_SCOPE_TABLES = [
+        'ALTNAME_DATA',
+        'ASSOC_DATA',
+        'BIOG_ADDR_DATA',
+        'BIOG_INST_DATA',
+        'BIOG_MAIN',
+        'BIOG_SOURCE_DATA',
+        'BIOG_TEXT_DATA',
+        'TEXT_DATA',
+        'ENTRY_DATA',
+        'EVENTS_DATA',
+        'KIN_DATA',
+        'POSSESSION_DATA',
+        'POSTED_TO_ADDR_DATA',
+        'POSTED_TO_OFFICE_DATA',
+        'STATUS_DATA',
+    ];
+
+    protected const LOCK_NAME = 'cbdb:rebuild-person-change-index';
+
+    protected PersonChangeIndexService $pci;
+
+    public function handle(PersonChangeIndexService $pci): int {
+        $this->pci = $pci;
+
+        if (!Schema::hasTable('person_change_index')) {
+            $this->error('資料表 person_change_index 不存在，請先執行 migrations。');
+
+            return 1;
+        }
+
+        $chunk = max(1, (int) $this->option('chunk'));
+        $commitInterval = max(1, (int) $this->option('commit-interval'));
+        $since = $this->normalizeSince($this->option('since'));
+        $sleepMs = max(0, (int) $this->option('sleep'));
+        [$idFrom, $idTo] = $this->resolveIdRange();
+
+        if ($idFrom !== null && $idTo !== null && $idFrom > $idTo) {
+            $this->error(sprintf('id 範圍無效：from(%d) > to(%d)', $idFrom, $idTo));
+
+            return 1;
+        }
+
+        // named lock 防併發（advisory，不鎖資料表）；SQLite 測試環境略過。
+        if (is_mysql() && !$this->acquireDbLock()) {
+            $this->error('已有另一個 cbdb:rebuild-person-change-index 正在執行，已拒絕重複啟動。');
+
+            return 1;
+        }
+
+        // 禁用查詢日誌避免記憶體累積。
+        DB::connection()->disableQueryLog();
+
+        $startedAt = microtime(true);
+        $this->info('開始重建 person_change_index...');
+        $this->line(sprintf(
+            '參數：chunk=%d, commit-interval=%d, since=%s, id-from=%s, id-to=%s, prune=%s',
+            $chunk,
+            $commitInterval,
+            $since ?? '（無）',
+            $idFrom ?? '（無）',
+            $idTo ?? '（無）',
+            $this->option('prune') ? 'yes' : 'no'
+        ));
+
+        try {
+            [$rangeLo, $rangeHi] = $this->resolveScanRange($idFrom, $idTo);
+            if ($rangeLo === null || $rangeHi === null) {
+                $this->warn('BIOG_MAIN 沒有可處理的 c_personid，跳過來源表掃描。');
+            } else {
+                foreach (self::SOURCE_TABLES as $table) {
+                    $this->processSourceTable($table, $rangeLo, $rangeHi, $chunk, $commitInterval, $since, $sleepMs);
+                }
+            }
+
+            $this->processAuditLog($since, $idFrom, $idTo, $commitInterval, $sleepMs);
+
+            if ($this->option('prune')) {
+                $this->pruneOrphans($chunk, $idFrom, $idTo);
+            }
+        } catch (Throwable $e) {
+            $this->error('重建失敗：' . $e->getMessage());
+
+            return 1;
+        } finally {
+            if (is_mysql()) {
+                $this->releaseDbLock();
+            }
+        }
+
+        $this->info(sprintf('person_change_index 重建完成，耗時 %.2f 秒。', microtime(true) - $startedAt));
+        $this->line(sprintf('目前列數：%s', number_format((int) DB::table('person_change_index')->count())));
+
+        return 0;
+    }
+
+    /**
+     * 逐來源表：以 c_personid 範圍分段聚合 MAX 日期，NULL-safe GREATEST upsert。
+     * BIOG_MAIN 額外權威覆寫 c_created_date（人物建檔時間）。
+     */
+    protected function processSourceTable(
+        string $table,
+        int $rangeLo,
+        int $rangeHi,
+        int $chunk,
+        int $commitInterval,
+        ?string $since,
+        int $sleepMs
+    ): void {
+        if (!Schema::hasTable($table)
+            || !Schema::hasColumn($table, 'c_personid')
+            || !Schema::hasColumn($table, 'c_modified_date')
+            || !Schema::hasColumn($table, 'c_created_date')) {
+            $this->line(sprintf('  - 跳過 %s（表或日期欄不存在）', $table));
+
+            return;
+        }
+
+        $writeCreated = $table === 'BIOG_MAIN';
+        $processed = 0;
+        $buffer = [];
+
+        // BIOG_MAIN 是 c_created_date 的權威來源（一人一列），即使在 --since 模式也必須全範圍掃描，
+        // 否則「只在子資源/audit 於 since 後變更」的人物，其 c_created_date 不會被權威回填而留下 NULL/舊值。
+        // --since 的省資源優化只套用在量大的子資源表與 audit_log。
+        $applySince = $since !== null && $table !== 'BIOG_MAIN';
+
+        for ($lo = $rangeLo; $lo <= $rangeHi; $lo += $chunk) {
+            $hi = min($lo + $chunk - 1, $rangeHi);
+
+            $query = DB::table($table)
+                ->selectRaw('c_personid, MAX(c_modified_date) AS m, MAX(c_created_date) AS cr')
+                ->whereNotNull('c_personid')
+                ->whereBetween('c_personid', [$lo, $hi]);
+
+            if ($applySince) {
+                $query->where(function ($w) use ($since) {
+                    $w->where('c_modified_date', '>=', $since)
+                        ->orWhere('c_created_date', '>=', $since);
+                });
+            }
+
+            $rows = $query->groupBy('c_personid')->get();
+
+            foreach ($rows as $row) {
+                $buffer[] = [
+                    'c_personid' => (int) $row->c_personid,
+                    'last' => $row->m,
+                    'created' => $writeCreated ? $row->cr : null,
+                ];
+                $processed++;
+
+                if (count($buffer) >= $commitInterval) {
+                    $this->flushBuffer($buffer, $writeCreated, $sleepMs);
+                    $buffer = [];
+                }
+            }
+        }
+
+        if (!empty($buffer)) {
+            $this->flushBuffer($buffer, $writeCreated, $sleepMs);
+        }
+
+        $this->line(sprintf('  - %s：聚合 %s 個 c_personid（記憶體 %s MB）', $table, number_format($processed), $this->memUsageMb()));
+    }
+
+    /**
+     * audit_log 一輪：補「子資源 update 未回寫自身 c_modified_date」缺口及任何不在來源表自身日期欄的變更。
+     * audit_log 無 c_personid 欄（在 row_pk/new_data/old_data 的 JSON 內），須掃描 + 解析。
+     *
+     * 逐 table_name 處理，並以 (occurred_at, id) keyset 分頁——使查詢能完全吃到
+     * (table_name, occurred_at, id) 複合索引（table_name 等值 + occurred_at 範圍 + ORDER BY occurred_at, id），
+     * 避免 filesort/temp；而非用 chunkById('id') 強制按 PK 排序導致索引失效、退化成全表掃描。
+     * occurred_at 為 NOT NULL，搭配唯一遞增的 id 當 tie-breaker，keyset 穩定不漏不重。
+     */
+    protected function processAuditLog(?string $since, ?int $idFrom, ?int $idTo, int $commitInterval, int $sleepMs): void {
+        if (!Schema::hasTable('audit_log')) {
+            $this->line('  - 跳過 audit_log（表不存在）');
+
+            return;
+        }
+
+        $pageSize = 2000;
+        $buffer = [];
+        $processed = 0;
+
+        foreach (self::AUDIT_SCOPE_TABLES as $tableName) {
+            $cursorOccurred = null;
+            $cursorId = null;
+
+            while (true) {
+                $query = DB::table('audit_log')
+                    ->select(['id', 'occurred_at', 'row_pk', 'new_data', 'old_data'])
+                    ->where('table_name', $tableName);
+
+                if ($since !== null) {
+                    $query->where('occurred_at', '>=', $since);
+                }
+
+                if ($cursorOccurred !== null) {
+                    $query->where(function ($w) use ($cursorOccurred, $cursorId) {
+                        $w->where('occurred_at', '>', $cursorOccurred)
+                            ->orWhere(function ($w2) use ($cursorOccurred, $cursorId) {
+                                $w2->where('occurred_at', '=', $cursorOccurred)
+                                    ->where('id', '>', $cursorId);
+                            });
+                    });
+                }
+
+                $logs = $query->orderBy('occurred_at')->orderBy('id')->limit($pageSize)->get();
+                if ($logs->isEmpty()) {
+                    break;
+                }
+
+                foreach ($logs as $log) {
+                    $cursorOccurred = $log->occurred_at;
+                    $cursorId = $log->id;
+
+                    $personId = $this->resolvePersonId($log);
+                    if ($personId === null) {
+                        continue;
+                    }
+                    if ($idFrom !== null && $personId < $idFrom) {
+                        continue;
+                    }
+                    if ($idTo !== null && $personId > $idTo) {
+                        continue;
+                    }
+
+                    // 同一 buffer 內保留較大的 occurred_at；GREATEST upsert 仍會與表內現值合併。
+                    if (!isset($buffer[$personId]) || $log->occurred_at > $buffer[$personId]) {
+                        $buffer[$personId] = $log->occurred_at;
+                    }
+                    $processed++;
+
+                    if (count($buffer) >= $commitInterval) {
+                        $this->flushAuditBuffer($buffer, $sleepMs);
+                        $buffer = [];
+                    }
+                }
+
+                if ($logs->count() < $pageSize) {
+                    break;
+                }
+            }
+        }
+
+        if (!empty($buffer)) {
+            $this->flushAuditBuffer($buffer, $sleepMs);
+        }
+
+        $this->line(sprintf('  - audit_log：掃描 %s 筆相關記錄（記憶體 %s MB）', number_format($processed), $this->memUsageMb()));
+    }
+
+    /**
+     * 從 audit_log 一列解析 c_personid：解碼 JSON 欄位後委派共用服務（row_pk → new_data → old_data）。
+     */
+    protected function resolvePersonId(object $log): ?int {
+        return $this->pci->resolvePersonId(
+            $this->decodeJsonColumn($log->row_pk ?? null),
+            $this->decodeJsonColumn($log->new_data ?? null),
+            $this->decodeJsonColumn($log->old_data ?? null)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function decodeJsonColumn($raw): ?array {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        if (is_array($raw)) {
+            return $raw;
+        }
+        $decoded = json_decode((string) $raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param array<int, array{c_personid:int,last:mixed,created:mixed}> $buffer
+     */
+    protected function flushBuffer(array $buffer, bool $writeCreated, int $sleepMs): void {
+        if (empty($buffer)) {
+            return;
+        }
+
+        $now = now()->format('Y-m-d H:i:s');
+        $rows = [];
+        foreach ($buffer as $item) {
+            $rows[] = [
+                'c_personid' => $item['c_personid'],
+                'c_last_modified_date' => $item['last'],
+                'c_created_date' => $writeCreated ? $item['created'] : null,
+                'updated_at' => $now,
+            ];
+        }
+
+        $this->upsertWatermark($rows, $writeCreated);
+        $this->throttle($sleepMs);
+    }
+
+    /**
+     * @param array<int,string> $buffer  c_personid => occurred_at
+     */
+    protected function flushAuditBuffer(array $buffer, int $sleepMs): void {
+        if (empty($buffer)) {
+            return;
+        }
+
+        $now = now()->format('Y-m-d H:i:s');
+        $rows = [];
+        foreach ($buffer as $personId => $occurredAt) {
+            $rows[] = [
+                'c_personid' => (int) $personId,
+                'c_last_modified_date' => $occurredAt,
+                'c_created_date' => null,
+                'updated_at' => $now,
+            ];
+        }
+
+        $this->upsertWatermark($rows, false);
+        $this->throttle($sleepMs);
+    }
+
+    /**
+     * NULL-safe GREATEST upsert，分子批寫入，包在具死鎖重試的短交易內。
+     *
+     * @param array<int, array<string, mixed>> $rows
+     */
+    protected function upsertWatermark(array $rows, bool $writeCreated): void {
+        // 共用 NULL-safe GREATEST upsert（與即時路徑 AuditLogService 同一份邏輯，集中於 PersonChangeIndexService）。
+        // 每子批包在具死鎖重試的短交易內；不開單一巨大交易、不鎖表。
+        foreach (array_chunk($rows, 500) as $batch) {
+            DB::transaction(function () use ($batch, $writeCreated) {
+                $this->pci->upsert($batch, $writeCreated);
+            }, 3);
+        }
+
+        // 每次 flush 後主動回收，避免低配機上逐段聚合大表時記憶體單調累積。
+        gc_collect_cycles();
+    }
+
+    /**
+     * 清除孤兒列（person_change_index 有、但 BIOG_MAIN 已無的 c_personid），分批避免大刪除。
+     * 套用 --id-from/--id-to 夾擠：分段續跑時只清該段孤兒，避免每段全表掃描。
+     */
+    protected function pruneOrphans(int $chunk, ?int $idFrom, ?int $idTo): void {
+        $deleted = 0;
+        do {
+            $query = DB::table('person_change_index as p')
+                ->leftJoin('BIOG_MAIN as b', 'p.c_personid', '=', 'b.c_personid')
+                ->whereNull('b.c_personid');
+
+            if ($idFrom !== null) {
+                $query->where('p.c_personid', '>=', $idFrom);
+            }
+            if ($idTo !== null) {
+                $query->where('p.c_personid', '<=', $idTo);
+            }
+
+            $ids = $query->limit($chunk)->pluck('p.c_personid')->all();
+
+            if (!empty($ids)) {
+                $deleted += DB::table('person_change_index')->whereIn('c_personid', $ids)->delete();
+            }
+        } while (!empty($ids));
+
+        $this->line(sprintf('  - prune：清除 %s 個孤兒 c_personid', number_format($deleted)));
+    }
+
+    protected function throttle(int $sleepMs): void {
+        if ($sleepMs > 0) {
+            usleep($sleepMs * 1000);
+        }
+    }
+
+    protected function memUsageMb(): string {
+        return number_format(memory_get_usage(true) / 1024 / 1024, 2);
+    }
+
+    protected function normalizeSince(?string $since): ?string {
+        $since = $since ? trim($since) : '';
+        if ($since === '') {
+            return null;
+        }
+
+        try {
+            return \Illuminate\Support\Carbon::parse($since)->format('Y-m-d H:i:s');
+        } catch (Throwable $e) {
+            $this->warn(sprintf('--since 無法解析（%s），忽略此參數。', $since));
+
+            return null;
+        }
+    }
+
+    /**
+     * @return array{0: ?int, 1: ?int}
+     */
+    protected function resolveIdRange(): array {
+        $person = $this->option('person');
+        if ($person !== null && $person !== '') {
+            $pid = (int) $person;
+
+            return [$pid, $pid];
+        }
+
+        $from = $this->option('id-from');
+        $to = $this->option('id-to');
+
+        return [
+            ($from !== null && $from !== '') ? (int) $from : null,
+            ($to !== null && $to !== '') ? (int) $to : null,
+        ];
+    }
+
+    /**
+     * 以 BIOG_MAIN 的 c_personid 範圍為掃描基準，套用 id-from/id-to 夾擠。
+     *
+     * @return array{0: ?int, 1: ?int}
+     */
+    protected function resolveScanRange(?int $idFrom, ?int $idTo): array {
+        $min = DB::table('BIOG_MAIN')->min('c_personid');
+        $max = DB::table('BIOG_MAIN')->max('c_personid');
+
+        if ($min === null || $max === null) {
+            return [null, null];
+        }
+
+        $lo = max((int) $min, $idFrom ?? (int) $min);
+        $hi = min((int) $max, $idTo ?? (int) $max);
+
+        if ($lo > $hi) {
+            return [null, null];
+        }
+
+        return [$lo, $hi];
+    }
+
+    protected function acquireDbLock(): bool {
+        $row = DB::selectOne('SELECT GET_LOCK(?, 0) AS acquired_lock', [self::LOCK_NAME]);
+        $value = is_object($row) ? ($row->acquired_lock ?? null) : null;
+
+        return (int) $value === 1;
+    }
+
+    protected function releaseDbLock(): void {
+        try {
+            DB::selectOne('SELECT RELEASE_LOCK(?)', [self::LOCK_NAME]);
+        } catch (Throwable $e) {
+            // 忽略釋放鎖失敗，避免覆蓋原始錯誤。
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends ConsoleKernel {
         \App\Console\Commands\RebuildIndexYear::class,
         \App\Console\Commands\RebuildIndexAddress::class,
         \App\Console\Commands\FetchChgisMap::class,
+        \App\Console\Commands\RebuildPersonChangeIndex::class,
     ];
 
     /**

--- a/app/Http/Controllers/Api/PersonListController.php
+++ b/app/Http/Controllers/Api/PersonListController.php
@@ -14,8 +14,18 @@ class PersonListController extends Controller {
             $perPage = 100;
         }
 
-        $paginator = BiogMain::select(['c_personid'])
-            ->orderBy('c_personid', 'asc')
+        // c_created_date 取自 BIOG_MAIN（人物建檔時間）；c_modified_date 取自 person_change_index
+        // 的人物層級水位線（c_last_modified_date），別名輸出為 c_modified_date。
+        // 刻意不選 BIOG_MAIN.c_modified_date（本表語意，會與別名衝突）；用 query builder 明確表名 join，
+        // 避免 SQLite/MySQL 表名大小寫差異。person_change_index 一人一列，leftJoin 為 1:1，不影響分頁筆數。
+        $paginator = BiogMain::query()
+            ->leftJoin('person_change_index', 'BIOG_MAIN.c_personid', '=', 'person_change_index.c_personid')
+            ->select([
+                'BIOG_MAIN.c_personid',
+                'BIOG_MAIN.c_created_date',
+                'person_change_index.c_last_modified_date as c_modified_date',
+            ])
+            ->orderBy('BIOG_MAIN.c_personid', 'asc')
             ->paginate($perPage);
 
         return response()->json([

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\BiogMain;
 use App\Observers\BiogMainObserver;
+use App\Services\PersonChangeIndexService;
 use App\Services\QueryProfile;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Pagination\Paginator;
@@ -20,6 +21,12 @@ class AppServiceProvider extends ServiceProvider {
     public function register() {
         $this->app->singleton(QueryProfile::class, function () {
             return new QueryProfile();
+        });
+
+        // person_change_index 水位線寫入服務：singleton 讓 tableExists() 的 schema 檢查
+        // 在單一 request/command 內只做一次（避免每筆 audit 寫入都查 information_schema）。
+        $this->app->singleton(PersonChangeIndexService::class, function () {
+            return new PersonChangeIndexService();
         });
     }
 

--- a/app/Services/AuditLogService.php
+++ b/app/Services/AuditLogService.php
@@ -6,6 +6,7 @@ use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class AuditLogService {
@@ -66,6 +67,27 @@ class AuditLogService {
             'old_data' => $this->encodeJson($oldData),
             'new_data' => $this->encodeJson($newData),
         ]);
+
+        // 單一寫者：每筆人物相關變更更新 person_change_index 水位線。
+        // 此處是所有 direct mutation 與提案核准套用的收斂點，掛這裡即一網打盡。
+        // recordChange 內含 scope 與 person_change_index 存在性守衛，非人物表或表未建時為 no-op。
+        //
+        // 用 afterCommit 把水位線更新延到外層 mutation 交易「提交後」才執行（交易外、獨立語句）：
+        //  - 若 mutation 回滾，callback 不執行（不為未持久化的變更跳水位線，語意正確）；
+        //  - 若水位線 upsert 自身失敗（含死鎖），只影響它自己，**絕不回滾已提交的使用者資料**；
+        //    失敗僅記 Log::warning，缺口由 rebuild 命令（權威來源）補回；
+        //  - 不在交易內時，afterCommit 會立即執行該 callback。
+        $occurredAtString = $occurredAt->format('Y-m-d H:i:s');
+        DB::afterCommit(function () use ($table, $rowPk, $newData, $oldData, $occurredAtString) {
+            try {
+                app(PersonChangeIndexService::class)->recordChange($table, $rowPk, $newData, $oldData, $occurredAtString);
+            } catch (\Throwable $e) {
+                Log::warning('person_change_index 即時更新失敗，將由 rebuild 補回', [
+                    'table' => $table,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        });
     }
 
     public function buildRowPkFromData(string $table, array $data): array {

--- a/app/Services/PersonChangeIndexService.php
+++ b/app/Services/PersonChangeIndexService.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * person_change_index（人物層級修改水位線）的共用寫入邏輯。
+ *
+ * 同時供：
+ * - 即時路徑 AuditLogService::logChange()（每筆 mutation 在 transaction commit 後更新水位線）
+ * - 重建命令 RebuildPersonChangeIndex（全量／增量回填）
+ *
+ * 集中「NULL-safe GREATEST upsert」與「c_personid 反查」這兩段最關鍵、最不能在兩處分歧的邏輯。
+ * 設計見 docs/PERSON_CHANGE_INDEX_DESIGN.md。
+ */
+class PersonChangeIndexService {
+    /**
+     * 人物相關、會貢獻水位線的表（含 audit_log.table_name 可能出現的 BIOG_TEXT_DATA 別名 TEXT_DATA）。
+     */
+    public const PERSON_SCOPED_TABLES = [
+        'ALTNAME_DATA',
+        'ASSOC_DATA',
+        'BIOG_ADDR_DATA',
+        'BIOG_INST_DATA',
+        'BIOG_MAIN',
+        'BIOG_SOURCE_DATA',
+        'BIOG_TEXT_DATA',
+        'TEXT_DATA',
+        'ENTRY_DATA',
+        'EVENTS_DATA',
+        'KIN_DATA',
+        'POSSESSION_DATA',
+        'POSTED_TO_ADDR_DATA',
+        'POSTED_TO_OFFICE_DATA',
+        'STATUS_DATA',
+    ];
+
+    private bool $tableConfirmed = false;
+
+    public function isPersonScopedTable(string $table): bool {
+        return in_array($table, self::PERSON_SCOPED_TABLES, true);
+    }
+
+    /**
+     * person_change_index 是否存在。
+     *
+     * 只快取「true」：一旦確認存在就快取（常駐表不會被刪），單一 request/command 內不再重查 schema。
+     * 不快取「false」：避免長駐程序（Octane/queue worker）若在 migration 前解析過此 singleton，
+     * 把 false 一路 stale 到 worker 重啟導致所有即時更新被誤判為 no-op——table 出現後會自癒。
+     * 也因此不用 static，避免測試間建表/刪表的快取污染。
+     */
+    public function tableExists(): bool {
+        if ($this->tableConfirmed) {
+            return true;
+        }
+
+        if (Schema::hasTable('person_change_index')) {
+            $this->tableConfirmed = true;
+        }
+
+        return $this->tableConfirmed;
+    }
+
+    /**
+     * 即時路徑：由一筆 audit 變更更新該人物水位線（由呼叫端透過 afterCommit 在交易提交後執行）。
+     * 不更新 c_created_date（人物建檔時間由 rebuild 從 BIOG_MAIN 權威覆寫）。
+     */
+    public function recordChange(string $table, ?array $rowPk, ?array $newData, ?array $oldData, string $occurredAt): void {
+        if (!$this->isPersonScopedTable($table) || !$this->tableExists()) {
+            return;
+        }
+
+        $personId = $this->resolvePersonId($rowPk, $newData, $oldData);
+        if ($personId === null) {
+            return;
+        }
+
+        $this->upsert([[
+            'c_personid' => $personId,
+            'c_last_modified_date' => $occurredAt,
+            'c_created_date' => null,
+            'updated_at' => $occurredAt,
+        ]], false);
+    }
+
+    /**
+     * 從變更資料解析 c_personid：依序 row_pk → new_data → old_data（DELETE 走 old_data）。
+     */
+    public function resolvePersonId(?array $rowPk, ?array $newData, ?array $oldData): ?int {
+        foreach ([$rowPk, $newData, $oldData] as $source) {
+            if (is_array($source) && isset($source['c_personid']) && is_numeric($source['c_personid'])) {
+                return (int) $source['c_personid'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * NULL-safe GREATEST upsert（單一 SQL statement）。呼叫端負責分批與交易。
+     *
+     * 兩庫等價語意：任一邊為 NULL → 取另一邊；皆有值 → 取較大；皆 NULL → 維持 NULL。
+     * MySQL/MariaDB scalar GREATEST 與 SQLite scalar max 遇 NULL 都回 NULL，故必須用 IF/CASE 包起來。
+     *
+     * @param array<int, array{c_personid:int,c_last_modified_date:?string,c_created_date:?string,updated_at:string}> $rows
+     */
+    public function upsert(array $rows, bool $writeCreated): void {
+        if (empty($rows) || !$this->tableExists()) {
+            return;
+        }
+
+        $placeholders = [];
+        $bindings = [];
+        foreach ($rows as $row) {
+            $placeholders[] = '(?, ?, ?, ?)';
+            $bindings[] = $row['c_personid'];
+            $bindings[] = $row['c_last_modified_date'];
+            $bindings[] = $row['c_created_date'];
+            $bindings[] = $row['updated_at'];
+        }
+        $values = implode(', ', $placeholders);
+
+        if (is_sqlite()) {
+            $createdClause = $writeCreated ? ', c_created_date = excluded.c_created_date' : '';
+            $sql = "INSERT INTO person_change_index (c_personid, c_last_modified_date, c_created_date, updated_at)
+                    VALUES {$values}
+                    ON CONFLICT(c_personid) DO UPDATE SET
+                        c_last_modified_date = CASE
+                            WHEN excluded.c_last_modified_date IS NULL THEN person_change_index.c_last_modified_date
+                            WHEN person_change_index.c_last_modified_date IS NULL THEN excluded.c_last_modified_date
+                            ELSE max(person_change_index.c_last_modified_date, excluded.c_last_modified_date)
+                        END{$createdClause},
+                        updated_at = excluded.updated_at";
+        } else {
+            // MySQL/MariaDB。MariaDB 10.3 支援 VALUES() 指涉新值。
+            $createdClause = $writeCreated ? ', c_created_date = VALUES(c_created_date)' : '';
+            $sql = "INSERT INTO person_change_index (c_personid, c_last_modified_date, c_created_date, updated_at)
+                    VALUES {$values}
+                    ON DUPLICATE KEY UPDATE
+                        c_last_modified_date = IF(
+                            VALUES(c_last_modified_date) IS NULL,
+                            c_last_modified_date,
+                            IF(
+                                c_last_modified_date IS NULL,
+                                VALUES(c_last_modified_date),
+                                GREATEST(c_last_modified_date, VALUES(c_last_modified_date))
+                            )
+                        ){$createdClause},
+                        updated_at = VALUES(updated_at)";
+        }
+
+        DB::statement($sql, $bindings);
+    }
+}

--- a/database/migrations/2026_06_18_000000_create_person_change_index_table.php
+++ b/database/migrations/2026_06_18_000000_create_person_change_index_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * person_change_index：人物層級「建檔／最後修改」水位線（sidecar 索引表）。
+ *
+ * 設計見 docs/PERSON_CHANGE_INDEX_DESIGN.md。
+ * - 與 BIOG_MAIN 既有的 c_modified_date 語意分離（本表是聚合層級 last-touched，BIOG_MAIN 欄位是本列修改）。
+ * - 只建表、不回填；部署後須手動執行 `php artisan cbdb:rebuild-person-change-index` 做初始全量回填。
+ * - 表名全小寫，與 app 層級表（audit_log、operations）一致。
+ */
+return new class () extends Migration {
+    public function up(): void {
+        // 刻意不做 hasTable 靜默跳過：這是 create migration，若該表已存在（schema drift）
+        // 應明確失敗，而非無聲略過導致欄位／索引與設計不符卻顯示成功。
+        Schema::create('person_change_index', function (Blueprint $table) {
+            column_comment($table->integer('c_personid'), '對應 BIOG_MAIN.c_personid')->primary();
+            column_comment($table->dateTime('c_last_modified_date')->nullable(), '人物層級 last-touched 水位線（跨本體與所有子資源）')->index();
+            column_comment($table->dateTime('c_created_date')->nullable(), '鏡像 BIOG_MAIN.c_created_date，方便排序／同步');
+            column_comment($table->dateTime('updated_at')->nullable(), '本投影列自身的維護時間（除錯用）');
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('person_change_index');
+    }
+};

--- a/database/migrations/2026_06_18_000001_add_index_to_audit_log_table.php
+++ b/database/migrations/2026_06_18_000001_add_index_to_audit_log_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 為 audit_log 補上 (table_name, occurred_at, id) 複合索引。
+ *
+ * person_change_index 的重建命令以「逐 table_name + (occurred_at, id) keyset 分頁」掃描 audit_log
+ * （WHERE table_name = ? [AND occurred_at >= ?] ORDER BY occurred_at, id）。原 audit_log 只有 PK，
+ * 在 MariaDB/MySQL 上會退化成全表掃描 + filesort，與低資源/分批設計衝突。
+ *
+ * 索引含尾欄 id，使 table_name 等值 + occurred_at 範圍 + 「ORDER BY occurred_at, id」keyset
+ * 能完全由索引滿足（避免額外 filesort/temp）。
+ *
+ * 注意：audit_log 沒有 c_personid 欄位（c_personid 在 row_pk/new_data 的 JSON 內），
+ * 「每 person 的 MAX(occurred_at)」仍須掃描 + 解析 JSON，無法靠索引消除；
+ * 本索引的作用是把掃描收斂到「相關表 + 時間窗」並支撐 keyset。詳見 docs/PERSON_CHANGE_INDEX_DESIGN.md。
+ */
+return new class () extends Migration {
+    public function up(): void {
+        // audit_log 由 2026_02_08 migration 必然先建立，這裡不做 hasTable 靜默跳過：
+        // 若該表不存在屬於異常狀態，應 fail-fast 而非掩蓋。
+        Schema::table('audit_log', function (Blueprint $table) {
+            $table->index(['table_name', 'occurred_at', 'id'], 'audit_log_table_name_occurred_at_id_index');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('audit_log', function (Blueprint $table) {
+            $table->dropIndex('audit_log_table_name_occurred_at_id_index');
+        });
+    }
+};

--- a/docs/PERSON_CHANGE_INDEX_DESIGN.md
+++ b/docs/PERSON_CHANGE_INDEX_DESIGN.md
@@ -1,0 +1,232 @@
+# Person Change Index 設計文件
+
+人物層級「建檔／最後修改」水位線,供 `/api/v2/persons` 輸出與下游增量同步使用。
+
+## 背景與需求
+
+下游需要在 `/api/v2/persons` 取得每個人物的:
+
+- `c_created_date`:該人物的建檔時間(BIOG_MAIN 建立時間)。
+- `c_modified_date`:該人物**任何**資訊被修改過的最後時間。「任何資訊」涵蓋人物本體(BIOG_MAIN)與其所有子資源(地址、別名、官職、親屬、事件、社會地位、入仕、著作、財產、社會機構、關係等)。
+
+## 關鍵設計決策
+
+### 1. 語意分離:不污染 BIOG_MAIN 既有的 `c_modified_date`
+
+BIOG_MAIN 既有的 `c_modified_date` 語意是「**BIOG_MAIN 這一列本身**被改」。若把子資源的改動灌進這個欄位,會破壞它的語意,且任何依賴它的稽核/邏輯都會被誤導。
+
+因此「人物聚合層級的 last-touched 水位線」是**獨立概念**,存於獨立的 sidecar 索引表,與 BIOG_MAIN 的欄位互不污染。這同時滿足 DDD 最佳實踐(聚合根在任一組成部分變動時更新自身時間戳)與「不污染既有欄位」的要求。
+
+### 2. 儲存:獨立 sidecar 索引表 `person_change_index`
+
+- **表名小寫** `person_change_index`,與 app 層級表(`audit_log`、`operations`)命名一致;CBDB 原生大寫表(`BIOG_MAIN` 等)是 canonical 資料,這張是衍生/反正規化索引,屬 app 層級。
+- 不動 BIOG_MAIN 的 schema 與語意。
+- `c_last_modified_date` 建索引,順便支援未來 `GET /api/v2/persons?modified_since=...` 的增量同步(下游「想知道誰改過」的真實需求)。
+- 它是投影(projection),可隨時由來源資料重建。
+
+Schema:
+
+```
+person_change_index
+  c_personid            int        PRIMARY KEY      -- 對應 BIOG_MAIN.c_personid
+  c_last_modified_date  datetime   nullable, INDEX  -- 人物層級 last-touched 水位線
+  c_created_date        datetime   nullable         -- 鏡像 BIOG_MAIN.c_created_date,方便排序/同步
+  updated_at            datetime   nullable         -- 本投影列自身的維護時間(除錯用)
+```
+
+> **欄位命名注意(review 修正)**:sidecar 欄位名是 `c_last_modified_date`,**不可命名為 `c_modified_date`**——後者是 BIOG_MAIN 既有欄位,命名衝突會破壞「語意分離」這個核心決策。API **輸出時**才把 `c_last_modified_date` 別名為 `c_modified_date`(見「API 變更」)。
+
+> **`c_created_date` 鏡像同步政策(review 修正,原本未定義)**:`c_created_date` 是 BIOG_MAIN 建檔時間的鏡像。
+> - **rebuild 命令**:每次都以 `c_created_date = BIOG_MAIN.c_created_date` **覆寫**(權威來源,修正任何漂移)。
+> - **即時 upsert(audit_log 路徑)**:僅在 **INSERT(該 person 首次出現)** 時寫入 `c_created_date`;既有列的 `c_created_date` 不在即時路徑更新(人物建檔時間極少變動,且 BIOG_MAIN.c_created_date 一旦改動會由下次 rebuild 校正)。即時 upsert 的 `ON DUPLICATE KEY UPDATE` 子句**只**動 `c_last_modified_date`,不動 `c_created_date`。
+
+相容性:用 Laravel Schema Builder,同時兼容 MariaDB/MySQL 與 SQLite;以 `is_mysql()` / `is_sqlite()` 分支,不寫 SQLite 不支援的語法(`COMMENT` / `ENGINE` / `USING BTREE`)。表名 `person_change_index` 全小寫;與 `BIOG_MAIN`(大寫)join 時一律用 query builder 明確寫出表名(`->join('person_change_index', 'BIOG_MAIN.c_personid', '=', 'person_change_index.c_personid')`),測試 schema 也須以**小寫**建立此表,避免跨 SQLite/MySQL 的表名大小寫差異(見「API 變更」與「風險」)。
+
+### 3. 水位線定義(計算來源)
+
+對每個 `c_personid`,以 **NULL-safe** 的方式取各來源最大值(NULL 視為「無貢獻」而非把結果打成 NULL,見下方警告):
+
+```
+c_created_date       = BIOG_MAIN.c_created_date
+c_last_modified_date = 取下列各值中「非 NULL 的最大者」:
+    MAX(具日期欄來源表的 c_modified_date),
+    MAX(具日期欄來源表的 c_created_date),
+    MAX(audit_log.occurred_at  其 row 可解析到此 c_personid)
+```
+
+- 為何同時納入「來源表自身時間欄」與「audit_log」:
+  - **來源表時間欄**涵蓋歷史 CBDB 匯入資料與所有會寫自身時間戳的路徑。
+  - **audit_log** 涵蓋 2026-02 之後經 mutation 的變更,**特別是目前子資源 update 路徑沒有回寫自身 `c_modified_date` 的缺口**(見「風險」)。
+  - 兩者取「非 NULL 最大值」,使結果對任一缺口都穩健。
+
+> ⚠ **NULL 處理(嚴重)**:**兩個資料庫的多參數 `max`/`GREATEST` 遇 NULL 都會回 NULL**——MySQL/MariaDB `GREATEST(x, NULL) = NULL`;SQLite scalar `max(x, NULL)` 同樣 **= NULL**(已實測 `SELECT max(NULL, '2025-01-01 00:00:00')` 回 NULL,**切勿誤信「SQLite max 忽略 NULL」**——那是「聚合 max(欄位)」的行為,scalar 多參數版不同)。因此**兩庫都**會把水位線打成 NULL,直接裸用 `GREATEST`/`max` 在兩庫皆錯。**所有** upsert(即時與重建)都必須用 NULL-safe 寫法,且不可讓「兩者皆 NULL」以外的情況產生 NULL:
+> - MySQL/MariaDB:`c_last_modified_date = IF(VALUES(c_last_modified_date) IS NULL, c_last_modified_date, IF(c_last_modified_date IS NULL, VALUES(c_last_modified_date), GREATEST(c_last_modified_date, VALUES(c_last_modified_date))))`。
+> - SQLite:`c_last_modified_date = CASE WHEN excluded.c_last_modified_date IS NULL THEN person_change_index.c_last_modified_date WHEN person_change_index.c_last_modified_date IS NULL THEN excluded.c_last_modified_date ELSE max(person_change_index.c_last_modified_date, excluded.c_last_modified_date) END`(`excluded.` 指涉新值)。
+> - 兩庫等價語意:「任一邊為 NULL → 取另一邊;皆有值 → 取較大;皆 NULL → 維持 NULL」。必須補一條跨資料庫測試,斷言含 NULL 中間值時 MySQL 與 SQLite 結果一致,且既有水位線**不被打成 NULL**。
+
+#### 來源表清單(已據實核對 schema:14 張人物相關表**全部**都有 datetime 的 `c_created_date`/`c_modified_date`,皆可走「MAX(自身日期欄)」)
+
+`ALTNAME_DATA, ASSOC_DATA, BIOG_ADDR_DATA, BIOG_INST_DATA, BIOG_MAIN, BIOG_SOURCE_DATA, BIOG_TEXT_DATA, ENTRY_DATA, EVENTS_DATA, KIN_DATA, POSSESSION_DATA, POSTED_TO_ADDR_DATA, POSTED_TO_OFFICE_DATA, STATUS_DATA`
+
+欄位來源拆兩批(都已是 datetime,無 varchar 殘留):
+- **12 張**由 `2025_12_09`/`2025_12_22` 兩支 timestamp migration 從原 varchar `YYYYMMDD` 轉為 datetime:`ALTNAME_DATA, ASSOC_DATA, BIOG_ADDR_DATA, BIOG_INST_DATA, BIOG_MAIN, BIOG_TEXT_DATA, ENTRY_DATA, EVENTS_DATA, KIN_DATA, POSSESSION_DATA, POSTED_TO_OFFICE_DATA, STATUS_DATA`。
+- **2 張**(`BIOG_SOURCE_DATA`、`POSTED_TO_ADDR_DATA`)baseline 原本沒有日期欄,由 `2025_11_14_000000_michael_restructure_plan_schema_updates.php`(:191、:211)**直接以 `datetime` 新增**(故不在 2025_12 轉換清單,但同樣是 datetime)。
+
+> ⚠ 早期 review 曾誤判這 2 張「沒有日期欄、只能靠 audit_log」(只看了 baseline 與 2025_12,漏看 2025_11_14)。**已更正:這 2 張可正常走 MAX(自身日期欄)。** rebuild 對 `POSTED_TO_ADDR_DATA` 聚合時須 `WHERE c_personid IS NOT NULL`(其 c_personid 為 nullable)。即時路徑對這 2 張的 c_personid 反查仍見「單一寫者」規則。
+
+> 子資源類別 → 表名對照(供 Step 0 盤點,避免實作者自由心證;14 張皆有 datetime 日期欄):別名=ALTNAME_DATA;地址=BIOG_ADDR_DATA;官職=POSTED_TO_OFFICE_DATA(+任職地址 POSTED_TO_ADDR_DATA,c_personid nullable);親屬=KIN_DATA;關係=ASSOC_DATA;事件=EVENTS_DATA;社會地位=STATUS_DATA;入仕=ENTRY_DATA;著作/文本=BIOG_TEXT_DATA;史料來源=BIOG_SOURCE_DATA;財產=POSSESSION_DATA;社會機構=BIOG_INST_DATA;人物本體=BIOG_MAIN。
+
+### 4. 維護機制:單一寫者(audit_log 收斂點)+ 可重建命令
+
+- **日常即時更新**:掛在 **`AuditLogService::logChange()`**(`app/Services/AuditLogService.php:38`),由 `table_name` + `row_pk` / `new_data` / `old_data` 解析 `c_personid`,對 `person_change_index` 做 **NULL-safe GREATEST upsert**(語意同「水位線定義」的 NULL 警告)。
+  - **掛載點務必是 `logChange()`,不是 `write()`、也不是任一 handler**(已驗證):`write()` 一律轉呼 `logChange()`;子資源 create/update/delete、BIOG_MAIN 本體 update、**提案核准套用**(direct-workflow 表經 `BiogMainRepository` 各 store/update;其餘表經 `OperationsProposalController::writeAuditLogForApproval()`)最終全部進到 `logChange()`。掛這裡即一網打盡,新增 handler 也不會漏。
+  - ⚠ **即時路徑也必須用 NULL-safe GREATEST,不能用 Laravel `upsert()` 的預設覆寫語意**(review 嚴重修正):否則一筆 `occurred_at` 早於現值的即時 mutation(時鐘漂移、或 occurred_at 取事務開始時間)會把水位線**回退**,「單調不回退」宣稱即破功。重建側與即時側共用**同一份** NULL-safe GREATEST 邏輯(集中於 `app/Services/PersonChangeIndexService.php`,命令與 logChange 皆委派之,避免兩處分歧)。
+  - **交易外隔離:`DB::afterCommit`(review 修正,真正的隔離)**:`logChange()` 用 `DB::afterCommit()` 把水位線更新延到外層 mutation 交易**提交後**才執行(交易外、獨立語句),再包 `try/catch`(失敗僅記 `Log::warning`)。如此:
+    - 若 mutation **回滾**,callback 不執行——不為未持久化的變更跳水位線,語意正確;
+    - 若水位線 upsert **自身失敗(含死鎖)**,只影響它自己,**絕不回滾已提交的使用者資料**(這修掉了「同交易內吞例外救不回已被 DB 回滾的交易」的問題);失敗的缺口由 rebuild 命令(權威來源)補回;
+    - 不在交易內呼叫時,`afterCommit` 會立即執行 callback。
+    - 即時路徑不另做死鎖重試(交易外單句失敗即交給 rebuild 補);命令側才有 `DB::transaction(.., 3)` 重試。
+  - **效能(review 修正)**:`PersonChangeIndexService` 註冊為 **container singleton**(`AppServiceProvider`),`tableExists()` **只快取 true**(常駐表確認存在後不再重查;不快取 false 以免長駐 worker 在 migration 前解析造成 stale-false,table 出現後自癒),避免每筆 audit 寫入都查 `information_schema`(批量核准會線性放大)。
+  - **`c_personid` 反查規則**(review 嚴重修正——以下三表的 `row_pk` 不含 c_personid):
+    - 多數表的 `row_pk` 已含 `c_personid`(`CompositePrimaryKey::SCHEMAS`),直接取用。
+    - **`POSTED_TO_OFFICE_DATA`(PK: c_office_id, c_posting_id)、`POSSESSION_DATA`(PK: c_possession_record_id)、`POSTED_TO_ADDR_DATA`(PK: c_addr_id, c_office_id, c_posting_id)** 的 `row_pk` **不含 c_personid**。解析時依序檢查 `row_pk` → `new_data` → `old_data`,取第一個含 `c_personid` 者(rebuild 命令 `RebuildPersonChangeIndex::resolvePersonId()` 即此序):對這三表 `row_pk` 會落空,改由 `new_data`(CREATE/UPDATE)或 `old_data`(**DELETE**,`new_data` 為 null)的**全列快照**取得 c_personid。因 audit_log 的 old/new_data 是全列快照且這三表都有 c_personid 欄,通常不需要再回查來源表;若三者皆無(理論上罕見)則該筆略過。
+    - `POSTED_TO_ADDR_DATA` 的 `c_personid` 為 nullable,可能為 NULL;落空時記一筆 warning 並略過該筆水位線更新(不可寫入 NULL c_personid)。
+- **完全重建/手動刷新**:獨立 artisan 命令(見下),因為有些歷史記錄不在 audit_log 裡,需要能從來源表完整重算。
+
+## artisan 重建命令
+
+```
+php artisan cbdb:rebuild-person-change-index
+    [--chunk=2000]            # keyset 分頁每批人數(低配機建議偏小)
+    [--commit-interval=5000]  # 每處理多少筆 upsert 提交一次並開新交易
+    [--since=DATETIME]        # 只重算這個時間後有變更的人物(部分刷新)
+    [--id-from=ID] [--id-to=ID]  # 只重算某段 c_personid(可分段/續跑)
+    [--person=ID]             # 只重算單一人物(除錯)
+    [--prune]                 # 額外清除孤兒列(BIOG_MAIN 已不存在的 c_personid)
+```
+
+用途:刷新與完全生成 `person_change_index`;日常增量由 audit_log 即時維護(Step 4),此命令供初始化全量回填、定期校正、手動刷新。
+
+> 「定期校正」由**部署層的 cron**(deployment scheduler)定時呼叫此命令(例如每日離峰 `--since` 增量校正),不在 `app/Console/Kernel.php::schedule()` 寫死頻率——頻率屬部署/ops 決策,且本專案 `schedule()` 慣例留空。注意:`--since` cron **只能校正 since 之後的漂移**,不能取代「部署後初次全量回填」,也不能取代偶發的「全量校正 / `--prune` 清孤兒」;建議排程仍保留週期性的全量(無 `--since`)校正。
+
+> **audit_log 一輪的查詢形狀(實作對齊索引)**:rebuild 的 audit_log 一輪**逐 `table_name`** 處理,並以 `(occurred_at, id)` keyset 分頁(`WHERE table_name = ? [AND occurred_at >= ?] ORDER BY occurred_at, id`)。索引為 **`(table_name, occurred_at, id)`** 三欄(migration `2026_06_18_000001`),使 table_name 等值 + occurred_at 範圍 + `ORDER BY occurred_at, id` 完全由索引滿足、避免 filesort/temp;**不可用 `chunkById('id')`**——按 PK `id` 排序會使該索引失效、退化成全表掃描。occurred_at 為 NOT NULL,id 為唯一遞增 tie-breaker,keyset 穩定不漏不重。(此查詢形狀討論主要針對 MariaDB 10.3;SQLite 僅測試路徑。)
+
+### 無鎖刷新策略(預設:分批 GREATEST upsert)
+
+手動刷新時資料可能同時被改,**不鎖表**的最佳做法是讓水位線**單調不回退**:
+
+- 逐來源表分批計算各 person 的 `MAX(c_modified_date/c_created_date)`,以 **NULL-safe GREATEST upsert** 進 `person_change_index`(MySQL/MariaDB 用 `IF(...)`、SQLite 用 `CASE WHEN ... END`,完整寫法見「水位線定義」的 NULL 警告;**切勿在 SQLite 裸用 `max(a, b)`——任一為 NULL 即回 NULL**)。
+- 每批一個**短交易**;**不使用 `LOCK TABLES`、不開單一巨大交易**。
+- **死鎖重試(review 補強)**:分批 upsert 在 MariaDB InnoDB(RR 隔離級)下,INSERT…ON DUPLICATE 對二級索引 `c_last_modified_date` 可能取 next-key/gap lock,與線上並發寫入偶發死鎖。每批包在具 deadlock retry 的 transaction(Laravel `DB::transaction($cb, $attempts)` 或捕捉 SQLSTATE 1213 重跑該批),避免低配機高並發下整批失敗。
+- 因為兩側都是 **NULL-safe GREATEST** 合併(且合併時 DB 在該列鎖內讀「當下表內現值」而非命令啟動時的快照):即使某 person 在本命令讀取其來源快照「之後」又被即時 mutation 改新,`GREATEST(線上新值, 重建舊值) = 線上新值`(此處 GREATEST 一律指上述 NULL-safe 變體),**即時更新不會被舊快照覆蓋**;反之亦然。命令與線上流量可並行。
+- 命令本身可重入/可續跑(idempotent),中斷後重跑結果一致。
+
+> 為何不用「影子表 + RENAME swap」當預設:swap 會把「重建視窗內落在舊表的即時更新」用舊快照蓋掉,需額外 catch-up(重放 `occurred_at >= 重建起點` 的 audit_log)才能補回,複雜且有時間窗風險。GREATEST upsert 天生免疫此問題。影子表 swap 僅在需要一次性清除大量孤兒列時才有優勢,改以 `--prune` 選項覆蓋該需求(upsert 全量後,`DELETE FROM person_change_index WHERE c_personid NOT IN (SELECT c_personid FROM BIOG_MAIN)`,同樣分批)。
+
+### 低配伺服器的資源節約(CPU / 記憶體都小)
+
+本機 CPU 與記憶體都偏低,重建命令**必須**沿用專案既有命令的省資源慣例(參考 `app/Console/Commands/RebuildNameSearchIndex.php` 與 `RebuildIndexYear.php`):
+
+- **以 `c_personid` 範圍分段為預設(不要 OFFSET、不要對複合主鍵亂用 chunkById)**:多數來源表是**複合主鍵**,**沒有單一遞增欄可供 `chunkById` keyset**;且 `c_personid` 在子資源表非唯一、部分可為 NULL,`chunkById('c_personid')` 會在 chunk 邊界**漏行或重複**。證據:`CompositePrimaryKey::SCHEMAS` 與 baseline schema(`2025_01_01_000000_import_cbdb_schema.php`)——例如 `POSTED_TO_OFFICE_DATA` PK=`(c_office_id, c_posting_id)`、`POSTED_TO_ADDR_DATA` PK=`(c_addr_id, c_office_id, c_posting_id)`(其 `c_personid` 還 nullable)、`POSSESSION_DATA` 才是單鍵 `c_possession_record_id`。因此統一做法:
+  - 對每張來源表 `SELECT c_personid, MAX(c_modified_date), MAX(c_created_date) ... WHERE c_personid BETWEEN ? AND ? GROUP BY c_personid`,以 **`c_personid` 範圍**(每段 `--chunk` 個 id)逐段推進(`c_personid` 在各表皆有索引)。`--id-from/--id-to` 直接作用在此範圍。
+  - 僅對**確實有單一主鍵**的表(BIOG_MAIN 的 `c_personid`、POSSESSION_DATA 的 `c_possession_record_id`)才可選用 `chunkById(<該單一主鍵>)`;但為一致與省心,**預設一律用 c_personid 範圍分段**。
+  - 大表(KIN_DATA、ASSOC_DATA 動輒百萬列)避免「整表一次 GROUP BY」造成 DB 端大臨時表/檔案排序的 CPU/記憶體峰值——用範圍分段把單次聚合規模壓在一個 `--chunk` 內。
+- **分批 upsert + 分段提交**:每累積 `--commit-interval`(**以「已處理的 c_personid 筆數」為單位**)就 `commit` 並重開交易。**不開單一巨大交易、不用 `LOCK TABLES`**(同 RebuildIndexYear「逐條規則各自提交,避免單一大 transaction 鎖表」)。
+- **關閉查詢日誌**:迴圈前 `DB::connection()->disableQueryLog()`,避免 query log 累積吃光記憶體。
+- **主動回收**:每段提交後 `gc_collect_cycles()`;`array_push($buf, ...$rows)` 取代 `array_merge` 以免複製;快取單一 `$timestamp = now()` 不在迴圈內重建物件。
+- **逐來源表累進**:14 張來源表**一張一張**處理(每張依上法聚合後 NULL-safe GREATEST upsert 進 `person_change_index`),不把多表 join 成巨大查詢——降低單次查詢峰值,每張處理完即釋放。另對 audit_log 也做一輪(涵蓋「子資源 update 未回寫自身 `c_modified_date`」這個既有缺口)。
+- **audit_log 一輪的成本與索引**:audit_log **沒有 `c_personid` 欄位**(它在 `row_pk`/`new_data` 的 JSON 內),所以「每 person 的 `MAX(occurred_at)`」**無法靠索引消除**,必須掃描 + 解析 JSON。為把掃描收斂到「相關表 + 時間窗」並支撐 keyset,已補 `audit_log (table_name, occurred_at, id)` 三欄複合索引(migration `2026_06_18_000001`):rebuild 的 audit_log 一輪**逐 `table_name`** 以 `WHERE table_name = ? [AND occurred_at >= ?] ORDER BY occurred_at, id` keyset 分頁,完全走此索引(避免 filesort),再在 PHP 端解析 JSON 取 c_personid 聚合;`--since` 也靠此時間窗。**注意:`?modified_since=` API 增量同步查的是 `person_change_index.c_last_modified_date` 索引,不掃 audit_log。**
+- **防併發**:用 MySQL named lock `GET_LOCK('cbdb:rebuild-person-change-index', 0)` / `RELEASE_LOCK`(同 RebuildIndexYear),避免兩個重建同時跑互相加壓;取不到鎖直接退出。
+- **進度與可觀測**:progress bar + 每段印出 `memory_get_usage(true)`,低配機上便於即時發現記憶體異常。
+- **可選降載**:提供 `--sleep=ms`(每段提交後 `usleep`)讓出 CPU,避免重建期間影響線上請求(視實測需要再加)。
+- **SQLite(測試)分支**:`INSERT ... ON CONFLICT(c_personid) DO UPDATE SET c_last_modified_date = <NULL-safe CASE>`(CASE 寫法見「水位線定義」NULL 警告,**不可裸用 `max(a,b)`**);測試資料量小,不需 named lock。
+
+## API 變更
+
+- `app/Http/Controllers/Api/PersonListController.php@index`(現況只有 `BiogMain::select(['c_personid'])->orderBy(...)->paginate()`,**無 c_created_date、無 join**,故這是新增輸出而非微調):
+  - select 明確列出欄位:`BIOG_MAIN.c_personid`、`BIOG_MAIN.c_created_date`(輸出為 `c_created_date`)、`person_change_index.c_last_modified_date as c_modified_date`。
+  - ⚠ **別名衝突(review 修正)**:BIOG_MAIN 本身也有 `c_modified_date` 欄位;**select 不可用 `*` 或一併帶出 `BIOG_MAIN.c_modified_date`**,否則與 sidecar 別名的 `c_modified_date` 衝突。只輸出 sidecar 來的那個。
+  - 用 query builder 明確 join,表名大小寫照寫:`->leftJoin('person_change_index', 'BIOG_MAIN.c_personid', '=', 'person_change_index.c_personid')`(避免 SQLite/MySQL 表名大小寫差異)。
+  - 對沒有 sidecar 列的人物,`c_modified_date` 會是 NULL(部署後須先跑一次 rebuild,見「文件變更/部署」)。
+  - 單次 indexed left join,效能可控;讀取端零跨表彙整。
+- (可選,建議一併評估)新增 `?modified_since=` 增量同步參數,利用 `c_last_modified_date` 索引。
+- 輸出範例:
+  ```json
+  { "c_personid": 10, "c_created_date": "2007-05-01 00:00:00", "c_modified_date": "2026-03-12 09:21:00" }
+  ```
+
+## 文件變更
+
+- `API.md`:
+  - 標題 `# API v2（現行版本）` → `# API v2`(v1 / v2 並行,移除「現行版本」字樣;視需要補一句 v1/v2 並行說明)。
+  - `GET /api/v2/persons` 輸出補上 `c_created_date` / `c_modified_date` 欄位說明(若做了 `modified_since` 一併寫)。
+- `CHANGELOG.md`:記錄本次新增。
+- 本設計文件 `docs/PERSON_CHANGE_INDEX_DESIGN.md`。
+- ⚠ **部署註記(review 嚴重修正)**:migration **只建表不回填**。部署到任何環境(staging/prod)後**必須手動執行一次** `php artisan cbdb:rebuild-person-change-index` 做初始全量回填,否則 `person_change_index` 全空、API 的 `c_modified_date` 全為 NULL。此步要寫進 README/部署清單與 CHANGELOG。
+
+## 測試計畫
+
+- `tests/Feature/ApiV2PersonListTest.php`:in-memory SQLite schema 補上 BIOG_MAIN 的 `c_created_date` 欄位與**小寫** `person_change_index` 表,驗證輸出含 `c_created_date` / `c_modified_date` 兩欄,且 `c_modified_date` 來自 sidecar(非 BIOG_MAIN 同名欄)。
+- 新增回歸測試:
+  - BIOG_MAIN update / 子資源 create / update / delete 後,該 person 的 `c_last_modified_date` 正確前進。
+  - **非 c_personid 主鍵表的 delete**(如 ASSOC_DATA、POSTED_TO_OFFICE_DATA、POSSESSION_DATA)後水位線仍前進——驗證 DELETE 時從 `old_data` 反查 c_personid 的路徑。
+  - **提案核准套用後**水位線也前進(非提交提案時)。註:proposal **delete** 的核准目前未實作(回 501),此案僅測 create/update 提案核准。
+  - **單調不回退(雙向)**:① 較舊的重建批次不蓋較新的即時值;② `occurred_at` 早於現值的即時 mutation 不使水位線回退(防線上路徑誤用覆寫語意)。
+  - **NULL-safe 跨庫一致**:含 NULL 中間值時,MySQL 與 SQLite 的 upsert 結果一致,且不把已有水位線打成 NULL。
+  - rebuild 命令:全量、`--since`、`--id-from/--id-to`(分段續跑)、`--person`、`--prune` 各模式;重入一致性。
+
+## 風險與注意事項
+
+1. **audit_log 覆蓋面(已於 review 驗證 ✓)**:子資源 create/update/delete、BIOG_MAIN 本體 update、提案核准套用(direct-workflow 經 `BiogMainRepository`;其餘經 `OperationsProposalController::writeAuditLogForApproval()`)最終都進 `AuditLogService::write()`→`logChange()`。掛載點固定在 `logChange()` 即全覆蓋。proposal delete 核准目前未實作(501),非繞過路徑。
+2. **NULL 處理(嚴重,已於設計修正)**:**兩庫的多參數 `GREATEST`/scalar `max` 遇 NULL 都回 NULL**(SQLite scalar `max(x,NULL)` 也回 NULL,只有聚合 `max(欄位)` 才忽略 NULL)。所有 upsert 必須 NULL-safe(MySQL 用 `IF`、SQLite 用 `CASE`),並補跨庫一致性測試。見「水位線定義」NULL 警告。
+3. **`c_personid` 反查(嚴重,已於設計修正)**:`POSTED_TO_OFFICE_DATA`、`POSSESSION_DATA`、`POSTED_TO_ADDR_DATA` 的 `row_pk` **不含 c_personid**,須從 `new_data`/`old_data` 取(DELETE 走 `old_data`),`POSTED_TO_ADDR_DATA` 的 c_personid 可能為 NULL 須略過。見「單一寫者」反查規則。
+4. **來源表日期欄(已據 schema 核實)**:14 張人物相關表**全部**都有 datetime 的 `c_created_date`/`c_modified_date`(12 張由 2025_12 轉換、`BIOG_SOURCE_DATA`/`POSTED_TO_ADDR_DATA` 由 `2025_11_14` 直接新增為 datetime),皆可走 MAX(自身日期欄);`POSTED_TO_ADDR_DATA` 聚合時須 `WHERE c_personid IS NOT NULL`。見「來源表清單」。
+5. **線上路徑必須 GREATEST(嚴重,已於設計修正)**:即時 upsert 不可用覆寫語意,否則單調性破功。
+6. **部署回填(嚴重,已於設計修正)**:部署後須手動跑一次 rebuild,否則 API 全 NULL。見「文件變更/部署註記」。
+7. **`c_created_date` 鏡像同步(已於設計修正)**:rebuild 覆寫、即時僅 INSERT 時寫。見 Schema 區塊政策。
+8. **子資源 update 不回寫自身 `c_modified_date` 的既有缺口**:故重建公式必須同時納入 audit_log.occurred_at;此缺口是否一併修復,列為可選項(不阻擋本需求)。
+9. **時區**:寫入用 `Carbon::now()`;留意 `DB_TIMEZONE` 與 `APP_TIMEZONE` 對齊(數字偏移如 `+08:00`),參見 `ToolsRepository` 註解。
+10. **相容性**:migration、upsert、join 同時兼容 MariaDB/MySQL 與 SQLite;語法依驅動分支;表名大小寫用 query builder 明確處理。
+11. **死鎖**:分批 upsert 需 deadlock retry。見「無鎖刷新策略」。
+12. BIOG_MAIN 既有 `c_modified_date` / `BiogMainMutationHandler::BLOCKED_FIELDS` 機制**不動**。
+
+## 每環節品質閘門(review gate)
+
+本計畫採「小環節推進」。**每完成一個小環節,必須通過兩道 review 閘門才能推進下一個環節**:
+
+### 第一道:review agent(讀代碼 + 讀修改)
+
+派出一組 review agent,讀本環節改動的程式碼與 `git diff`,檢查:正確性 bug、MariaDB/SQLite 相容性、效能與記憶體(低配機)、是否鎖表、語意污染(勿動 BIOG_MAIN 既有 `c_modified_date`)、GREATEST 單調性、`c_personid` 反查正確性、測試是否覆蓋。
+
+**反覆修正,直到 review agent 回報「無嚴重 issues」為止。**
+
+### 第二道:codex 終端命令(非我方 agent)
+
+第一道通過後,呼叫 `codex` CLI(終端命令)再做一次獨立 review。Windows PowerShell 呼叫方式:
+
+```powershell
+# 1. 讓 Node.js 走代理(Windows Registry 的代理設定 Node.js 不讀,必須顯式設環境變數)
+$env:HTTPS_PROXY = "http://127.0.0.1:7890"; $env:HTTP_PROXY = "http://127.0.0.1:7890"
+
+# 2. 用 Write-Output 以管道傳 prompt(繞過 stdin 等待;否則 codex exec 會卡在等手動輸入)
+# 3. codex exec --dangerously-bypass-approvals-and-sandbox:非交互模式 + 跳過沙盒審批
+Write-Output "請 review 本環節的改動(git diff 與相關檔案),聚焦嚴重問題:正確性 bug、MariaDB/SQLite 相容性、效能/記憶體、鎖表風險、語意污染、測試缺口。只回報嚴重 issues。" | codex exec --dangerously-bypass-approvals-and-sandbox
+```
+
+**依 codex 回報修正,反覆執行直到無嚴重 issues,才推進下一個小環節。**
+
+> 兩道閘門順序固定:先 review agent 收斂,再 codex 收斂。任何一道發現嚴重 issue 都回到修正,不可跳關。
+
+## 實作步驟(供 goal 執行)
+
+> 下列每個 step 視為一個「小環節」,完成後都要走一遍上方「每環節品質閘門」(review agent → codex,各自到無嚴重 issues)再推進下一個 step。
+
+0. **先建立分支**做這件事(例如 `feature/person-change-index`),勿直接在 `develop` 上開發。
+1. **前提驗證**(多數已於本文件 review 階段完成,結論見「風險」1–8):實作前再快速複核「14 張來源表的 datetime 日期欄」與「三張無 c_personid 主鍵表的反查來源(含 DELETE old_data)」在當前 schema 仍成立。
+2. **migration**:建立**小寫** `person_change_index`(schema 如上),`c_last_modified_date` 建索引;兼容雙資料庫;**只建表不回填**。
+3. **artisan 命令** `cbdb:rebuild-person-change-index`:NULL-safe GREATEST upsert + 死鎖重試 + 省資源慣例 + `--chunk/--commit-interval/--since/--id-from/--id-to/--person/--prune`。先用它做初始全量回填。
+4. **單一寫者**:在 `AuditLogService::logChange()` 加入 `c_personid` 解析(含三張特殊表與 DELETE old_data)+ **NULL-safe GREATEST** upsert person_change_index(嚴禁覆寫語意)。
+5. **API**:`PersonListController@index` 明確 select + leftJoin 輸出 `c_created_date` / `c_modified_date`(避免 BIOG_MAIN.c_modified_date 同名衝突;評估 `?modified_since=`)。
+6. **測試**:依「測試計畫」補齊(含雙向單調性、NULL 跨庫一致、非 c_personid 主鍵 delete、`--id-from/--id-to`);跑 `./vendor/bin/phpunit --filter ApiV2PersonList` 及相關 mutation 測試。
+7. **文件**:更新 `API.md`(移除「現行版本」)、`CHANGELOG.md`(含部署後須跑 rebuild 的提醒)、README 部署清單。
+8. **提交前**:`./vendor/bin/php-cs-fixer fix`;`git diff` 核對;commit message 用繁體中文。

--- a/tests/Feature/ApiV2PersonListTest.php
+++ b/tests/Feature/ApiV2PersonListTest.php
@@ -21,10 +21,22 @@ class ApiV2PersonListTest extends TestCase {
             $table->integer('c_personid')->primary();
             $table->string('c_name_chn')->nullable();
             $table->string('c_name')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            // BIOG_MAIN 本表也有 c_modified_date（本列語意）；用來驗證 API 不會誤輸出它，
+            // 而是輸出 person_change_index 的人物層級水位線。
+            $table->dateTime('c_modified_date')->nullable();
+        });
+
+        Schema::create('person_change_index', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->dateTime('c_last_modified_date')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->dateTime('updated_at')->nullable();
         });
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('person_change_index');
         Schema::dropIfExists('BIOG_MAIN');
         parent::tearDown();
     }
@@ -133,5 +145,55 @@ class ApiV2PersonListTest extends TestCase {
         $response = $this->getJson('/api/v2/persons');
 
         $response->assertOk()->assertJson(['ok' => true]);
+    }
+
+    public function test_outputs_created_date_and_modified_date_from_sidecar(): void {
+        DB::table('BIOG_MAIN')->insert([
+            [
+                'c_personid' => 10,
+                'c_name_chn' => '甲',
+                'c_name' => 'A',
+                'c_created_date' => '2007-01-01 00:00:00',
+                'c_modified_date' => '2010-01-01 00:00:00', // BIOG_MAIN 本表語意，不應被輸出
+            ],
+        ]);
+        DB::table('person_change_index')->insert([
+            [
+                'c_personid' => 10,
+                'c_last_modified_date' => '2026-03-12 09:21:00',
+                'c_created_date' => '2007-01-01 00:00:00',
+                'updated_at' => '2026-03-12 09:21:00',
+            ],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons');
+        $response->assertOk();
+
+        $row = $response->json('data.0');
+        $this->assertSame(10, $row['c_personid']);
+        // c_created_date 來自 BIOG_MAIN
+        $this->assertSame('2007-01-01 00:00:00', $row['c_created_date']);
+        // c_modified_date 來自 person_change_index 水位線，而非 BIOG_MAIN.c_modified_date(2010)
+        $this->assertSame('2026-03-12 09:21:00', $row['c_modified_date']);
+    }
+
+    public function test_modified_date_is_null_when_no_sidecar_row(): void {
+        DB::table('BIOG_MAIN')->insert([
+            [
+                'c_personid' => 5,
+                'c_name_chn' => '甲',
+                'c_name' => 'A',
+                'c_created_date' => '2007-01-01 00:00:00',
+                'c_modified_date' => '2010-01-01 00:00:00',
+            ],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons');
+        $response->assertOk();
+
+        $row = $response->json('data.0');
+        $this->assertSame('2007-01-01 00:00:00', $row['c_created_date']);
+        $this->assertArrayHasKey('c_modified_date', $row);
+        $this->assertNull($row['c_modified_date']);
     }
 }

--- a/tests/Feature/PersonChangeIndexLiveUpdateTest.php
+++ b/tests/Feature/PersonChangeIndexLiveUpdateTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\AuditLogService;
+use App\Services\PersonChangeIndexService;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * 即時路徑（AuditLogService::logChange → PersonChangeIndexService::recordChange）回歸測試。
+ * 覆蓋：即時更新、單調不回退、DELETE 從 old_data 反查、非人物表忽略、表缺守衛不拋錯。
+ */
+class PersonChangeIndexLiveUpdateTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+
+        Schema::create('person_change_index', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->dateTime('c_last_modified_date')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->dateTime('updated_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('person_change_index');
+        Schema::dropIfExists('audit_log');
+        parent::tearDown();
+    }
+
+    private function write(string $table, string $op, array $rowPk, ?array $old, ?array $new, string $occurredAt): void {
+        (new AuditLogService())->write($table, $op, $rowPk, $old, $new, 'user', '1', null, Carbon::parse($occurredAt));
+    }
+
+    public function test_live_update_bumps_watermark_and_is_monotonic(): void {
+        $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 7], null, ['c_personid' => 7], '2026-05-05 08:00:00');
+        $this->assertSame(
+            '2026-05-05 08:00:00',
+            DB::table('person_change_index')->where('c_personid', 7)->value('c_last_modified_date')
+        );
+
+        // 較早的 out-of-order 事件不得使水位線回退
+        $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 7], null, ['c_personid' => 7], '2020-01-01 00:00:00');
+        $this->assertSame(
+            '2026-05-05 08:00:00',
+            DB::table('person_change_index')->where('c_personid', 7)->value('c_last_modified_date')
+        );
+
+        // 較新的事件前進
+        $this->write('KIN_DATA', 'UPDATE', ['c_personid' => 7, 'c_kin_id' => 1, 'c_kin_code' => 1], null, ['c_personid' => 7], '2027-07-07 00:00:00');
+        $this->assertSame(
+            '2027-07-07 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 7)->value('c_last_modified_date')
+        );
+
+        // 即時路徑不寫 c_created_date（待 rebuild 從 BIOG_MAIN 回填）
+        $this->assertNull(DB::table('person_change_index')->where('c_personid', 7)->value('c_created_date'));
+    }
+
+    public function test_delete_on_non_personid_pk_table_resolves_from_old_data(): void {
+        // POSTED_TO_OFFICE_DATA 的 row_pk 不含 c_personid；DELETE 時 new_data 為 null，須從 old_data 解析
+        $this->write(
+            'POSTED_TO_OFFICE_DATA',
+            'DELETE',
+            ['c_office_id' => 9, 'c_posting_id' => 9],
+            ['c_personid' => 8, 'c_office_id' => 9],
+            null,
+            '2026-06-06 00:00:00'
+        );
+
+        $this->assertSame(
+            '2026-06-06 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 8)->value('c_last_modified_date')
+        );
+    }
+
+    public function test_non_person_table_does_not_touch_index(): void {
+        $this->write('SOME_CODE_TABLE', 'UPDATE', ['code' => 1], null, ['code' => 1], '2099-01-01 00:00:00');
+
+        $this->assertSame(0, DB::table('person_change_index')->count());
+        // 但 audit_log 仍寫入
+        $this->assertSame(1, DB::table('audit_log')->where('table_name', 'SOME_CODE_TABLE')->count());
+    }
+
+    public function test_watermark_updates_after_transaction_commits(): void {
+        DB::transaction(function () {
+            $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 11], null, ['c_personid' => 11], '2026-08-08 00:00:00');
+            // 交易尚未提交，afterCommit 尚未執行，此時水位線應仍未寫入
+            $this->assertSame(0, DB::table('person_change_index')->where('c_personid', 11)->count());
+        });
+
+        // 交易提交後，afterCommit 觸發水位線更新
+        $this->assertSame(
+            '2026-08-08 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 11)->value('c_last_modified_date')
+        );
+    }
+
+    public function test_watermark_not_updated_when_transaction_rolls_back(): void {
+        try {
+            DB::transaction(function () {
+                $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 12], null, ['c_personid' => 12], '2026-09-09 00:00:00');
+
+                throw new \RuntimeException('force rollback');
+            });
+        } catch (\RuntimeException $e) {
+            // 預期
+        }
+
+        // 交易回滾：水位線不應為「未持久化的變更」跳動
+        $this->assertSame(0, DB::table('person_change_index')->where('c_personid', 12)->count());
+    }
+
+    public function test_missing_index_table_does_not_break_audit_write(): void {
+        Schema::dropIfExists('person_change_index');
+
+        $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 7], null, ['c_personid' => 7], '2026-05-05 08:00:00');
+
+        // audit_log 照常寫入，不因水位線副表缺失而拋錯
+        $this->assertSame(1, DB::table('audit_log')->where('table_name', 'ALTNAME_DATA')->count());
+    }
+
+    public function test_after_commit_callback_failure_only_logs_warning_and_does_not_break_commit(): void {
+        Log::spy();
+
+        $failingService = new class () extends PersonChangeIndexService {
+            public function recordChange(string $table, ?array $rowPk, ?array $newData, ?array $oldData, string $occurredAt): void {
+                throw new \RuntimeException('simulated upsert failure');
+            }
+        };
+        $this->app->instance(PersonChangeIndexService::class, $failingService);
+
+        DB::transaction(function () {
+            $this->write('ALTNAME_DATA', 'UPDATE', ['c_personid' => 13], null, ['c_personid' => 13], '2026-10-10 00:00:00');
+
+            // 交易內只寫 audit_log；水位線 callback 等到 commit 後才執行
+            $this->assertSame(1, DB::table('audit_log')->where('table_name', 'ALTNAME_DATA')->count());
+            $this->assertSame(0, DB::table('person_change_index')->where('c_personid', 13)->count());
+        });
+
+        // callback 失敗不應回滾已提交的 audit / mutation 交易
+        $this->assertSame(1, DB::table('audit_log')->where('table_name', 'ALTNAME_DATA')->count());
+        $this->assertSame(0, DB::table('person_change_index')->where('c_personid', 13)->count());
+
+        Log::shouldHaveReceived('warning')->once()->withArgs(function (string $message, array $context): bool {
+            return $message === 'person_change_index 即時更新失敗，將由 rebuild 補回'
+                && ($context['table'] ?? null) === 'ALTNAME_DATA'
+                && ($context['error'] ?? null) === 'simulated upsert failure';
+        });
+    }
+}

--- a/tests/Feature/RebuildPersonChangeIndexCommandTest.php
+++ b/tests/Feature/RebuildPersonChangeIndexCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class RebuildPersonChangeIndexCommandTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+        DB::statement('PRAGMA foreign_keys = OFF');
+
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->dateTime('c_created_date')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+        });
+
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('c_personid')->nullable()->index();
+            $table->dateTime('c_created_date')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+        });
+
+        Schema::create('person_change_index', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->dateTime('c_last_modified_date')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->dateTime('updated_at')->nullable();
+        });
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('person_change_index');
+        Schema::dropIfExists('ALTNAME_DATA');
+        Schema::dropIfExists('BIOG_MAIN');
+
+        parent::tearDown();
+    }
+
+    public function test_rebuild_uses_audit_log_keyset_without_skipping_same_occurred_at_rows(): void {
+        $people = [];
+        $logs = [];
+        $occurredAt = '2026-06-18 10:00:00';
+
+        for ($personId = 1; $personId <= 2001; $personId++) {
+            $people[] = [
+                'c_personid' => $personId,
+                'c_created_date' => '2020-01-01 00:00:00',
+                'c_modified_date' => '2020-01-01 00:00:00',
+            ];
+
+            $logs[] = [
+                'occurred_at' => $occurredAt,
+                'created_at' => $occurredAt,
+                'table_name' => 'ALTNAME_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'system',
+                'actor_id' => 'system',
+                'operation_id' => str_pad((string) $personId, 26, '0', STR_PAD_LEFT),
+                'row_pk' => json_encode(['c_personid' => $personId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'row_pk_text' => 'c_personid=' . $personId,
+                'old_data' => null,
+                'new_data' => json_encode(['c_personid' => $personId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ];
+        }
+
+        DB::table('BIOG_MAIN')->insert($people);
+        DB::table('audit_log')->insert($logs);
+
+        $this->artisan('cbdb:rebuild-person-change-index')
+            ->assertExitCode(0);
+
+        $this->assertSame(2001, DB::table('person_change_index')->count());
+        $this->assertSame(
+            $occurredAt,
+            DB::table('person_change_index')->where('c_personid', 2001)->value('c_last_modified_date')
+        );
+    }
+
+    public function test_rebuild_since_and_prune_respect_audit_window_and_delete_orphans(): void {
+        DB::table('BIOG_MAIN')->insert([
+            [
+                'c_personid' => 10,
+                'c_created_date' => '2020-01-01 00:00:00',
+                'c_modified_date' => '2020-01-02 00:00:00',
+            ],
+            [
+                'c_personid' => 20,
+                'c_created_date' => '2020-02-01 00:00:00',
+                'c_modified_date' => '2020-02-02 00:00:00',
+            ],
+        ]);
+
+        DB::table('person_change_index')->insert([
+            [
+                'c_personid' => 999,
+                'c_last_modified_date' => '2026-01-01 00:00:00',
+                'c_created_date' => '2026-01-01 00:00:00',
+                'updated_at' => '2026-01-01 00:00:00',
+            ],
+        ]);
+
+        DB::table('audit_log')->insert([
+            [
+                'occurred_at' => '2026-06-09 09:00:00',
+                'created_at' => '2026-06-09 09:00:00',
+                'table_name' => 'POSTED_TO_OFFICE_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'system',
+                'actor_id' => 'system',
+                'operation_id' => '00000000000000000000000010',
+                'row_pk' => json_encode(['c_office_id' => 1, 'c_posting_id' => 1], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'row_pk_text' => 'c_office_id=1&c_posting_id=1',
+                'old_data' => null,
+                'new_data' => json_encode(['c_personid' => 10], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ],
+            [
+                'occurred_at' => '2026-06-17 12:00:00',
+                'created_at' => '2026-06-17 12:00:00',
+                'table_name' => 'POSTED_TO_OFFICE_DATA',
+                'operation' => 'DELETE',
+                'actor_type' => 'system',
+                'actor_id' => 'system',
+                'operation_id' => '00000000000000000000000020',
+                'row_pk' => json_encode(['c_office_id' => 2, 'c_posting_id' => 2], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'row_pk_text' => 'c_office_id=2&c_posting_id=2',
+                'old_data' => json_encode(['c_personid' => 20], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'new_data' => null,
+            ],
+        ]);
+
+        $this->artisan('cbdb:rebuild-person-change-index', [
+            '--since' => '2026-06-10 00:00:00',
+            '--prune' => true,
+        ])->assertExitCode(0);
+
+        $this->assertNull(DB::table('person_change_index')->where('c_personid', 999)->first());
+
+        $this->assertSame(
+            '2020-01-02 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 10)->value('c_last_modified_date')
+        );
+        $this->assertSame(
+            '2026-06-17 12:00:00',
+            DB::table('person_change_index')->where('c_personid', 20)->value('c_last_modified_date')
+        );
+        $this->assertSame(
+            '2020-02-01 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 20)->value('c_created_date')
+        );
+    }
+}


### PR DESCRIPTION
## 摘要

在 `/api/v2/persons` 為每筆人物新增輸出：
- **`c_created_date`** — 人物建檔時間（取自 `BIOG_MAIN`）。
- **`c_modified_date`** — 人物**任何**資訊（本體或子資源：地址、別名、官職、親屬、事件、社會地位、入仕、著作、財產、社會機構、關係等）最後一次被修改的時間。

`c_modified_date` 為人物**聚合層級**的修改水位線，存於新 sidecar 表 `person_change_index`，與 `BIOG_MAIN` 本表的 `c_modified_date`（僅反映本列修改）**語意分離、互不污染**。

設計文件：[`docs/PERSON_CHANGE_INDEX_DESIGN.md`](docs/PERSON_CHANGE_INDEX_DESIGN.md)。

## 主要改動

- **新表** `person_change_index(c_personid PK, c_last_modified_date INDEX, c_created_date, updated_at)`；`audit_log` 補 `(table_name, occurred_at, id)` 複合索引。
- **即時維護**：`AuditLogService::logChange()`（所有 direct mutation 與提案核准套用的收斂點）以 `DB::afterCommit` 在交易**提交後**做 best-effort 更新（失敗僅記 log、缺口由 rebuild 補回，**絕不回滾使用者資料**）。
- **重建命令** `php artisan cbdb:rebuild-person-change-index`：供初始全量回填、定期校正、手動刷新。NULL-safe GREATEST upsert（兩庫等價、單調不回退）、`c_personid` 範圍分段、named lock 防併發、`disableQueryLog`/`gc`/分段提交省資源；支援 `--since/--id-from/--id-to/--person/--prune/--chunk/--commit-interval/--sleep`。
- **共用服務** `PersonChangeIndexService` 集中關鍵 NULL-safe SQL 與 `c_personid` 反查，命令與即時路徑共用同一份邏輯。
- **API** `PersonListController@index` leftJoin 輸出兩欄（明確表名、別名避免同名衝突）。
- **文件**：API.md 移除「（現行版本）」並補 v1/v2 並行說明；CHANGELOG/README 同步。

## 相容性與設計重點

- 同時兼容 **MariaDB 10.3** 與 **SQLite**（upsert/索引/join 皆分支處理；兩庫 `GREATEST`/`max` 遇 NULL 都回 NULL，故統一 NULL-safe `IF`/`CASE`）。
- 水位線**單調不回退**：即時與重建共用 GREATEST 合併，亂序事件不致回退。
- 14 張人物相關來源表皆已具 datetime 的 `c_created_date`/`c_modified_date`。

## ⚠ 部署注意

migration **只建表不回填**。部署到任何環境後須**手動執行一次** `php artisan cbdb:rebuild-person-change-index` 做初始全量回填，否則 `c_modified_date` 全為 `null`。之後日常由系統即時維護，並可定期以 `--since` 增量校正。

## 測試

- 新增 `RebuildPersonChangeIndexCommandTest`、`PersonChangeIndexLiveUpdateTest`（含 afterCommit 提交/回滾行為）；`ApiV2PersonListTest` 補新欄位。
- 完整測試套件 **1434 tests / 5562 assertions 全數通過**；`php-cs-fixer` 全綠。

## 品質流程

每個小環節皆通過「一組 review agent → `codex` 終端 review」雙閘門收斂到無嚴重 issue 才推進。

🤖 Generated with [Claude Code](https://claude.com/claude-code)