### PR TITLE
feat(api): /api/v2/persons 新增 modified_since 增量同步參數

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # API v2
 
-v1 與 v2 並行提供：v1 為舊版端口，v2 為較新端口；兩者目前同時可用。本文件描述 v2。
+v1 與 v2 並行提供，兩者目前同時可用。本文件分兩部分：**上半部**為 v2（`/api/v2/...`，回傳 `ok` + `data` + `pagination` 結構）；**下半部**「舊版 API 文檔」為 v1 舊版端口（`/api/...`，如 `post_list`）。以下先介紹 v2。
 
 v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagination` 結構。基底 URL：`https://input.cbdb.fas.harvard.edu/api/v2/...`
 
@@ -22,11 +22,22 @@ v2 端口使用 `page` / `per_page` 分頁參數，回傳 `ok` + `data` + `pagin
 | ------ | ------ | ------ | ------ |
 | per_page | 數字 | 100 | 每頁筆數，上限 1000 |
 | page | 數字 | 1 | 頁碼 |
+| modified_since | 日期時間字串 | 無 | 增量同步：只回傳 `c_modified_date` **大於等於**(含邊界)此時間的人物 |
+
+`modified_since` 說明：
+
+- 用於下游增量同步：先做一次完整抓取，之後帶上次取得的最大 `c_modified_date` 再次請求，即可只取「之後有變更」的人物。
+- 接受格式：`YYYY-MM-DD`、`YYYY-MM-DD HH:MM:SS`、或帶時區的 ISO8601（如 `2026-06-15T00:00:00Z`、`2026-06-15T08:00:00+08:00`）。**不接受**相對／關鍵字（如 `now`、`+1 day`）。
+- 時區：未帶時區後綴者以伺服器時區（`+08:00`）解讀；帶時區者會換算為伺服器時區後比較。
+- 容錯：格式或日期無效時（含曆法非法如 `2026-02-31`、時間越界如 `24:00:00`）**忽略此參數並回傳全部**（寧可多回，不漏資料）。
+- 尚未回填水位線（`c_modified_date` 為 null）的人物**不會**被 `modified_since` 命中。
 
 ### 輸入示例
 
 `/api/v2/persons` 取第一頁（預設每頁 100 筆）  
-`/api/v2/persons?per_page=500&page=2` 取第二頁，每頁 500 筆
+`/api/v2/persons?per_page=500&page=2` 取第二頁，每頁 500 筆  
+`/api/v2/persons?modified_since=2026-06-15%2008:00:00` 取 2026-06-15 08:00 以後有變更的人物  
+`/api/v2/persons?modified_since=2026-06-15T00:00:00Z&per_page=500` 以 UTC 時間增量同步，每頁 500 筆
 
 ### 輸出格式
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `/api/v2/persons` 新增 c_created_date / c_modified_date（人物層級修改水位線）
 - `/api/v2/persons` 每筆人物新增輸出 `c_created_date`（建檔時間，取自 BIOG_MAIN）與 `c_modified_date`（人物**任何**資訊——本體或子資源——最後修改時間）。
+- `/api/v2/persons` 新增 `modified_since` 查詢參數供增量同步（只回傳 `c_modified_date >= modified_since` 的人物，含邊界）；嚴格格式守衛 + 時區正規化，無法辨識則忽略（回全部）；命令 `--since` 共用同套規則。水位線納入建檔時間，確保「只有建檔時間、從未被改」的人物不被漏抓。
 - `c_modified_date` 為人物聚合層級水位線，存於新 sidecar 表 `person_change_index`，與 BIOG_MAIN 本表 `c_modified_date`（僅本列語意）分離互不污染。
 - 日常由 `AuditLogService::logChange()` 收斂點即時維護（`DB::afterCommit` 交易外 best-effort，失敗由 rebuild 補回）；新增 `php artisan cbdb:rebuild-person-change-index` 供初始全量回填、定期校正、手動刷新（NULL-safe GREATEST upsert、c_personid 範圍分段、named lock、省資源；支援 `--since/--id-from/--id-to/--person/--prune/--chunk/--commit-interval`）。
 - ⚠ **部署注意**：migration 只建表不回填，部署後須**手動執行一次** `php artisan cbdb:rebuild-person-change-index`，否則 `c_modified_date` 全為 null。

--- a/app/Console/Commands/RebuildPersonChangeIndex.php
+++ b/app/Console/Commands/RebuildPersonChangeIndex.php
@@ -204,7 +204,10 @@ class RebuildPersonChangeIndex extends Command {
             foreach ($rows as $row) {
                 $buffer[] = [
                     'c_personid' => (int) $row->c_personid,
-                    'last' => $row->m,
+                    // 水位線 = max(該表 c_modified_date, c_created_date)：建檔本身也是一次「異動」，
+                    // 否則「只有建檔時間、從未被改」的人物水位線會是 NULL，被 modified_since 漏掉（under-fetch）。
+                    // 符合設計 GREATEST(MAX(modified), MAX(created), audit) 公式。
+                    'last' => $this->maxDate($row->m, $row->cr),
                     'created' => $writeCreated ? $row->cr : null,
                 ];
                 $processed++;
@@ -439,19 +442,35 @@ class RebuildPersonChangeIndex extends Command {
         return number_format(memory_get_usage(true) / 1024 / 1024, 2);
     }
 
+    /**
+     * 兩個可為 NULL 的 datetime 字串取較大者（'Y-m-d H:i:s' 字典序＝時間序）。
+     * 任一為 NULL 取另一；皆 NULL 回 NULL。
+     */
+    protected function maxDate(?string $a, ?string $b): ?string {
+        if ($a === null) {
+            return $b;
+        }
+        if ($b === null) {
+            return $a;
+        }
+
+        return $a >= $b ? $a : $b;
+    }
+
     protected function normalizeSince(?string $since): ?string {
-        $since = $since ? trim($since) : '';
-        if ($since === '') {
+        if ($since === null || trim($since) === '') {
             return null;
         }
 
-        try {
-            return \Illuminate\Support\Carbon::parse($since)->format('Y-m-d H:i:s');
-        } catch (Throwable $e) {
-            $this->warn(sprintf('--since 無法解析（%s），忽略此參數。', $since));
-
-            return null;
+        // 與 API 的 modified_since 共用同一套嚴格解析（PersonChangeIndexService::parseThreshold）：
+        // 完整鎖定形狀 + checkdate/時間範圍 + 時區正規化。無法安全辨識則忽略 --since
+        // （退回全量重建＝over-fetch，安全方向），避免相對/曆法非法輸入把門檻推晚而漏掉區間變更。
+        $normalized = PersonChangeIndexService::parseThreshold($since);
+        if ($normalized === null) {
+            $this->warn(sprintf('--since 無法辨識（%s），已忽略（改為全量重建）。', trim($since)));
         }
+
+        return $normalized;
     }
 
     /**

--- a/app/Http/Controllers/Api/PersonListController.php
+++ b/app/Http/Controllers/Api/PersonListController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\BiogMain;
+use App\Services\PersonChangeIndexService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -14,17 +15,27 @@ class PersonListController extends Controller {
             $perPage = 100;
         }
 
+        $modifiedSince = PersonChangeIndexService::parseThreshold($request->input('modified_since'));
+
         // c_created_date 取自 BIOG_MAIN（人物建檔時間）；c_modified_date 取自 person_change_index
         // 的人物層級水位線（c_last_modified_date），別名輸出為 c_modified_date。
         // 刻意不選 BIOG_MAIN.c_modified_date（本表語意，會與別名衝突）；用 query builder 明確表名 join，
         // 避免 SQLite/MySQL 表名大小寫差異。person_change_index 一人一列，leftJoin 為 1:1，不影響分頁筆數。
-        $paginator = BiogMain::query()
+        $query = BiogMain::query()
             ->leftJoin('person_change_index', 'BIOG_MAIN.c_personid', '=', 'person_change_index.c_personid')
             ->select([
                 'BIOG_MAIN.c_personid',
                 'BIOG_MAIN.c_created_date',
                 'person_change_index.c_last_modified_date as c_modified_date',
-            ])
+            ]);
+
+        // 增量同步：只回傳 c_modified_date >= modified_since 的人物（含邊界、利用水位線索引）。
+        // c_last_modified_date 為 NULL（無水位線列）者不符 >= 比較而被排除——語意正確（修改時間未知不算「此後被改」）。
+        if ($modifiedSince !== null) {
+            $query->where('person_change_index.c_last_modified_date', '>=', $modifiedSince);
+        }
+
+        $paginator = $query
             ->orderBy('BIOG_MAIN.c_personid', 'asc')
             ->paginate($perPage);
 

--- a/app/Services/PersonChangeIndexService.php
+++ b/app/Services/PersonChangeIndexService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Throwable;
 
 /**
  * person_change_index（人物層級修改水位線）的共用寫入邏輯。
@@ -41,6 +43,57 @@ class PersonChangeIndexService {
 
     public function isPersonScopedTable(string $table): bool {
         return in_array($table, self::PERSON_SCOPED_TABLES, true);
+    }
+
+    /**
+     * 將使用者輸入的時間門檻（API `modified_since`、命令 `--since`）嚴格解析為 app 時區的
+     * 'Y-m-d H:i:s'；無法安全辨識時回 null（呼叫端據此「不過濾」＝over-fetch 安全方向，絕不漏資料）。
+     *
+     * 兩處共用同一份邏輯，避免分歧。防線：
+     *  1. 完整鎖定字串形狀（日期 + 可選時間 + 可選時區後綴），擋掉相對/關鍵字輸入（now / `+1 day` 等）。
+     *  2. checkdate() 驗曆法、時分秒範圍驗證——擋掉「形狀合法但曆法非法」（如 2026-02-31、24:00:00），
+     *     否則 Carbon::parse 會把它們進位成更晚時間，造成 under-fetch 並違反「無法辨識則忽略」。
+     *  3. 時區正規化：帶時區後綴者換算到 app 時區再比較；無後綴者以 app 時區解讀（與 DB 牆鐘一致）。
+     */
+    public static function parseThreshold($value): ?string {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return null;
+        }
+
+        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$/', $value, $m)) {
+            return null;
+        }
+
+        if (!checkdate((int) $m[2], (int) $m[3], (int) $m[1])) {
+            return null;
+        }
+
+        if (isset($m[4]) && $m[4] !== '') {
+            $hour = (int) $m[4];
+            $minute = (int) $m[5];
+            $second = (isset($m[6]) && $m[6] !== '') ? (int) $m[6] : 0;
+            if ($hour > 23 || $minute > 59 || $second > 59) {
+                return null;
+            }
+        }
+
+        try {
+            $appTimezone = (string) config('app.timezone');
+            $hasExplicitTimezone = preg_match('/(?:Z|[+-]\d{2}:?\d{2})$/', $value) === 1;
+
+            $threshold = $hasExplicitTimezone
+                ? Carbon::parse($value)
+                : Carbon::parse($value, $appTimezone);
+
+            return $threshold->setTimezone($appTimezone)->format('Y-m-d H:i:s');
+        } catch (Throwable $e) {
+            return null;
+        }
     }
 
     /**

--- a/docs/PERSON_CHANGE_INDEX_DESIGN.md
+++ b/docs/PERSON_CHANGE_INDEX_DESIGN.md
@@ -149,7 +149,7 @@ php artisan cbdb:rebuild-person-change-index
   - 用 query builder 明確 join,表名大小寫照寫:`->leftJoin('person_change_index', 'BIOG_MAIN.c_personid', '=', 'person_change_index.c_personid')`(避免 SQLite/MySQL 表名大小寫差異)。
   - 對沒有 sidecar 列的人物,`c_modified_date` 會是 NULL(部署後須先跑一次 rebuild,見「文件變更/部署」)。
   - 單次 indexed left join,效能可控;讀取端零跨表彙整。
-- (可選,建議一併評估)新增 `?modified_since=` 增量同步參數,利用 `c_last_modified_date` 索引。
+- **已實作** `?modified_since=` 增量同步參數,利用 `c_last_modified_date` 索引(`where c_last_modified_date >= ?`,含邊界、NULL 水位線排除)。解析經嚴格格式守衛(完整鎖定 `^\d{4}-\d{2}-\d{2}...$`,擋掉相對/關鍵字輸入)+ 時區正規化到 app 時區(`setTimezone`);無法辨識則忽略過濾(over-fetch 安全方向)。命令的 `--since` 與此共用同一套守衛/時區規則。為避免「只有建檔時間、從未被改」的人物水位線為 NULL 而被漏掉,重建水位線取 `max(MAX(c_modified_date), MAX(c_created_date))`(符合 GREATEST 公式)。
 - 輸出範例:
   ```json
   { "c_personid": 10, "c_created_date": "2007-05-01 00:00:00", "c_modified_date": "2026-03-12 09:21:00" }

--- a/tests/Feature/ApiV2PersonListTest.php
+++ b/tests/Feature/ApiV2PersonListTest.php
@@ -177,6 +177,112 @@ class ApiV2PersonListTest extends TestCase {
         $this->assertSame('2026-03-12 09:21:00', $row['c_modified_date']);
     }
 
+    public function test_modified_since_filters_by_watermark_inclusive(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 3, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 4, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null], // 無 sidecar 列
+        ]);
+        DB::table('person_change_index')->insert([
+            ['c_personid' => 1, 'c_last_modified_date' => '2026-01-01 00:00:00', 'c_created_date' => null, 'updated_at' => '2026-01-01 00:00:00'],
+            ['c_personid' => 2, 'c_last_modified_date' => '2026-06-15 00:00:00', 'c_created_date' => null, 'updated_at' => '2026-06-15 00:00:00'], // 邊界
+            ['c_personid' => 3, 'c_last_modified_date' => '2026-12-31 00:00:00', 'c_created_date' => null, 'updated_at' => '2026-12-31 00:00:00'],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons?modified_since=2026-06-15 00:00:00');
+        $response->assertOk();
+
+        $ids = array_column($response->json('data'), 'c_personid');
+        // 含邊界(2)、之後(3)；排除之前(1) 與無水位線(4)
+        $this->assertEqualsCanonicalizing([2, 3], $ids);
+        $this->assertSame(2, $response->json('pagination.total'));
+    }
+
+    public function test_modified_since_normalizes_timezone_to_app_timezone(): void {
+        // app 時區固定為 +08（與 DB datetime 牆鐘一致），確保 UTC 輸入被正確轉換
+        config()->set('app.timezone', 'Asia/Shanghai');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+        ]);
+        DB::table('person_change_index')->insert([
+            // 04:00 (+08) 早於 UTC 00:00 換算後的 08:00 門檻 → 應排除
+            ['c_personid' => 1, 'c_last_modified_date' => '2026-06-15 04:00:00', 'c_created_date' => null, 'updated_at' => '2026-06-15 04:00:00'],
+            // 12:00 (+08) 晚於 08:00 門檻 → 應納入
+            ['c_personid' => 2, 'c_last_modified_date' => '2026-06-15 12:00:00', 'c_created_date' => null, 'updated_at' => '2026-06-15 12:00:00'],
+        ]);
+
+        // UTC 00:00 → 轉成 +08 的 08:00 門檻
+        $response = $this->getJson('/api/v2/persons?modified_since=2026-06-15T00:00:00Z');
+        $response->assertOk();
+
+        $ids = array_column($response->json('data'), 'c_personid');
+        $this->assertEqualsCanonicalizing([2], $ids);
+    }
+
+    public function test_modified_since_ignores_relative_keyword_input(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+        ]);
+        DB::table('person_change_index')->insert([
+            ['c_personid' => 1, 'c_last_modified_date' => '2000-01-01 00:00:00', 'c_created_date' => null, 'updated_at' => '2000-01-01 00:00:00'],
+        ]);
+
+        // 'now' 不以 YYYY-MM-DD 起頭 → 被守衛擋掉 → 不過濾（回傳全部，over-fetch 安全），
+        // 而非被 Carbon 解析成當下時間導致漏資料
+        $response = $this->getJson('/api/v2/persons?modified_since=now');
+        $response->assertOk();
+        $this->assertSame(2, $response->json('pagination.total'));
+    }
+
+    public function test_invalid_modified_since_is_ignored(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+        ]);
+
+        $response = $this->getJson('/api/v2/persons?modified_since=not-a-date');
+        $response->assertOk();
+
+        // 無法解析 → 不套用過濾，回傳全部
+        $this->assertSame(2, $response->json('pagination.total'));
+    }
+
+    public function test_modified_since_rejects_date_with_relative_suffix(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+        ]);
+        DB::table('person_change_index')->insert([
+            ['c_personid' => 1, 'c_last_modified_date' => '2000-01-01 00:00:00', 'c_created_date' => null, 'updated_at' => '2000-01-01 00:00:00'],
+        ]);
+
+        // 「合法日期前綴 + 相對後綴」必須被完整鎖定的守衛擋掉（否則 Carbon 會解成更晚門檻而漏資料）→ 不過濾，回全部
+        $response = $this->getJson('/api/v2/persons?' . http_build_query(['modified_since' => '2026-06-15 +1 day']));
+        $response->assertOk();
+        $this->assertSame(2, $response->json('pagination.total'));
+    }
+
+    public function test_modified_since_rejects_calendar_invalid_dates(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+            ['c_personid' => 2, 'c_created_date' => '2007-01-01 00:00:00', 'c_modified_date' => null],
+        ]);
+        DB::table('person_change_index')->insert([
+            ['c_personid' => 1, 'c_last_modified_date' => '2000-01-01 00:00:00', 'c_created_date' => null, 'updated_at' => '2000-01-01 00:00:00'],
+        ]);
+
+        // 形狀合法但曆法非法：不可被 Carbon 進位成更晚門檻（會漏資料），須視為無效→不過濾→回全部
+        foreach (['2026-02-31', '2026-06-15 24:00:00', '2026-13-01', '2026-06-15 12:60:00'] as $bad) {
+            $response = $this->getJson('/api/v2/persons?' . http_build_query(['modified_since' => $bad]));
+            $response->assertOk();
+            $this->assertSame(2, $response->json('pagination.total'), "輸入 {$bad} 應被忽略並回全部");
+        }
+    }
+
     public function test_modified_date_is_null_when_no_sidecar_row(): void {
         DB::table('BIOG_MAIN')->insert([
             [

--- a/tests/Feature/RebuildPersonChangeIndexCommandTest.php
+++ b/tests/Feature/RebuildPersonChangeIndexCommandTest.php
@@ -103,6 +103,25 @@ class RebuildPersonChangeIndexCommandTest extends TestCase {
         );
     }
 
+    public function test_rebuild_sets_watermark_from_created_date_when_never_modified(): void {
+        // 只有建檔時間、c_modified_date 為 NULL（從未被改）的人物：
+        // 水位線應 = 建檔時間（建檔本身是一次異動），而非 NULL，否則會被 modified_since 漏掉。
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 50, 'c_created_date' => '2026-02-02 00:00:00', 'c_modified_date' => null],
+        ]);
+
+        $this->artisan('cbdb:rebuild-person-change-index')->assertExitCode(0);
+
+        $this->assertSame(
+            '2026-02-02 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 50)->value('c_last_modified_date')
+        );
+        $this->assertSame(
+            '2026-02-02 00:00:00',
+            DB::table('person_change_index')->where('c_personid', 50)->value('c_created_date')
+        );
+    }
+
     public function test_rebuild_since_and_prune_respect_audit_window_and_delete_orphans(): void {
         DB::table('BIOG_MAIN')->insert([
             [
@@ -174,5 +193,61 @@ class RebuildPersonChangeIndexCommandTest extends TestCase {
             '2020-02-01 00:00:00',
             DB::table('person_change_index')->where('c_personid', 20)->value('c_created_date')
         );
+    }
+
+    public function test_invalid_since_is_ignored_to_avoid_under_fetch(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 10, 'c_created_date' => '2020-01-01 00:00:00', 'c_modified_date' => '2020-01-02 00:00:00'],
+            ['c_personid' => 20, 'c_created_date' => '2020-02-01 00:00:00', 'c_modified_date' => '2020-02-02 00:00:00'],
+        ]);
+
+        DB::table('audit_log')->insert([
+            [
+                'occurred_at' => '2026-06-09 09:00:00',
+                'created_at' => '2026-06-09 09:00:00',
+                'table_name' => 'POSTED_TO_OFFICE_DATA',
+                'operation' => 'UPDATE',
+                'actor_type' => 'system',
+                'actor_id' => 'system',
+                'operation_id' => '00000000000000000000000010',
+                'row_pk' => json_encode(['c_office_id' => 1, 'c_posting_id' => 1], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'row_pk_text' => 'c_office_id=1&c_posting_id=1',
+                'old_data' => null,
+                'new_data' => json_encode(['c_personid' => 10], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            ],
+            [
+                'occurred_at' => '2026-06-17 12:00:00',
+                'created_at' => '2026-06-17 12:00:00',
+                'table_name' => 'POSTED_TO_OFFICE_DATA',
+                'operation' => 'DELETE',
+                'actor_type' => 'system',
+                'actor_id' => 'system',
+                'operation_id' => '00000000000000000000000020',
+                'row_pk' => json_encode(['c_office_id' => 2, 'c_posting_id' => 2], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'row_pk_text' => 'c_office_id=2&c_posting_id=2',
+                'old_data' => json_encode(['c_personid' => 20], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'new_data' => null,
+            ],
+        ]);
+
+        foreach (['2026-02-31', '2026-06-15 24:00:00', '2026-13-01', '2026-06-15 12:60:00'] as $bad) {
+            DB::table('person_change_index')->delete();
+
+            $this->artisan('cbdb:rebuild-person-change-index', [
+                '--since' => $bad,
+            ])->expectsOutputToContain('--since 無法辨識')
+                ->assertExitCode(0);
+
+            $this->assertSame(
+                '2026-06-09 09:00:00',
+                DB::table('person_change_index')->where('c_personid', 10)->value('c_last_modified_date'),
+                "invalid --since {$bad} 應退回全量重建，不能漏掉較早的 person 10"
+            );
+            $this->assertSame(
+                '2026-06-17 12:00:00',
+                DB::table('person_change_index')->where('c_personid', 20)->value('c_last_modified_date'),
+                "invalid --since {$bad} 應退回全量重建，不能漏掉較晚的 person 20"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 摘要

為 `/api/v2/persons` 新增 **`modified_since`** 查詢參數，供下游增量同步：只回傳 `c_modified_date`（人物聚合層級修改水位線）**大於等於**（含邊界）指定時間的人物，利用 `person_change_index.c_last_modified_date` 索引。

並順手修正一個會造成**漏抓人物**的水位線缺口，以及 API.md 文件結構描述。

## 主要改動

- **`modified_since` 參數**（`PersonListController`）：`where c_last_modified_date >= ?`，含邊界；NULL 水位線（未回填者）天然不命中。
- **嚴格解析**（共用 `PersonChangeIndexService::parseThreshold`，**API 與命令 `--since` 同一份**，避免分歧）：
  - 完整鎖定 datetime 形狀的 regex（擋掉 `now` / `+1 day` 等相對、關鍵字輸入）。
  - `checkdate()` + 時分秒範圍驗證（擋掉「形狀合法但曆法非法」如 `2026-02-31`、`24:00:00`，否則 `Carbon::parse` 會進位成更晚門檻而漏資料）。
  - 時區正規化到 app 時區（帶 `Z`/offset 者換算；無後綴者以 app 時區解讀），避免 UTC 輸入晚 8 小時漏資料。
  - 任一不過 → 回 null → **忽略過濾（over-fetch，絕不漏資料）**。
- **rebuild 水位線修正**：改取 `max(MAX(c_modified_date), MAX(c_created_date))`（符合設計 `GREATEST(modified, created, audit)` 公式），使「只有建檔時間、從未被改」的人物水位線 = 建檔時間而非 NULL，否則會被 `modified_since` 漏抓。
- **文件**：API.md 新增 `modified_since` 參數表/說明/範例；更正開頭——文件**上半為 v2**（`/api/v2/...`）、**下半「舊版 API 文檔」為 v1**（`/api/...`，如 `post_list`），兩者並行；CHANGELOG 與設計文件同步。

## 設計重點：絕不 under-fetch（漏資料）

增量同步最危險的是漏資料。所有無法安全辨識的輸入一律退回「不過濾／全量」的 over-fetch 安全方向；時區、曆法、相對輸入三類陷阱都已封堵並有測試。

## 測試

新增/擴充：`modified_since` 含邊界、時區轉換、相對關鍵字被擋、曆法非法被擋；rebuild 建檔-only 水位線；命令 `--since` 無效退回全量。**完整測試套件 1442 tests / 5600 assertions 全通過**；`php-cs-fixer` 全綠。

## 品質流程

每個小環節皆通過「一組 review agent → `codex` 終端 review」雙閘門收斂到無嚴重 issue 才推進；其中 codex 逐層揪出時區、相對輸入、曆法非法、水位線漏建檔等 under-fetch 隱患並全數修補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)