### PR TITLE
人物清單頁朝代與地名一併帶出英文

### DIFF
--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -153,8 +153,10 @@ class BasicInformationController extends Controller {
             'c_name_chn' => $item->c_name_chn,
             'c_name' => $item->c_name,
             'c_dynasty_chn' => $item->c_dynasty_chn ?? '',
+            'c_dynasty' => $item->c_dynasty ?? '',
             'c_index_year' => $item->c_index_year,
             'addr_name_chn' => $item->ADDR_c_name_chn ?? '',
+            'addr_name' => $item->ADDR_c_name ?? '',
             'zi' => $item->c_alt_name_chn_zi ?? '',
             'hao' => $item->c_alt_name_chn_hao ?? '',
         ], $names->items());
@@ -178,6 +180,7 @@ class BasicInformationController extends Controller {
             'dynasty_facets' => array_map(fn ($f) => [
                 'c_dy' => $f->c_dy,
                 'c_dynasty_chn' => $f->c_dynasty_chn,
+                'c_dynasty' => $f->c_dynasty ?? null,
                 'count' => $f->count,
             ], is_array($dynastyFacets) ? $dynastyFacets : $dynastyFacets->all()),
             'can_add' => Auth::check() && Auth::user()->isActive(),

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -405,7 +405,7 @@ class BiogMainRepository {
             // 第二步：用這些 personid 去 JOIN 查詢完整資訊
             $personIds = $personIdsPaginator->pluck('c_personid')->toArray();
 
-            $detailedItems = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
+            $detailedItems = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'ADDR_CODES.c_name AS ADDR_c_name', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
                 ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
                 ->leftJoin('ADDR_CODES', 'ADDR_CODES.c_addr_id', '=', 'BIOG_MAIN.c_index_addr_id')
                 ->leftJoin('ALTNAME_DATA as A1', function ($join) {
@@ -443,7 +443,7 @@ class BiogMainRepository {
 
         // 20251109優化：當輸入為純數字時，直接按 c_personid 精確查詢，避免複雜的多條件搜尋
         if (ctype_digit($request->q)) {
-            $names = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
+            $names = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'ADDR_CODES.c_name AS ADDR_c_name', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
                 ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
                 ->leftJoin('ADDR_CODES', 'ADDR_CODES.c_addr_id', '=', 'BIOG_MAIN.c_index_addr_id')
                 ->leftJoin('ALTNAME_DATA as A1', function ($join) {
@@ -477,7 +477,7 @@ class BiogMainRepository {
 
         // 如果倒排索引查到結果，按找到的 personIds 查詢完整資訊
         if (!empty($personIds)) {
-            $query = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
+            $query = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'ADDR_CODES.c_name AS ADDR_c_name', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao')
                 ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
                 ->leftJoin('ADDR_CODES', 'ADDR_CODES.c_addr_id', '=', 'BIOG_MAIN.c_index_addr_id')
                 ->leftJoin('ALTNAME_DATA as A1', function ($join) {
@@ -522,7 +522,7 @@ class BiogMainRepository {
         //20210827修改拼音檢索時以字為單位
         //$names = BiogMain::select(['c_personid', 'c_name_chn', 'c_name'])->where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_personid', $request->q)->paginate($num);
         //20211112註記，已得到查詢條件，維持SQL LeftJoin的特性，一次性提供完整資料。
-        $names = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao');
+        $names = BiogMain::select('BIOG_MAIN.c_personid', 'BIOG_MAIN.c_name_chn', 'BIOG_MAIN.c_name', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', 'BIOG_MAIN.c_index_year', 'ADDR_CODES.c_name_chn AS ADDR_c_name_chn', 'ADDR_CODES.c_name AS ADDR_c_name', 'A1.c_alt_name_chn as c_alt_name_chn_zi', 'A2.c_alt_name_chn as c_alt_name_chn_hao');
         $names = $names->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy'); //單筆
         $names = $names->leftJoin('ADDR_CODES', 'ADDR_CODES.c_addr_id', '=', 'BIOG_MAIN.c_index_addr_id'); //單筆
         $names = $names->leftJoin('ALTNAME_DATA as A1', function ($names) {
@@ -607,8 +607,8 @@ class BiogMainRepository {
                 ->whereIn('BIOG_MAIN.c_personid', $personIds)
                 ->whereNotNull('BIOG_MAIN.c_dy')
                 ->where('BIOG_MAIN.c_dy', '>', 0)
-                ->select('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', DB::raw('COUNT(*) as count'))
-                ->groupBy('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn')
+                ->select('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', DB::raw('COUNT(*) as count'))
+                ->groupBy('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty')
                 ->orderByDesc('count')
                 ->get();
 
@@ -643,8 +643,8 @@ class BiogMainRepository {
         $validDynasties = (clone $fallbackBaseQuery)
             ->whereNotNull('BIOG_MAIN.c_dy')
             ->where('BIOG_MAIN.c_dy', '>', 0)
-            ->select('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', DB::raw('COUNT(*) as count'))
-            ->groupBy('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn')
+            ->select('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty', DB::raw('COUNT(*) as count'))
+            ->groupBy('BIOG_MAIN.c_dy', 'DYNASTIES.c_dynasty_chn', 'DYNASTIES.c_dynasty')
             ->orderByDesc('count')
             ->get();
 

--- a/resources/js/inertia/Pages/BasicInformation/Index.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/Index.tsx
@@ -6,6 +6,7 @@ import { Input } from '../../components/ui/Input';
 import { Select } from '../../components/ui/Select';
 import { Pagination, type PaginationMeta } from '../../components/ui/Pagination';
 import { useTranslation } from '../../hooks/useTranslation';
+import { formatBilingualLabel } from '../../components/PersonBrowser/shared/formatters';
 import type { SharedProps } from '../../types/page';
 
 interface PersonRow {
@@ -13,8 +14,10 @@ interface PersonRow {
     c_name_chn: string | null;
     c_name: string | null;
     c_dynasty_chn: string;
+    c_dynasty?: string | null;
     c_index_year: number | string | null;
     addr_name_chn: string;
+    addr_name?: string | null;
     zi: string;
     hao: string;
 }
@@ -22,6 +25,7 @@ interface PersonRow {
 interface DynastyFacet {
     c_dy: number | string;
     c_dynasty_chn: string;
+    c_dynasty?: string | null;
     count: number;
 }
 
@@ -35,13 +39,15 @@ interface PersonIndexPageProps extends SharedProps {
     create_url: string;
 }
 
-const COLUMNS: { key: keyof PersonRow; label: string }[] = [
+// 部分欄位以「中文 / 英文（拼音）」雙語呈現（對齊全站 formatBilingualLabel 慣例）；
+// 其餘欄位沿用 row[key] 直接顯示。
+const COLUMNS: { key: keyof PersonRow; label: string; render?: (row: PersonRow) => React.ReactNode }[] = [
     { key: 'c_personid', label: 'c_personid' },
     { key: 'c_name_chn', label: 'c_name_chn' },
     { key: 'c_name', label: 'c_name' },
-    { key: 'c_dynasty_chn', label: 'dynasty' },
+    { key: 'c_dynasty_chn', label: 'dynasty', render: (row) => formatBilingualLabel(row.c_dynasty_chn, row.c_dynasty ?? null) ?? '' },
     { key: 'c_index_year', label: 'index year' },
-    { key: 'addr_name_chn', label: 'index address' },
+    { key: 'addr_name_chn', label: 'index address', render: (row) => formatBilingualLabel(row.addr_name_chn, row.addr_name ?? null) ?? '' },
     { key: 'zi', label: 'zi' },
     { key: 'hao', label: 'hao' },
 ];
@@ -80,7 +86,7 @@ export default function PersonIndex() {
                             </option>
                             {dynasty_facets.map((f) => (
                                 <option key={String(f.c_dy)} value={String(f.c_dy)}>
-                                    {f.c_dynasty_chn} ({f.count})
+                                    {formatBilingualLabel(f.c_dynasty_chn, f.c_dynasty ?? null) ?? f.c_dynasty_chn} ({f.count})
                                 </option>
                             ))}
                         </Select>
@@ -121,7 +127,7 @@ export default function PersonIndex() {
                                     {COLUMNS.map((c) => (
                                         <td key={c.label} className="px-3 py-1.5">
                                             <a href={editUrl(row.c_personid)} target="_blank" rel="noreferrer" className="text-primary hover:underline">
-                                                {row[c.key] ?? ''}
+                                                {c.render ? c.render(row) : (row[c.key] ?? '')}
                                             </a>
                                         </td>
                                     ))}

--- a/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AddressDisplayWithMap from './shared/AddressDisplayWithMap';
+import { formatBilingualLabel } from './shared/formatters';
 import { APP_THEME } from '../../theme';
 
 export interface PersonSummary {
@@ -76,7 +77,7 @@ export default function PersonSummaryPanel({ summary, loading, error }: Props) {
             <div style={tagRowStyle}>
                 <Tag label="ID" value={`#${summary.c_personid}`} />
                 <Tag label="性別" value={summary.gender} />
-                <Tag label="朝代" value={summary.dynasty_chn} />
+                <Tag label="朝代" value={formatBilingualLabel(summary.dynasty_chn, summary.dynasty)} />
                 <Tag
                     label="籍貫"
                     value={summary.index_addr_chn || summary.index_addr ? (


### PR DESCRIPTION
## 背景
使用者回饋（舊 Bootstrap 版）：addresses 與 dynasties 沒有英文。經徹底檢查，新版 React 界面的 **Addresses 分頁、Postings 分頁、摘要側欄「籍貫」、BasicInfoView** 都已是雙語（`AddressDisplayWithMap` → `formatBilingualLabel`），朝代在 BasicInfoView 也已雙語。**唯一主要缺口是 Person Records 清單頁（`/app/basicinformation`）**：朝代欄、index address 欄、朝代篩選下拉都只有中文，且後端根本沒撈英文/拼音欄位。

## 變更（設計：同格內「中文 / 英文」，對齊全站 formatBilingualLabel 慣例）
**後端**
- `BiogMainRepository::namesByQuery()` 四條查詢路徑 SELECT 各加 `DYNASTIES.c_dynasty`（英文朝代）與 `ADDR_CODES.c_name AS ADDR_c_name`（羅馬拼音地名）。
- `dynastyFacetsByQuery()` 兩條路徑的 SELECT 與 GROUP BY 各加 `DYNASTIES.c_dynasty`（`c_dy→c_dynasty` 為 1:1，不影響分組與計數）。
- `BasicInformationController::appIndex()` 把 `c_dynasty` / `addr_name` 帶進每列、`c_dynasty` 帶進每個朝代分面（未設定朝代分面以 `?? null` 安全處理）。

**前端**
- `Index.tsx`：朝代欄、index address 欄、朝代篩選下拉改用 `formatBilingualLabel` 顯示「宋 / Song」「臨川 / Linchuan」，缺英文時自動退回只顯示中文。
- `PersonSummaryPanel.tsx`：順手補「朝代」tag 為雙語（資料本就有，與旁邊已雙語的籍貫一致）。

## 驗證
- 三道 code review 迭代至無嚴重 issue：backend agent（四條 SELECT/兩個 facet 區塊、GROUP BY 計數、`?? null`、SQLite 相容、欄位存在）＋ frontend agent（型別/import/優雅退回）＋ **codex（No serious issues，並自行跑過 npm run build）**。
- `php-cs-fixer`（0 fixed）、`npm run build` 通過。
- 本地 `php artisan serve` 目視確認 `/app/basicinformation`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)