### PR TITLE
fix(pinyin): 修生成姓名拼音失敗 + 擴充親屬稱謂覆蓋

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -633,8 +633,19 @@ class ApiController extends Controller {
         return null;
     }
 
+    /**
+     * 稱謂 → 英文片語映射。供「（X母）」「宗氏（X妻）」等女性/親屬以關係命名者一鍵轉寫拼音。
+     *
+     * ⚠️ 順序很重要：多字稱謂（祖母/祖父/孫女）必須排在其單字後綴（母/父/女）之前，
+     * 確保正則 alternation 先嘗試較長者（雖然結尾的「）」錨點通常已能消歧，longest-first 更穩妥）。
+     */
     private function relationshipPhrases(): array {
         return [
+            // 多字稱謂（longest-first）
+            '祖母' => 'Grandmother of',
+            '祖父' => 'Grandfather of',
+            '孫女' => 'Granddaughter of',
+            // 既有女性/親屬稱謂
             '妻' => 'Wife of',
             '母' => 'Mother of',
             '女' => 'Daughter of',
@@ -643,6 +654,16 @@ class ApiController extends Controller {
             '妹' => 'Younger Sister of',
             '姐' => 'Elder Sister of',
             '姊' => 'Elder Sister of',
+            '嫂' => 'Sister-in-law of',
+            // 擴充：男性與其餘常見親屬。
+            // 註：刻意不收單字「子」「孫」——兩者皆為極常見的名字/詞用字（如「公孫」「王孫」本身可為姓氏/詞），
+            // 且 CBDB 中以「某之子／某之孫」為名者罕見（多有本名），收錄會把「（李子）」「（公孫）」這類
+            // 括號別名誤判為關係稱謂，得不償失。需要孫輩女性時仍可用多字「孫女」（Granddaughter，無歧義）。
+            '夫' => 'Husband of',
+            '父' => 'Father of',
+            '兄' => 'Elder Brother of',
+            '弟' => 'Younger Brother of',
+            '婿' => 'Son-in-law of',
         ];
     }
 }

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -170,22 +170,22 @@ export default function BasicInfoEditor({
     };
 
     // 生成拼音：用中文姓名查 /api/select/search/pinyin，回填拼音姓/名。
+    // 注意：此端點回傳「純文字字串」（如 "An Shi"、"(Wife of Li Bai)"），不是 {data:[...]} 自動完成結構，
+    // 故以 r.text() 讀取（舊版 Blade 編輯器亦直接取用字串）。誤用 r.json() 會在解析純文字時拋錯 → 一律「生成拼音失敗」。
     const generatePinyin = async () => {
         setError(null); setMessage(null); // 清掉前次錯誤/訊息，避免本次成功時頂部殘留舊 error alert。
         try {
             // 不再吞掉 HTTP 失敗：!r.ok 即拋出，落到下方 catch 顯示 generate_pinyin_failed（否則 500/422 會被誤當成功）。
-            const surnameRes = await fetch(`${pinyinEndpoint}?q=${encodeURIComponent(fields.c_surname_chn ?? '')}`, {
-                headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin',
-            }).then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); });
-            const mingziRes = await fetch(`${pinyinEndpoint}?q=${encodeURIComponent(fields.c_mingzi_chn ?? '')}&split=0`, {
-                headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin',
-            }).then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); });
-            const pick = (res: unknown): string => {
-                const rows = Array.isArray((res as { data?: unknown[] })?.data) ? (res as { data: Array<Record<string, unknown>> }).data : [];
-                const first = rows[0];
-                return first ? String(first.text ?? first.c_name ?? first.value ?? '') : '';
+            const fetchPinyin = async (q: string, split: boolean): Promise<string> => {
+                const r = await fetch(`${pinyinEndpoint}?q=${encodeURIComponent(q)}${split ? '' : '&split=0'}`, {
+                    headers: { Accept: 'text/plain', 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin',
+                });
+                if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                return (await r.text()).trim();
             };
-            const sp = pick(surnameRes); const mp = pick(mingziRes);
+            // 姓氏走預設 split=1（已知姓氏後插空格）；名走 split=0（整體轉換、不再拆姓）。
+            const sp = await fetchPinyin(fields.c_surname_chn ?? '', true);
+            const mp = await fetchPinyin(fields.c_mingzi_chn ?? '', false);
             // 回填拼音姓/名後，同步重算派生「拼音全名」(c_name)，使下方自動生成框即時更新（資料流收尾）。
             setFields((p) => { const next = { ...p, c_surname: sp || p.c_surname, c_mingzi: mp || p.c_mingzi }; return { ...next, ...deriveNames(next) }; });
             setPinyinDone(true);

--- a/tests/Feature/ApiSearchPinyinTest.php
+++ b/tests/Feature/ApiSearchPinyinTest.php
@@ -102,6 +102,69 @@ class ApiSearchPinyinTest extends TestCase {
     }
 
     #[Test]
+    public function search_pinyin_converts_expanded_relationship_patterns_to_english_phrases(): void {
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '李', 'lastname_pinyin' => 'Li'],
+            ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
+        ]);
+
+        $cases = [
+            '（李白夫）' => 'Husband of Li Bai',
+            '（李白父）' => 'Father of Li Bai',
+            '（王安石兄）' => 'Elder Brother of Wang Anshi',
+            '（李白弟）' => 'Younger Brother of Li Bai',
+            '（李白婿）' => 'Son-in-law of Li Bai',
+            '（王安石嫂）' => 'Sister-in-law of Wang Anshi',
+        ];
+
+        foreach ($cases as $query => $expectedPhrase) {
+            $response = $this->get('/api/select/search/pinyin?q='.urlencode($query));
+            $response->assertOk();
+            $this->assertSame('('.$expectedPhrase.')', trim($response->getContent()));
+        }
+    }
+
+    #[Test]
+    public function search_pinyin_prefers_multi_char_titles_over_single_char_suffix(): void {
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '李', 'lastname_pinyin' => 'Li'],
+            ['lastname_chn' => '王', 'lastname_pinyin' => 'Wang'],
+            ['lastname_chn' => '宗', 'lastname_pinyin' => 'Zong'],
+        ]);
+
+        // 多字稱謂不可被其單字後綴（母/父/女）誤切：祖母≠母、祖父≠父、孫女≠女。
+        $cases = [
+            '（李白祖母）' => '(Grandmother of Li Bai)',
+            '（王安石祖父）' => '(Grandfather of Wang Anshi)',
+            '（李白孫女）' => '(Granddaughter of Li Bai)',
+            // 前綴形（特例 2）同樣須正確消歧
+            '宗氏（李白祖母）' => 'Zong Shi (Grandmother of Li Bai)',
+        ];
+
+        foreach ($cases as $query => $expected) {
+            $response = $this->get('/api/select/search/pinyin?q='.urlencode($query));
+            $response->assertOk();
+            $this->assertSame($expected, trim($response->getContent()));
+        }
+    }
+
+    #[Test]
+    public function search_pinyin_does_not_treat_non_relationship_parenthetical_as_relationship(): void {
+        DB::table('pinyin')->insert([
+            ['lastname_chn' => '李', 'lastname_pinyin' => 'Li'],
+            ['lastname_chn' => '公', 'lastname_pinyin' => 'Gong'],
+        ]);
+
+        // 「子」「孫」非稱謂（刻意未收）：「（李子）」「（公孫）」這類括號別名/詞不應被誤判為關係稱謂。
+        foreach (['（李子）', '（公孫）'] as $query) {
+            $response = $this->get('/api/select/search/pinyin?q='.urlencode($query));
+            $response->assertOk();
+            $content = trim($response->getContent());
+            $this->assertStringNotContainsString(' of ', $content);
+        }
+    }
+
+    #[Test]
     public function search_pinyin_with_split_zero_does_not_split_by_surname(): void {
         DB::table('pinyin')->insert([
             'lastname_chn' => '安',


### PR DESCRIPTION
## 問題（使用者反映）
新版 React 人物編輯器點「生成姓名拼音」一律提示「生成拼音失敗」，尤以「某人之妻 → Wife of …」這類無本名、靠關係命名者最受影響。

## 根因
`/api/select/search/pinyin`（`ApiController@searchPinyin`）回傳的是**純文字字串**（如 `An Shi`、`(Wife of Li Bai)`），但新版 `BasicInfoEditor.generatePinyin` 卻用 `r.json()` 解析、並讀取 `{data:[{text}]}` 自動完成結構 → 對純文字呼叫 `JSON.parse` 必拋錯 → 落入 catch 顯示「生成拼音失敗」。**後端完全正常**（`ApiSearchPinyinTest` 全綠）；舊版 Blade 編輯器本就直接取用回應字串，所以「之前可以」。此 bug 實際上讓新版編輯器的拼音按鈕對**所有**輸入都失敗（編輯器無客戶端中→拼音，按鈕是唯一途徑）。

## 親屬稱謂覆蓋（回答「舊版是否完備」）
**不完備**：`78ef346`(#914) 之前**只有「妻」一例**；#914 擴至 8 例（妻/母/女/妾/媳/妹/姐/姊）。本次再補 **祖母/祖父/孫女/嫂/夫/父/兄/弟/婿**。

## 變更
- **前端**：`generatePinyin` 改用 `r.text()`（`fetchPinyin(q, split)` 輔助），回填 `c_surname`/`c_mingzi`；姓 `split=1`、名 `split=0`，與舊版接線一致；回空字串保留原值不覆寫。
- **後端**：`relationshipPhrases()` 擴充，多字稱謂排於單字後綴之前（靠正則的 `）` 錨點消歧，`祖母≠母`…）。**刻意不收單字「子」「孫」**——皆為常見名字/詞用字（如「公孫」「王孫」），會把括號別名誤判為關係稱謂（孫輩女性仍可用無歧義的「孫女」）。
- **測試**：補擴充稱謂、多字消歧（含 `宗氏（…祖母）` 前綴形）、以及 `（李子）`／`（公孫）` 不被誤判的防呆案例。**9 測 / 55 斷言全綠**。

## 驗證
- review agent + codex 兩輪審查至 no serious issues（首輪 codex 揪出 `孫` 誤判面已移除）。
- `ApiSearchPinyinTest` 9/9 綠；`npm run build` 綠；前端變更 TypeScript 無新增錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)