### PR TITLE
feat(altname): 別名拼音 c_alt_name 改為必填（新增與編輯皆強制）

### DIFF
--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -85,6 +85,8 @@ export default function AltnameEditor({
 
     const save = async (sm: 'direct' | 'proposal') => {
         setSaving(true); setError(null); setMessage(null);
+        // 別名（拼音）c_alt_name 必填：建立與編輯皆不可為空（使用者指定，較 legacy 嚴格）。
+        if ((fields.c_alt_name ?? '') === '') { setSaving(false); setError(tr('altname_pinyin_required', '請輸入別名（拼音）')); return; }
         let changes: Record<string, string | null>;
         let target: Record<string, string | number>;
         let endpoint: string;
@@ -180,7 +182,7 @@ export default function AltnameEditor({
                         value={fields.c_alt_name_type_code ?? '0'} initialLabel={labels.c_alt_name_type_code ?? ''} disabled={!editable}
                         onChange={(v, l) => { set('c_alt_name_type_code', v); setLabel('c_alt_name_type_code', l); }} />)}
                 {textRow('c_alt_name_chn', tr('altname_chn', '別名（中）'), 'c_alt_name_chn', 'text', false, true)}
-                {textRow('c_alt_name', tr('altname_pinyin_label', '別名（拼音）'), 'c_alt_name')}
+                {textRow('c_alt_name', tr('altname_pinyin_label', '別名（拼音）'), 'c_alt_name', 'text', false, true)}
                 {textRow('c_sequence', tr('sequence', '次序'), 'c_sequence', 'number', false, mode === 'create')}
 
                 {gridCell(tr('source_field', '出處'), { code: 'c_source' },

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -433,6 +433,7 @@ return [
     'index_year_source' => 'Index Year Source',
     // Validation warnings.
     'altname_required' => 'Please enter the alternative name (Chinese)',
+    'altname_pinyin_required' => 'Please enter the alternative name (Pinyin)',
     'sequence_required' => 'Please enter a sequence number',
     'pk_required' => 'Primary key fields cannot be empty',
     'please_select_source' => 'Please select a source',

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -433,6 +433,7 @@ return [
     'index_year_source' => '指數年來源',
     // 驗證警告。
     'altname_required' => '請輸入別名（中文）',
+    'altname_pinyin_required' => '請輸入別名（拼音）',
     'sequence_required' => '請輸入序號',
     'pk_required' => '主鍵欄位不可為空',
     'please_select_source' => '請選擇出處',


### PR DESCRIPTION
## 需求
別名編輯器的 **Alt. Name (Pinyin) `c_alt_name`** 改為**必填**（新增與編輯皆強制）。legacy 與原 React 版皆未要求此欄。

## 變更
- `AltnameEditor.tsx`：`save()` 起始加入 `c_alt_name` 非空檢查，涵蓋 **create / edit × direct / proposal** 四條路徑；`doDelete()` 不受影響。
- UI：`c_alt_name` 欄位標記 required 星號（恆顯示）。
- i18n：新增 `altname_pinyin_required`（en／zh-TW `biogmains`，key 同步）。

## 行為說明
- 既有 Pinyin 為空的舊列（legacy 未收集）在編輯時也需補齊 Pinyin 才能儲存——此為刻意設計（資料清理），已與需求方確認。
- 規則為前端驗證（與既有 `c_alt_name_chn`／`c_sequence` 必填一致）；v2 mutation API 不受影響、`c_alt_name` schema 仍 nullable。

## 驗證
- `npm run build` ✅、`php -l` ✅、`php-cs-fixer`（cs check）0 fixes ✅
- review agent + codex 皆判定 SAFE / Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)