### PR TITLE
i18n：Query Playground 表描述隨語系 + 抽共用 CodesTableDescription helper

### DIFF
--- a/app/Repositories/CodesRepository.php
+++ b/app/Repositories/CodesRepository.php
@@ -9,6 +9,8 @@
 
 namespace App\Repositories;
 
+use App\Support\CodesTableDescription;
+
 class CodesRepository {
     /**
      * Get the list of allowed code tables.
@@ -101,7 +103,7 @@ class CodesRepository {
                 }
                 $result[] = [
                     'name' => $name,
-                    'description' => $this->localizedTableDescription((string) $name, (string) $description),
+                    'description' => CodesTableDescription::for((string) $name),
                 ];
             }
 
@@ -122,20 +124,6 @@ class CodesRepository {
         }
 
         return $result;
-    }
-
-    /**
-     * Resolve a code table's list description for the current locale.
-     *
-     * Prefers the `codes.table_desc.<TABLE>` translation (en/zh-TW), falling back to the
-     * raw config/codes.php value when no translation key exists. `trans()` returns the key
-     * itself on a miss (and an array for a group key), so both are guarded.
-     */
-    private function localizedTableDescription(string $name, string $fallback): string {
-        $key = 'codes.table_desc.' . $name;
-        $translated = trans($key);
-
-        return (is_string($translated) && $translated !== $key) ? $translated : $fallback;
     }
 
     /**

--- a/app/Services/QueryPlaygroundService.php
+++ b/app/Services/QueryPlaygroundService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Support\CodesTableDescription;
 use Illuminate\Support\Facades\Schema;
 
 class QueryPlaygroundService {
@@ -27,7 +28,7 @@ class QueryPlaygroundService {
         return array_map(function ($table) {
             return [
                 'name' => $table,
-                'description' => config("codes.tables.{$table}", ''),
+                'description' => CodesTableDescription::for($table),
                 'internal' => self::isInternalTable($table),
             ];
         }, $allowedTables);
@@ -105,13 +106,13 @@ class QueryPlaygroundService {
                 }
 
                 $tableSchemas[$tableName] = [
-                    'description' => config("codes.tables.{$tableName}", ''),
+                    'description' => CodesTableDescription::for($tableName),
                     'columns' => $columnEntries,
                     'error' => null,
                 ];
             } catch (\Throwable $exception) {
                 $tableSchemas[$tableName] = [
-                    'description' => config("codes.tables.{$tableName}", ''),
+                    'description' => CodesTableDescription::for($tableName),
                     'columns' => [],
                     'error' => $exception->getMessage(),
                 ];

--- a/app/Support/CodesTableDescription.php
+++ b/app/Support/CodesTableDescription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support;
+
+class CodesTableDescription {
+    /**
+     * Resolve a code table's description for the current locale.
+     *
+     * Prefers the `codes.table_desc.<TABLE>` translation (en/zh-TW), falling back to the
+     * raw config/codes.php value when no translation key exists. `trans()` returns the key
+     * itself on a miss (and an array for a group key), so both are guarded.
+     *
+     * Shared by CodesRepository (/app/codes list) and QueryPlaygroundService (QBE table
+     * list / schema panel) so a single lookup rule governs every user-facing surface.
+     */
+    public static function for(string $table): string {
+        $key = 'codes.table_desc.' . $table;
+        $translated = trans($key);
+
+        if (is_string($translated) && $translated !== $key) {
+            return $translated;
+        }
+
+        return (string) config("codes.tables.{$table}", '');
+    }
+}

--- a/tests/Unit/CodesTableDescriptionTest.php
+++ b/tests/Unit/CodesTableDescriptionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\QueryPlaygroundService;
+use App\Support\CodesTableDescription;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CodesTableDescriptionTest extends TestCase {
+    #[Test]
+    public function it_prefers_translation_and_follows_locale() {
+        Config::set('codes.tables', ['TEST_CODES' => '測試代碼表']);
+        app('translator')->addLines(['codes.table_desc.TEST_CODES' => 'Test Codes Table'], 'en');
+        app('translator')->addLines(['codes.table_desc.TEST_CODES' => '測試代碼表（譯）'], 'zh-TW');
+
+        app()->setLocale('en');
+        $this->assertSame('Test Codes Table', CodesTableDescription::for('TEST_CODES'));
+
+        app()->setLocale('zh-TW');
+        $this->assertSame('測試代碼表（譯）', CodesTableDescription::for('TEST_CODES'));
+    }
+
+    #[Test]
+    public function it_falls_back_to_config_when_no_translation() {
+        Config::set('codes.tables', ['ZZZ_FAKE' => '假表原文說明']);
+
+        app()->setLocale('en');
+        $this->assertSame('假表原文說明', CodesTableDescription::for('ZZZ_FAKE'));
+
+        app()->setLocale('zh-TW');
+        $this->assertSame('假表原文說明', CodesTableDescription::for('ZZZ_FAKE'));
+    }
+
+    #[Test]
+    public function it_returns_empty_string_for_unknown_table() {
+        Config::set('codes.tables', []);
+
+        $this->assertSame('', CodesTableDescription::for('NOT_A_TABLE'));
+    }
+
+    #[Test]
+    public function qbe_table_list_descriptions_follow_locale() {
+        // QueryPlaygroundService::getQbeTables() 的說明欄改用共用 helper，隨語系顯示。
+        // 用不存在於真實 lang 檔的合成表名，確保驗到的是 addLines 而非真實翻譯碰巧同字。
+        Config::set('codes.tables', ['QBE_FAKE' => '假 QBE 表原文']);
+        app('translator')->addLines(['codes.table_desc.QBE_FAKE' => 'Fake QBE Table'], 'en');
+
+        // 合成表名只在 en 有翻譯 → 證明 getQbeTables 確實走 helper 並隨語系取到英文
+        //（config-fallback 路徑已由 it_falls_back_to_config_when_no_translation 覆蓋）。
+        app()->setLocale('en');
+        $tablesEn = (new QueryPlaygroundService())->getQbeTables();
+        $this->assertSame('Fake QBE Table', collect($tablesEn)->firstWhere('name', 'QBE_FAKE')['description']);
+    }
+}


### PR DESCRIPTION
承 #1104 審查提到、仍讀 config 中文表描述的另兩處。

## 變更
- **新增 `App\Support\CodesTableDescription::for($table)`**：優先取 `codes.table_desc.<表名>` 翻譯、缺鍵退回 `config('codes.tables')` 原文 —— 成為代碼表描述的**單一解析來源**。
- **`QueryPlaygroundService`**（QBE 表清單 `getQbeTables` + schema 面板 `getTableSchemas` 成功／例外兩路徑）改用 helper，說明**隨語系**顯示。
- **`CodesRepository`** 移除私有方法、改委派 helper（行為不變、DRY）。
- **補測試** `CodesTableDescriptionTest`：翻譯命中／config 退回／未知表／QBE 端到端。

## 刻意未動：`DatabaseSchemaService`（原被點名的第二處）
該處第 115 行的表描述**只用在 `generateSchemaPrompt()`——一段餵給 NL→SQL 的 LLM 提示詞**，整段鷹架（`以下是可用的数据库表结构信息`／`表名:`／`说明:`／`字段:`）與 DB `COLUMN_COMMENT` 皆為簡體中文，**不是 UI 顯示**（唯一呼叫者是 `NaturalLanguageQueryService`）。只把該行英文化會造成混語提示、反而不利 NL 生成，故維持中文。若日後要整段提示雙語化，是另一個獨立議題。

## 安全
只動顯示字串；SQL 允許清單（`array_keys(config('codes.tables'))`）、CTE／SSE／NL tool-calling、授權皆未觸及。

## 測試
`CodesTableDescriptionTest` + `QueryPlaygroundTest` + `CodesControllerTest`：87 passed。review agent + codex 皆 SHIP，無 Critical/High/Medium。

🤖 Generated with [Claude Code](https://claude.com/claude-code)