### PR TITLE
feat(logs): 日誌頁狀態一眼可辨——重設計 NL Query / AI Fill Logs 狀態視覺

### DIFF
--- a/resources/js/inertia/Pages/Admin/AiFillLogs/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/AiFillLogs/Index.tsx
@@ -11,6 +11,8 @@ import { useDataTableQuery } from '../../../components/data-table/useDataTableQu
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 import { cn } from '../../../lib/utils';
+import { LOG_TONE, LOG_CARD_BASE, LOG_HEADER_BASE, LOG_PILL_BASE } from '../logCardStyles';
+import { LogCollapsible } from '../LogCollapsible';
 
 interface ComparisonRow {
     field: string;
@@ -58,19 +60,10 @@ interface AiFillLogsPageProps extends SharedProps {
 }
 
 const CATEGORY_BADGE: Record<string, string> = {
-    posting: 'bg-blue-100 text-blue-800',
-    assoc: 'bg-cyan-100 text-cyan-800',
-    status: 'bg-yellow-100 text-yellow-800',
+    posting: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300',
+    assoc: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-500/15 dark:text-cyan-300',
+    status: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-300',
 };
-
-function Collapsible({ label, children }: { label: string; children: React.ReactNode }) {
-    return (
-        <details className="mb-2 rounded border border-border">
-            <summary className="cursor-pointer px-3 py-1.5 text-sm font-medium hover:bg-muted">{label}</summary>
-            <div className="border-t border-border p-2">{children}</div>
-        </details>
-    );
-}
 
 export default function AiFillLogsIndex() {
     const props = usePage<AiFillLogsPageProps>().props;
@@ -163,7 +156,7 @@ export default function AiFillLogsIndex() {
                 </div>
             </form>
 
-            <div className="mb-3 rounded border border-blue-300 bg-blue-50 px-4 py-2 text-sm text-blue-800">
+            <div className="mb-3 rounded border border-blue-300 bg-blue-50 px-4 py-2 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200">
                 <i className="fas fa-info-circle mr-1" aria-hidden />
                 {t('ai_log_summary', {
                     total: String(logs.meta.total),
@@ -173,27 +166,23 @@ export default function AiFillLogsIndex() {
             </div>
 
             {logs.data.length === 0 ? (
-                <div className="rounded border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+                <div className="rounded border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/40 dark:text-yellow-200">
                     <i className="fas fa-exclamation-triangle mr-1" aria-hidden /> {t('ai_log_no_records')}
                 </div>
             ) : (
                 <div className="space-y-4">
-                    {logs.data.map((log) => (
-                        <div
-                            key={log.id}
-                            className={cn(
-                                'rounded-lg border bg-card',
-                                log.has_submission ? 'border-green-400' : 'border-blue-400'
-                            )}
-                        >
-                            <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2 text-sm">
-                                <strong>#{log.id}</strong>
-                                <span className={cn('rounded px-2 py-0.5 text-xs font-semibold', CATEGORY_BADGE[log.category] ?? 'bg-gray-100 text-gray-800')}>
+                    {logs.data.map((log) => {
+                        const tone = LOG_TONE[log.has_submission ? 'success' : 'neutral'];
+                        return (
+                        <article key={log.id} className={cn(LOG_CARD_BASE, tone.card)}>
+                            <header className={cn(LOG_HEADER_BASE, tone.header)}>
+                                <span className="font-mono font-semibold text-muted-foreground">#{log.id}</span>
+                                <span className={cn('rounded px-2 py-0.5 text-xs font-semibold', CATEGORY_BADGE[log.category] ?? 'bg-muted text-muted-foreground')}>
                                     {categoryLabel(log.category)}
                                 </span>
                                 <span>
-                                    <i className="fas fa-user mr-1" aria-hidden />
-                                    {log.user_name ?? t('ai_log_unknown_user')}
+                                    <i className="fas fa-user mr-1 text-muted-foreground" aria-hidden />
+                                    <span className="font-medium text-foreground">{log.user_name ?? t('ai_log_unknown_user')}</span>
                                     {log.user_email && <small className="ml-1 text-muted-foreground">({log.user_email})</small>}
                                 </span>
                                 {log.person_url && (
@@ -212,10 +201,11 @@ export default function AiFillLogsIndex() {
                                         {log.execution_time_ms}ms
                                     </span>
                                 )}
-                                <span className="ml-auto rounded bg-muted px-2 py-0.5 text-xs">
+                                <span className={cn(LOG_PILL_BASE, tone.pill)}>
+                                    <i className={cn('fas', log.has_submission ? 'fa-check-circle' : 'fa-minus-circle')} aria-hidden />
                                     {log.has_submission ? t('ai_log_submitted') : t('ai_log_not_submitted')}
                                 </span>
-                            </div>
+                            </header>
 
                             <div className="space-y-3 p-4">
                                 <div>
@@ -227,20 +217,20 @@ export default function AiFillLogsIndex() {
 
                                 {log.statistics && (
                                     <div className="flex flex-wrap gap-1 text-xs">
-                                        <span className="rounded bg-green-100 px-2 py-0.5 text-green-800">
+                                        <span className="rounded bg-emerald-100 px-2 py-0.5 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300">
                                             {t('ai_log_matched', { count: String(log.statistics.matched_count ?? 0) })}
                                         </span>
                                         {(log.statistics.suggested_count ?? 0) > 0 && (
-                                            <span className="rounded bg-yellow-100 px-2 py-0.5 text-yellow-800">
+                                            <span className="rounded bg-yellow-100 px-2 py-0.5 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-300">
                                                 {t('ai_log_suggested', { count: String(log.statistics.suggested_count) })}
                                             </span>
                                         )}
                                         {(log.statistics.not_found_count ?? 0) > 0 && (
-                                            <span className="rounded bg-blue-100 px-2 py-0.5 text-blue-800">
+                                            <span className="rounded bg-blue-100 px-2 py-0.5 text-blue-800 dark:bg-blue-500/15 dark:text-blue-300">
                                                 {t('ai_log_not_matched', { count: String(log.statistics.not_found_count) })}
                                             </span>
                                         )}
-                                        <span className="rounded bg-gray-100 px-2 py-0.5 text-gray-800">
+                                        <span className="rounded bg-muted px-2 py-0.5 text-muted-foreground">
                                             {t('ai_log_empty', { count: String(log.statistics.empty_count ?? 0) })}
                                         </span>
                                     </div>
@@ -261,23 +251,24 @@ export default function AiFillLogsIndex() {
                                 )}
 
                                 {log.ai_raw_pretty && (
-                                    <Collapsible label={t('ai_log_ai_raw')}>
+                                    <LogCollapsible label={t('ai_log_ai_raw')}>
                                         <pre className="max-h-96 overflow-auto bg-muted/40 p-2 text-xs">{log.ai_raw_pretty}</pre>
-                                    </Collapsible>
+                                    </LogCollapsible>
                                 )}
                                 {log.ai_matched_pretty && (
-                                    <Collapsible label={t('ai_log_ai_matched')}>
+                                    <LogCollapsible label={t('ai_log_ai_matched')}>
                                         <pre className="max-h-96 overflow-auto bg-muted/40 p-2 text-xs">{log.ai_matched_pretty}</pre>
-                                    </Collapsible>
+                                    </LogCollapsible>
                                 )}
                                 {log.user_submitted_pretty && (
-                                    <Collapsible label={t('ai_log_user_submitted')}>
+                                    <LogCollapsible label={t('ai_log_user_submitted')}>
                                         <pre className="max-h-96 overflow-auto bg-muted/40 p-2 text-xs">{log.user_submitted_pretty}</pre>
-                                    </Collapsible>
+                                    </LogCollapsible>
                                 )}
                             </div>
-                        </div>
-                    ))}
+                        </article>
+                        );
+                    })}
 
                     <Pagination
                         meta={logs.meta}
@@ -315,13 +306,13 @@ export default function AiFillLogsIndex() {
                                         <td
                                             className={cn(
                                                 'px-2 py-1 break-all',
-                                                r.ai_type === 'matched' && 'text-green-700',
-                                                r.ai_type === 'suggested' && 'text-yellow-700'
+                                                r.ai_type === 'matched' && 'text-emerald-700 dark:text-emerald-400',
+                                                r.ai_type === 'suggested' && 'text-yellow-700 dark:text-yellow-400'
                                             )}
                                         >
                                             {r.ai_value}
                                         </td>
-                                        <td className={cn('px-2 py-1 break-all', r.matches && 'text-green-700')}>
+                                        <td className={cn('px-2 py-1 break-all', r.matches && 'text-emerald-700 dark:text-emerald-400')}>
                                             {r.user_value}
                                         </td>
                                     </tr>

--- a/resources/js/inertia/Pages/Admin/LogCollapsible.tsx
+++ b/resources/js/inertia/Pages/Admin/LogCollapsible.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * 日誌頁共用的折疊區塊（NL Query Logs / AI Fill Logs）。
+ *
+ * 兩頁原各自內聯一份 <details>，已出現樣式漂移（一邊多了 mb-2）。此處統一為
+ * 無外距版本，垂直間距交由父層 `space-y-3` 控制，確保兩頁一致。
+ */
+export function LogCollapsible({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <details className="rounded border border-border">
+            <summary className="cursor-pointer px-3 py-1.5 text-sm font-medium hover:bg-muted">{label}</summary>
+            <div className="border-t border-border p-2">{children}</div>
+        </details>
+    );
+}

--- a/resources/js/inertia/Pages/Admin/NlQueryLogs/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/NlQueryLogs/Index.tsx
@@ -10,6 +10,8 @@ import { useDataTableQuery } from '../../../components/data-table/useDataTableQu
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 import { cn } from '../../../lib/utils';
+import { LOG_TONE, LOG_CARD_BASE, LOG_HEADER_BASE, LOG_PILL_BASE } from '../logCardStyles';
+import { LogCollapsible } from '../LogCollapsible';
 
 interface LlmSummary {
     model: string | null;
@@ -47,15 +49,6 @@ interface NlQueryLogsPageProps extends SharedProps {
 
 const nf = new Intl.NumberFormat();
 
-function Collapsible({ label, children }: { label: string; children: React.ReactNode }) {
-    return (
-        <details className="rounded border border-border">
-            <summary className="cursor-pointer px-3 py-1.5 text-sm font-medium hover:bg-muted">{label}</summary>
-            <div className="border-t border-border p-2">{children}</div>
-        </details>
-    );
-}
-
 export default function NlQueryLogsIndex() {
     const props = usePage<NlQueryLogsPageProps>().props;
     const { logs, users, filters, playground_url } = props;
@@ -84,8 +77,8 @@ export default function NlQueryLogsIndex() {
 
     return (
         <DashboardLayout
-            title="NL Query Logs"
-            breadcrumbs={[{ label: 'NL Query Logs' }]}
+            title={t('log_page_title')}
+            breadcrumbs={[{ label: t('log_page_title') }]}
         >
             <div className="mb-3">
                 <a
@@ -142,7 +135,7 @@ export default function NlQueryLogsIndex() {
                 </div>
             </form>
 
-            <div className="mb-3 rounded border border-blue-300 bg-blue-50 px-4 py-2 text-sm text-blue-800">
+            <div className="mb-3 rounded border border-blue-300 bg-blue-50 px-4 py-2 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200">
                 <i className="fas fa-info-circle mr-1" aria-hidden />
                 {t('log_record_count', {
                     total: String(logs.meta.total),
@@ -152,18 +145,20 @@ export default function NlQueryLogsIndex() {
             </div>
 
             {logs.data.length === 0 ? (
-                <div className="rounded border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+                <div className="rounded border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/40 dark:text-yellow-200">
                     <i className="fas fa-exclamation-triangle mr-1" aria-hidden /> {t('log_no_records')}
                 </div>
             ) : (
                 <div className="space-y-4">
-                    {logs.data.map((log) => (
-                        <div key={log.id} className={cn('rounded-lg border bg-card', log.success ? 'border-green-400' : 'border-red-400')}>
-                            <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2 text-sm">
-                                <strong>#{log.id}</strong>
+                    {logs.data.map((log) => {
+                        const tone = LOG_TONE[log.success ? 'success' : 'danger'];
+                        return (
+                        <article key={log.id} className={cn(LOG_CARD_BASE, tone.card)}>
+                            <header className={cn(LOG_HEADER_BASE, tone.header)}>
+                                <span className="font-mono font-semibold text-muted-foreground">#{log.id}</span>
                                 <span>
-                                    <i className="fas fa-user mr-1" aria-hidden />
-                                    {log.user_name ?? tc('unknown')}
+                                    <i className="fas fa-user mr-1 text-muted-foreground" aria-hidden />
+                                    <span className="font-medium text-foreground">{log.user_name ?? tc('unknown')}</span>
                                     {log.user_email && <small className="ml-1 text-muted-foreground">({log.user_email})</small>}
                                 </span>
                                 <span className="text-muted-foreground">
@@ -176,10 +171,11 @@ export default function NlQueryLogsIndex() {
                                         {log.execution_time_ms}ms
                                     </span>
                                 )}
-                                <span className={cn('ml-auto rounded px-2 py-0.5 text-xs font-semibold', log.success ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800')}>
+                                <span className={cn(LOG_PILL_BASE, tone.pill)}>
+                                    <i className={cn('fas', log.success ? 'fa-check-circle' : 'fa-times-circle')} aria-hidden />
                                     {log.success ? t('log_status_success') : t('log_status_failure')}
                                 </span>
-                            </div>
+                            </header>
 
                             <div className="space-y-3 p-4">
                                 <div>
@@ -194,7 +190,7 @@ export default function NlQueryLogsIndex() {
                                         {log.generated_sql && (
                                             <div>
                                                 <h6 className="mb-1 font-medium">
-                                                    <i className="fas fa-code mr-1 text-green-600" aria-hidden /> {t('log_generated_sql')}
+                                                    <i className="fas fa-code mr-1 text-emerald-600" aria-hidden /> {t('log_generated_sql')}
                                                 </h6>
                                                 <pre className="max-h-52 overflow-auto rounded bg-muted/40 p-2 text-xs">{log.generated_sql}</pre>
                                             </div>
@@ -212,9 +208,9 @@ export default function NlQueryLogsIndex() {
                                     log.error_message && (
                                         <div>
                                             <h6 className="mb-1 font-medium">
-                                                <i className="fas fa-exclamation-triangle mr-1 text-red-600" aria-hidden /> {t('log_error_message')}
+                                                <i className="fas fa-exclamation-triangle mr-1 text-destructive" aria-hidden /> {t('log_error_message')}
                                             </h6>
-                                            <div className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">{log.error_message}</div>
+                                            <div className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{log.error_message}</div>
                                         </div>
                                     )
                                 )}
@@ -234,18 +230,19 @@ export default function NlQueryLogsIndex() {
                                 )}
 
                                 {log.llm_prompt && (
-                                    <Collapsible label={t('log_llm_prompt')}>
+                                    <LogCollapsible label={t('log_llm_prompt')}>
                                         <pre className="max-h-96 overflow-auto bg-muted/40 p-2 text-xs">{log.llm_prompt}</pre>
-                                    </Collapsible>
+                                    </LogCollapsible>
                                 )}
                                 {log.llm_response && (
-                                    <Collapsible label={t('log_llm_response')}>
+                                    <LogCollapsible label={t('log_llm_response')}>
                                         <pre className="max-h-[32rem] overflow-auto bg-muted/40 p-2 text-xs">{log.llm_response}</pre>
-                                    </Collapsible>
+                                    </LogCollapsible>
                                 )}
                             </div>
-                        </div>
-                    ))}
+                        </article>
+                        );
+                    })}
 
                     <Pagination
                         meta={logs.meta}

--- a/resources/js/inertia/Pages/Admin/logCardStyles.ts
+++ b/resources/js/inertia/Pages/Admin/logCardStyles.ts
@@ -1,0 +1,55 @@
+/**
+ * 日誌卡片狀態視覺語言（NL Query Logs / AI Fill Logs 共用）。
+ *
+ * 設計目標：在長列表中「一眼」分辨每筆記錄的狀態（成功/失敗、已提交/未提交）。
+ * 舊版 AdminLTE 以整條實色標題列達成可掃視性；此處改用更貼合 React 設計系統的
+ * 三段式語言，既醒目又不刺眼，且支援深色模式：
+ *   1. card   —— 四邊維持中性 border-border、僅左側 4px 強調條（border-l-4）染色，
+ *               長列表縱向掃視的周邊視覺訊號；不再四邊上色，避免比全站其它元件更吵
+ *   2. header —— 淡色標題帶，整列染色取代舊版實色 bar
+ *   3. pill   —— 右側實色狀態徽章（含圖示），修正舊新版「灰底徽章兩態無區別」的問題
+ *
+ * tone 語意：
+ *   success —— NL 查詢成功 / AI 結果已被使用者提交（醒目綠，代表「有效」記錄）
+ *   danger  —— NL 查詢失敗，採全站 --destructive（Harvard 紅）語意 token，避免同頁兩種紅
+ *   neutral —— AI 結果未提交（中性灰，與 success 形成強對比，讓已提交的記錄跳出來）
+ */
+export type LogTone = 'success' | 'danger' | 'neutral';
+
+export interface LogToneClasses {
+    /** <article> 外框：四邊細框 + 左側 4px 強調條 */
+    card: string;
+    /** 標題列背景帶 */
+    header: string;
+    /** 右側狀態徽章 */
+    pill: string;
+}
+
+export const LOG_TONE: Record<LogTone, LogToneClasses> = {
+    success: {
+        card: 'border-border border-l-4 border-l-emerald-500',
+        header: 'bg-emerald-50 dark:bg-emerald-950/40',
+        pill: 'bg-emerald-700 text-white',
+    },
+    danger: {
+        card: 'border-border border-l-4 border-l-destructive',
+        header: 'bg-destructive/10 dark:bg-destructive/20',
+        pill: 'bg-destructive text-destructive-foreground',
+    },
+    neutral: {
+        card: 'border-border border-l-4 border-l-slate-300 dark:border-l-slate-600',
+        header: 'bg-muted/40',
+        pill: 'bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-100',
+    },
+};
+
+/** <article> 外框共用基底（與 tone.card 併用）。 */
+export const LOG_CARD_BASE = 'overflow-hidden rounded-lg border bg-card shadow-sm';
+
+/** 標題列共用基底（與 tone.header 併用）。 */
+export const LOG_HEADER_BASE =
+    'flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-4 py-2.5 text-sm';
+
+/** 狀態徽章共用基底（與 tone.pill 併用）。 */
+export const LOG_PILL_BASE =
+    'ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold';

--- a/resources/lang/en/query.php
+++ b/resources/lang/en/query.php
@@ -109,6 +109,7 @@ return [
     'qa_show_details'          => '▶ Show Details (SQL, Evidence)',
 
     // NL Query Logs page
+    'log_page_title'         => 'NL Query Logs',
     'log_back_link'          => '← Back to Query Playground',
     'log_keyword_search'     => 'Keyword Search',
     'log_search_placeholder' => 'Search question, SQL, username or email',

--- a/resources/lang/zh-TW/query.php
+++ b/resources/lang/zh-TW/query.php
@@ -109,6 +109,7 @@ return [
     'qa_show_details'          => '▶ 顯示詳細資訊（SQL、證據來源）',
 
     // NL Query Logs page
+    'log_page_title'         => '自然語言查詢日誌',
     'log_back_link'          => '← 返回查詢練習場',
     'log_keyword_search'     => '關鍵字搜尋',
     'log_search_placeholder' => '搜尋問題、SQL、用戶名稱或郵箱',


### PR DESCRIPTION
## 背景
舊版（AdminLTE）以整條實色標題列標示狀態，長列表中可一眼分辨。新版 React/Inertia 兩頁只剩細邊框＋小徽章，難以掃視；其中 **AI Fill Logs 的「已提交／未提交」徽章兩態皆 `bg-muted` 灰色，完全沒有顏色差異**。

## 設計方案
新增共用狀態視覺語言 `logCardStyles.ts`（success / danger / neutral 三態），貼合全站 shadcn/Tailwind 設計系統、支援深色模式：
1. 左側 4px 強調條（縱向掃視的周邊視覺訊號）
2. 淡色標題帶（取代舊版實色 bar，較柔和）
3. 含圖示的實色狀態徽章（修正灰底兩態無區別）

## 變更
- **NL Query Logs**：成功 emerald／失敗改用全站 `--destructive`（Harvard 紅）語意 token，避免同頁兩種紅。
- **AI Fill Logs**：已提交 emerald 跳出、未提交中性灰；修正核心 bug。
- accessory chips（分類徽章、統計徽章、提示橫幅、比較 modal 文字）補齊深色模式變體。
- 狀態徽章對比 emerald-600 → emerald-700（WCAG AA）。
- 抽出共用 `LogCollapsible`，消除兩頁重複且已漂移的折疊元件。
- NL Query Logs 硬編碼標題改用 i18n key `log_page_title`（zh-TW／en 同步）。

## 驗證
- 每環節皆經 review agent（程式碼＋設計）→ codex（terminal）雙重審查至無嚴重 issue。
- `NlQueryLogsInertiaTest` + `AiFillLogInertiaTest` 共 7 測試全綠。
- 變更檔 TypeScript 零錯誤；`npm run build` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)