### PR TITLE
同步檢視表與代碼表列表頁設計語言、移除側邊欄舊 /view 入口

### DIFF
--- a/app/Support/Navigation.php
+++ b/app/Support/Navigation.php
@@ -265,19 +265,16 @@ class Navigation {
      */
     protected static function viewsChildren(): array {
         return [
+            // 只保留新版 React 總覽入口（→ app.view.index）；舊 Blade /view 已翻 flag=new，
+            // 側邊欄不再列出其連結（舊路由仍保留、可直接訪問作為回退）。標籤還原為「檢視表總覽」。
             self::item(
                 'views-overview-new',
-                'nav.views_overview_new',
+                'nav.views_overview',
                 'fas fa-layer-group',
                 self::routeUrl('app.view.index'),
-                ['pages' => [], 'patterns' => ['app.view.*']]
-            ),
-            self::item(
-                'views-overview',
-                'nav.views_overview',
-                'fas fa-list-ul',
-                self::routeUrl('view.index'),
-                ['pages' => ['檢視表總覽'], 'patterns' => []]
+                // 同時涵蓋新版 route（app.view.*）與舊 Blade /view 頁（page_title '檢視表總覽'）的 active 狀態，
+                // 讓直接訪問舊頁時仍會高亮此總覽節點。
+                ['pages' => ['檢視表總覽'], 'patterns' => ['app.view.*']]
             ),
             self::viewItem('altname-data', 'views.view_altname_data', 'fas fa-user-tag', '別名資料檢視'),
             self::viewItem('assoc-data', 'views.view_assoc_data', 'fas fa-project-diagram', '社會關係資料檢視'),

--- a/resources/js/inertia/Pages/Codes/Index.tsx
+++ b/resources/js/inertia/Pages/Codes/Index.tsx
@@ -71,13 +71,15 @@ export default function CodesIndex() {
                     autoComplete="off"
                 />
                 <div className="overflow-x-auto rounded-md border border-border">
-                    <table className="w-full text-sm">
-                        <thead className="bg-muted/50">
+                    {/* 字號／內距與 app/view 的 DataTable 對齊（同一套設計語言）：body 1rem、表頭 0.92rem/600、cell px-3 py-2。 */}
+                    <table className="w-full text-base">
+                        {/* 表頭樣式／配色與 app/view 列表對齊：實色 muted 底、灰字、2px 底線、0.92rem/600（保留排序）。 */}
+                        <thead className="bg-muted">
                             <tr>
                                 {(['name', 'description'] as const).map((col) => (
                                     <th
                                         key={col}
-                                        className="cursor-pointer select-none px-3 py-2 text-left font-medium hover:bg-muted"
+                                        className="cursor-pointer select-none border-b-2 border-border px-3 py-2.5 text-left text-[0.92rem] font-semibold text-muted-foreground hover:bg-muted"
                                         onClick={() => toggleSort(col)}
                                     >
                                         {col === 'name' ? t('table_name') : t('description')}{' '}
@@ -89,14 +91,21 @@ export default function CodesIndex() {
                             </tr>
                         </thead>
                         <tbody>
-                            {visible.map((row) => (
-                                <tr key={row.name} className={cn('border-t border-border hover:bg-muted/30')}>
-                                    <td className="px-3 py-1.5">
+                            {visible.map((row, i) => (
+                                <tr
+                                    key={row.name}
+                                    className={cn(
+                                        'border-t border-border',
+                                        // 斑馬紋間隔色：與 app/view 列表用完全相同的 token（偶數列 --card、奇數列 --surface-sunken）。
+                                        i % 2 === 1 && 'bg-[var(--surface-sunken)]'
+                                    )}
+                                >
+                                    <td className="px-3 py-2">
                                         <a href={row.url} className="text-primary hover:underline">
                                             {row.name}
                                         </a>
                                     </td>
-                                    <td className="px-3 py-1.5">{row.description}</td>
+                                    <td className="px-3 py-2">{row.description}</td>
                                 </tr>
                             ))}
                         </tbody>

--- a/resources/js/inertia/Pages/ViewTables/List.tsx
+++ b/resources/js/inertia/Pages/ViewTables/List.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Link } from '@inertiajs/react';
 import DashboardLayout from '../../Layouts/DashboardLayout';
+import { Input } from '../../components/ui/Input';
 import { useTranslation } from '../../hooks/useTranslation';
 
 interface ViewDefinition {
@@ -50,37 +51,21 @@ export default function List({ views }: Props) {
                     <h2 style={{ margin: 0, fontSize: '1.55rem', fontWeight: 700 }}>{t('views_overview_title')}</h2>
                 </div>
 
-                <div style={sectionStyle}>
-                    <div style={sectionBodyStyle}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-                            <div style={{ color: 'var(--muted-foreground)', fontSize: '0.85rem' }}>
-                                {t('views_count_summary', { total: String(views.length), shown: String(filteredViews.length) })}
-                            </div>
-                            <div style={filterBarStyle}>
-                                <input
-                                    type="text"
-                                    value={query}
-                                    onChange={(event) => setQuery(event.target.value)}
-                                    placeholder={t('search_placeholder')}
-                                    style={searchInputStyle}
-                                />
-                                {query !== '' && (
-                                    <button type="button" onClick={() => setQuery('')} style={clearButtonStyle}>
-                                        {t('clear')}
-                                    </button>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div style={sectionStyle}>
-                    <div style={sectionHeaderStyle}>{t('view_list')}</div>
-                    <div style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
+                {/* 結構／搜尋框與 app/codes 列表完全對齊：外層卡片（rounded-lg border p-4）+ 內層圓角邊框表格盒
+                    （overflow-x-auto rounded-md border）；搜尋框改用共用 Input 組件（同樣式）。 */}
+                <div className="mt-4 rounded-lg border border-border bg-card p-4">
+                    <Input
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder={t('search_placeholder')}
+                        className="mb-3 max-w-md"
+                        autoComplete="off"
+                    />
+                    <div className="overflow-x-auto rounded-md border border-border">
                         <table style={{
                             width: '100%',
                             borderCollapse: 'collapse',
-                            fontSize: '0.9rem',
+                            fontSize: '1rem',
                             minWidth: 860,
                         }}>
                             <thead>
@@ -92,13 +77,6 @@ export default function List({ views }: Props) {
                                 </tr>
                             </thead>
                             <tbody>
-                                {filteredViews.length === 0 && (
-                                    <tr>
-                                        <td colSpan={4} style={{ ...tdStyle, textAlign: 'center', color: 'var(--muted-foreground)', padding: '28px 12px' }}>
-                                            {t('no_views_found')}
-                                        </td>
-                                    </tr>
-                                )}
                                 {filteredViews.map((view, index) => (
                                     <tr
                                         key={view.key}
@@ -131,6 +109,9 @@ export default function List({ views }: Props) {
                             </tbody>
                         </table>
                     </div>
+                    {filteredViews.length === 0 && (
+                        <p className="py-2 text-sm text-muted-foreground">{t('no_views_found')}</p>
+                    )}
                 </div>
             </div>
         </DashboardLayout>
@@ -141,7 +122,8 @@ const thStyle: React.CSSProperties = {
     padding: '10px 12px',
     textAlign: 'left',
     fontWeight: 600,
-    fontSize: '0.85rem',
+    // 表頭字號與 app/codes 列表對齊：0.92rem。
+    fontSize: '0.92rem',
     color: 'var(--muted-foreground)',
     borderBottom: '2px solid var(--border)',
     whiteSpace: 'nowrap',
@@ -151,51 +133,4 @@ const tdStyle: React.CSSProperties = {
     padding: '8px 12px',
     borderBottom: '1px solid var(--border)',
     verticalAlign: 'top',
-};
-
-const sectionStyle: React.CSSProperties = {
-    backgroundColor: 'var(--card)',
-    border: '1px solid var(--border)',
-    borderRadius: 4,
-    overflow: 'hidden',
-    marginBottom: 16,
-};
-
-const sectionHeaderStyle: React.CSSProperties = {
-    padding: '10px 14px',
-    borderBottom: '1px solid var(--border)',
-    backgroundColor: 'var(--muted)',
-    color: 'var(--muted-foreground)',
-    fontSize: '0.9rem',
-    fontWeight: 600,
-};
-
-const sectionBodyStyle: React.CSSProperties = {
-    padding: 14,
-};
-
-const filterBarStyle: React.CSSProperties = {
-    display: 'flex',
-    gap: 8,
-    alignItems: 'center',
-    flexWrap: 'wrap',
-};
-
-const searchInputStyle: React.CSSProperties = {
-    width: 320,
-    maxWidth: '100%',
-    padding: '8px 12px',
-    border: '1px solid var(--input)',
-    borderRadius: 4,
-    fontSize: '0.9rem',
-};
-
-const clearButtonStyle: React.CSSProperties = {
-    padding: '8px 14px',
-    border: '1px solid var(--border)',
-    borderRadius: 4,
-    backgroundColor: 'var(--card)',
-    color: 'var(--muted-foreground)',
-    cursor: 'pointer',
-    fontSize: '0.9rem',
 };

--- a/resources/js/inertia/Pages/ViewTables/Show.tsx
+++ b/resources/js/inertia/Pages/ViewTables/Show.tsx
@@ -175,19 +175,8 @@ export default function Show({
                     </div>
                 </div>
 
-                <div style={sectionStyle}>
-                    <div style={sectionHeaderStyle}>{t('current_status')}</div>
-                    <div style={summaryGridStyle}>
-                        {summaryCards.map((card) => (
-                            <div key={card.label} style={summaryItemStyle}>
-                                <div style={summaryLabelStyle}>{card.label}</div>
-                                <div style={summaryValueStyle}>{card.value}</div>
-                                <div style={summaryHelpStyle}>{card.help}</div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
+                {/* 檢視內容（搜尋＋表格）移到摘要卡片之前：開頁即可看到搜尋框與資料，
+                    對齊 app/codes 把搜尋放在最上方、方便視線的設計。 */}
                 <div style={sectionStyle}>
                     <div style={sectionHeaderStyle}>{t('view_content')}</div>
                     <div style={sectionBodyStyle}>
@@ -221,6 +210,19 @@ export default function Show({
                                 currentPage={debug.current_page}
                             />
                         </div>
+                    </div>
+                </div>
+
+                <div style={sectionStyle}>
+                    <div style={sectionHeaderStyle}>{t('current_status')}</div>
+                    <div style={summaryGridStyle}>
+                        {summaryCards.map((card) => (
+                            <div key={card.label} style={summaryItemStyle}>
+                                <div style={summaryLabelStyle}>{card.label}</div>
+                                <div style={summaryValueStyle}>{card.value}</div>
+                                <div style={summaryHelpStyle}>{card.help}</div>
+                            </div>
+                        ))}
                     </div>
                 </div>
             </div>

--- a/resources/js/inertia/components/DataTable.tsx
+++ b/resources/js/inertia/components/DataTable.tsx
@@ -14,7 +14,7 @@ export default function DataTable({ columns, rows, emptyMessage = '無資料' }:
             <table style={{
                 width: '100%',
                 borderCollapse: 'collapse',
-                fontSize: '0.85rem',
+                fontSize: '1rem',
                 minWidth: Math.max(600, columnEntries.length * 120),
             }}>
                 <thead>
@@ -23,13 +23,13 @@ export default function DataTable({ columns, rows, emptyMessage = '無資料' }:
                             <th
                                 key={key}
                                 style={{
-                                    padding: '8px 10px',
+                                    padding: '10px 12px',
                                     borderBottom: '2px solid var(--border)',
                                     backgroundColor: 'var(--muted)',
                                     textAlign: 'left',
                                     whiteSpace: 'nowrap',
                                     fontWeight: 600,
-                                    fontSize: '0.8rem',
+                                    fontSize: '0.92rem',
                                     color: 'var(--muted-foreground)',
                                 }}
                             >
@@ -63,7 +63,7 @@ export default function DataTable({ columns, rows, emptyMessage = '無資料' }:
                                     <td
                                         key={key}
                                         style={{
-                                            padding: '6px 10px',
+                                            padding: '8px 12px',
                                             borderBottom: '1px solid var(--border)',
                                             maxWidth: 300,
                                             overflow: 'hidden',


### PR DESCRIPTION
## 目的
讓 `/app/view`（檢視表總覽）與 `/app/codes`（代碼表總覽）兩個列表頁採用**同一套設計語言**，並清掉側邊欄殘留、指向舊 Blade `/view` 的重複入口。

## 變更
- **統一列表表格樣式**（兩頁一致）：表格內文 `1rem`、表頭 `0.92rem/600`＋實色 muted 底＋灰字＋`2px` 底線、cell 內距 `8px 12px`、斑馬紋（偶列 `--card`／奇列 `--surface-sunken`）、搜尋框置於卡片頂部靠左、外層卡片＋內層圓角邊框表格盒（兩層結構）。
- `ViewTables/List.tsx` 重構為與 `Codes/Index.tsx` 相同結構，搜尋框改用共用 `Input` 組件；移除不再使用的 style const（連帶移除舊的「清除」按鈕與計數行以對齊 codes）。
- 詳情頁 `ViewTables/Show.tsx` 版塊順序調整、`components/DataTable.tsx` 表格字號/內距同步為 `1rem`，使整個 `/view` 區域視覺一致。
- `app/Support/Navigation.php`：移除側邊欄指向舊 `view.index` 的重複總覽項，改為單一指向 `app.view.index` 的「檢視表總覽」；保留舊頁 `page_title`（檢視表總覽）的 active 高亮。舊 `/view` 路由**維持保留作回退**（未刪除、未改導向）。

## 驗證
- `./vendor/bin/phpunit --filter Navigation` → 10 綠。
- Playwright 以真實登入態擷取兩頁**計算樣式**：字號／表頭配色與邊框／斑馬紋／內距／圓角表格盒／搜尋框樣式與位置 **0 差異**；側邊欄已無指向舊 `/view` 的連結。
- 前端 `npm run build` 通過；`tsc` 無本次新增錯誤（僅既有的 PageProps 類型問題）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)