### PR TITLE
fix(editor): 出處＋頁碼共佔一行（新增 gPairRow，修寬螢幕被拆散）

### DIFF
--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -5,7 +5,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
-    gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
+    gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
     gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
@@ -185,11 +185,14 @@ export default function AltnameEditor({
                 {textRow('c_alt_name', tr('altname_pinyin_label', '別名（拼音）'), 'c_alt_name', 'text', false, true)}
                 {textRow('c_sequence', tr('sequence', '次序'), 'c_sequence', 'number', false, mode === 'create')}
 
-                {gridCell(tr('source_field', '出處'), { code: 'c_source' },
-                    <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
-                        value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
-                        onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
-                {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', 'text', sourceHighlight)}
+                {/* 出處 + 頁碼 共佔一行（gPairRow：寬螢幕也並排、不被外層拆散） */}
+                <div style={gPairRow}>
+                    {gridCell(tr('source_field', '出處'), { code: 'c_source' },
+                        <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
+                            value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
+                            onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
+                    {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', 'text', sourceHighlight)}
+                </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
                     <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>

--- a/resources/js/inertia/components/EntryEditor.tsx
+++ b/resources/js/inertia/components/EntryEditor.tsx
@@ -6,7 +6,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
-    gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
+    gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
     gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
@@ -283,12 +283,15 @@ export default function EntryEditor({
                         value={instCombined} initialLabel={labels.c_inst_code ?? ''} disabled={!editable}
                         onChange={onPickInst} />)}
 
-                {gridCell(tr('source_field', '出處'), { code: 'c_source' },
-                    <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
-                        value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
-                        aria-invalid={sourceHighlight}
-                        onChange={(v, l) => { set('c_source', v || '0'); setLabel('c_source', l); }} />)}
-                {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
+                {/* 出處 + 頁碼 共佔一行（gPairRow：寬螢幕也並排、不被外層拆散） */}
+                <div style={gPairRow}>
+                    {gridCell(tr('source_field', '出處'), { code: 'c_source' },
+                        <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
+                            value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
+                            aria-invalid={sourceHighlight}
+                            onChange={(v, l) => { set('c_source', v || '0'); setLabel('c_source', l); }} />)}
+                    {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
+                </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
                     <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>

--- a/resources/js/inertia/components/PersonEditorShared/grid.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/grid.tsx
@@ -17,6 +17,9 @@ export const gridSectionHeadStyle: React.CSSProperties = { fontSize: '0.82rem', 
 // 響應式雙欄：寬螢幕 2 欄、窄螢幕自動降為 1 欄（min(100%,22rem) 使極窄時不溢出）。
 export const gGrid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 22rem), 1fr))', gap: '14px 22px', marginBottom: 4 };
 export const gFull: React.CSSProperties = { gridColumn: '1 / -1' };
+// 成對欄位「共佔一行」：占滿外層整行（1/-1），內部再以響應式雙欄並排兩欄；
+// 避免外層 auto-fit 在寬螢幕變 3 欄時把本該並排的兩欄拆到不同列（窄螢幕仍自動堆疊）。
+export const gPairRow: React.CSSProperties = { gridColumn: '1 / -1', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 16rem), 1fr))', gap: '14px 22px' };
 export const gLabelStyle: React.CSSProperties = { display: 'block', fontSize: '0.9rem', fontWeight: 600, color: 'var(--foreground)', marginBottom: 5 };
 export const gCodeStyle: React.CSSProperties = { fontWeight: 400, color: 'var(--muted-foreground)', fontSize: '0.78rem', marginLeft: 6 };
 export const gInputStyle: React.CSSProperties = { width: '100%', height: 40, padding: '0 11px', borderRadius: 8, border: '1px solid var(--input)', fontSize: '1rem', boxSizing: 'border-box', background: 'var(--background)', color: 'var(--foreground)' };

--- a/resources/js/inertia/components/TextEditor.tsx
+++ b/resources/js/inertia/components/TextEditor.tsx
@@ -5,7 +5,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
-    gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
+    gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
     gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
@@ -179,11 +179,14 @@ export default function TextEditor({
                         value={fields.c_textid ?? '0'} initialLabel={labels.c_textid ?? ''} disabled={!editable}
                         onChange={(v, l) => { set('c_textid', v || '0'); setLabel('c_textid', l); }} />)}
 
-                {gridCell(tr('source_field', '出處'), { code: 'c_source' },
-                    <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
-                        value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
-                        onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
-                {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
+                {/* 出處 + 頁碼 共佔一行（gPairRow：寬螢幕也並排、不被外層拆散） */}
+                <div style={gPairRow}>
+                    {gridCell(tr('source_field', '出處'), { code: 'c_source' },
+                        <CodeAutocomplete mode="search" endpoint="/api/select/search/text"
+                            value={fields.c_source ?? ''} initialLabel={labels.c_source ?? ''} disabled={!editable}
+                            onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
+                    {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
+                </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
                     <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>


### PR DESCRIPTION
## 問題
texts／altnames／entries 三個編輯器的 **出處 (c_source)** 與 **頁碼 (c_pages)** 應並排於同一列，但外層 `gGrid` 為 `repeat(auto-fit, minmax(min(100%,22rem),1fr))`，**寬螢幕會變 3 欄**，使這兩欄被拆到不同列（出處留在上一列、頁碼被擠到下一列獨佔）。

## 修正
- `grid.tsx` 新增 `gPairRow`：占滿外層整行（`gridColumn: 1 / -1`）+ 內部響應式雙欄（`auto-fit, minmax(min(100%,16rem),1fr)`）。成對欄位因此**永遠共佔一行**、桌機並排、窄螢幕自動堆疊。
- `TextEditor`／`EntryEditor`／`AltnameEditor` 將「出處＋頁碼」包進 `gPairRow`。
- 欄位綁定全數保留（含 EntryEditor 的 `aria-invalid`、`c_source` 的 `||'0'`、`c_pages` 的 sourceHighlight）；內部 gap 與外層一致、對齊不變。

## 驗證
- `npm run build` ✅
- review agent + codex 皆判定 SAFE / Clean（含 grid track 數學、focus-loss 規則、三編輯器一致性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)