### PR TITLE
fix(dark-mode): 原生捲軸隨深色翻轉 + Dashboard 統計圖標改 Lucide 柔和化

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -35,6 +35,10 @@
  *   destructive = Harvard 紅 #A51C30
  */
 :root {
+    /* 讓瀏覽器以淺色繪製原生 UI（捲軸、表單控件、下拉等）；深色模式於 .dark 覆蓋為 dark。
+       color-scheme 可繼承，僅此一處即同時修正頁面與所有巢狀捲動容器的捲軸顏色。 */
+    color-scheme: light;
+
     --background: hsl(0 0% 100%);
     --foreground: hsl(210 11% 15%);            /* AdminLTE body 文字 #212529 近似 */
     --card: hsl(0 0% 100%);
@@ -105,6 +109,9 @@
 }
 
 .dark {
+    /* 原生捲軸/表單控件改以深色繪製（修正深色頁面殘留的白色捲軸）。 */
+    color-scheme: dark;
+
     --background: hsl(210 10% 15%);
     --foreground: hsl(213 9% 85%);
     --card: hsl(210 10% 19%);

--- a/resources/js/inertia/Pages/Dashboard/Index.tsx
+++ b/resources/js/inertia/Pages/Dashboard/Index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { usePage } from '@inertiajs/react';
+import { User, IdCard, Briefcase, BookText, Users, History, type LucideIcon } from 'lucide-react';
 import DashboardLayout from '../../Layouts/DashboardLayout';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { SharedProps } from '../../types/page';
@@ -25,11 +26,13 @@ interface DashboardPageProps extends SharedProps {
 
 const nf = new Intl.NumberFormat();
 
-function InfoBox({ icon, color, label, value }: { icon: string; color: string; label: string; value: number }) {
+// 統計卡圖示改用 Lucide 線性圖示（現代、與 shadcn 風格一致），並以「柔和淡底 + 彩色線圖」取代
+// 舊版高飽和實心色塊；每個色調都帶 dark: 變體，深淺模式皆協調不刺眼。
+function InfoBox({ icon: Icon, tone, label, value }: { icon: LucideIcon; tone: string; label: string; value: number }) {
     return (
         <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 shadow-sm">
-            <span className={cn('flex h-12 w-12 items-center justify-center rounded text-white', color)}>
-                <i className={icon} aria-hidden />
+            <span className={cn('flex h-12 w-12 items-center justify-center rounded-lg', tone)}>
+                <Icon className="h-6 w-6" strokeWidth={2} aria-hidden />
             </span>
             <div>
                 <div className="text-xs text-muted-foreground">{label}</div>
@@ -77,12 +80,12 @@ export default function DashboardIndex() {
     return (
         <DashboardLayout title={tNav('dashboard')}>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
-                <InfoBox icon="fas fa-user" color="bg-sky-500" label={t('stat_persons')} value={props.totalPersons} />
-                <InfoBox icon="fas fa-id-card" color="bg-green-500" label={t('stat_altnames')} value={props.totalAltnames} />
-                <InfoBox icon="fas fa-briefcase" color="bg-amber-500" label={t('stat_offices')} value={props.totalOffices} />
-                <InfoBox icon="fas fa-book" color="bg-blue-600" label={t('stat_texts')} value={props.totalTexts} />
-                <InfoBox icon="fas fa-users" color="bg-gray-500" label={t('stat_users')} value={props.totalUsers} />
-                <InfoBox icon="fas fa-history" color="bg-red-500" label={t('stat_operations')} value={props.totalOperations} />
+                <InfoBox icon={User} tone="bg-sky-500/12 text-sky-600 dark:bg-sky-400/15 dark:text-sky-400" label={t('stat_persons')} value={props.totalPersons} />
+                <InfoBox icon={IdCard} tone="bg-emerald-500/12 text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400" label={t('stat_altnames')} value={props.totalAltnames} />
+                <InfoBox icon={Briefcase} tone="bg-amber-500/12 text-amber-600 dark:bg-amber-400/15 dark:text-amber-400" label={t('stat_offices')} value={props.totalOffices} />
+                <InfoBox icon={BookText} tone="bg-blue-500/12 text-blue-600 dark:bg-blue-400/15 dark:text-blue-400" label={t('stat_texts')} value={props.totalTexts} />
+                <InfoBox icon={Users} tone="bg-violet-500/12 text-violet-600 dark:bg-violet-400/15 dark:text-violet-400" label={t('stat_users')} value={props.totalUsers} />
+                <InfoBox icon={History} tone="bg-rose-500/12 text-rose-600 dark:bg-rose-400/15 dark:text-rose-400" label={t('stat_operations')} value={props.totalOperations} />
             </div>
 
             <div className="mt-4 rounded-lg border border-border bg-card">


### PR DESCRIPTION
兩個使用者反映的深色模式細節，分兩個小環節（各經 review agent + codex 雙閘）。

## 1. 滾動條在深色模式仍是白色
`.dark` class 掛在 `<html>`（`useDarkMode` → `documentElement`）但從未宣告 `color-scheme`，瀏覽器便以淺色繪製原生 UI（捲軸、表單控件）。
**修法**：`inertia.css` 於 `:root` 加 `color-scheme: light`、`.dark` 加 `color-scheme: dark`。`color-scheme` 可繼承，**僅此一處**即同時修正頁面捲軸與所有巢狀捲動容器，並一併讓原生表單控件深色。既有 `.sidebar-scroll` 自訂捲軸設了自己的 `scrollbar-color`，不受影響。

## 2. Dashboard 統計圖標飽和度偏高
6 張統計卡原為高飽和實心色塊（`bg-sky-500`…）+ 白色 Font Awesome 圖標。
**修法**（經你確認的「Dashboard 局部換 Lucide」方向）：改用 **Lucide 線性圖示**（現代、契合本設計系統所模仿的 shadcn 風格），置於**柔和淡底**（`bg-…-500/12`）+ **彩色線圖**，並補 `dark:` 變體（深色用 `-400`），深淺皆協調不刺眼。`InfoBox` 由 `{icon: FA字串, color}` 改為 `{icon: LucideIcon, tone}`。圖標語意：User=人物、IdCard=別名、Briefcase=官職、BookText=著作、Users=使用者、History=操作。

> 註：全站其餘仍用 Font Awesome；本次僅 Dashboard 統計卡局部採 Lucide（你已確認）。全站圖標庫遷移屬獨立大項目，未納入本次。

## 驗證
- review agent + codex 兩輪皆 **no serious issues**。
- `npm run build` 綠（lucide 具名匯入 tree-shake，僅打包 6 個圖標）；TypeScript 無新增錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)