### PR TITLE
feat(pinyin): Phase A M2 只讀掃描命令 cbdb:scan-pinyin-v

### DIFF
--- a/app/Console/Commands/ScanPinyinV.php
+++ b/app/Console/Commands/ScanPinyinV.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Support\PinyinUmlaut;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 只讀掃描拼音欄位中的 `v`，依《漢語拼音方案》音節規則分類，輸出 CSV 供人工複核。
+ *
+ * - **只讀不寫**，可安全在生產執行（見 PINYIN_V_TO_UMLAUT_MIGRATION §5.4 / §D）。
+ * - 分類：
+ *     `pinyin`  —— 含可轉音節（lv/lve/nv/nve），`PinyinUmlaut::normalize()` 會改變其值 → 應轉為 ü。
+ *     `other-v` —— 含 `v` 但非可轉音節（如 Silva/Calvin/Vietnam）→ 規則不動它，僅列出供人工瞄一眼。
+ * - Phase A 掃描人名欄（BIOG_MAIN.c_surname/c_mingzi、ALTNAME_DATA.c_alt_name）。
+ *   `c_name` 為派生欄不掃（改姓/名後由系統重算，見 §D-3）。
+ * - Phase B（其他 code 表拼音欄）屬之後的獨立 goal，屆時再擴充欄位清單。
+ */
+class ScanPinyinV extends Command {
+    /** @var string */
+    protected $signature = 'cbdb:scan-pinyin-v
+                            {--phase=A : 掃描階段（目前僅實作 A＝人名欄）}
+                            {--out= : CSV 輸出路徑（預設 storage/app/pinyin-scan-{phase}.csv）}
+                            {--limit=0 : 每欄最多輸出列數（0＝不限；供抽樣）}';
+
+    /** @var string */
+    protected $description = '只讀掃描拼音欄位中的 v，分類 pinyin(可轉)/other-v(疑似西文)，輸出 CSV 供人工複核。只讀不寫。';
+
+    /**
+     * Phase A 掃描欄位；ids 為輸出用的定位欄（非必為完整 PK，僅供人工在 CSV 中定位）。
+     *
+     * @return array<int, array{table:string, column:string, ids:array<int,string>, kind:string}>
+     */
+    private function phaseAColumns(): array {
+        return [
+            ['table' => 'BIOG_MAIN', 'column' => 'c_surname', 'ids' => ['c_personid'], 'kind' => 'name'],
+            ['table' => 'BIOG_MAIN', 'column' => 'c_mingzi', 'ids' => ['c_personid'], 'kind' => 'name'],
+            // ALTNAME_DATA 定位需 3-key（c_personid, c_alt_name_chn, c_alt_name_type_code）供 M4 遷移解析
+            ['table' => 'ALTNAME_DATA', 'column' => 'c_alt_name', 'ids' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'], 'kind' => 'name'],
+        ];
+    }
+
+    public function handle(): int {
+        $phase = strtoupper((string) $this->option('phase'));
+        if ($phase !== 'A') {
+            $this->error("目前僅實作 Phase A；Phase B 屬之後的獨立 goal。");
+
+            return self::FAILURE;
+        }
+        $limit = max(0, (int) $this->option('limit'));
+        $out = (string) ($this->option('out') ?: storage_path("app/pinyin-scan-{$phase}.csv"));
+
+        $fh = @fopen($out, 'w');
+        if ($fh === false) {
+            $this->error("無法寫入輸出檔：{$out}");
+
+            return self::FAILURE;
+        }
+        fputcsv($fh, ['table', 'column', 'ids', 'current', 'proposed', 'class']);
+
+        $summary = [];
+        $rowsWritten = 0;
+
+        try {
+            foreach ($this->phaseAColumns() as $spec) {
+                [$table, $column, $ids] = [$spec['table'], $spec['column'], $spec['ids']];
+                if (!Schema::hasTable($table) || !Schema::hasColumn($table, $column)) {
+                    $this->warn("略過（表/欄不存在）：{$table}.{$column}");
+
+                    continue;
+                }
+                $key = "{$table}.{$column}";
+                $summary[$key] = ['pinyin' => 0, 'other-v' => 0];
+
+                // 只讀：僅撈含 v 的列（LIKE 對 ASCII 大小寫不敏感，v 與 V 皆命中）。
+                $select = array_values(array_unique([...$ids, $column]));
+                $query = DB::table($table)->select($select)->where($column, 'like', '%v%');
+                // 依完整定位鍵排序：ALTNAME_DATA 的 c_personid 非唯一，只排單欄時
+                // each()（offset 分頁）可能在 chunk 邊界漏掉/重複同分列，掃描必須零遺漏。
+                foreach ($ids as $idCol) {
+                    $query->orderBy($idCol);
+                }
+                if ($limit > 0) {
+                    $query->limit($limit);
+                }
+
+                $query->each(function ($row) use ($fh, $table, $column, $ids, &$summary, &$rowsWritten, $key) {
+                    $current = (string) ($row->{$column} ?? '');
+                    $proposed = PinyinUmlaut::normalize($current);
+                    $class = $proposed !== $current ? 'pinyin' : 'other-v';
+                    $summary[$key][$class]++;
+                    $idParts = array_map(static fn ($c) => (string) ($row->{$c} ?? ''), $ids);
+                    fputcsv($fh, [$table, $column, implode('|', $idParts), $current, $proposed, $class]);
+                    $rowsWritten++;
+                });
+            }
+        } finally {
+            fclose($fh);
+        }
+
+        // 摘要
+        $this->info("拼音 v 掃描（Phase {$phase}）——只讀");
+        $this->table(['table.column', 'pinyin (可轉)', 'other-v (疑似西文)'], array_map(
+            static fn ($k, $v) => [$k, $v['pinyin'], $v['other-v']],
+            array_keys($summary),
+            array_values($summary),
+        ));
+        $this->line("共輸出 {$rowsWritten} 列至：{$out}");
+        $this->line('提醒：本表僅供人工複核；正式批量修正以人工複核清單（Google Sheet）為權威（見 §D-2）。');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends ConsoleKernel {
         \App\Console\Commands\RebuildIndexAddress::class,
         \App\Console\Commands\FetchChgisMap::class,
         \App\Console\Commands\RebuildPersonChangeIndex::class,
+        \App\Console\Commands\ScanPinyinV::class,
     ];
 
     /**

--- a/tests/Feature/ScanPinyinVTest.php
+++ b/tests/Feature/ScanPinyinVTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * cbdb:scan-pinyin-v 只讀掃描命令（Phase A：人名欄）。
+ */
+class ScanPinyinVTest extends TestCase {
+    private string $out;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+
+        Schema::create('BIOG_MAIN', function ($t) {
+            $t->integer('c_personid')->primary();
+            $t->string('c_surname')->nullable();
+            $t->string('c_mingzi')->nullable();
+        });
+        Schema::create('ALTNAME_DATA', function ($t) {
+            $t->integer('c_personid');
+            $t->string('c_alt_name_chn')->nullable();
+            $t->integer('c_alt_name_type_code')->default(0);
+            $t->string('c_alt_name')->nullable();
+        });
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_surname' => 'Lv', 'c_mingzi' => 'Mengzheng'],   // pinyin surname
+            ['c_personid' => 2, 'c_surname' => 'Wang', 'c_mingzi' => 'Anshi'],      // clean, no v
+            ['c_personid' => 3, 'c_surname' => 'Silva', 'c_mingzi' => 'Bing'],      // western v (other-v)
+            ['c_personid' => 4, 'c_surname' => 'Yelv', 'c_mingzi' => 'Chucai'],     // joined pinyin
+            ['c_personid' => 5, 'c_surname' => 'Wang', 'c_mingzi' => 'Lvbu'],       // pinyin in c_mingzi (可轉)
+            ['c_personid' => 6, 'c_surname' => 'LV', 'c_mingzi' => 'Meng'],         // 大寫 V，LIKE 須同命中
+        ]);
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 1, 'c_alt_name_chn' => '呂胤', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Lv Yin'],  // pinyin
+            ['c_personid' => 9, 'c_alt_name_chn' => '席爾瓦', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Silva'], // other-v
+        ]);
+
+        $this->out = sys_get_temp_dir() . '/cbdb-scan-pinyin-' . uniqid() . '.csv';
+    }
+
+    protected function tearDown(): void {
+        @unlink($this->out);
+        parent::tearDown();
+    }
+
+    /** @return array<int, array<string, string>> */
+    private function readCsv(): array {
+        $rows = array_map('str_getcsv', file($this->out, FILE_IGNORE_NEW_LINES));
+        $header = array_shift($rows);
+
+        return array_map(static fn ($r) => array_combine($header, $r), $rows);
+    }
+
+    #[Test]
+    public function it_classifies_pinyin_vs_other_v_and_writes_csv(): void {
+        $this->artisan('cbdb:scan-pinyin-v', ['--out' => $this->out])->assertSuccessful();
+
+        $rows = $this->readCsv();
+        $index = [];
+        foreach ($rows as $r) {
+            $index["{$r['table']}.{$r['column']}|{$r['current']}"] = $r;
+        }
+
+        // 可轉音節：proposed 為 ü、class=pinyin
+        $this->assertSame('Lü', $index['BIOG_MAIN.c_surname|Lv']['proposed']);
+        $this->assertSame('pinyin', $index['BIOG_MAIN.c_surname|Lv']['class']);
+        $this->assertSame('Yelü', $index['BIOG_MAIN.c_surname|Yelv']['proposed']);
+        $this->assertSame('pinyin', $index['BIOG_MAIN.c_surname|Yelv']['class']);
+        $this->assertSame('Lü Yin', $index['ALTNAME_DATA.c_alt_name|Lv Yin']['proposed']);
+        $this->assertSame('pinyin', $index['ALTNAME_DATA.c_alt_name|Lv Yin']['class']);
+
+        // 西文名：不轉、class=other-v，proposed==current
+        $this->assertSame('other-v', $index['BIOG_MAIN.c_surname|Silva']['class']);
+        $this->assertSame('Silva', $index['BIOG_MAIN.c_surname|Silva']['proposed']);
+        $this->assertSame('other-v', $index['ALTNAME_DATA.c_alt_name|Silva']['class']);
+
+        // 無 v 的列不應出現（Wang / Anshi）
+        $this->assertArrayNotHasKey('BIOG_MAIN.c_surname|Wang', $index);
+
+        // ALTNAME 定位欄（3-key）帶出
+        $this->assertSame('1|呂胤|4', $index['ALTNAME_DATA.c_alt_name|Lv Yin']['ids']);
+
+        // c_mingzi 欄同樣被掃描與分類（非僅 c_surname）
+        $this->assertSame('Lübu', $index['BIOG_MAIN.c_mingzi|Lvbu']['proposed']);
+        $this->assertSame('pinyin', $index['BIOG_MAIN.c_mingzi|Lvbu']['class']);
+        $this->assertSame('5', $index['BIOG_MAIN.c_mingzi|Lvbu']['ids']);
+
+        // 大寫 V 也須命中並轉為 Ü（LIKE 對大小寫不敏感）
+        $this->assertSame('LÜ', $index['BIOG_MAIN.c_surname|LV']['proposed']);
+        $this->assertSame('pinyin', $index['BIOG_MAIN.c_surname|LV']['class']);
+    }
+
+    #[Test]
+    public function it_honors_limit_per_column(): void {
+        $this->artisan('cbdb:scan-pinyin-v', ['--out' => $this->out, '--limit' => 1])->assertSuccessful();
+
+        $rows = $this->readCsv();
+        // 每欄最多 1 列；共 3 欄（c_surname/c_mingzi/c_alt_name）→ 至多 3 列
+        $this->assertLessThanOrEqual(3, count($rows));
+
+        $perColumn = [];
+        foreach ($rows as $r) {
+            $perColumn["{$r['table']}.{$r['column']}"] = ($perColumn["{$r['table']}.{$r['column']}"] ?? 0) + 1;
+        }
+        foreach ($perColumn as $col => $n) {
+            $this->assertLessThanOrEqual(1, $n, "{$col} 超過 --limit=1");
+        }
+        // 依 c_personid 排序，c_surname 首列應為 person 1 的 Lv
+        $surnameRows = array_values(array_filter($rows, static fn ($r) => $r['column'] === 'c_surname'));
+        $this->assertSame('Lv', $surnameRows[0]['current']);
+    }
+
+    #[Test]
+    public function it_rejects_non_phase_a(): void {
+        $this->artisan('cbdb:scan-pinyin-v', ['--phase' => 'B', '--out' => $this->out])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_is_read_only(): void {
+        $biogBefore = DB::table('BIOG_MAIN')->get()->toArray();
+        $altBefore = DB::table('ALTNAME_DATA')->get()->toArray();
+        $this->artisan('cbdb:scan-pinyin-v', ['--out' => $this->out])->assertSuccessful();
+        $this->assertEquals($biogBefore, DB::table('BIOG_MAIN')->get()->toArray(), '掃描命令不得修改 BIOG_MAIN');
+        $this->assertEquals($altBefore, DB::table('ALTNAME_DATA')->get()->toArray(), '掃描命令不得修改 ALTNAME_DATA');
+    }
+}


### PR DESCRIPTION
## Phase A · M2：只讀掃描命令（重開，base=develop）

> 原 #1097 因 M1 分支合併後被刪除而自動關閉；本 PR 內容相同，改以 develop 為 base。

新增 `cbdb:scan-pinyin-v`，掃描人名欄中含 `v` 的列並依《漢語拼音方案》分類，輸出 CSV 供人工複核。**只讀不寫，可安全於生產執行。**

### 範圍（Phase A 人名欄）
- `BIOG_MAIN.c_surname` / `c_mingzi`、`ALTNAME_DATA.c_alt_name`（帶完整 3-key 定位）
- `c_name` 派生欄不掃

### 分類
- `pinyin`：可轉音節（lv/lve/nv/nve）→ 應轉 ü
- `other-v`：含 v 但非可轉（Silva/Calvin…）→ 僅列出供瞄

### 品質
- 依完整定位鍵排序，避免 `each()` 分頁在非唯一鍵邊界漏/重複
- `fclose` 於 `finally`；4 測試 / 31 斷言（分類+CSV、只讀 BIOG_MAIN+ALTNAME、--limit、--phase=B 拒絕、c_mingzi、大寫 V）

> 已過 review agent + codex 雙審，無 blocking issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)