### PR TITLE
fix(test): 修 i18n 系列 PR 造成的 CI 失敗（cs-fixer + Inertia 說明斷言）

### DIFF
--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -423,7 +423,7 @@ class CodesControllerTest extends TestCase {
         // 真實情況：en/zh-TW 兩檔皆備齊全部 81 個 key，故 zh-TW 不會落到 en fallback。
         config(['codes.tables' => [
             'TEST_CODES' => '測試代碼表',   // 兩語系皆有翻譯 → 隨語系
-            'ZZZ_FAKE'   => '假表原文說明', // 兩語系皆無翻譯 → 退回 config
+            'ZZZ_FAKE' => '假表原文說明', // 兩語系皆無翻譯 → 退回 config
         ]]);
         config(['codes.ui_hidden' => []]);
         app('translator')->addLines(['codes.table_desc.TEST_CODES' => 'Test Codes Table'], 'en');

--- a/tests/Feature/CodesIndexInertiaTest.php
+++ b/tests/Feature/CodesIndexInertiaTest.php
@@ -20,6 +20,13 @@ class CodesIndexInertiaTest extends TestCase {
         config(['codes.ui_hidden' => []]);
         config(['migration_flags.pages.codes' => 'old']);
 
+        // 說明欄現在改由 codes.table_desc.<表名> 翻譯驅動（見 CodesTableDescription），
+        // 會蓋過 config 原文；此處覆寫翻譯以維持測試確定性、不耦合真實 lang 檔內容。
+        app('translator')->addLines([
+            'codes.table_desc.OFFICE_CODES' => '官職代碼',
+            'codes.table_desc.ADDR_CODES' => '地址代碼',
+        ], 'zh-TW');
+
         $this->get(route('app.codes.index'))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page


### PR DESCRIPTION
#1104 / #1106 合併後 develop 的 CI 兩項失敗，此 PR 修復：

1. **PHP CS Fixer**：`CodesControllerTest` 內 `'ZZZ_FAKE'   =>` 多空白對齊違反 `binary_operator_spaces` → 改單空白。（先前本機 cs-fixer 命中舊 cache 誤報 clean，未攔到。）
2. **PHPUnit**：`CodesIndexInertiaTest::it_renders_codes_index_with_flag_aware_urls` 斷言說明 `官職代碼`，但說明欄現由 `codes.table_desc` 翻譯驅動、會蓋過 config 原文（真實 zh-TW 為 `官職代碼表`）→ 測試改用 `addLines` 覆寫翻譯，維持確定性且不耦合真實 lang 檔內容。此為反映**新的正確行為**（翻譯優先於 config），非遮蔽退化。

## 驗證
- 全庫 `./vendor/bin/phpunit`：**2038 passed**
- `php-cs-fixer --config=.php-cs-fixer.dist.php --dry-run`：追蹤檔全 clean（僅 gitignore 的 `tests/storage/views/*` 編譯快取被列，CI 不會看到）
- codex：SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)