### PR TITLE
feat(pinyin): Phase A M3 查詢展開——v 同查 v 與 ü（§D-8）

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -447,8 +447,10 @@ class ApiController extends Controller {
 
     public function searchBiog(Request $request) {
         // 20251218性能優化：使用與 /api/name 相同的 FTS 索引查詢邏輯
-        // #85：拼音 ü→v 規範化（CBDB 以 v 存 ü 韻）。
-        $request->q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($request->q));
+        // #85 + §D-8：$request->q 為主要形式（數字／FTS／orderByRaw），$qForms 為綁定用的 v／ü 展開集。
+        $rawQ = $request->q ?? '';
+        $request->q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($rawQ));
+        $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
         $num = 20;
 
         // 優化1：當輸入為純數字時，直接按 c_personid 精確查詢
@@ -483,11 +485,14 @@ class ApiController extends Controller {
 
                 $data = $query->paginate($num);
             } else {
-                // 回退方案：FTS 未找到結果時，使用原有的 LIKE 查詢
-                $data = BiogMain::where('c_name_chn', 'like', '%'.$request->q.'%')
-                    ->orWhere('c_name', 'like', '%'.$request->q.'%')
-                    ->orWhere('c_personid', $request->q)
-                    ->paginate($num);
+                // 回退方案：FTS 未找到結果時，使用原有的 LIKE 查詢（§D-8：c_name 以展開集 OR 同查 v／ü 形）
+                $data = BiogMain::where(function ($sub) use ($request, $qForms) {
+                    $sub->where('c_name_chn', 'like', '%'.$request->q.'%')
+                        ->orWhere('c_personid', $request->q);
+                    foreach ($qForms as $form) {
+                        $sub->orWhere('c_name', 'like', '%'.$form.'%');
+                    }
+                })->paginate($num);
             }
         }
 

--- a/app/Http/Controllers/CbdbApiController.php
+++ b/app/Http/Controllers/CbdbApiController.php
@@ -268,8 +268,10 @@ class CbdbApiController extends Controller {
     }
 
     protected function searchPersonCandidates(string $name, int $limit = 20): array {
-        // #85：拼音 ü→v 規範化（CBDB 以 v 存 ü 韻）。
-        $term = \App\Support\PinyinSearchNormalizer::umlautToV(trim($name));
+        // #85 + §D-8：$term 為主要形式（數字／FTS），$termForms 為綁定用的 v／ü 展開集。
+        $rawTerm = trim($name);
+        $term = \App\Support\PinyinSearchNormalizer::umlautToV($rawTerm);
+        $termForms = \App\Support\PinyinSearchNormalizer::expand($rawTerm);
 
         if ($term === '') {
             return [];
@@ -321,10 +323,11 @@ class CbdbApiController extends Controller {
             $this->appendPersonIdsFromQuery(
                 DB::table('BIOG_MAIN')
                     ->select('c_personid')
-                    ->where(function ($query) use ($term) {
-                        $query->where('c_name_chn', $term)
-                            ->orWhere('c_name', $term)
-                            ->orWhere('c_name_rm', $term);
+                    ->where(function ($query) use ($term, $termForms) {
+                        $query->where('c_name_chn', $term);
+                        foreach ($termForms as $form) {
+                            $query->orWhere('c_name', $form)->orWhere('c_name_rm', $form);
+                        }
                     })
                     ->orderBy('c_personid'),
                 $collector,
@@ -334,9 +337,11 @@ class CbdbApiController extends Controller {
             $this->appendPersonIdsFromQuery(
                 DB::table('ALTNAME_DATA')
                     ->select('c_personid')
-                    ->where(function ($query) use ($term) {
-                        $query->where('c_alt_name_chn', $term)
-                            ->orWhere('c_alt_name', $term);
+                    ->where(function ($query) use ($term, $termForms) {
+                        $query->where('c_alt_name_chn', $term);
+                        foreach ($termForms as $form) {
+                            $query->orWhere('c_alt_name', $form);
+                        }
                     })
                     ->orderBy('c_personid'),
                 $collector,
@@ -348,10 +353,12 @@ class CbdbApiController extends Controller {
             $this->appendPersonIdsFromQuery(
                 DB::table('BIOG_MAIN')
                     ->select('c_personid')
-                    ->where(function ($query) use ($likeTerm) {
-                        $query->where('c_name_chn', 'like', $likeTerm)
-                            ->orWhere('c_name', 'like', $likeTerm)
-                            ->orWhere('c_name_rm', 'like', $likeTerm);
+                    ->where(function ($query) use ($likeTerm, $termForms) {
+                        $query->where('c_name_chn', 'like', $likeTerm);
+                        foreach ($termForms as $form) {
+                            $like = '%' . $form . '%';
+                            $query->orWhere('c_name', 'like', $like)->orWhere('c_name_rm', 'like', $like);
+                        }
                     })
                     ->orderBy('c_personid'),
                 $collector,
@@ -361,9 +368,11 @@ class CbdbApiController extends Controller {
             $this->appendPersonIdsFromQuery(
                 DB::table('ALTNAME_DATA')
                     ->select('c_personid')
-                    ->where(function ($query) use ($likeTerm) {
-                        $query->where('c_alt_name_chn', 'like', $likeTerm)
-                            ->orWhere('c_alt_name', 'like', $likeTerm);
+                    ->where(function ($query) use ($likeTerm, $termForms) {
+                        $query->where('c_alt_name_chn', 'like', $likeTerm);
+                        foreach ($termForms as $form) {
+                            $query->orWhere('c_alt_name', 'like', '%' . $form . '%');
+                        }
                     })
                     ->orderBy('c_personid'),
                 $collector,

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -380,8 +380,11 @@ class BiogMainRepository {
      */
     public static function namesByQuery(Request $request, $num = 20) {
         //20220303增加addslashes()防禦查詢參數
-        // #85：拼音 ü→v 規範化（CBDB 以 v 存 ü 韻，如 呂=Lv）——使用者輸入 ü 或 v 皆可命中。
-        $request->q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($request->q ?? ''));
+        // #85 + §D-8 查詢展開：遷移後人名以正字 ü 儲存；$request->q 保留主要形式（供數字判斷／
+        // FTS／orderByRaw 內插，addslashes 防禦），$qForms 為綁定用的 v／ü 展開集（OR 同查）。
+        $rawQ = $request->q ?? '';
+        $request->q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($rawQ));
+        $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
         if ($temp = $request->num) {
             $num = addslashes($temp);
         }
@@ -535,19 +538,21 @@ class BiogMainRepository {
                   ->where('A2.c_alt_name_type_code', '=', 5);
         });
 
-        $names = $names->where(function ($query) use ($request) {
+        $names = $names->where(function ($query) use ($request, $qForms) {
             $query->where('BIOG_MAIN.c_name_chn', 'like', '%'.$request->q.'%')
-                ->orWhere('BIOG_MAIN.c_name', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_surname', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_mingzi', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_personid', $request->q)
-                #20230626增加[外文全名]與[外文羅馬字轉寫姓名]可查得
-                ->orWhere('BIOG_MAIN.c_name_proper', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_name_rm', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_mingzi_proper', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_surname_proper', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_mingzi_rm', 'like', $request->q)
-                ->orWhere('BIOG_MAIN.c_surname_rm', 'like', $request->q);
+                ->orWhere('BIOG_MAIN.c_personid', $request->q);
+            // §D-8：拼音／羅馬字欄位以展開集 OR 同查 v／ü 形（單一形輸入時 $qForms 僅一元、行為不變）。
+            #20230626增加[外文全名]與[外文羅馬字轉寫姓名]可查得
+            $pinyinCols = [
+                'c_name', 'c_surname', 'c_mingzi',
+                'c_name_proper', 'c_name_rm', 'c_mingzi_proper',
+                'c_surname_proper', 'c_mingzi_rm', 'c_surname_rm',
+            ];
+            foreach ($pinyinCols as $col) {
+                foreach ($qForms as $form) {
+                    $query->orWhere("BIOG_MAIN.{$col}", 'like', $form);
+                }
+            }
         });
 
         // 朝代篩選
@@ -585,8 +590,10 @@ class BiogMainRepository {
             return collect();
         }
 
-        // #85：拼音 ü→v 規範化（與 namesByQuery 一致，使朝代分面與搜尋結果同口徑）。
-        $q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($q));
+        // #85 + §D-8：與 namesByQuery 同口徑——$q 為主要形式（FTS／personid），$qForms 為 v／ü 展開集。
+        $rawQ = $q;
+        $q = addslashes(\App\Support\PinyinSearchNormalizer::umlautToV($rawQ));
+        $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
 
         // 純數字：單筆精確查詢，不需要 facet
         if (ctype_digit($q)) {
@@ -627,18 +634,20 @@ class BiogMainRepository {
         // 回退 LIKE 路徑
         $fallbackBaseQuery = DB::table('BIOG_MAIN')
             ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
-            ->where(function ($query) use ($q) {
+            ->where(function ($query) use ($q, $qForms) {
                 $query->where('BIOG_MAIN.c_name_chn', 'like', '%' . $q . '%')
-                    ->orWhere('BIOG_MAIN.c_name', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_surname', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_mingzi', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_personid', $q)
-                    ->orWhere('BIOG_MAIN.c_name_proper', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_name_rm', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_mingzi_proper', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_surname_proper', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_mingzi_rm', 'like', $q)
-                    ->orWhere('BIOG_MAIN.c_surname_rm', 'like', $q);
+                    ->orWhere('BIOG_MAIN.c_personid', $q);
+                // §D-8：與 namesByQuery 一致，拼音／羅馬字欄位以展開集 OR 同查 v／ü 形。
+                $pinyinCols = [
+                    'c_name', 'c_surname', 'c_mingzi',
+                    'c_name_proper', 'c_name_rm', 'c_mingzi_proper',
+                    'c_surname_proper', 'c_mingzi_rm', 'c_surname_rm',
+                ];
+                foreach ($pinyinCols as $col) {
+                    foreach ($qForms as $form) {
+                        $query->orWhere("BIOG_MAIN.{$col}", 'like', $form);
+                    }
+                }
             });
 
         $validDynasties = (clone $fallbackBaseQuery)

--- a/app/Services/EntryQueryService.php
+++ b/app/Services/EntryQueryService.php
@@ -249,21 +249,28 @@ class EntryQueryService {
         }
 
         if ($filters['person_keyword'] !== null) {
-            // #85：拼音 ü→v 規範化（CBDB 以 v 存 ü 韻）。
-            $keyword = '%' . \App\Support\PinyinSearchNormalizer::umlautToV($filters['person_keyword']) . '%';
+            // #85 + §D-8：拼音欄位以 v／ü 展開集 OR 同查（中文欄位 no-op、單一形時行為不變）。
+            $keywordForms = array_map(
+                static fn ($f) => '%' . $f . '%',
+                \App\Support\PinyinSearchNormalizer::expand($filters['person_keyword'])
+            );
 
-            $query->where(function (Builder $builder) use ($keyword) {
-                $builder->where('bm.c_name_chn', 'like', $keyword)
-                    ->orWhere('bm.c_name', 'like', $keyword);
+            $query->where(function (Builder $builder) use ($keywordForms) {
+                foreach ($keywordForms as $kw) {
+                    $builder->orWhere('bm.c_name_chn', 'like', $kw)
+                        ->orWhere('bm.c_name', 'like', $kw);
+                }
 
                 if (Schema::hasTable('ALTNAME_DATA')) {
-                    $builder->orWhereExists(function (Builder $subquery) use ($keyword) {
+                    $builder->orWhereExists(function (Builder $subquery) use ($keywordForms) {
                         $subquery->select(DB::raw(1))
                             ->from('ALTNAME_DATA as alt')
                             ->whereColumn('alt.c_personid', 'bm.c_personid')
-                            ->where(function (Builder $altQuery) use ($keyword) {
-                                $altQuery->where('alt.c_alt_name_chn', 'like', $keyword)
-                                    ->orWhere('alt.c_alt_name', 'like', $keyword);
+                            ->where(function (Builder $altQuery) use ($keywordForms) {
+                                foreach ($keywordForms as $kw) {
+                                    $altQuery->orWhere('alt.c_alt_name_chn', 'like', $kw)
+                                        ->orWhere('alt.c_alt_name', 'like', $kw);
+                                }
                             });
                     });
                 }

--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -26,7 +26,10 @@ class PersonBrowserService {
      * @return array{data: array, pagination: array}
      */
     public function search(Request $request): array {
-        $q = \App\Support\PinyinSearchNormalizer::umlautToV(trim($request->input('q', '')));
+        // #85 + §D-8：$q 為主要形式（FTS／numeric），$qForms 為綁定用的 v／ü 展開集。
+        $rawQ = trim($request->input('q', ''));
+        $q = \App\Support\PinyinSearchNormalizer::umlautToV($rawQ);
+        $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
         $dynasty = $request->input('c_dy', '');
         $perPage = (int) $request->input('per_page', 20);
         $page = (int) $request->input('page', 1);
@@ -72,14 +75,16 @@ class PersonBrowserService {
                     $idQuery->whereIn('BIOG_MAIN.c_personid', $ftsIds)
                         ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
                 } else {
-                    // 回退：多欄位 LIKE 搜尋
-                    $idQuery->where(function ($sub) use ($q) {
-                        $sub->where('BIOG_MAIN.c_name_chn', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_name', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_surname', 'like', $q)
-                            ->orWhere('BIOG_MAIN.c_mingzi', 'like', $q)
-                            ->orWhere('BIOG_MAIN.c_name_proper', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_name_rm', 'like', '%' . $q . '%');
+                    // 回退：多欄位 LIKE 搜尋（§D-8：拼音欄位以展開集 OR 同查 v／ü 形）
+                    $idQuery->where(function ($sub) use ($qForms) {
+                        foreach ($qForms as $form) {
+                            $sub->orWhere('BIOG_MAIN.c_name_chn', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_name', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_surname', 'like', $form)
+                                ->orWhere('BIOG_MAIN.c_mingzi', 'like', $form)
+                                ->orWhere('BIOG_MAIN.c_name_proper', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_name_rm', 'like', '%' . $form . '%');
+                        }
                     })
                         ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
                 }
@@ -189,13 +194,19 @@ class PersonBrowserService {
                 if (!empty($ftsIds)) {
                     $query->whereIn('BIOG_MAIN.c_personid', $ftsIds);
                 } else {
-                    $query->where(function ($sub) use ($q) {
-                        $sub->where('BIOG_MAIN.c_name_chn', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_name', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_surname', 'like', $q)
-                            ->orWhere('BIOG_MAIN.c_mingzi', 'like', $q)
-                            ->orWhere('BIOG_MAIN.c_name_proper', 'like', '%' . $q . '%')
-                            ->orWhere('BIOG_MAIN.c_name_rm', 'like', '%' . $q . '%');
+                    // §D-8：與 search() 的主查詢同口徑——朝代分面同樣以 v／ü 展開集 OR 同查，
+                    // 否則 v 形輸入命中的 ü 資料會出現在人物列表、卻在朝代側欄漏計。
+                    // expand($q) 對已折疊的 $q 仍還原出 {v 形, ü 形} 集合，故無需改動呼叫端。
+                    $qForms = \App\Support\PinyinSearchNormalizer::expand($q);
+                    $query->where(function ($sub) use ($qForms) {
+                        foreach ($qForms as $form) {
+                            $sub->orWhere('BIOG_MAIN.c_name_chn', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_name', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_surname', 'like', $form)
+                                ->orWhere('BIOG_MAIN.c_mingzi', 'like', $form)
+                                ->orWhere('BIOG_MAIN.c_name_proper', 'like', '%' . $form . '%')
+                                ->orWhere('BIOG_MAIN.c_name_rm', 'like', '%' . $form . '%');
+                        }
                     });
                 }
             }

--- a/app/Support/PinyinSearchNormalizer.php
+++ b/app/Support/PinyinSearchNormalizer.php
@@ -3,18 +3,24 @@
 namespace App\Support;
 
 /**
- * 人物拼音搜尋的 ü／v 規範化。
+ * 人物拼音搜尋的 ü／v 規範化與查詢展開。
  *
- * CBDB 的漢語拼音欄位（BIOG_MAIN.c_name / c_surname / c_mingzi）以 **v** 表示 ü 韻
- * （例：呂 = "Lv"、女 = "Nv"），全庫無字面 ü（已實測：c_name/surname/mingzi 字面 ü = 0）。
- * 但使用者可能輸入正規拼音的 ü（如「Lü」），亦可能輸入 CBDB 慣例的 v（如「Lv」）。
+ * 歷史背景：CBDB 漢語拼音欄位長期以 **v** 表示 ü 韻（例：呂 = "Lv"、女 = "Nv"）。
+ * v→ü 遷移（見 docs/PINYIN_V_TO_UMLAUT_MIGRATION.md）後，人名資料改以正字 **ü** 儲存，
+ * 但使用者仍可能輸入 v 形（CBDB 舊慣例，如 Lv）、ü 形（正規拼音，如 Lü）或 u 形（Lu）。
  *
- * 本規範化把查詢字串中的 ü／Ü 一律折成 v／V，使兩種輸入都能命中 v 形儲存的資料。
+ * ── umlautToV（舊 #85 單向折疊，遷移前）：把 ü→v，命中 v 形儲存的資料。保留供
+ *    過渡期與非展開呼叫點使用；遷移完成後其單獨使用已不足（見下）。
  *
- * 為何只折查詢端、且只能「ü→v」單向：
- * - 資料端無字面 ü，毋須改寫欄位（避免在 LIKE 兩側加 REPLACE 拖累，且維持簡單）。
- * - DB collation 為 utf8mb4_unicode_ci（重音不敏感，視 ü ≈ u）。若反向把 v 展開成 ü 去比對，
- *   "Lü" 會被 collation 當成 "Lu" 命中大量「盧/陸」等 u 群 → 誤撈。故**絕不可**把 v 改寫為 ü 比對。
+ * ── expand（§D-8 查詢展開，遷移後）：回傳應以 **OR 同時比對**的拼音形式集合，處理 v↔ü：
+ *    v 形輸入補 ü 形（命中已遷移 ü 資料）、ü 形輸入補 v 形（命中過渡期殘留 v 資料）。
+ *    u 形輸入不在此程式展開——它由生產環境 accent-insensitive collation 直接摺疊命中 ü 資料
+ *    （§D-8：「u 已由 collation 摺疊命中 ü，無需改」）；故 expand() 不做 u→v。
+ *
+ * collation 注意：生產環境 general_ci／unicode_ci 皆重音不敏感（ü ≈ u）。故 ü 形在 LIKE
+ * 會連帶折成 u、命中 u 群（Lü≈Lu → 盧/陸）。此擴大命中為 §D-8 已接受之搜尋語意
+ * （等同使用者直接打 u），與 #85 當年「資料端純 v、擴 ü 無益且誤撈」的前提已因遷移而反轉。
+ * SQLite（測試）不折疊 ü/u，撰測時須以字面形式驗證，勿據 SQLite 推斷生產折疊行為。
  */
 class PinyinSearchNormalizer {
     /**
@@ -22,5 +28,27 @@ class PinyinSearchNormalizer {
      */
     public static function umlautToV(?string $term): string {
         return str_replace(['ü', 'Ü'], ['v', 'V'], (string) $term);
+    }
+
+    /**
+     * 查詢展開：回傳應以 OR 同時比對的拼音形式（去重、保序）。
+     *
+     * 三個來源形式：
+     *  - 原字：命中 ü 形輸入對 ü 資料、u 形輸入（prod 折疊）、過渡期殘留 v 資料。
+     *  - PinyinUmlaut::normalize（v→ü，僅動 lv/lve/nv/nve 音節簇）：命中 v 形輸入對已遷移的 ü 資料。
+     *  - umlautToV（ü→v）：命中 ü 形輸入對過渡期殘留 v 資料。
+     *
+     * 對中文／數字／不含可轉音節或 ü 的西文名（如 Calvin）三形式相等 → 回傳單一形，行為與展開前一致。
+     *
+     * @return array<int, string> 至少一個元素；空字串輸入回傳 ['']。
+     */
+    public static function expand(?string $term): array {
+        $raw = (string) $term;
+
+        return array_values(array_unique([
+            $raw,
+            PinyinUmlaut::normalize($raw),
+            self::umlautToV($raw),
+        ]));
     }
 }

--- a/app/v1.php
+++ b/app/v1.php
@@ -31,9 +31,17 @@ class v1 extends Model {
     }
 
     public function search(Request $request) {
-        // #85：拼音 ü→v 規範化（CBDB 以 v 存 ü 韻）。
-        $request->q = \App\Support\PinyinSearchNormalizer::umlautToV($request->q ?? '');
-        $data = BiogMain::where('c_name_chn', 'like', $request->q)->orWhere('c_name', 'like', $request->q)->orWhere('c_personid', $request->q)->paginate(10);
+        // #85 + §D-8：$request->q 主要形式，$qForms 為綁定用的 v／ü 展開集。
+        $rawQ = $request->q ?? '';
+        $request->q = \App\Support\PinyinSearchNormalizer::umlautToV($rawQ);
+        $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
+        $data = BiogMain::where(function ($sub) use ($request, $qForms) {
+            $sub->where('c_name_chn', 'like', $request->q)
+                ->orWhere('c_personid', $request->q);
+            foreach ($qForms as $form) {
+                $sub->orWhere('c_name', 'like', $form);
+            }
+        })->paginate(10);
         $data->appends(['q' => $request->q])->links();
 
         return $data;

--- a/tests/Feature/BiogMainNameSearchTest.php
+++ b/tests/Feature/BiogMainNameSearchTest.php
@@ -329,6 +329,32 @@ class BiogMainNameSearchTest extends TestCase {
     }
 
     #[Test]
+    public function test_umlaut_stored_name_found_by_v_input_after_migration(): void {
+        // §D-8 查詢展開（遷移後情境）：人名以正字 ü 儲存（Lü Kun）。習慣打 v 的使用者須仍命中。
+        // 註：SQLite 不折疊 ü/u，故此處命中完全來自 expand() 的 OR 展開，非 collation——
+        //     正好驗證程式端展開邏輯本身（生產環境另有 collation 摺疊，非本測試對象）。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 5002,
+            'c_name_chn' => '呂坤',
+            'c_name' => 'Lü Kun',   // 遷移後以正字 ü 儲存
+            'c_surname' => '呂',
+            'c_mingzi' => '坤',
+            'c_index_year' => 1536,
+            'c_dy' => 15,
+            'c_index_addr_id' => 100,
+        ]);
+        // 刻意不建 FTS 列 → 落到 LIKE 退路（與正式環境一致：FTS 僅索引中文）。
+
+        $idsFor = fn (string $q): array => collect(
+            BiogMainRepository::namesByQuery(new Request(['q' => $q]), 20)->items()
+        )->pluck('c_personid')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains(5002, $idsFor('Lv Kun'), 'v 形輸入應命中以 ü 儲存的呂坤(5002)');
+        $this->assertContains(5002, $idsFor('Lü Kun'), 'ü 形輸入應命中呂坤(5002)');
+        $this->assertContains(5002, $idsFor('lv kun'), '小寫 v 形亦應命中（LIKE ASCII 大小寫不敏感）');
+    }
+
+    #[Test]
     public function test_pinyin_normalizer_helper(): void {
         // ü／Ü 折成 v／V；中文／無 ü 字串為 no-op；null 安全。
         $this->assertSame('Lv Zhen', \App\Support\PinyinSearchNormalizer::umlautToV('Lü Zhen'));

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -930,6 +930,27 @@ class PersonBrowserTest extends TestCase {
     }
 
     #[Test]
+    public function test_search_finds_umlaut_stored_name_by_v_input(): void {
+        // §D-8 查詢展開：遷移後以正字 ü 儲存的名（Lü Kun），習慣打 v 的使用者（Lv Kun）須仍搜得到。
+        // SQLite 不折疊 ü/u，命中純來自 expand() 的 OR 展開，驗證 PersonBrowser 入口的程式端展開。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 777,
+            'c_name_chn' => '呂坤',
+            'c_name' => 'Lü Kun',
+            'c_surname' => 'Lü',
+            'c_mingzi' => 'Kun',
+            'c_dy' => 2,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson(route('app.person-browser.search') . '?' . http_build_query(['q' => 'Lv Kun']));
+
+        $response->assertOk();
+        $ids = collect($response->json('data'))->pluck('c_personid')->map(fn ($id) => (int) $id)->all();
+        $this->assertContains(777, $ids, 'v 形輸入「Lv Kun」應命中以 ü 儲存的呂坤(777)');
+    }
+
+    #[Test]
     public function test_search_by_alt_name_via_fts(): void {
         $response = $this->actingAs($this->user)
             ->getJson(route('app.person-browser.search') . '?q=太白');

--- a/tests/Feature/SearchByEntryControllerTest.php
+++ b/tests/Feature/SearchByEntryControllerTest.php
@@ -375,6 +375,24 @@ class SearchByEntryControllerTest extends TestCase {
     }
 
     #[Test]
+    public function test_person_keyword_expands_v_to_umlaut(): void {
+        // §D-8 查詢展開：以正字 ü 儲存的別名（Lü Kun），習慣打 v 的使用者（Lv Kun）
+        // 須經 ALTNAME EXISTS 子查詢的展開集命中（SQLite 不折疊，純驗程式端展開）。
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 2, 'c_alt_name' => 'Lü Kun', 'c_alt_name_chn' => '呂坤'],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson(route('app.search-by.entry.query', [
+                'person_keyword' => 'Lv Kun',
+            ]));
+
+        $response->assertOk()
+            ->assertJsonPath('data.summary.person_count', 1)
+            ->assertJsonPath('data.records.data.0.c_personid', 2);
+    }
+
+    #[Test]
     public function test_query_can_include_subordinate_places(): void {
         $response = $this->actingAs($this->user)
             ->getJson(route('app.search-by.entry.query', [

--- a/tests/Unit/PinyinSearchNormalizerTest.php
+++ b/tests/Unit/PinyinSearchNormalizerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\PinyinSearchNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PinyinSearchNormalizer：ü／v 折疊（#85）與查詢展開（§D-8）。
+ */
+class PinyinSearchNormalizerTest extends TestCase {
+    #[Test]
+    #[DataProvider('umlautToVCases')]
+    public function it_folds_umlaut_to_v(string $in, string $expected): void {
+        $this->assertSame($expected, PinyinSearchNormalizer::umlautToV($in));
+    }
+
+    /** @return array<string, array{0:string,1:string}> */
+    public static function umlautToVCases(): array {
+        return [
+            'lower ü' => ['Lü', 'Lv'],
+            'upper Ü' => ['LÜ', 'LV'],
+            'joined' => ['Yelü', 'Yelv'],
+            'no umlaut' => ['Wang', 'Wang'],
+            'chinese' => ['呂', '呂'],
+        ];
+    }
+
+    #[Test]
+    public function it_returns_empty_form_for_empty_input(): void {
+        $this->assertSame([''], PinyinSearchNormalizer::expand(''));
+        $this->assertSame([''], PinyinSearchNormalizer::expand(null));
+    }
+
+    #[Test]
+    public function it_expands_v_form_to_both_v_and_umlaut(): void {
+        // 使用者打 v 形（CBDB 舊慣例）→ 同查 v 形（殘留）與 ü 形（已遷移）
+        $forms = PinyinSearchNormalizer::expand('Lv');
+        $this->assertContains('Lv', $forms);
+        $this->assertContains('Lü', $forms);
+        $this->assertCount(2, $forms);
+    }
+
+    #[Test]
+    public function it_expands_umlaut_form_to_both_umlaut_and_v(): void {
+        // 使用者打 ü 形（正規拼音）→ 同查 ü 形（已遷移）與 v 形（殘留）
+        $forms = PinyinSearchNormalizer::expand('Lü');
+        $this->assertContains('Lü', $forms);
+        $this->assertContains('Lv', $forms);
+        $this->assertCount(2, $forms);
+    }
+
+    #[Test]
+    public function it_expands_joined_and_uppercase_syllables(): void {
+        $this->assertEqualsCanonicalizing(['Yelv', 'Yelü'], PinyinSearchNormalizer::expand('Yelv'));
+        $this->assertEqualsCanonicalizing(['NV', 'NÜ'], PinyinSearchNormalizer::expand('NV'));
+    }
+
+    #[Test]
+    #[DataProvider('singleFormCases')]
+    public function it_is_a_noop_for_non_convertible_input(string $in): void {
+        // 中文／數字／無可轉音節或 ü 的西文名 → 展開後仍為單一形（行為不變）
+        $this->assertSame([$in], PinyinSearchNormalizer::expand($in));
+    }
+
+    /** @return array<string, array{0:string}> */
+    public static function singleFormCases(): array {
+        return [
+            'plain surname' => ['Wang'],
+            'western with lv+vowel' => ['Calvin'],  // lv 後接母音 i，非可轉音節
+            'western v-start' => ['Vasco'],
+            'chinese' => ['呂胤'],
+            'numeric' => ['1762'],
+        ];
+    }
+}


### PR DESCRIPTION
## Phase A · M3：搜尋查詢展開

遷移後人名以正字 **ü** 儲存；本 PR 讓使用者輸入 **v／ü** 皆能命中，跨全部人名搜尋入口。

### 核心
新增 `PinyinSearchNormalizer::expand(?string): array`——回傳應以 **OR 同時比對**的拼音形式集：
`{原字, v→ü 正規化, ü→v 折疊}` 去重。對中文／數字／西文名（Calvin/Vasco/Silva）為 **no-op**（單一形、行為不變）。`u` 形不在此程式展開——由生產 accent-insensitive collation 直接摺疊命中 ü（§D-8）。

### 掛入入口（5 + legacy）
- `BiogMainRepository::namesByQuery` ＋ `dynastyFacetsByQuery`（同口徑）
- `PersonBrowserService::search` ＋ `buildDynastyCounts`（朝代分面同步）
- `ApiController::searchBiog`、`CbdbApiController::searchPersonCandidates`（4 段）、`EntryQueryService::search`（含 ALTNAME EXISTS）、`v1.php`

### 設計權衡（明確記錄）
`expand` 的 ü 形在 prod collation 會連帶折成 u（Lü≈Lu → 盧/陸），此擴大命中為 **§D-8 已接受**之搜尋語意（等同打 u），並刻意反轉 #85『絕不可 v→ü』的舊前提——該前提在資料端為純 v 時成立，遷移後資料端為 ü，展開 ü 形反成必要。**建議與 M5 資料翻轉相近時程合併。**

### 測試
- `PinyinSearchNormalizerTest`：14 例（含西文名 no-op）
- 遷移後情境端對端：`namesByQuery`、`PersonBrowser`（HTTP）、`EntryQuery`（EXISTS 子查詢）——ü 儲存的名以 v 形輸入命中；SQLite 不折疊 → 純驗程式端展開
- 既有搜尋回歸全綠（141 tests / 962 assertions）

> 已過 review agent（揪出並修正 PersonBrowser 朝代分面漏展開）+ codex 雙審，無 blocking issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)