### PR TITLE
fix(pinyin): M4 execute 補 person_id + 孤兒多空格不拆姓

### DIFF
--- a/app/Console/Commands/MigratePinyinV.php
+++ b/app/Console/Commands/MigratePinyinV.php
@@ -317,6 +317,8 @@ class MigratePinyinV extends Command {
             $payload = [
                 'resource' => $m['resource'],
                 'mode' => 'direct',
+                // person 子資源（basicinformation／altnames）API 要求頂層 person_id ＝ 該人 c_personid。
+                'person_id' => $m['pk']['c_personid'] ?? 0,
                 'target' => ['pk' => $m['pk']],
                 'changes' => $m['changes'],
             ];

--- a/app/Services/Pinyin/PinyinMigrationPlanner.php
+++ b/app/Services/Pinyin/PinyinMigrationPlanner.php
@@ -291,8 +291,13 @@ class PinyinMigrationPlanner {
             // 現庫姓含空格（罕見：帶空格複姓、或描述性條目如「Tao hua shi nü」）→ 第一空格拆不可靠，交人工。
             return ['', '', null, 'orphan-cname'];
         }
+        if (substr_count($n, ' ') >= 2) {
+            // 現庫有姓、但完整名多空格（描述性/親屬「之女·妻」類，如「次室女」）：第一空格拆姓不可靠，
+            // 是否可拆需語義判斷（親屬關係女可拆、其餘不可）→ 一律交人工待批量規則，絕不誤拆。
+            return ['', '', null, 'orphan-multiword'];
+        }
 
-        // 現庫有姓且為單一 token：以 Sheet 完整名第一個空格拆（CBDB 姓恆單 token）。
+        // 現庫有姓、單 token、完整名單空格：以第一個空格拆（CBDB 姓恆單 token）。
         $parts = explode(' ', $n, 2);
         $mingzi = isset($parts[1]) ? ltrim($parts[1]) : '';
         if ($blank($mingzi)) {

--- a/tests/Feature/MigratePinyinVCommandTest.php
+++ b/tests/Feature/MigratePinyinVCommandTest.php
@@ -183,4 +183,32 @@ class MigratePinyinVCommandTest extends TestCase {
             putenv('CBDB_MIGRATE_TOKEN='.$prev);
         }
     }
+
+    #[Test]
+    public function execute_payload_includes_person_id(): void {
+        \Illuminate\Support\Facades\Http::fake(['*' => \Illuminate\Support\Facades\Http::response(['ok' => true], 200)]);
+        $prev = getenv('CBDB_MIGRATE_TOKEN');
+        putenv('CBDB_MIGRATE_TOKEN=test-token');
+
+        $this->artisan('cbdb:migrate-pinyin-v', [
+            '--table' => 'altname',
+            '--altname-csv' => $this->csv,
+            '--out-dir' => $this->outDir,
+            '--execute' => true,
+            '--base-url' => 'http://api.test',
+        ])->assertSuccessful();
+
+        putenv($prev === false ? 'CBDB_MIGRATE_TOKEN' : 'CBDB_MIGRATE_TOKEN='.$prev);
+
+        // payload 必含頂層 person_id ＝ pk.c_personid（否則 /api/v2/mutate 回 422）
+        \Illuminate\Support\Facades\Http::assertSent(function ($request) {
+            $d = $request->data();
+
+            return $request->url() === 'http://api.test/api/v2/mutate'
+                && ($d['resource'] ?? null) === 'altnames'
+                && ($d['mode'] ?? null) === 'direct'
+                && ($d['person_id'] ?? null) === 10
+                && ($d['target']['pk']['c_personid'] ?? null) === 10;
+        });
+    }
 }

--- a/tests/Feature/PinyinMigrationPlannerTest.php
+++ b/tests/Feature/PinyinMigrationPlannerTest.php
@@ -137,6 +137,8 @@ class PinyinMigrationPlannerTest extends TestCase {
             ['c_personid' => 32, 'c_name_chn' => '呂洵', 'c_surname' => 'Lv', 'c_mingzi' => 'Xun', 'c_name' => 'Lv Xun'],
             // 33：現庫姓含空格（帶空格複姓/描述性）→ 第一空格拆不可靠、交人工
             ['c_personid' => 33, 'c_name_chn' => '桃花石女', 'c_surname' => 'Tao hua', 'c_mingzi' => 'shi nv', 'c_name' => 'Tao hua shi nv'],
+            // 34：現庫有姓(單token)、但完整名多空格（描述性/親屬女如「次室女」）→ 不拆姓、交人工待規則
+            ['c_personid' => 34, 'c_name_chn' => '次室女', 'c_surname' => 'Ci', 'c_mingzi' => 'shi nv', 'c_name' => 'Ci shi nv'],
         ]);
         $this->regenMap['呂建中'] = ['c_surname' => 'Lü', 'c_mingzi' => 'Jianzhong', 'c_name' => 'Lü Jianzhong'];
 
@@ -145,6 +147,7 @@ class PinyinMigrationPlannerTest extends TestCase {
             ['id' => 31, 'field' => 'c_name', 'wrong_pinyin' => 'nv zi', 'correct_pinyin' => 'nü zi'],
             ['id' => 32, 'field' => 'c_name', 'wrong_pinyin' => 'Lv Xun', 'correct_pinyin' => 'Lü Xun (2)'],
             ['id' => 33, 'field' => 'c_name', 'wrong_pinyin' => 'Tao hua shi nv', 'correct_pinyin' => 'Tao hua shi nü'],
+            ['id' => 34, 'field' => 'c_name', 'wrong_pinyin' => 'Ci shi nv', 'correct_pinyin' => 'Ci shi nü'],
         ]);
         $byId = [];
         foreach ($plan['mutations'] as $m) {
@@ -163,6 +166,8 @@ class PinyinMigrationPlannerTest extends TestCase {
         $this->assertSame('orphan-cname', $reasons[32]);
         // 33：現庫姓含空格 → 交人工
         $this->assertSame('orphan-cname', $reasons[33]);
+        // 34：完整名多空格 → 不拆姓、交人工待規則
+        $this->assertSame('orphan-multiword', $reasons[34]);
     }
 
     #[Test]


### PR DESCRIPTION
tiny test 實測 /api/v2/mutate 對 person 子資源要求頂層 person_id（缺回 422）→ payload 補 person_id＝pk.c_personid。孤兒多空格（描述性/親屬「之女·妻」如「次室女」）現庫有姓時歸 orphan-multiword 交人工、不拆姓（親屬女可拆/其餘不可需語義判斷，待人工規則）。review+codex 雙審無 blocking，10+16 測試綠（含 person_id payload Http::fake 斷言）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)