### PR TITLE
重設計使用者帳號下拉選單

### DIFF
--- a/resources/js/inertia/components/shell/Navbar.tsx
+++ b/resources/js/inertia/components/shell/Navbar.tsx
@@ -120,30 +120,36 @@ export default function Navbar({ onToggleSidebar, isDark, onToggleDark, breadcru
                             <>
                                 {/* 點擊外部關閉 */}
                                 <div className="fixed inset-0 z-10" onClick={() => setUserMenuOpen(false)} />
-                                <div className="absolute right-0 z-20 mt-1 w-56 rounded border border-border bg-popover py-2 text-popover-foreground shadow-lg">
-                                    <div className="border-b border-border px-4 pb-2">
-                                        <div className="font-semibold">{user.name}</div>
+                                <div
+                                    role="menu"
+                                    className="absolute right-0 z-20 mt-1 w-56 overflow-hidden rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-lg"
+                                >
+                                    <div className="px-4 py-2">
+                                        <div className="truncate font-semibold">{user.name}</div>
                                         {user.institution ? (
-                                            <div className="text-xs text-muted-foreground">{user.institution}</div>
+                                            <div className="truncate text-xs text-muted-foreground">{user.institution}</div>
                                         ) : null}
                                     </div>
-                                    <div className="flex justify-between gap-2 px-4 pt-2">
-                                        {shell.profile_url ? (
-                                            <a
-                                                href={shell.profile_url}
-                                                className="rounded border border-border px-3 py-1 text-sm hover:bg-muted"
-                                            >
-                                                {tCommon('profile_settings')}
-                                            </a>
-                                        ) : <span />}
-                                        <button
-                                            type="button"
-                                            onClick={logout}
-                                            className="rounded border border-border px-3 py-1 text-sm hover:bg-muted"
+                                    <div className="my-1 border-t border-border" />
+                                    {shell.profile_url ? (
+                                        <a
+                                            href={shell.profile_url}
+                                            role="menuitem"
+                                            className="flex items-center gap-2.5 px-4 py-2 text-sm hover:bg-muted"
                                         >
-                                            {tCommon('sign_out')}
-                                        </button>
-                                    </div>
+                                            <i className="fas fa-user-cog w-4 text-center text-muted-foreground" aria-hidden />
+                                            {tCommon('profile_settings')}
+                                        </a>
+                                    ) : null}
+                                    <button
+                                        type="button"
+                                        onClick={logout}
+                                        role="menuitem"
+                                        className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-sm text-destructive hover:bg-destructive/10"
+                                    >
+                                        <i className="fas fa-sign-out-alt w-4 text-center" aria-hidden />
+                                        {tCommon('sign_out')}
+                                    </button>
                                 </div>
                             </>
                         )}


### PR DESCRIPTION
## 摘要
修正右上角使用者帳號下拉選單的設計。原本是兩個並排帶框按鈕（Profile Settings／Sign out），用 `flex justify-between` 撐開，導致「Sign out」被擠成兩行，且在下拉選單中放並排按鈕不符 UI 慣例。

## 變更
- 改為符合最佳實踐的**垂直堆疊下拉選單**：標頭（姓名＋機構，加 `truncate`）＋ 分隔線 ＋ 整行可點的選單項
- 加上 `fa-user-cog`／`fa-sign-out-alt` 圖示與整行 hover 高亮
- 「Sign out」以 `text-destructive` + `hover:bg-destructive/10` 標示為離開／危險動作
- 補上 `role=menu` / `role=menuitem` 無障礙語意

## 驗證
- 三道 code review 全數通過（2 組 review agent + codex，均無嚴重 issue）
- `npm run build` 通過
- 本地 `php artisan serve` 目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)