### PR TITLE
出處分頁書名一併帶出拼音

### DIFF
--- a/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx
@@ -7,6 +7,7 @@ import { NavButton } from '../../ui/NavButton';
 import { useTabPager } from '../shared/useTabPager';
 import { stableKey } from '../shared/stableKey';
 import { buildTextUrl, type TextCodeRecord } from '../shared/textLookup';
+import { formatBilingualLabel } from '../shared/formatters';
 import { useTextCodes } from '../shared/useTextCodes';
 import { getCsrfToken } from '../shared/csrf';
 import { buildEditV2CreateUrl, buildEditV2EditUrl } from '../shared/legacyEditUrl';
@@ -184,10 +185,17 @@ const linkStyle: React.CSSProperties = {
     textDecoration: 'none',
 };
 
-/** 出處欄：對齊 legacy `{{ $value->c_title_chn }}`（中文書名），缺則回退 text 記錄／英文名／text_id。 */
+/**
+ * 出處欄：優先以 text 記錄組出「中文書名 / 拼音」（對齊著述分頁的雙語顯示，把出處書名的拼音一併帶出）；
+ * 缺 text 記錄時回退列自帶的中文／拼音書名，最後回退 text_id。
+ */
 function renderSourceTitle(item: SourceItem, textRecords: Record<number, TextCodeRecord>): React.ReactNode {
     const record = textRecords[item.text_id ?? 0];
-    return record?.c_title_chn ?? item.title_chn ?? item.title ?? (item.text_id ? String(item.text_id) : null);
+    // 中文書名與拼音各自獨立取值（皆優先 text 記錄、缺則回退列自帶欄位），保留「中文優先」原則的同時把拼音一併帶出；
+    // 兩者皆缺時回退 text_id。
+    const chn = record?.c_title_chn ?? item.title_chn ?? null;
+    const pinyin = record?.c_title ?? item.title ?? null;
+    return formatBilingualLabel(chn, pinyin) ?? (item.text_id ? String(item.text_id) : null);
 }
 
 /**


### PR DESCRIPTION
## 摘要
人物編輯頁「出處（sources）」分頁原本只顯示中文書名（`c_title_chn`），而「著述（texts）」分頁顯示「中文書名 / 拼音」。本 PR 讓出處分頁也一併帶出拼音，兩者顯示一致。

## 為什麼原本沒有？
查 legacy blade，`texts/index.blade.php` 與 `sources/index.blade.php` **原本都只顯示 `c_title_chn`**。React 遷移時 texts 分頁被加強為雙語顯示，但 sources 分頁被留在 legacy 原樣——屬遷移遺漏的不一致，**非刻意設計**。拼音資料本就可用（`tabSources()` 已帶 `TEXT_CODES.c_title` 成 `item.title`，`/api/v2/texts` 亦回傳 `c_title`）。

## 變更
`resources/js/inertia/components/PersonBrowser/tabs/SourcesTab.tsx` 的 `renderSourceTitle`：
```ts
const chn = record?.c_title_chn ?? item.title_chn ?? null;
const pinyin = record?.c_title ?? item.title ?? null;
return formatBilingualLabel(chn, pinyin) ?? (item.text_id ? String(item.text_id) : null);
```
中文與拼音各自獨立取值（皆優先 text 記錄、缺則回退列自帶欄位），保留「中文優先」原則的同時帶出拼音。

## 驗證
- 三道 code review 迭代至無嚴重 issue：review agent（正確性 + 資料可用性）＋ codex。codex 首輪抓到 fallback 順序回歸，修正為中文/拼音獨立取值後覆審通過。
- `npm run build` 通過
- 本地 `php artisan serve` 目視確認 `/app/basicinformation/1762/edit?tab=sources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)