### PR TITLE
fix(i18n)：/app/basicinformation 表格欄位標題隨語系切換

### DIFF
--- a/resources/js/inertia/Pages/BasicInformation/Index.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/Index.tsx
@@ -39,17 +39,17 @@ interface PersonIndexPageProps extends SharedProps {
     create_url: string;
 }
 
-// 部分欄位以「中文 / 英文（拼音）」雙語呈現（對齊全站 formatBilingualLabel 慣例）；
-// 其餘欄位沿用 row[key] 直接顯示。
-const COLUMNS: { key: keyof PersonRow; label: string; render?: (row: PersonRow) => React.ReactNode }[] = [
-    { key: 'c_personid', label: 'c_personid' },
-    { key: 'c_name_chn', label: 'c_name_chn' },
-    { key: 'c_name', label: 'c_name' },
-    { key: 'c_dynasty_chn', label: 'dynasty', render: (row) => formatBilingualLabel(row.c_dynasty_chn, row.c_dynasty ?? null) ?? '' },
-    { key: 'c_index_year', label: 'index year' },
-    { key: 'addr_name_chn', label: 'index address', render: (row) => formatBilingualLabel(row.addr_name_chn, row.addr_name ?? null) ?? '' },
-    { key: 'zi', label: 'zi' },
-    { key: 'hao', label: 'hao' },
+// 欄位標題以 biogmains 翻譯 key（labelKey）呈現，隨語系切換；部分欄位以
+// 「中文 / 英文（拼音）」雙語呈現（對齊全站 formatBilingualLabel 慣例），其餘沿用 row[key]。
+const COLUMNS: { key: keyof PersonRow; labelKey: string; render?: (row: PersonRow) => React.ReactNode }[] = [
+    { key: 'c_personid', labelKey: 'col_personid' },
+    { key: 'c_name_chn', labelKey: 'col_name_chn' },
+    { key: 'c_name', labelKey: 'col_name' },
+    { key: 'c_dynasty_chn', labelKey: 'col_dynasty', render: (row) => formatBilingualLabel(row.c_dynasty_chn, row.c_dynasty ?? null) ?? '' },
+    { key: 'c_index_year', labelKey: 'col_index_year' },
+    { key: 'addr_name_chn', labelKey: 'col_index_address', render: (row) => formatBilingualLabel(row.addr_name_chn, row.addr_name ?? null) ?? '' },
+    { key: 'zi', labelKey: 'col_zi' },
+    { key: 'hao', labelKey: 'col_hao' },
 ];
 
 export default function PersonIndex() {
@@ -110,7 +110,7 @@ export default function PersonIndex() {
                     <thead className="bg-muted/50">
                         <tr>
                             {COLUMNS.map((c) => (
-                                <th key={c.label} className="px-3 py-2 text-left font-medium">{c.label}</th>
+                                <th key={c.key} className="px-3 py-2 text-left font-medium">{t(c.labelKey)}</th>
                             ))}
                         </tr>
                     </thead>
@@ -125,7 +125,7 @@ export default function PersonIndex() {
                             names.data.map((row) => (
                                 <tr key={row.c_personid} className="border-t border-border hover:bg-muted/30">
                                     {COLUMNS.map((c) => (
-                                        <td key={c.label} className="px-3 py-1.5">
+                                        <td key={c.key} className="px-3 py-1.5">
                                             <a href={editUrl(row.c_personid)} target="_blank" rel="noreferrer" className="text-primary hover:underline">
                                                 {c.render ? c.render(row) : (row[c.key] ?? '')}
                                             </a>

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -136,6 +136,16 @@ return [
     'person_name_chn_label' => 'Name (Chinese)',
     'search_placeholder' => 'Search Person (ID / Name / Pinyin)',
     'all_dynasties_opt' => 'All Dynasties',
+
+    // Person Records list (/app/basicinformation) table column headers.
+    'col_personid' => 'Person ID',
+    'col_name_chn' => 'Name (CHN)',
+    'col_name' => 'Name (Pinyin)',
+    'col_dynasty' => 'Dynasty',
+    'col_index_year' => 'Index Year',
+    'col_index_address' => 'Index Address',
+    'col_zi' => 'Courtesy Name (Zi)',
+    'col_hao' => 'Style Name (Hao)',
     'basicinfo_check_alert' => 'Before leaving: please confirm that [Given Name] and [Ming] are filled in.',
     'basicinfo_pinyin_alert' => 'Pinyin generation complete.',
 

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -136,6 +136,16 @@ return [
     'person_name_chn_label' => '姓名（中）',
     'search_placeholder' => '搜尋人物（ID / 姓名 / 拼音）',
     'all_dynasties_opt' => '全部朝代',
+
+    // 人物記錄清單（/app/basicinformation）表格欄位標題。
+    'col_personid' => '人物 ID',
+    'col_name_chn' => '姓名（中）',
+    'col_name' => '姓名（拼音）',
+    'col_dynasty' => '朝代',
+    'col_index_year' => '指數年',
+    'col_index_address' => '指數地址',
+    'col_zi' => '字',
+    'col_hao' => '號',
     'basicinfo_check_alert' => '訊息提示：要離開視窗了，請您確認[名]和[Ming]是否填寫。',
     'basicinfo_pinyin_alert' => '訊息提示：「生成拼音」已經完成。',
 

--- a/tests/Feature/BasicInformationPagesLoadTest.php
+++ b/tests/Feature/BasicInformationPagesLoadTest.php
@@ -649,6 +649,31 @@ class BasicInformationPagesLoadTest extends TestCase {
     }
 
     #[Test]
+    public function test_app_basicinformation_index_localizes_column_headers() {
+        // 迴歸：欄位標題原本硬編 raw column 名（c_personid/zi/hao…），不隨語系切換。
+        // 現改用 biogmains.col_* 翻譯 key；此處驗證兩語系都帶出正確標題。
+        $this->get(route('app.basicinformation.index'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('page_translations.biogmains.col_personid', '人物 ID')
+                ->where('page_translations.biogmains.col_name', '姓名（拼音）')
+                ->where('page_translations.biogmains.col_index_year', '指數年')
+                ->where('page_translations.biogmains.col_index_address', '指數地址')
+                ->where('page_translations.biogmains.col_zi', '字')
+                ->where('page_translations.biogmains.col_hao', '號')
+                ->etc());
+
+        $this->withSession(['locale' => 'en'])
+            ->get(route('app.basicinformation.index'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('page_translations.biogmains.col_personid', 'Person ID')
+                ->where('page_translations.biogmains.col_name', 'Name (Pinyin)')
+                ->where('page_translations.biogmains.col_index_address', 'Index Address')
+                ->where('page_translations.biogmains.col_zi', 'Courtesy Name (Zi)')
+                ->where('page_translations.biogmains.col_hao', 'Style Name (Hao)')
+                ->etc());
+    }
+
+    #[Test]
     public function test_basicinformation_index_with_empty_query_and_pagination() {
         $response = $this->get('/basicinformation?q=&page=2');
         $response->assertStatus(200);


### PR DESCRIPTION
## 問題
`/app/basicinformation`（人物記錄清單）表格欄位標題顯示原始欄位名（`c_personid`、`c_name_chn`、`c_name`、`zi`、`hao`、`index year`、`index address`…），且**中英文切換無效**——因為這些標題在 `Index.tsx` 的 `COLUMNS` 常數裡是**硬編字串**，從未經過 `t()`。頁面其餘字串（標題、搜尋框、朝代下拉、筆數、分頁、新增鈕）本就走翻譯，所以只有欄位標題壞。

## 修法
- `COLUMNS` 的 `label` 改 `labelKey`，表頭以 `{t(c.labelKey)}`（`biogmains` 群組）呈現；React key 由 `c.label` 改用穩定的 `c.key`。
- `en`／`zh-TW` `biogmains.php` 各補 8 個 `col_*` 標題 key（parity 405/405）。
- `col_index_address` 中文用「**指數地址**」——與同群組 `index_addr` 及同表相鄰的 `col_index_year`「指數年」一致（reviewer 指出原「籍貫」與全站命名不一致）。
- 補迴歸測試：驗證 `col_*` 在 zh-TW／en 兩語系都帶出正確標題（斷言控制器 `page_translations.biogmains` 實際 payload）。

## 驗證
- `npm run build` ✅
- `BasicInformationPagesLoadTest`：32 passed
- `php-cs-fixer --config=.php-cs-fixer.dist.php --dry-run`：clean
- review agent + codex 皆 SHIP，無 Critical/High/Medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)