### PR TITLE
生成拼音：左括號後首字母大寫

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -591,6 +591,12 @@ class ApiController extends Controller {
             $res = preg_replace('/^\s+\(/u', '(', $res);
             $res = trim($res);
 
+            // 左括號後第一個字母大寫（與人名各段首字母大寫慣例一致）。
+            // 僅針對小寫字母，故已為大寫的關係片語（如 "(Wife of ...)"）不受影響。
+            $res = preg_replace_callback('/\((\p{Ll})/u', static function (array $m): string {
+                return '('.mb_strtoupper($m[1], 'UTF-8');
+            }, $res);
+
             return $res;
         } else {
             return '';

--- a/tests/Feature/ApiSearchPinyinTest.php
+++ b/tests/Feature/ApiSearchPinyinTest.php
@@ -183,6 +183,34 @@ class ApiSearchPinyinTest extends TestCase {
     }
 
     #[Test]
+    public function search_pinyin_capitalizes_first_letter_after_left_parenthesis(): void {
+        // 人名含括號（非關係稱謂，如別名/字號）時，左括號後首字母應大寫，
+        // 與人名各段首字母大寫慣例一致。split=0 模擬基本資料編輯器「名」欄的生成拼音。
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('李白（青蓮）').'&split=0');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertSame('Libai (Qinglian)', $content);
+        $this->assertStringNotContainsString('（', $content);
+        $this->assertStringNotContainsString('）', $content);
+    }
+
+    #[Test]
+    public function search_pinyin_keeps_relationship_phrase_capitalization_unchanged(): void {
+        DB::table('pinyin')->insert([
+            'lastname_chn' => '李',
+            'lastname_pinyin' => 'Li',
+        ]);
+
+        // 關係片語括號內已為大寫英文（(Wife of ...)），大寫化不得誤傷或重覆處理。
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('（李白妻）'));
+
+        $response->assertOk();
+        $this->assertSame('(Wife of Li Bai)', trim($response->getContent()));
+    }
+
+    #[Test]
     public function search_pinyin_converts_prefixed_relationship_patterns_to_english_phrases(): void {
         DB::table('pinyin')->insert([
             ['lastname_chn' => '宗', 'lastname_pinyin' => 'Zong'],


### PR DESCRIPTION
## 摘要
針對使用者提出的兩點：

1. **舊版保存時的括號標準化是否在新版實現？** — 經確認**已實現**，無需改碼。`BracketNormalizer::normalizeBiogMain`（`app/Services/BracketNormalizer.php`）於新版三條保存路徑皆已套用：
   - 建立（direct）：`BiogMainCreateHandler` → `BiogMainRepository::store()`（`:355`）
   - 更新（direct）：`BiogMainRepository::updateById()`（`:259`）
   - 提案（create／update）：`BiogMainMutationHandler::prepareProposalPayload()`（`:201`）

2. **basicinformation 人名含括號時，生成拼音左括號後首字母未大寫** — 本 PR 修正。

## 改動
- **`app/Http/Controllers/ApiController.php`（`searchPinyin`）**：在既有括號正規化（全角轉半角、括號前補空格）之後，新增一步將**左括號後第一個小寫字母轉為大寫**，使人名括號別名（如 `(qinglian)` → `(Qinglian)`）符合人名各段首字母大寫慣例。
  - 僅比對小寫字母（`\p{Ll}`），故關係片語（如 `(Wife of ...)`、`(Mother of ...)`）已為大寫者不受影響。
  - 此端點為前後端唯一生成拼音入口（React `BasicInfoEditor` 姓 split=1、名 split=0 皆走此），一處修正即全覆蓋。
- **`tests/Feature/ApiSearchPinyinTest.php`**：新增兩則測試——括號別名大寫（`李白（青蓮）` split=0 → `Libai (Qinglian)`）、關係片語不受影響（回歸）。

## 測試與審查
- `./vendor/bin/phpunit --filter ApiSearchPinyinTest` → **11 tests, 61 assertions, OK**
- `./vendor/bin/php-cs-fixer fix`：兩檔案皆無需調整
- 已通過 review agent 與 codex 兩輪代碼審查，邊界案例（多重括號、非字母、`ü`→`Ü`、空字串）均驗證正確，無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)