### PR TITLE
fix(editor): 地名搜尋朝代過濾改用起止年，修正官職零結果並補齊事件/社會關係

### DIFF
--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -724,6 +724,8 @@ class BasicInformationController extends Controller {
 
         $person = BiogMain::find($personId);
         $cDy = $person ? (int) $person->c_dy : 0;
+        // 地名搜尋以朝代起止「年」過濾（對齊 legacy .dynasty_start/.dynasty_end），非朝代代碼。
+        $dynasty = $cDy ? DB::table('DYNASTIES')->where('c_dy', $cDy)->first() : null;
 
         $hasPk = $request->filled('c_sequence') && $request->filled('c_event_code');
         $mode = $hasPk ? 'edit' : 'create';
@@ -770,6 +772,8 @@ class BasicInformationController extends Controller {
             'person_id' => $personId,
             'person_label' => $personLabel,
             'dynasty_code' => $cDy ?: null,
+            'dynasty_start' => (string) ($dynasty->c_start ?? ''),
+            'dynasty_end' => (string) ($dynasty->c_end ?? ''),
             'edit_mode' => $mode,
             'initial_fields' => (object) $initialFields,
             'initial_labels' => (object) $initialLabels,
@@ -1077,6 +1081,8 @@ class BasicInformationController extends Controller {
         // 人物朝代（供官名/地名搜尋過濾，對齊 legacy $biog_dy）。
         $dynastyCode = DB::table('BIOG_MAIN')->where('c_personid', $personId)->value('c_dy');
         $dynastyCode = $dynastyCode !== null ? (int) $dynastyCode : null;
+        // 地名搜尋以朝代起止「年」過濾（對齊 legacy .dynasty_start/.dynasty_end），非朝代代碼。
+        $dynasty = $dynastyCode ? DB::table('DYNASTIES')->where('c_dy', $dynastyCode)->first() : null;
 
         // 編輯模式：c_office_id 與 c_posting_id 皆存在（0 為合法 office id，故以 has() 判斷）。
         $hasPk = $request->has('c_office_id') && $request->has('c_posting_id')
@@ -1149,6 +1155,8 @@ class BasicInformationController extends Controller {
             'person_id' => $personId,
             'person_label' => $personLabel,
             'dynasty_code' => $dynastyCode,
+            'dynasty_start' => (string) ($dynasty->c_start ?? ''),
+            'dynasty_end' => (string) ($dynasty->c_end ?? ''),
             'edit_mode' => $mode,
             'initial_fields' => (object) $initialFields,
             'initial_labels' => (object) $initialLabels,
@@ -1193,6 +1201,8 @@ class BasicInformationController extends Controller {
 
         $dynastyCode = DB::table('BIOG_MAIN')->where('c_personid', $personId)->value('c_dy');
         $dynastyCode = $dynastyCode !== null ? (int) $dynastyCode : null;
+        // 地名搜尋以朝代起止「年」過濾（對齊 legacy .dynasty_start/.dynasty_end），非朝代代碼。
+        $dynasty = $dynastyCode ? DB::table('DYNASTIES')->where('c_dy', $dynastyCode)->first() : null;
 
         // 編輯模式：以 9 段複合主鍵（除 c_personid，由路由帶入）皆存在判斷。
         $pkCols = ['c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id', 'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year'];
@@ -1290,6 +1300,8 @@ class BasicInformationController extends Controller {
             'person_id' => $personId,
             'person_label' => $personLabel,
             'dynasty_code' => $dynastyCode,
+            'dynasty_start' => (string) ($dynasty->c_start ?? ''),
+            'dynasty_end' => (string) ($dynasty->c_end ?? ''),
             'edit_mode' => $mode,
             'initial_fields' => (object) $initialFields,
             'initial_labels' => (object) $initialLabels,

--- a/resources/js/inertia/Pages/BasicInformation/AssocEditV2.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/AssocEditV2.tsx
@@ -12,6 +12,8 @@ interface PageProps extends SharedProps {
     person_id: number;
     person_label: string;
     dynasty_code: number | null;
+    dynasty_start: string;
+    dynasty_end: string;
     edit_mode: 'create' | 'edit';
     initial_fields: Fields;
     initial_labels: Fields;
@@ -49,6 +51,8 @@ export default function AssocEditV2() {
                 personId={p.person_id}
                 personLabel={p.person_label}
                 dynastyCode={p.dynasty_code}
+                dynastyStart={p.dynasty_start}
+                dynastyEnd={p.dynasty_end}
                 mode={p.edit_mode}
                 initialFields={p.initial_fields}
                 initialLabels={p.initial_labels}

--- a/resources/js/inertia/Pages/BasicInformation/EventEditV2.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/EventEditV2.tsx
@@ -13,6 +13,8 @@ interface PageProps extends SharedProps {
     person_id: number;
     person_label: string;
     dynasty_code: number | null;
+    dynasty_start: string;
+    dynasty_end: string;
     edit_mode: 'create' | 'edit';
     initial_fields: Fields;
     initial_labels: Fields;
@@ -45,6 +47,8 @@ export default function EventEditV2() {
                 personId={p.person_id}
                 personLabel={p.person_label}
                 dynastyCode={p.dynasty_code}
+                dynastyStart={p.dynasty_start}
+                dynastyEnd={p.dynasty_end}
                 mode={p.edit_mode}
                 initialFields={p.initial_fields}
                 initialLabels={p.initial_labels}

--- a/resources/js/inertia/Pages/BasicInformation/OfficeEditV2.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/OfficeEditV2.tsx
@@ -12,6 +12,8 @@ interface PageProps extends SharedProps {
     person_id: number;
     person_label: string;
     dynasty_code: number | null;
+    dynasty_start: string;
+    dynasty_end: string;
     edit_mode: 'create' | 'edit';
     initial_fields: Fields;
     initial_labels: Fields;
@@ -50,6 +52,8 @@ export default function OfficeEditV2() {
                 personId={p.person_id}
                 personLabel={p.person_label}
                 dynastyCode={p.dynasty_code}
+                dynastyStart={p.dynasty_start}
+                dynastyEnd={p.dynasty_end}
                 mode={p.edit_mode}
                 initialFields={p.initial_fields}
                 initialLabels={p.initial_labels}

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -39,6 +39,8 @@ interface Props {
     personId: number;
     personLabel: string;
     dynastyCode?: number | null;
+    dynastyStart?: string;   // 人物朝代起年（addr 搜尋過濾 dy_start，非朝代代碼）
+    dynastyEnd?: string;     // 人物朝代末年（dy_end）
     mode: 'create' | 'edit';
     initialFields: Fields;
     initialLabels?: Fields;
@@ -79,7 +81,7 @@ const NON_PK = [
 ];
 
 export default function AssocEditor({
-    personId, personLabel, dynastyCode = null, mode, initialFields, initialLabels = {},
+    personId, personLabel, dynastyCode = null, dynastyStart, dynastyEnd, mode, initialFields, initialLabels = {},
     canEdit, canPropose, createEndpoint, mutateEndpoint, deleteEndpoint, indexUrl,
     aiEnabled = false, aiSuggestEndpoint, aiModel, routeName, t,
 }: Props) {
@@ -430,10 +432,10 @@ export default function AssocEditor({
     const textRow = (key: string, label: string, code: string, highlight = false, hint?: string) => (
         gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
     );
-    const searchRow = (key: string, label: string, code: string, endpoint: string, highlight = false, sentinel = '0', required = false, sentinelLabel?: string) => (
+    const searchRow = (key: string, label: string, code: string, endpoint: string, highlight = false, sentinel = '0', required = false, sentinelLabel?: string, extraQuery?: Record<string, string>) => (
         gridCell(label, { code, required },
             <CodeAutocomplete mode="search" endpoint={endpoint} value={fields[key] ?? sentinel} initialLabel={labels[key] ?? ''}
-                disabled={!editable} aria-invalid={highlight} sentinelLabel={sentinelLabel}
+                disabled={!editable} aria-invalid={highlight} sentinelLabel={sentinelLabel} extraQuery={extraQuery}
                 onChange={(v, l) => { set(key, v || sentinel); setLabel(key, l); }} />)
     );
     const listRow = (key: string, label: string, code: string, model: string, idKey: string, labelKeys: string[]) => (
@@ -543,7 +545,7 @@ export default function AssocEditor({
                     {searchRow('c_tertiary_personid', tr('tertiary_person', '中介人物'), 'c_tertiary_personid', '/api/select/search/biog')}
                     {textRow('c_tertiary_type_notes', tr('tertiary_notes', '中介說明'), 'c_tertiary_type_notes')}
                     {searchRow('c_assoc_claimer_id', tr('claimer_person', '見證人物'), 'c_assoc_claimer_id', '/api/select/search/biog')}
-                    {searchRow('c_addr_id', tr('place_name', '地點'), 'c_addr_id', '/api/select/search/addr')}
+                    {searchRow('c_addr_id', tr('place_name', '地點'), 'c_addr_id', '/api/select/search/addr', false, '0', false, undefined, { dy_start: dynastyStart ?? '', dy_end: dynastyEnd ?? '' })}
                     {gridCell(tr('socialinst_field', '社會機構'), { code: 'social_institution' },
                         <CodeAutocomplete mode="search" endpoint="/api/select/search/socialinstcode" value={instValue} initialLabel={labels.c_inst_code ?? ''} disabled={!editable} onChange={onInstChange} />)}
                 </div>

--- a/resources/js/inertia/components/EventEditor.tsx
+++ b/resources/js/inertia/components/EventEditor.tsx
@@ -28,6 +28,8 @@ interface Props {
     personId: number;
     personLabel: string;
     dynastyCode?: number | null;
+    dynastyStart?: string;   // 人物朝代起年（addr 搜尋過濾 dy_start，非朝代代碼）
+    dynastyEnd?: string;     // 人物朝代末年（dy_end）
     mode: 'create' | 'edit';
     initialFields: Fields;
     initialLabels?: Fields;
@@ -54,7 +56,7 @@ const NON_PK = [
 type EraGroup = typeof YR;
 
 export default function EventEditor({
-    personId, personLabel, dynastyCode = null, mode, initialFields, initialLabels = {}, initialAddr = [],
+    personId, personLabel, dynastyCode = null, dynastyStart, dynastyEnd, mode, initialFields, initialLabels = {}, initialAddr = [],
     canEdit, canPropose, createEndpoint, mutateEndpoint, deleteEndpoint, indexUrl, t,
 }: Props) {
     const tr = (k: string, fb: string) => { const v = t ? t(k) : k; return v && v !== k ? v : fb; };
@@ -236,6 +238,7 @@ export default function EventEditor({
                     {editable ? (
                         <CodeAutocomplete key={addrKey} mode="search" endpoint="/api/select/search/addr" value="" initialLabel=""
                             placeholder={tr('add_place', '搜尋並加入地名…')}
+                            extraQuery={{ dy_start: dynastyStart ?? '', dy_end: dynastyEnd ?? '' }}
                             onChange={(v, l) => addAddr(v, l)} />
                     ) : null}
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: editable ? 6 : 0 }}>

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -35,6 +35,8 @@ interface Props {
     personId: number;
     personLabel: string;
     dynastyCode?: number | null;
+    dynastyStart?: string;   // 人物朝代起年（addr 搜尋過濾 dy_start，非朝代代碼）
+    dynastyEnd?: string;     // 人物朝代末年（dy_end）
     mode: 'create' | 'edit';
     initialFields: Fields;
     initialLabels?: Fields;
@@ -64,7 +66,7 @@ const NON_PK = [
 ];
 
 export default function OfficeEditor({
-    personId, personLabel, dynastyCode = null, mode, initialFields, initialLabels = {}, initialAddr = [],
+    personId, personLabel, dynastyCode = null, dynastyStart, dynastyEnd, mode, initialFields, initialLabels = {}, initialAddr = [],
     canEdit, canPropose, createEndpoint, mutateEndpoint, deleteEndpoint, indexUrl, aiEnabled = false, aiModel, aiExtractEndpoint, t,
 }: Props) {
     const tr = (k: string, fb: string) => { const v = t ? t(k) : k; return v && v !== k ? v : fb; };
@@ -319,7 +321,7 @@ export default function OfficeEditor({
                     {editable ? (
                         <CodeAutocomplete key={addrKey} mode="search" endpoint="/api/select/search/addr"
                             value="" initialLabel="" placeholder={tr('add_place', '搜尋並新增地名…')}
-                            extraQuery={dynastyCode != null ? { dy_start: String(dynastyCode), dy_end: String(dynastyCode) } : undefined}
+                            extraQuery={{ dy_start: dynastyStart ?? '', dy_end: dynastyEnd ?? '' }}
                             onChange={addAddr} />
                     ) : null}
                     {addr.length ? (


### PR DESCRIPTION
## 問題
官職編輯器（`/app/basicinformation/{id}/offices/edit-v2`）的「地名 (c_addr)」搜尋輸入「成都」零結果。

根因：`OfficeEditor` 把**朝代代碼**（如宋=15）同時當作 `dy_start`/`dy_end` 傳給 `/api/select/search/addr`，但後端 `AddrCodeRepository::searchAddr` 把這兩個參數當作**年份**與地址 `c_firstyear~c_lastyear` 取交集，導致幾乎所有地名被濾掉。

## 修正
- **OfficeEditor**：地名搜尋改傳 `DYNASTIES.c_start/c_end`（年份）；官名搜尋仍用朝代代碼，未動。
- **EventEditor / AssocEditor**：原本**完全未傳**年代過濾（與 legacy `_form.blade.php` 不一致），一併補齊 parity。
- 後端：`appOfficeEditV2`/`appEventEditV2`/`appAssocEditV2` 補出 `dynasty_start`/`dynasty_end` props。
- `AssocEditor.searchRow` 新增選用 `extraQuery` 參數（附加於最後，其餘呼叫不受影響）。

## 不受影響
- 以**純數字 ID** 搜尋仍可跨時代強行帶出地名（後端 `ctype_digit` 跳過年代過濾），行為不變。
- 無朝代資料的人物 → 空字串 → 前端略過該參數 → 後端不套用過濾（不會零結果）。
- PersonBrowser 的 `*EditorModal` 為未渲染的死碼，本次不動。

## 驗證
- `npm run build` ✅、`php-cs-fixer` ✅、`BasicInformationPagesLoadTest`（31 tests）✅
- 兩輪 review agent + 兩輪 codex 皆無 critical/major

🤖 Generated with [Claude Code](https://claude.com/claude-code)