### PR TITLE
feat(pinyin): Phase A M4 人名遷移規劃器 + dry-run 指令

### DIFF
--- a/app/Console/Commands/MigratePinyinV.php
+++ b/app/Console/Commands/MigratePinyinV.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Repositories\BiogMainRepository;
+use App\Services\Pinyin\PinyinMigrationPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * 人名拼音 v→ü 遷移執行指令（預設 dry-run，只計算不寫入）。
+ *
+ * 機制見 docs/PINYIN_V_TO_UMLAUT_MIGRATION.md §D-3/§D-5/§D-6（重生 + Sheet oracle + 寫入前漂移檢查）。
+ * 權威來源為 Frank 的 Google Sheet（兩分頁 CSV）。本指令**只有加 --execute 才會寫入**，
+ * 且寫入一律走受審計的 /api/v2/mutate（mode:direct），逐筆有 audit / operations 可回退。
+ *
+ * **Token 安全**：--execute 的 Bearer token 只從環境變數 `CBDB_MIGRATE_TOKEN` 讀取，
+ * 絕不接受 CLI 參數、絕不輸出到畫面／log／檔案。
+ */
+class MigratePinyinV extends Command {
+    /** 公開 Google Sheet（非機密）。 */
+    private const SHEET_ID = '19SOyBtA8cKE9aq_hIkxRiT-e2i6f5bFDIY_TcNAn57I';
+    private const GID_BIOG = '248977087';
+    private const GID_ALTNAME = '1425535916';
+
+    /** @var string */
+    protected $signature = 'cbdb:migrate-pinyin-v
+                            {--table=both : both|biog|altname}
+                            {--biog-csv= : BIOG_MAIN CSV 路徑（省略且 --fetch 時自 Sheet 下載）}
+                            {--altname-csv= : ALTNAME CSV 路徑}
+                            {--fetch : 自公開 Google Sheet 下載 CSV（需網路）}
+                            {--surname= : 僅處理某姓氏拼音（BIOG_MAIN，一姓一批）}
+                            {--limit=0 : 最多處理筆數（抽樣，0＝不限）}
+                            {--out-dir= : 產物輸出目錄（預設 storage/app/pinyin-migration）}
+                            {--execute : 實際寫入（走 /api/v2/mutate）；省略＝dry-run 只計算}
+                            {--base-url=http://localhost : --execute 時的 API base URL}';
+
+    /** @var string */
+    protected $description = '人名拼音 v→ü 遷移：Sheet 驅動、重生+oracle+漂移檢查，預設 dry-run。--execute 才寫入（走審計 API）。';
+
+    public function handle(): int {
+        $table = (string) $this->option('table');
+        if (!in_array($table, ['both', 'biog', 'altname'], true)) {
+            $this->error('--table 只能是 both|biog|altname');
+
+            return self::FAILURE;
+        }
+
+        $execute = (bool) $this->option('execute');
+        $limit = max(0, (int) $this->option('limit'));
+        $outDir = (string) ($this->option('out-dir') ?: storage_path('app/pinyin-migration'));
+        if (!is_dir($outDir) && !@mkdir($outDir, 0775, true) && !is_dir($outDir)) {
+            $this->error("無法建立輸出目錄：{$outDir}");
+
+            return self::FAILURE;
+        }
+
+        $token = null;
+        if ($execute) {
+            $token = getenv('CBDB_MIGRATE_TOKEN') ?: null;
+            if (!$token) {
+                $this->error('--execute 需要環境變數 CBDB_MIGRATE_TOKEN（Bearer token）；為安全，token 不接受 CLI 參數。');
+
+                return self::FAILURE;
+            }
+        }
+
+        $repo = app(BiogMainRepository::class);
+        $regenerator = function (string $chn) use ($repo): array {
+            $d = $repo->auto_pinyin(['c_name_chn' => $chn]);
+
+            return [
+                'c_surname' => (string) ($d['c_surname'] ?? ''),
+                'c_mingzi' => (string) ($d['c_mingzi'] ?? ''),
+                'c_name' => (string) ($d['c_name'] ?? ''),
+            ];
+        };
+        $planner = new PinyinMigrationPlanner($regenerator);
+
+        $mode = $execute ? '**寫入模式（--execute）**' : 'dry-run（只計算、不寫入）';
+        $this->info("人名拼音 v→ü 遷移 — {$mode}");
+
+        $totalMutations = 0;
+        $totalExceptions = 0;
+        $applyFailures = 0;
+        $hadLoadError = false;
+        $processedAny = false;
+
+        foreach (['biog', 'altname'] as $side) {
+            if ($table !== 'both' && $table !== $side) {
+                continue;
+            }
+            $rows = $this->loadRows($side, $limit);
+            if ($rows === null) {
+                // 硬錯誤（下載失敗／路徑錯／缺欄位）——已在 loadRows 內報錯。
+                $hadLoadError = true;
+
+                continue;
+            }
+            if ($rows === []) {
+                continue;   // 該側未提供 CSV 或空表：略過（非錯誤）。
+            }
+            $processedAny = true;
+            if ($side === 'biog' && $this->option('surname')) {
+                $sn = (string) $this->option('surname');
+                $rows = array_values(array_filter($rows, static fn ($r) => str_starts_with($r['wrong_pinyin'], $sn) || str_starts_with($r['correct_pinyin'], $sn)));
+            }
+
+            $plan = $side === 'biog' ? $planner->planBiogMain($rows) : $planner->planAltname($rows);
+            $this->reportPlan($side, $plan, $outDir);
+            $totalMutations += count($plan['mutations']);
+            $totalExceptions += count($plan['exceptions']);
+
+            if ($execute && $plan['mutations'] !== []) {
+                $applyFailures += $this->applyMutations($plan['mutations'], (string) $this->option('base-url'), (string) $token, $outDir, $side);
+            }
+        }
+
+        $this->newLine();
+        $this->line("合計預定變更 {$totalMutations} 筆、例外 {$totalExceptions} 筆。產物於：{$outDir}");
+        if (!$execute) {
+            $this->line('這是 dry-run；加 --execute 並設 CBDB_MIGRATE_TOKEN 才會實際寫入。');
+        }
+
+        // 退出碼語義（供批次/CI）：任何載入硬錯誤、寫入失敗、或完全沒處理到任何側 → 失敗。
+        if ($hadLoadError) {
+            $this->error('有 CSV 載入失敗，未完整執行。');
+
+            return self::FAILURE;
+        }
+        if (!$processedAny) {
+            $this->error('沒有可處理的資料（請提供 --biog-csv/--altname-csv 或 --fetch）。');
+
+            return self::FAILURE;
+        }
+        if ($applyFailures > 0) {
+            $this->error("有 {$applyFailures} 筆寫入失敗（詳見 *-apply-failures.json）。");
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * 載入某一側的 Sheet 列（CSV）。
+     *
+     * @return array<int, array<string, string>>|null
+     */
+    private function loadRows(string $side, int $limit): ?array {
+        $path = (string) ($side === 'biog' ? $this->option('biog-csv') : $this->option('altname-csv'));
+        $fetchedTemp = null;
+
+        if ($path === '' && $this->option('fetch')) {
+            $gid = $side === 'biog' ? self::GID_BIOG : self::GID_ALTNAME;
+            $url = 'https://docs.google.com/spreadsheets/d/'.self::SHEET_ID."/export?format=csv&gid={$gid}";
+            $resp = Http::get($url);
+            if (!$resp->successful()) {
+                $this->error("下載 Sheet 失敗（{$side}）：HTTP {$resp->status()}");
+
+                return null;
+            }
+            $tmp = tempnam(sys_get_temp_dir(), 'pyv');
+            file_put_contents($tmp, $resp->body());
+            $path = $tmp;
+            $fetchedTemp = $tmp;
+        }
+
+        if ($path === '') {
+            // 未提供 CSV（且未 --fetch）：軟略過，非錯誤。
+            $this->warn("略過 {$side}：未提供 CSV（--{$side}-csv= 或 --fetch）。");
+
+            return [];
+        }
+        if (!is_file($path)) {
+            $this->error("CSV 路徑不存在（{$side}）：{$path}");
+
+            return null;
+        }
+
+        $fh = fopen($path, 'r');
+        if ($fh === false) {
+            $this->error("無法讀取 CSV：{$path}");
+
+            return null;
+        }
+        $header = fgetcsv($fh, null, ',', '"', '');
+        if ($header === false) {
+            fclose($fh);
+            if ($fetchedTemp !== null) {
+                @unlink($fetchedTemp);
+            }
+
+            return [];
+        }
+        $header = array_map(static fn ($h) => trim((string) $h), $header);
+        // BIOG 需要 field 欄（決定改 c_surname/c_mingzi/c_name）；缺欄多半是傳錯分頁，早失敗以免後段不透明。
+        if ($side === 'biog' && !in_array('field', $header, true)) {
+            fclose($fh);
+            if ($fetchedTemp !== null) {
+                @unlink($fetchedTemp);
+            }
+            $this->error("BIOG CSV 缺少 field 欄（可能傳錯分頁）：{$path}");
+
+            return null;
+        }
+        $validFields = ['c_surname', 'c_mingzi', 'c_name'];
+        $rows = [];
+        while (($data = fgetcsv($fh, null, ',', '"', '')) !== false) {
+            $data = array_map(static fn ($v) => (string) $v, $data);
+            // 空白/短列（Sheet 匯出常見）：欄數不符就跳過——array_combine 在 PHP 8 會擲 ValueError，不可依賴回傳 false。
+            if (count($header) !== count($data)) {
+                continue;
+            }
+            $assoc = array_combine($header, $data);
+            if (!isset($assoc['id'], $assoc['wrong_pinyin'], $assoc['correct_pinyin'])) {
+                continue;
+            }
+            // BIOG：field 必須是已知欄位，否則跳過（避免規劃器讀到未預期欄名）。
+            if ($side === 'biog' && !in_array($assoc['field'] ?? '', $validFields, true)) {
+                continue;
+            }
+            $rows[] = $assoc;
+            if ($limit > 0 && count($rows) >= $limit) {
+                break;
+            }
+        }
+        fclose($fh);
+        if ($fetchedTemp !== null) {
+            @unlink($fetchedTemp);
+        }
+
+        return $rows;
+    }
+
+    /** @param array{mutations:array,exceptions:array,skipped:array,alreadyDone:array} $plan */
+    private function reportPlan(string $side, array $plan, string $outDir): void {
+        $this->newLine();
+        $this->info(strtoupper($side).'：預定變更 '.count($plan['mutations'])
+            .'、例外 '.count($plan['exceptions'])
+            .'、跳過(漂移/落空) '.count($plan['skipped'])
+            .'、已遷移 '.count($plan['alreadyDone']));
+
+        // 抽樣預覽（前 5 筆變更）
+        $samples = array_slice($plan['mutations'], 0, 5);
+        if ($samples !== []) {
+            $this->table(['pk', 'from', 'to'], array_map(static fn ($m) => [
+                json_encode($m['pk'], JSON_UNESCAPED_UNICODE),
+                (string) ($m['preview']['from'] ?? ''),
+                (string) ($m['preview']['to'] ?? ''),
+            ], $samples));
+        }
+
+        // 產物：把 mutations / exceptions / skipped 各寫一份 JSON 供人工複核。
+        foreach (['mutations', 'exceptions', 'skipped', 'alreadyDone'] as $bucket) {
+            $file = $outDir.DIRECTORY_SEPARATOR."{$side}-{$bucket}.json";
+            file_put_contents($file, json_encode($plan[$bucket], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        }
+    }
+
+    /**
+     * 實際送出變更（走 /api/v2/mutate，mode:direct）。Token 僅用於 header，不輸出。
+     *
+     * @param  array<int, array>  $mutations
+     * @return int  失敗筆數（供退出碼判斷）
+     */
+    private function applyMutations(array $mutations, string $baseUrl, string $token, string $outDir, string $side): int {
+        $endpoint = rtrim($baseUrl, '/').'/api/v2/mutate';
+        $ok = 0;
+        $fail = 0;
+        $failures = [];
+
+        foreach ($mutations as $m) {
+            $payload = [
+                'resource' => $m['resource'],
+                'mode' => 'direct',
+                'target' => ['pk' => $m['pk']],
+                'changes' => $m['changes'],
+            ];
+            $resp = Http::withToken($token)->acceptJson()->post($endpoint, $payload);
+            if ($resp->successful()) {
+                $ok++;
+            } else {
+                $fail++;
+                // 只記錄 pk 與狀態/訊息，絕不含 token。
+                $failures[] = ['pk' => $m['pk'], 'status' => $resp->status(), 'body' => $resp->json() ?? $resp->body()];
+            }
+        }
+
+        $this->line("  送出 {$side}：成功 {$ok}、失敗 {$fail}");
+        if ($failures !== []) {
+            file_put_contents(
+                $outDir.DIRECTORY_SEPARATOR."{$side}-apply-failures.json",
+                json_encode($failures, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+        }
+
+        return $fail;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends ConsoleKernel {
         \App\Console\Commands\FetchChgisMap::class,
         \App\Console\Commands\RebuildPersonChangeIndex::class,
         \App\Console\Commands\ScanPinyinV::class,
+        \App\Console\Commands\MigratePinyinV::class,
     ];
 
     /**

--- a/app/Services/Pinyin/PinyinMigrationPlanner.php
+++ b/app/Services/Pinyin/PinyinMigrationPlanner.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Services\Pinyin;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 人名拼音 v→ü 遷移的「規劃器」（只計算、不寫入）。
+ *
+ * 依 docs/PINYIN_V_TO_UMLAUT_MIGRATION.md §D-3／§D-5／§D-6 與 Frank #1087 審查：
+ * - BIOG_MAIN：以 auto_pinyin 重新合成（regenerate），寫入前先做漂移檢查（現值須 == Sheet wrong_pinyin），
+ *   並以 oracle 閘把關（重生結果須 == Sheet correct_pinyin）；只送 c_surname/c_mingzi，c_name 由 handler 重算。
+ * - ALTNAME_DATA：以 (c_personid, c_alt_name=wrong_pinyin) 定位完整 3-key PK；>1 命中→歧義例外。
+ *
+ * 產物為「預定變更集 + 例外／跳過清單」，供 dry-run 複核與（M5）實際送出。
+ * 本類別**不做任何寫入**、亦不觸碰 token。
+ */
+class PinyinMigrationPlanner {
+    /** @var \Closure(string): array{c_surname:string,c_mingzi:string,c_name:string} */
+    private $regenerator;
+
+    /**
+     * @param \Closure $regenerator 以中文名（c_name_chn）重新合成拼音，回傳含 c_surname/c_mingzi/c_name 的陣列。
+     */
+    public function __construct(\Closure $regenerator) {
+        $this->regenerator = $regenerator;
+    }
+
+    /**
+     * 規劃 BIOG_MAIN 人名修正。
+     *
+     * @param  array<int, array{id:int|string, field:string, wrong_pinyin:string, correct_pinyin:string}>  $rows
+     * @return array{mutations:array<int,array>, exceptions:array<int,array>, skipped:array<int,array>, alreadyDone:array<int,array>}
+     */
+    public function planBiogMain(array $rows): array {
+        $byPerson = [];
+        foreach ($rows as $row) {
+            // 依 §D-3 忽略 Sheet 的 c_name 直寫列作為「待寫欄位」，但仍留作 oracle 核對。
+            $byPerson[(int) $row['id']][] = $row;
+        }
+
+        $out = ['mutations' => [], 'exceptions' => [], 'skipped' => [], 'alreadyDone' => []];
+
+        foreach ($byPerson as $personId => $personRows) {
+            $current = DB::table('BIOG_MAIN')->where('c_personid', $personId)->first();
+            if ($current === null) {
+                $out['exceptions'][] = ['id' => $personId, 'reason' => 'person-not-found'];
+
+                continue;
+            }
+            $current = (array) $current;
+
+            // 重生（regenerate）：以現有中文名重新合成拼音。
+            $regen = ($this->regenerator)((string) ($current['c_name_chn'] ?? ''));
+
+            $driftFields = [];       // 現值既非 wrong 也非 correct → 未預期漂移
+            $mismatchFields = [];    // 重生結果 != Sheet correct → oracle 不過
+            $allAlready = true;      // 全部欄位現值已 == correct
+
+            foreach ($personRows as $row) {
+                $field = $row['field'];
+                $wrong = $row['wrong_pinyin'];
+                $correct = $row['correct_pinyin'];
+                $currentVal = (string) ($current[$field] ?? '');
+                $regenVal = (string) ($regen[$field] ?? '');
+
+                if ($currentVal === $wrong) {
+                    $allAlready = false;
+                } elseif ($currentVal === $correct) {
+                    // 該欄位已遷移；不影響其它欄位判斷。
+                } else {
+                    $allAlready = false;
+                    $driftFields[] = ['field' => $field, 'current' => $currentVal, 'expected_wrong' => $wrong];
+                }
+
+                // oracle：重生結果須等於 Sheet correct（含 c_name 列作為額外核對）。
+                if ($regenVal !== $correct) {
+                    $mismatchFields[] = ['field' => $field, 'regenerated' => $regenVal, 'expected_correct' => $correct];
+                }
+            }
+
+            if ($allAlready) {
+                $out['alreadyDone'][] = ['id' => $personId, 'c_name_chn' => $current['c_name_chn'] ?? ''];
+
+                continue;
+            }
+            if ($driftFields !== []) {
+                $out['skipped'][] = ['id' => $personId, 'reason' => 'drift', 'fields' => $driftFields];
+
+                continue;
+            }
+            if ($mismatchFields !== []) {
+                $out['exceptions'][] = ['id' => $personId, 'reason' => 'regenerate-mismatch', 'fields' => $mismatchFields];
+
+                continue;
+            }
+
+            // 通過：決定 changes。
+            // - 若有 c_name 列（完整名已被 oracle 驗證）：**一律送兩個分量的重生值**，確保 handler
+            //   重算的 c_name == 已驗證的 correct（避免只送 surname、卻讓另一分量殘留 v → c_name 仍錯）。
+            // - 若無 c_name 列：只送 Sheet 明確標記的分量，尊重人工 scoping（不動未標記的欄位）。
+            $hasCNameRow = false;
+            $flagged = [];
+            foreach ($personRows as $row) {
+                if ($row['field'] === 'c_name') {
+                    $hasCNameRow = true;
+                } elseif (in_array($row['field'], ['c_surname', 'c_mingzi'], true)) {
+                    $flagged[$row['field']] = true;
+                }
+            }
+
+            if ($hasCNameRow) {
+                $changes = [
+                    'c_surname' => (string) $regen['c_surname'],
+                    'c_mingzi' => (string) $regen['c_mingzi'],
+                ];
+            } else {
+                $changes = [];
+                foreach (array_keys($flagged) as $field) {
+                    $changes[$field] = (string) ($regen[$field] ?? '');
+                }
+            }
+
+            $out['mutations'][] = [
+                'resource' => 'basicinformation',
+                'pk' => ['c_personid' => (int) $personId],
+                'changes' => $changes,
+                'preview' => [
+                    'c_name_chn' => $current['c_name_chn'] ?? '',
+                    'from' => trim(((string) ($current['c_surname'] ?? '')).' '.((string) ($current['c_mingzi'] ?? ''))),
+                    'to' => trim(((string) $regen['c_surname']).' '.((string) $regen['c_mingzi'])),
+                ],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * 規劃 ALTNAME_DATA 別名修正（複合主鍵定位，§D-5）。
+     *
+     * @param  array<int, array{id:int|string, wrong_pinyin:string, correct_pinyin:string}>  $rows
+     * @return array{mutations:array<int,array>, exceptions:array<int,array>, skipped:array<int,array>, alreadyDone:array<int,array>}
+     */
+    public function planAltname(array $rows): array {
+        $out = ['mutations' => [], 'exceptions' => [], 'skipped' => [], 'alreadyDone' => []];
+
+        foreach ($rows as $row) {
+            $personId = (int) $row['id'];
+            $wrong = $row['wrong_pinyin'];
+            $correct = $row['correct_pinyin'];
+
+            $matches = DB::table('ALTNAME_DATA')
+                ->where('c_personid', $personId)
+                ->where('c_alt_name', $wrong)
+                ->get()
+                ->map(fn ($r) => (array) $r)
+                ->all();
+
+            if (count($matches) === 0) {
+                // 定位落空：可能已遷移（現存 correct）或值已漂移。
+                $alreadyExists = DB::table('ALTNAME_DATA')
+                    ->where('c_personid', $personId)
+                    ->where('c_alt_name', $correct)
+                    ->exists();
+                if ($alreadyExists) {
+                    $out['alreadyDone'][] = ['id' => $personId, 'c_alt_name' => $correct];
+                } else {
+                    $out['skipped'][] = ['id' => $personId, 'reason' => 'not-found', 'wrong_pinyin' => $wrong];
+                }
+
+                continue;
+            }
+            if (count($matches) > 1) {
+                $out['exceptions'][] = ['id' => $personId, 'reason' => 'ambiguous', 'wrong_pinyin' => $wrong, 'match_count' => count($matches)];
+
+                continue;
+            }
+
+            $m = $matches[0];
+            $out['mutations'][] = [
+                'resource' => 'altnames',
+                'pk' => [
+                    'c_personid' => $personId,
+                    'c_alt_name_chn' => $m['c_alt_name_chn'] ?? '',
+                    'c_alt_name_type_code' => (int) ($m['c_alt_name_type_code'] ?? 0),
+                ],
+                'changes' => ['c_alt_name' => $correct],
+                'preview' => ['from' => $wrong, 'to' => $correct, 'c_alt_name_chn' => $m['c_alt_name_chn'] ?? ''],
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/tests/Feature/MigratePinyinVCommandTest.php
+++ b/tests/Feature/MigratePinyinVCommandTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * cbdb:migrate-pinyin-v 指令的 dry-run 端對端（ALTNAME 側，不需拼音庫）。
+ */
+class MigratePinyinVCommandTest extends TestCase {
+    private string $csv;
+    private string $outDir;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+
+        Schema::create('ALTNAME_DATA', function ($t) {
+            $t->integer('c_personid');
+            $t->string('c_alt_name_chn')->nullable();
+            $t->integer('c_alt_name_type_code')->default(0);
+            $t->string('c_alt_name')->nullable();
+        });
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 10, 'c_alt_name_chn' => '呂胤', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Lv Yin'],
+        ]);
+
+        $this->csv = sys_get_temp_dir().'/pyv-alt-'.uniqid().'.csv';
+        file_put_contents($this->csv, "table,field,id,wrong_pinyin,correct_pinyin\nALTNAME_DATA,c_alt_name,10,Lv Yin,Lü Yin\n");
+        $this->outDir = sys_get_temp_dir().'/pyv-out-'.uniqid();
+    }
+
+    protected function tearDown(): void {
+        @unlink($this->csv);
+        foreach (glob($this->outDir.'/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->outDir);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function dry_run_plans_altname_without_writing(): void {
+        $before = DB::table('ALTNAME_DATA')->get()->toArray();
+
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--altname-csv' => $this->csv,
+            '--out-dir' => $this->outDir,
+        ])->assertSuccessful();
+
+        // dry-run 不得寫入
+        $this->assertEquals($before, DB::table('ALTNAME_DATA')->get()->toArray(), 'dry-run 不得修改資料');
+
+        // 產物：預定變更含正確 3-key PK 與 changes
+        $mutations = json_decode((string) file_get_contents($this->outDir.'/altname-mutations.json'), true);
+        $this->assertCount(1, $mutations);
+        $this->assertSame([
+            'c_personid' => 10,
+            'c_alt_name_chn' => '呂胤',
+            'c_alt_name_type_code' => 4,
+        ], $mutations[0]['pk']);
+        $this->assertSame(['c_alt_name' => 'Lü Yin'], $mutations[0]['changes']);
+    }
+
+    #[Test]
+    public function it_tolerates_blank_and_short_csv_rows(): void {
+        // Sheet 匯出常見的空白行/短行不得使指令崩潰（PHP 8 array_combine 會擲 ValueError）。
+        file_put_contents(
+            $this->csv,
+            "table,field,id,wrong_pinyin,correct_pinyin\n"
+            ."ALTNAME_DATA,c_alt_name,10,Lv Yin,Lü Yin\n"
+            ."\n"                          // 空白行
+            ."ALTNAME_DATA,c_alt_name\n"   // 短行（欄數不足）
+            ."ALTNAME_DATA,c_alt_name,10,Lv Yin,Lü Yin,extra,cols\n"  // 長行（欄數過多）
+        );
+
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--altname-csv' => $this->csv,
+            '--out-dir' => $this->outDir,
+        ])->assertSuccessful();
+
+        // 只有那筆合法列被規劃
+        $mutations = json_decode((string) file_get_contents($this->outDir.'/altname-mutations.json'), true);
+        $this->assertCount(1, $mutations);
+    }
+
+    #[Test]
+    public function it_fails_when_csv_path_missing(): void {
+        // 硬錯誤：指定的 CSV 路徑不存在 → 非零退出（供批次/CI）。
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--altname-csv' => sys_get_temp_dir().'/does-not-exist-'.uniqid().'.csv',
+            '--out-dir' => $this->outDir,
+        ])->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_no_csv_provided(): void {
+        // 完全沒提供 CSV（也未 --fetch）→ 沒有可處理的資料 → 失敗。
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--out-dir' => $this->outDir,
+        ])->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_biog_csv_missing_field_column(): void {
+        // BIOG CSV 缺 field 欄（多半傳錯分頁）→ 載入階段早失敗，不進規劃器。
+        $biogCsv = sys_get_temp_dir().'/pyv-biog-'.uniqid().'.csv';
+        file_put_contents($biogCsv, "table,id,wrong_pinyin,correct_pinyin\nBIOG_MAIN,1,Lv,Lü\n");
+
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'biog',
+            '--biog-csv' => $biogCsv,
+            '--out-dir' => $this->outDir,
+        ])->assertFailed();
+
+        @unlink($biogCsv);
+    }
+
+    #[Test]
+    public function execute_without_token_env_fails(): void {
+        // 安全：--execute 但未設 CBDB_MIGRATE_TOKEN → 直接失敗、不寫入。
+        $prev = getenv('CBDB_MIGRATE_TOKEN');
+        putenv('CBDB_MIGRATE_TOKEN');   // 清空
+
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--altname-csv' => $this->csv,
+            '--out-dir' => $this->outDir,
+            '--execute' => true,
+        ])->assertFailed();
+
+        if ($prev !== false) {
+            putenv('CBDB_MIGRATE_TOKEN='.$prev);
+        }
+    }
+}

--- a/tests/Feature/PinyinMigrationPlannerTest.php
+++ b/tests/Feature/PinyinMigrationPlannerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\Pinyin\PinyinMigrationPlanner;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 人名拼音 v→ü 遷移規劃器：重生 + Sheet oracle + 寫入前漂移檢查（§D-3/§D-5）。
+ *
+ * 規劃器只計算不寫入；regenerator 以 stub 注入，避免依賴 pinyin 表／拼音庫。
+ */
+class PinyinMigrationPlannerTest extends TestCase {
+    /** @var array<string, array{c_surname:string,c_mingzi:string,c_name:string}> */
+    private array $regenMap = [];
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+
+        Schema::create('BIOG_MAIN', function ($t) {
+            $t->integer('c_personid')->primary();
+            $t->string('c_name_chn')->nullable();
+            $t->string('c_surname')->nullable();
+            $t->string('c_mingzi')->nullable();
+            $t->string('c_name')->nullable();
+        });
+        Schema::create('ALTNAME_DATA', function ($t) {
+            $t->integer('c_personid');
+            $t->string('c_alt_name_chn')->nullable();
+            $t->integer('c_alt_name_type_code')->default(0);
+            $t->string('c_alt_name')->nullable();
+        });
+    }
+
+    private function planner(): PinyinMigrationPlanner {
+        return new PinyinMigrationPlanner(function (string $chn): array {
+            return $this->regenMap[$chn] ?? ['c_surname' => '', 'c_mingzi' => '', 'c_name' => ''];
+        });
+    }
+
+    #[Test]
+    public function it_plans_biog_regenerate_with_oracle_and_drift(): void {
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '呂坤', 'c_surname' => 'Lv', 'c_mingzi' => 'Kun', 'c_name' => 'Lv Kun'],   // 待遷移
+            ['c_personid' => 2, 'c_name_chn' => '呂坤', 'c_surname' => 'Lü', 'c_mingzi' => 'Kun', 'c_name' => 'Lü Kun'],   // 已遷移
+            ['c_personid' => 3, 'c_name_chn' => '王安', 'c_surname' => 'Wang', 'c_mingzi' => 'An', 'c_name' => 'Wang An'], // 漂移（現值既非 wrong 也非 correct）
+            ['c_personid' => 4, 'c_name_chn' => '呂坤', 'c_surname' => 'Lv', 'c_mingzi' => 'Kun', 'c_name' => 'Lv Kun'],   // oracle 不過
+        ]);
+
+        // 重生：呂坤→Lü Kun（正確）；person 4 用另一中文名，重生給錯值以觸發 oracle 不過。
+        $this->regenMap['呂坤'] = ['c_surname' => 'Lü', 'c_mingzi' => 'Kun', 'c_name' => 'Lü Kun'];
+        $this->regenMap['歪坤'] = ['c_surname' => 'Xx', 'c_mingzi' => 'Kun', 'c_name' => 'Xx Kun'];
+        DB::table('BIOG_MAIN')->where('c_personid', 4)->update(['c_name_chn' => '歪坤']);
+
+        $rows = [
+            ['id' => 1, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+            ['id' => 2, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+            ['id' => 3, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+            ['id' => 4, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+            ['id' => 99, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'], // 查無此人
+        ];
+
+        $plan = $this->planner()->planBiogMain($rows);
+
+        // person 1：預定變更，changes 只送 c_surname，值取自重生。
+        $this->assertCount(1, $plan['mutations']);
+        $mut = $plan['mutations'][0];
+        $this->assertSame(['c_personid' => 1], $mut['pk']);
+        $this->assertSame('basicinformation', $mut['resource']);
+        $this->assertSame(['c_surname' => 'Lü'], $mut['changes']);
+        $this->assertSame('Lü Kun', $mut['preview']['to']);
+
+        // person 2：已遷移
+        $this->assertSame([2], array_column($plan['alreadyDone'], 'id'));
+        // person 3：漂移跳過
+        $this->assertSame(3, $plan['skipped'][0]['id']);
+        $this->assertSame('drift', $plan['skipped'][0]['reason']);
+        // person 4 oracle 不過 + person 99 查無此人 → 兩個例外
+        $reasons = array_column($plan['exceptions'], 'reason');
+        $this->assertContains('regenerate-mismatch', $reasons);
+        $this->assertContains('person-not-found', $reasons);
+    }
+
+    #[Test]
+    public function it_sends_both_components_when_c_name_row_present_else_respects_scoping(): void {
+        DB::table('BIOG_MAIN')->insert([
+            // person 5：surname 列 + c_name 列、無 mingzi 列；mingzi 仍殘留 v → 必須兩分量一併送出。
+            ['c_personid' => 5, 'c_name_chn' => '呂綠', 'c_surname' => 'Lv', 'c_mingzi' => 'Lv', 'c_name' => 'Lv Lv'],
+            // person 6：只有 surname 列、無 c_name 列；mingzi 無 v → 只送 surname，尊重 scoping。
+            ['c_personid' => 6, 'c_name_chn' => '呂坤', 'c_surname' => 'Lv', 'c_mingzi' => 'Kun', 'c_name' => 'Lv Kun'],
+        ]);
+        $this->regenMap['呂綠'] = ['c_surname' => 'Lü', 'c_mingzi' => 'Lü', 'c_name' => 'Lü Lü'];
+        $this->regenMap['呂坤'] = ['c_surname' => 'Lü', 'c_mingzi' => 'Kun', 'c_name' => 'Lü Kun'];
+
+        $plan = $this->planner()->planBiogMain([
+            ['id' => 5, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+            ['id' => 5, 'field' => 'c_name', 'wrong_pinyin' => 'Lv Lv', 'correct_pinyin' => 'Lü Lü'],
+            ['id' => 6, 'field' => 'c_surname', 'wrong_pinyin' => 'Lv', 'correct_pinyin' => 'Lü'],
+        ]);
+
+        $byId = [];
+        foreach ($plan['mutations'] as $m) {
+            $byId[$m['pk']['c_personid']] = $m;
+        }
+
+        // person 5：有 c_name 列 → 兩分量都送，重算 c_name 才會等於已驗證的 correct。
+        $this->assertSame(['c_surname' => 'Lü', 'c_mingzi' => 'Lü'], $byId[5]['changes']);
+        // person 6：無 c_name 列 → 只送標記的 surname。
+        $this->assertSame(['c_surname' => 'Lü'], $byId[6]['changes']);
+    }
+
+    #[Test]
+    public function it_resolves_altname_pk_and_flags_ambiguity(): void {
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 10, 'c_alt_name_chn' => '呂胤', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Lv Yin'],   // 可定位
+            ['c_personid' => 11, 'c_alt_name_chn' => '甲', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Lv X'],       // 歧義（同 personid+值 2 筆）
+            ['c_personid' => 11, 'c_alt_name_chn' => '乙', 'c_alt_name_type_code' => 5, 'c_alt_name' => 'Lv X'],
+            ['c_personid' => 12, 'c_alt_name_chn' => '丙', 'c_alt_name_type_code' => 4, 'c_alt_name' => 'Lü Z'],       // 已遷移
+        ]);
+
+        $rows = [
+            ['id' => 10, 'wrong_pinyin' => 'Lv Yin', 'correct_pinyin' => 'Lü Yin'],
+            ['id' => 11, 'wrong_pinyin' => 'Lv X', 'correct_pinyin' => 'Lü X'],
+            ['id' => 12, 'wrong_pinyin' => 'Lv Z', 'correct_pinyin' => 'Lü Z'],   // 定位落空、但 correct 已存在
+            ['id' => 13, 'wrong_pinyin' => 'Lv Q', 'correct_pinyin' => 'Lü Q'],   // 完全查無
+        ];
+
+        $plan = $this->planner()->planAltname($rows);
+
+        // person 10：完整 3-key PK + changes
+        $this->assertCount(1, $plan['mutations']);
+        $mut = $plan['mutations'][0];
+        $this->assertSame([
+            'c_personid' => 10,
+            'c_alt_name_chn' => '呂胤',
+            'c_alt_name_type_code' => 4,
+        ], $mut['pk']);
+        $this->assertSame(['c_alt_name' => 'Lü Yin'], $mut['changes']);
+
+        // person 11：歧義例外
+        $this->assertSame('ambiguous', $plan['exceptions'][0]['reason']);
+        $this->assertSame(11, $plan['exceptions'][0]['id']);
+        // person 12：已遷移
+        $this->assertSame([12], array_column($plan['alreadyDone'], 'id'));
+        // person 13：落空跳過
+        $this->assertSame(13, $plan['skipped'][0]['id']);
+        $this->assertSame('not-found', $plan['skipped'][0]['reason']);
+    }
+}


### PR DESCRIPTION
## Phase A · M4：人名 v→ü 遷移工具（**預設 dry-run，不寫入**）

依 docs §D-3/§D-5/§D-6 與 Frank #1087 審查機制實作。**本 PR 不觸碰資料**；真正寫入是 M5（加 `--execute` + token）。

### 機制（重生 + Sheet oracle + 寫入前漂移檢查）
- **BIOG_MAIN**：對受影響 c_personid 呼叫 `auto_pinyin(c_name_chn)` 重新合成拼音（止血後自然產 ü）。
  - **漂移檢查**：現值須 == Sheet `wrong_pinyin`，否則歸類 已遷移／漂移跳過（冪等、不覆寫他人變更）。
  - **oracle 閘**：重生結果須 == Sheet `correct_pinyin`，否則入例外清單。
  - 有 c_name 列時一律送 c_surname+c_mingzi 兩分量（確保 handler 重算的 c_name == 已驗證 correct）；無 c_name 列則只送 Sheet 標記分量（尊重人工 scoping）。原 §D-4「204 孤兒」由重生天然涵蓋。
- **ALTNAME**：以 (c_personid, c_alt_name=wrong_pinyin) 定位完整 3-key PK；>1 命中→歧義例外。
- 寫入走 `/api/v2/mutate` mode:direct（audit 自動、可 operations 回退）。

### 安全
- **Token 只從環境變數 `CBDB_MIGRATE_TOKEN` 讀取**，絕不接受 CLI 參數、絕不輸出到畫面/log/檔案（apply-failures 只記 pk/status/body）。
- `--execute` 缺 token → 直接失敗。**無 --execute 零寫入**（規劃器純讀）。
- 退出碼語義：CSV 載入硬錯誤／缺 field 欄／無資料／寫入失敗 → 非零（供批次/CI）。

### 檔案
- `app/Services/Pinyin/PinyinMigrationPlanner.php`（純計算、可測）
- `app/Console/Commands/MigratePinyinV.php`（CSV 載入 + 摘要/抽樣 + JSON 產物 + --execute）

### 測試（9 例 / 31 斷言）
規劃器：重生+oracle+漂移四結局、hasCNameRow 送兩分量 vs scoping、ALTNAME PK/歧義/已遷移/落空。
指令 dry-run：不寫入、產物正確、空白/短/長 CSV 行容錯、CSV 路徑錯/無資料/缺 field 欄 → 失敗、--execute 缺 token → 失敗。

> 已過 review agent（修 array_combine 崩潰 + mixed 列殘留 v 缺口）+ codex（修退出碼語義 + field 欄驗證）雙審。**未經明確指示不合併**；M5 才是實際寫入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)