### PR TITLE
feat(assoc/kin): 關聯人物／親屬姓名下方加「前往此人物頁」連結

### DIFF
--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -9,6 +9,7 @@ import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate
 import MirrorConflictNotice, { MirrorConflict } from './PersonEditorShared/MirrorConflictNotice';
 import MirrorSuspectedNotice, { MirrorSuspected } from './PersonEditorShared/MirrorSuspectedNotice';
 import OppositeEdgeNotice from './PersonEditorShared/OppositeEdgeNotice';
+import PersonJumpLink from './PersonEditorShared/PersonJumpLink';
 import { useOppositeEdgeDetection } from './PersonEditorShared/useOppositeEdgeDetection';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gHintStyle, gOkStyle, gErrStyle,
@@ -487,7 +488,13 @@ export default function AssocEditor({
             <GridSection title={tr('assoc_core_section', '社會關係')}>
                 <div style={gGrid}>
                     {searchRow('c_assoc_code', tr('assoc_field', '社會關係'), 'c_assoc_code', '/api/select/search/assoccode', assocHighlight, '0', true)}
-                    {searchRow('c_assoc_id', tr('assoc_person', '關聯人物'), 'c_assoc_id', '/api/select/search/biog', false, '0', true)}
+                    {/* 關聯人物：選定後於下方提供「前往此人物頁」連結（新分頁，不影響本頁編輯）。 */}
+                    {gridCell(tr('assoc_person', '關聯人物'), { code: 'c_assoc_id', required: true }, <>
+                        <CodeAutocomplete mode="search" endpoint="/api/select/search/biog"
+                            value={fields.c_assoc_id ?? '0'} initialLabel={labels.c_assoc_id ?? ''} disabled={!editable}
+                            onChange={(v, l) => { set('c_assoc_id', v || '0'); setLabel('c_assoc_id', l); }} />
+                        <PersonJumpLink personId={fields.c_assoc_id} name={labels.c_assoc_id} tr={tr} />
+                    </>)}
                     {/* 關係次數（書信計次）：重要、非出處，移入核心區，置於社會關係/關聯人物之後。 */}
                     {textRow('c_assoc_count', tr('assoc_count_field', '數量'), 'c_assoc_count', false, tr('assoc_count_hint', '此欄位僅適用於書信：當無法以標題及日期區分多次信件時，則僅建「一筆」社會關係，並將信件總數填於此欄。請填阿拉伯數字'))}
                     {/* 次序不重要，下移至核心欄之後（去強調）。 */}

--- a/resources/js/inertia/components/KinEditor.tsx
+++ b/resources/js/inertia/components/KinEditor.tsx
@@ -8,6 +8,7 @@ import MirrorConflictNotice, { MirrorConflict } from './PersonEditorShared/Mirro
 import MirrorSuspectedNotice, { MirrorSuspected } from './PersonEditorShared/MirrorSuspectedNotice';
 import MirrorDeleteMultipleNotice, { MirrorDeleteMultiple } from './PersonEditorShared/MirrorDeleteMultipleNotice';
 import OppositeEdgeNotice from './PersonEditorShared/OppositeEdgeNotice';
+import PersonJumpLink from './PersonEditorShared/PersonJumpLink';
 import { useOppositeEdgeDetection } from './PersonEditorShared/useOppositeEdgeDetection';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gHintStyle, gOkStyle, gErrStyle,
@@ -295,7 +296,13 @@ export default function KinEditor({
 
             <div style={gGrid}>
                 {searchRow('c_kin_code', tr('kinship_relation', '親屬關係'), 'c_kin_code', '/api/select/search/kincode', false, '0', true)}
-                {searchRow('c_kin_id', tr('relative_name', '親屬姓名'), 'c_kin_id', '/api/select/search/biog', false, '0', true)}
+                {/* 親屬姓名：選定後於下方提供「前往此人物頁」連結（新分頁，不影響本頁編輯）。 */}
+                {gridCell(tr('relative_name', '親屬姓名'), { code: 'c_kin_id', required: true }, <>
+                    <CodeAutocomplete mode="search" endpoint="/api/select/search/biog"
+                        value={fields.c_kin_id ?? '0'} initialLabel={labels.c_kin_id ?? ''} disabled={!editable}
+                        onChange={(v, l) => { set('c_kin_id', v || '0'); setLabel('c_kin_id', l); }} />
+                    <PersonJumpLink personId={fields.c_kin_id} name={labels.c_kin_id} tr={tr} />
+                </>)}
 
                 {/* 互逆配對碼：依正向碼取候選，預設第一個（同 legacy），反向關係有歧義（父→子/女、第幾子…）故可手選。 */}
                 {gridCell(tr('reverse_pair_label', '互逆配對碼'), { code: 'c_kinship_pair', full: true }, <>

--- a/resources/js/inertia/components/PersonEditorShared/PersonJumpLink.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/PersonJumpLink.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+/**
+ * 「前往此人物頁」連結。
+ *
+ * 用於人物參照欄（如社會關係的「關聯人物」c_assoc_id、親屬的「親屬姓名」c_kin_id）：
+ * 當欄位已選定一位真實人物時，於欄位下方顯示一個連到該人物詳情頁
+ * （/app/basicinformation/{id}，=app.basicinformation.show）的小連結。
+ *
+ * 設計考量：
+ *  - 僅在 value 為「正整數 personid」時顯示；哨兵 0 / 空 / 負值（未選）不顯示，避免連到無效頁。
+ *  - target="_blank"：子資源編輯器常有未存變更（dirty 守衛），同分頁跳轉會遺失正在編輯的內容，
+ *    故一律於「新分頁」開啟，使用者可邊編輯邊查看對方人物。
+ *  - 樣式低調（小字、品牌色、外部連結圖示），置於輸入框下方，不與輸入框搶視覺；
+ *    顏色用 var(--primary) 隨深色模式翻轉。人物姓名置於 title（tooltip），可見文字保持精簡
+ *    （姓名已顯示在上方輸入框，不重複佔版面）。
+ */
+export default function PersonJumpLink({
+    personId,
+    name,
+    tr,
+}: {
+    personId?: string | number | null;
+    name?: string;
+    tr: (k: string, fb: string) => string;
+}) {
+    const id = Number(personId);
+    if (!Number.isInteger(id) || id <= 0) {
+        return null;
+    }
+    const nm = (name ?? '').trim();
+    const title = tr('goto_person_page_title', '在新分頁開啟此人物的詳情頁') + (nm ? `：${nm}` : '');
+    return (
+        <a
+            href={`/app/basicinformation/${id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={title}
+            style={linkStyle}
+        >
+            <i className="fas fa-external-link-alt" aria-hidden style={{ fontSize: '0.78em' }} />
+            {tr('goto_person_page', '前往人物頁面')}
+        </a>
+    );
+}
+
+const linkStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 5,
+    marginTop: 5,
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    color: 'var(--primary)',
+    textDecoration: 'underline',
+    textUnderlineOffset: 2,
+    width: 'fit-content',
+};

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -200,6 +200,9 @@ return [
     'kinship_list' => 'Kinship',
     'kinship_relation' => 'Kinship Relation',
     'relative_name' => 'Relative Name',
+    // "Go to person page" link shown under a person-reference field (Associated Person / Relative Name)
+    'goto_person_page' => 'Open person page',
+    'goto_person_page_title' => "Open this person's page in a new tab",
     'paired_kinship' => 'Paired Kinship',
     'no_paired_kinship' => 'No corresponding kinship',
     'reverse_pair_label' => 'Reciprocal pair code',

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -200,6 +200,9 @@ return [
     'kinship_list' => '親屬清單',
     'kinship_relation' => '親屬關係',
     'relative_name' => '親戚姓名',
+    // 人物參照欄下方的「前往此人物頁」連結（關聯人物 / 親屬姓名共用）
+    'goto_person_page' => '前往人物頁面',
+    'goto_person_page_title' => '在新分頁開啟此人物的詳情頁',
     'paired_kinship' => '成對親屬關係',
     'no_paired_kinship' => '無對應親屬關係',
     'reverse_pair_label' => '互逆配對碼',


### PR DESCRIPTION
## 需求
社會關係編輯器「關聯人物」(`c_assoc_id`) 與親屬編輯器「親屬姓名」(`c_kin_id`) 都是人物參照欄，過去無法直接從這裡跳到該人。本 PR 於這兩個欄位下方加「前往此人物頁」連結。

## 設計
- 僅在已選定真實人物（value 為正整數 personid）時顯示；哨兵 0／空／負值不顯示；隨選擇即時更新。
- 一律 `target="_blank"` 開新分頁——編輯器有未存變更/dirty 守衛，同分頁跳轉會遺失編輯內容；新分頁讓使用者邊編輯邊看對方人物。
- 連到 `/app/basicinformation/{id}`（`app.basicinformation.show`），非 edit URL。
- 樣式低調（外部連結圖示＋下劃線＋`var(--primary)` 隨深色模式翻轉），姓名置於 tooltip。
- 抽成共用元件 `PersonJumpLink`，兩編輯器共用、易擴展。
- i18n：`goto_person_page` / `goto_person_page_title`（zh-TW + en，biogmains）。

## 驗證
行為與原 `searchRow` 完全 parity、無回歸；review agent + codex 雙閘無嚴重問題；`npm run build` 綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)