### PR TITLE
feat(deploy): person_change_index 表為空時自動觸發初始回填

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -58,4 +58,30 @@ php artisan view:cache
 echo "檢查 CHGIS 底圖..."
 php artisan cbdb:fetch-chgis-map || echo "警告: CHGIS 底圖下載失敗，地圖功能將於首次訪問時重試"
 
+# 6. person_change_index 初次部署自動全量回填
+#    僅當「表已存在且為空」時觸發（典型情境：migration 已建表、尚未做初始回填）。
+#    表不存在（尚未 migrate）或已有資料時皆略過，避免每次部署重跑昂貴回填。
+#    探測輸出 PCI_STATE=<empty|filled|absent> 哨兵，以 grep 解析以容忍任何額外輸出；
+#    探測或回填失敗都不中斷部署（與 CHGIS 步驟一致）。
+echo "檢查 person_change_index 是否需要初始回填..."
+pci_probe="$(php artisan tinker --execute="echo 'PCI_STATE='.(Schema::hasTable('person_change_index') ? (DB::table('person_change_index')->exists() ? 'filled' : 'empty') : 'absent');" 2>/dev/null || true)"
+pci_state="$(printf '%s' "$pci_probe" | grep -oE 'PCI_STATE=(empty|filled|absent)' | head -n1 | cut -d= -f2 || true)"
+
+case "$pci_state" in
+  empty)
+    echo "person_change_index 為空，開始初始全量回填（一次性，可能耗時）..."
+    php artisan cbdb:rebuild-person-change-index \
+      || echo "警告: person_change_index 初始回填失敗，可稍後手動執行 php artisan cbdb:rebuild-person-change-index"
+    ;;
+  filled)
+    echo "person_change_index 已有資料，略過初始回填。"
+    ;;
+  absent)
+    echo "person_change_index 表不存在，略過（待執行 migration 後再部署即會自動回填）。"
+    ;;
+  *)
+    echo "警告: 無法判定 person_change_index 狀態（tinker 探測失敗），略過自動回填。"
+    ;;
+esac
+
 echo "部署完成！"


### PR DESCRIPTION
## 變更內容

在 `deploy.sh` 新增**步驟 6**：部署時探測 `person_change_index` 表狀態，僅當「表已存在且為空」時，自動執行 `php artisan cbdb:rebuild-person-change-index` 做初始全量回填。

## 設計重點

- 以 `php artisan tinker --execute` 輸出 `PCI_STATE=<empty|filled|absent>` 哨兵，再以 `grep -oE` 解析，容忍 tinker 任何額外輸出（banner／dump）。
- 三種狀態 + 探測失敗皆有處理，且**只有 `empty` 會觸發回填**：
  - `empty` → 執行初始回填
  - `filled` → 略過（避免每次部署重跑昂貴回填）
  - `absent` → 略過（尚未 migrate）
  - 探測失敗 → 印警告並略過（不會誤觸發）
- `set -euo pipefail` 下以 `|| true` / `|| echo` 防止探測或回填失敗中斷部署（與既有 CHGIS 步驟一致）。
- 以 `->exists()` 取代 `count() > 0`，僅需判空，避免每次部署對全表做 `COUNT(*)`。

## 注意事項

`deploy.sh` 不含 `php artisan migrate`（沿用現行「migration 另外執行」流程）。因此全新環境的第一次部署時表為 `absent`、不會回填；待執行 migration 後再部署一次即會自動回填。一般工作流（先 migrate → 再 deploy）下行為符合預期。

## 檢查

- `bash -n deploy.sh` 語法通過
- 兩組 review agent（正確性／設計）審查：無嚴重問題
- codex 審查：無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)