### PR TITLE
docs(env): 釐清 GEMINI_API_ENDPOINT 為 OpenAI 相容端點

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,8 @@ PUSHER_APP_SECRET=
 # Get your API key from: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=
 # OpenAI-compatible API endpoint
+# 可指向任何 OpenAI 相容端點(如 Google Gemini、HUIT OpenAI-Direct 代理等);
+# GEMINI_* 為歷史變數名,不代表只能用 Gemini。
 GEMINI_API_ENDPOINT=https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
 # Model name (e.g., gemini-3-flash-preview, gemini-2.0-flash-exp)
 GEMINI_MODEL=gemini-3-flash-preview


### PR DESCRIPTION
## 變更

`.env.example` 補充註解,說明 `GEMINI_API_ENDPOINT` 為 OpenAI 相容端點,可指向任何相容服務(Google Gemini、HUIT OpenAI-Direct 代理等),`GEMINI_*` 僅為歷史變數名,不限於 Gemini。

## 背景

排查 HUIT「Bedrock API v1 將於 6/30/26 停用」通知時釐清:

- 本專案實際使用 HUIT **OpenAI-Direct** 代理(非 Bedrock),不受該通知影響。
- 但 OpenAI-Direct 有自己的版本死線:**v1 服務至 2026/9/30,10/1 起只剩 v2**。
- 已在本地 `.env` 將端點切換至 v2 並實測通過(HTTP 200,`Authorization: Bearer` 在 v2 仍被接受,程式零改動)。`.env` 不入版控,故本 PR 僅含 `.env.example` 文件註解。

🤖 Generated with [Claude Code](https://claude.com/claude-code)