### PR TITLE
fix(admin)：React 版著作批次載入補回逐列直接編輯拼音

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -79,6 +79,7 @@ class AdminBatchLoadBookTitlesController extends Controller {
                 'store' => route('app.admin.batch-load-book-titles.store', [], false),
                 'undo' => route('app.admin.batch-load-book-titles.undo', [], false),
                 'reset' => route('app.admin.batch-load-book-titles', [], false),
+                'update_pinyin' => route('app.admin.batch-load-book-titles.update-pinyin', [], false),
             ],
             'page_translations' => [
                 'admin' => is_array($t = trans('admin')) ? $t : [],

--- a/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../../components/ui/Button';
 import { FormField } from '../../../components/ui/FormField';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { getCsrfToken } from '../../../components/PersonBrowser/shared/csrf';
 import type { SharedProps } from '../../../types/page';
 import { cn } from '../../../lib/utils';
 
@@ -32,7 +33,7 @@ interface BatchBooksPageProps extends SharedProps {
     batch_errors: string[];
     batch_id: string | null;
     toast: Toast | null;
-    urls: { store: string; undo: string; reset: string };
+    urls: { store: string; undo: string; reset: string; update_pinyin: string };
 }
 
 export default function BatchLoadBookTitles() {
@@ -46,6 +47,13 @@ export default function BatchLoadBookTitles() {
     const [confirmUndo, setConfirmUndo] = useState(false);
     const [toastShown, setToastShown] = useState<Toast | null>(toast);
 
+    // 逐列拼音就地編輯狀態（重建舊 Blade 版的直接編輯拼音功能）。
+    const [rows, setRows] = useState<ResultRow[]>(results);
+    const [editId, setEditId] = useState<number | null>(null);
+    const [draft, setDraft] = useState('');
+    const [busyId, setBusyId] = useState<number | null>(null);
+    const [rowStatus, setRowStatus] = useState<{ id: number; msg: string; kind: 'success' | 'error' } | null>(null);
+
     useEffect(() => {
         setToastShown(toast);
         if (toast) {
@@ -53,6 +61,79 @@ export default function BatchLoadBookTitles() {
             return () => clearTimeout(id);
         }
     }, [toast]);
+
+    // 重新匯入/回退後 props.results 會變，同步本地列並清空編輯狀態。
+    useEffect(() => {
+        setRows(results);
+        setEditId(null);
+        setDraft('');
+        setRowStatus(null);
+    }, [results]);
+
+    const flashToast = (tt: Toast) => {
+        setToastShown(tt);
+        setTimeout(() => setToastShown(null), 3000);
+    };
+
+    const startEdit = (r: ResultRow) => {
+        setEditId(r.c_textid);
+        setDraft(r.title_pinyin ?? '');
+        setRowStatus(null);
+    };
+    const cancelEdit = () => {
+        setEditId(null);
+        setDraft('');
+        setRowStatus(null);
+    };
+
+    const savePinyin = async (r: ResultRow) => {
+        if (busyId !== null) {
+            return; // 防止進行中重複送出（避免重複審計記錄）
+        }
+        const value = draft.trim();
+        if (value === '') {
+            setRowStatus({ id: r.c_textid, msg: t('batch_pinyin_empty'), kind: 'error' });
+            return;
+        }
+        if (!batch_id) {
+            return;
+        }
+        setBusyId(r.c_textid);
+        setRowStatus(null);
+        try {
+            const res = await fetch(urls.update_pinyin, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': getCsrfToken(),
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify({ c_textid: r.c_textid, batch_id, pinyin: value }),
+            });
+            const json = await res.json().catch(() => null);
+            if (!res.ok || !json || json.ok === false) {
+                const msg = (json && json.message) || t('batch_pinyin_save_failed');
+                setRowStatus({ id: r.c_textid, msg, kind: 'error' });
+                flashToast({ msg, type: 'error' });
+                return;
+            }
+            // 以伺服器實際存回的值更新該列（可能經正規化/截斷）。
+            const stored = String(json.c_title ?? '');
+            setRows((prev) => prev.map((x) => (x.c_textid === r.c_textid ? { ...x, title_pinyin: stored } : x)));
+            setEditId(null);
+            setDraft('');
+            setRowStatus({ id: r.c_textid, msg: t('batch_pinyin_saved') + stored, kind: 'success' });
+            flashToast({ msg: t('batch_pinyin_updated') + json.c_textid, type: 'success' });
+            // 成功狀態 4 秒後自動清除（對齊舊版行為）。
+            setTimeout(() => setRowStatus((cur) => (cur?.id === r.c_textid && cur.kind === 'success' ? null : cur)), 4000);
+        } catch {
+            setRowStatus({ id: r.c_textid, msg: t('batch_network_error'), kind: 'error' });
+        } finally {
+            setBusyId(null);
+        }
+    };
 
     const submit = (force: boolean) => {
         form.transform((d) => (force ? { entries: d.entries, force: '1' } : { entries: d.entries }));
@@ -66,7 +147,7 @@ export default function BatchLoadBookTitles() {
     };
 
     const copyResults = () => {
-        const payload = results.map((r) => `${r.c_textid}\t${r.title}`).join('\n');
+        const payload = rows.map((r) => `${r.c_textid}\t${r.title}`).join('\n');
         navigator.clipboard?.writeText(payload);
     };
 
@@ -126,7 +207,7 @@ export default function BatchLoadBookTitles() {
                     </div>
                 </form>
 
-                {results.length > 0 && (
+                {rows.length > 0 && (
                     <>
                         <div className="mt-5 flex items-center gap-2">
                             <Button type="button" variant="outline" size="sm" onClick={copyResults}>{t('batch_copy_textid_btn')}</Button>
@@ -146,12 +227,67 @@ export default function BatchLoadBookTitles() {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {results.map((r) => (
+                                    {rows.map((r) => (
                                         <tr key={`${r.line}-${r.c_textid}`} className="border-t border-border">
                                             <td className="px-3 py-1.5">{r.line}</td>
                                             <td className="px-3 py-1.5">{r.author_id}</td>
                                             <td className="px-3 py-1.5">{r.title}</td>
-                                            <td className="px-3 py-1.5">{r.title_pinyin}</td>
+                                            <td className="px-3 py-1.5">
+                                                {batch_id && editId === r.c_textid ? (
+                                                    <div className="flex flex-col gap-1">
+                                                        <div className="flex items-center gap-1">
+                                                            <input
+                                                                autoFocus
+                                                                value={draft}
+                                                                spellCheck={false}
+                                                                disabled={busyId === r.c_textid}
+                                                                onFocus={(e) => e.target.select()}
+                                                                onChange={(e) => setDraft(e.target.value)}
+                                                                onKeyDown={(e) => {
+                                                                    if (e.key === 'Enter') { e.preventDefault(); savePinyin(r); }
+                                                                    if (e.key === 'Escape') { cancelEdit(); }
+                                                                }}
+                                                                className="w-44 rounded border border-input bg-background px-2 py-1 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                                            />
+                                                            <Button type="button" size="sm" disabled={busyId === r.c_textid} onClick={() => savePinyin(r)}>
+                                                                {t('batch_pinyin_save')}
+                                                            </Button>
+                                                            <Button type="button" size="sm" variant="secondary" disabled={busyId === r.c_textid} onClick={cancelEdit}>
+                                                                {tc('cancel')}
+                                                            </Button>
+                                                        </div>
+                                                        {(busyId === r.c_textid || rowStatus?.id === r.c_textid) && (
+                                                            <span
+                                                                className={cn(
+                                                                    'text-xs',
+                                                                    busyId === r.c_textid ? 'text-muted-foreground'
+                                                                        : rowStatus?.kind === 'error' ? 'text-red-600' : 'text-green-600'
+                                                                )}
+                                                            >
+                                                                {busyId === r.c_textid ? t('batch_pinyin_saving') : rowStatus?.msg}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                ) : (
+                                                    <div className="flex items-center gap-2">
+                                                        <span>{r.title_pinyin}</span>
+                                                        {batch_id && (
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => startEdit(r)}
+                                                                title={t('batch_pinyin_edit_title')}
+                                                                aria-label={t('batch_pinyin_edit_title')}
+                                                                className="text-muted-foreground hover:text-primary"
+                                                            >
+                                                                <i className="fas fa-pen text-xs" aria-hidden="true" />
+                                                            </button>
+                                                        )}
+                                                        {rowStatus?.id === r.c_textid && rowStatus.kind === 'success' && (
+                                                            <span className="text-xs text-green-600">{rowStatus.msg}</span>
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </td>
                                             <td className="px-3 py-1.5">{r.source}</td>
                                             <td className="px-3 py-1.5">{r.dynasty}</td>
                                             <td className="px-3 py-1.5">{r.text_type}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -450,6 +450,9 @@ Route::middleware('auth')->group(function () {
         ->middleware('inertia')->name('app.admin.batch-load-book-titles.store');
     Route::post('app/admin/batch-load-book-titles/undo', 'AdminBatchLoadBookTitlesController@undo')
         ->middleware('inertia')->name('app.admin.batch-load-book-titles.undo');
+    // 逐列直接編輯拼音（回傳 JSON，React 以 fetch 呼叫並就地更新該列；重用既有 updatePinyin）
+    Route::post('app/admin/batch-load-book-titles/update-pinyin', 'AdminBatchLoadBookTitlesController@updatePinyin')
+        ->name('app.admin.batch-load-book-titles.update-pinyin');
     Route::get('admin/batch-load-social-institutes', 'AdminBatchLoadSocialInstitutesController@showForm')->name('admin.batch-load-social-institutes');
     Route::post('admin/batch-load-social-institutes', 'AdminBatchLoadSocialInstitutesController@store')->name('admin.batch-load-social-institutes.store');
     // Inertia + React 版（store 重用，依請求路徑重導）

--- a/tests/Feature/AdminBatchLoadBookTitlesPinyinRouteTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesPinyinRouteTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 迴歸：React 版 /app/admin/batch-load-book-titles 曾漏掉舊 Blade 版的「直接編輯拼音」
+ * 功能——app 命名空間下缺少 update-pinyin 路由，前端也無法呼叫 updatePinyin。
+ * 此處鎖定 app 版 update-pinyin 路由存在且指向既有的 updatePinyin 方法。
+ */
+class AdminBatchLoadBookTitlesPinyinRouteTest extends TestCase {
+    #[Test]
+    public function app_update_pinyin_route_is_registered_and_maps_to_controller() {
+        $this->assertTrue(
+            Route::has('app.admin.batch-load-book-titles.update-pinyin'),
+            'app 版 update-pinyin 路由必須存在，否則新界面無法直接編輯拼音'
+        );
+
+        $route = Route::getRoutes()->getByName('app.admin.batch-load-book-titles.update-pinyin');
+        $this->assertSame('app/admin/batch-load-book-titles/update-pinyin', $route->uri());
+        $this->assertContains('POST', $route->methods());
+        $this->assertSame(
+            'App\Http\Controllers\AdminBatchLoadBookTitlesController@updatePinyin',
+            $route->getActionName()
+        );
+    }
+}


### PR DESCRIPTION
## 問題
新版 React `/app/admin/batch-load-book-titles` 遺漏了舊 Blade 版的「**直接編輯拼音**」功能——結果表只唯讀顯示拼音、無法逐列編輯。缺口三層：前端無編輯 UI、`app/` 命名空間缺 `update-pinyin` 路由、後端 `updatePinyin()` 雖在但連不到。

## 修法
- **routes**：補 `POST app/admin/batch-load-book-titles/update-pinyin` → `updatePinyin`（JSON 端點，置於既有 `auth` group、走 web CSRF；不掛 `inertia` middleware，因為以 `fetch` 呼叫、回傳 JSON）。
- **控制器**：`appShowForm` 的 `urls` 補 `update_pinyin`。
- **Index.tsx**：還原逐列就地編輯（✎ → 輸入（Enter 存 / Esc 取消）→ Save/Cancel）；`fetch` 帶 `X-CSRF-TOKEN`、以伺服器實際存回值更新該列、per-row 狀態 + toast；重用既有 `admin.batch_pinyin_*` 翻譯。含進行中防重複送出、保存中提示、成功 4 秒自清、聚焦全選。
- **測試**：補路由迴歸測試（鎖定 app 版 `update-pinyin` 存在且指向 `updatePinyin`）。

## 安全
沿用未改動的 `updatePinyin()`：後端仍以 `c_notes === "[batch_id]"` 把關，僅能改當前批次列；`ensureAdmin()` 全程守門。`batch_id` 來自 session prop。

## 行為註記
手動編輯只做 trim／小寫，**不套 `v→ü`**（沿用舊版；避免 `Denver` 類外文羅馬字誤判）。自動生成（`buildPinyin`）仍照舊套 `PinyinUmlaut`。此一致性議題已與維護者確認、暫維持現狀。

## 驗證
- `npm run build` ✅
- `AdminBatchLoadBookTitlesTest`（既有 updatePinyin 全套）+ 新路由測試：39 passed
- cs-fixer（CI config）clean
- review agent + codex 皆 SHIP，無 Critical/High/Medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)