### PR TITLE
fix(operations): Compare 稽核日誌標頭超長複合主鍵改為折行

### DIFF
--- a/resources/js/inertia/Pages/Admin/Operations/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/Operations/Index.tsx
@@ -442,7 +442,7 @@ function CompareBody({ row, t }: { row: OpRow; t: (k: string) => string }) {
                 <div className="text-xs text-muted-foreground">{t('audit_log_count_item').replace(':count', String(row.audit_logs.length))}</div>
                 {row.audit_logs.map((a, i) => (
                     <div key={i} className="rounded border border-border p-2">
-                        <div className="mb-1.5 text-xs">
+                        <div className="mb-1.5 break-all text-xs">
                             <strong>{a.table_name ?? t('unknown_table')}</strong> · {(a.operation ?? 'UNKNOWN').toUpperCase()} · <span className="font-mono">{a.row_pk_text}</span>
                         </div>
                         <DiffTable diff={a.diff} t={t} />


### PR DESCRIPTION
## 問題
`/app/operations` 的 Compare 彈窗，稽核日誌標頭會顯示複合主鍵字串，例如：

```
ENTRY_DATA · UPDATE · c_personid=133235&c_entry_code=110&c_sequence=0&c_kin_code=0&...
```

此字串無空白，瀏覽器預設不會在 `&` / `=` 處斷行 → 溢出容器、穿出版面。

## 修法
於標頭 `<div>` 加上 `break-all`。`word-break` 為可繼承屬性，會套用到內層 `font-mono` span 的長字串，使其逐字折行。與同彈窗 `DiffTable`／`KeyValueTable` 值欄、資源描述列既有的 `break-all` 慣例一致（單行、純 CSS 改動）。

## 驗證
- review agent（程式碼）：0 correctness issues，確認 `word-break` 繼承生效、`break-all` 為正確 utility（非 `break-words`）、無其他未修溢出點。
- codex（terminal）：no serious findings。

🤖 Generated with [Claude Code](https://claude.com/claude-code)