### PR TITLE
修正基本資料編輯頁：切分頁後顯示舊值、並復刻回車保存

### DIFF
--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -35,6 +35,7 @@ interface Props {
     duplicateCollateralUrl?: string;
     saveasUrl?: string;
     t?: (k: string) => string;   // person/biogmains 翻譯
+    onSaved?: () => void;        // 儲存成功後回呼（供上層刷新分頁快取，避免切分頁回來看到舊值）
 }
 
 const READONLY_DERIVED = ['c_name_chn', 'c_name', 'c_name_proper', 'c_name_rm'];
@@ -63,7 +64,7 @@ interface DateGroup {
 export default function BasicInfoEditor({
     personId, initialFields, initialLabels = {},
     canEdit, canPropose, mutateEndpoint, deleteEndpoint, pinyinEndpoint = '/api/select/search/pinyin',
-    indexUrl = '/basicinformation', duplicateCollateralUrl, saveasUrl, t,
+    indexUrl = '/basicinformation', duplicateCollateralUrl, saveasUrl, t, onSaved,
 }: Props) {
     // useTranslation 在缺 key 時回傳 key 本身；故須在 t(k)===k（未翻譯）時退回中文 fallback，
     // 否則按鈕/標籤會顯示原始 key（如 save_directly）而非中文。
@@ -247,6 +248,9 @@ export default function BasicInfoEditor({
             }
             const baseline: Fields = { ...fields, ...patch };
             setSavedSnapshot(JSON.stringify(baseline));
+            // 通知上層儲存成功：上層據此刷新分頁快取，使「切分頁再切回」時載入到已存的新值，
+            // 而非最初載入時的舊快照（本元件仍保持掛載、不重載，成功提示不受影響）。
+            onSaved?.();
         } catch (e) {
             setError(e instanceof Error ? e.message : tr('save_failed', '儲存失敗'));
         } finally { setSaving(false); }
@@ -331,8 +335,24 @@ export default function BasicInfoEditor({
     const flEarly: DateGroup = { year: 'c_fl_earliest_year', nhCode: 'c_fl_ey_nh_code', nhYear: 'c_fl_ey_nh_year', notes: 'c_fl_ey_notes' };
     const flLate: DateGroup = { year: 'c_fl_latest_year', nhCode: 'c_fl_ly_nh_code', nhYear: 'c_fl_ly_nh_year', notes: 'c_fl_ly_notes' };
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || !dirty) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            {/* 隱藏提交鈕：讓表單具備「預設提交按鈕」，使單行輸入框按 Enter 觸發原生隱式提交（→ onFormSubmit）。
+                可見動作按鈕皆為 type="button"（點擊行為不變）；此鈕僅供 Enter，並以 tabIndex=-1／aria-hidden 排除於鍵盤焦點與無障礙。 */}
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={hiddenSubmitStyle} />
             {/* 不再重複「人物基本資料 — {人物}」標題：詳情中樞 banner 已顯示人物、分頁標籤已示「基本資料」。 */}
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -477,9 +497,12 @@ export default function BasicInfoEditor({
                     </div>
                 ) : null}
             </div>
-        </div>
+        </form>
     );
 }
+
+// 隱藏提交按鈕：畫面外但仍為可提交候選（不可用 display:none／hidden，否則部分瀏覽器不觸發隱式提交）。
+const hiddenSubmitStyle: React.CSSProperties = { position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, border: 0, overflow: 'hidden', clip: 'rect(0 0 0 0)' };
 
 // BasicInfo 專屬（非版面）樣式：唯讀派生子區塊、生成拼音按鈕列。
 // 唯讀派生子區塊：虛線框 + 淡背景，明確標示「自動生成」。

--- a/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
+++ b/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
@@ -176,6 +176,28 @@ export default function TabContentLoader({
         setFetchSeq((s) => s + 1);
     };
 
+    // 靜默刷新指定分頁的快取資料：於背景重新抓取並就地更新 cache[tabKey].data，
+    // 不觸發 loading 態、不卸載當前掛載的元件（其 state 為當前真相），
+    // 以便使用者切換分頁後再回來時「重新掛載」讀到最新資料，而非最初載入的舊快照。
+    // 失敗時保留既有快取，避免把已顯示的資料清成錯誤態。
+    const refreshTabCache = (tabKey: string) => {
+        if (personId == null || !tabKey) return;
+        const url = tabEndpoint
+            .replace('__PERSON_ID__', String(personId))
+            .replace('__TAB_KEY__', tabKey);
+        fetch(url)
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then((data) => {
+                setCache((prev) => ({ ...prev, [tabKey]: { loading: false, error: null, data } }));
+            })
+            .catch(() => {
+                /* 保留既有快取 */
+            });
+    };
+
     if (personId == null) {
         return null;
     }
@@ -237,6 +259,12 @@ export default function TabContentLoader({
                     duplicateCollateralUrl={`/basicinformation/${personId}/Duplicate_Collateral_Info`}
                     saveasUrl={`/basicinformation/${personId}/saveas`}
                     t={tEditor}
+                    onSaved={() => {
+                        // 儲存成功後靜默刷新 basic_info 快取（修：切分頁再切回顯示舊值），
+                        // 並通知上層刷新摘要計數。
+                        refreshTabCache('basic_info');
+                        onBasicInfoSaved?.();
+                    }}
                 />
             );
         }


### PR DESCRIPTION
## 摘要
針對 `/app/basicinformation/{id}/edit`（React/Inertia，flag=new）回報的兩個問題，經本機 Playwright 重現、修復並回歸確認。

## 問題一：儲存後切分頁再切回，顯示的是舊內容（需整頁重整才見新值）
**重現（Playwright）**：編輯 `c_notes` 存檔 → 切到 `?tab=texts` → 切回 basic_info，欄位顯示存檔前的舊值；整頁重整後才是新值。

**根因**：`TabContentLoader` 以 `cache` state 逐分頁快取伺服器資料。`basicInfoEditorIsNew` 分支用 `cache['basic_info'].data` 提供 `<BasicInfoEditor>` 的 `initialFields`（僅在掛載時經 `useState` 取用）。存檔只更新了編輯器自身 state，**未使該分頁快取失效**；切走時編輯器卸載，切回時以舊快照重新掛載。（另一 `BasicInfoView` 分支存檔時本已呼叫 `retryActiveTab()`，此編輯器分支缺漏。）

**修法**：
- `BasicInfoEditor` 新增可選 `onSaved` 回呼，於 direct／proposal 存檔成功後觸發。
- `TabContentLoader` 新增 `refreshTabCache(tabKey)`：於背景重新抓取分頁端點並就地更新 `cache[tabKey].data`，**不設 loading、不卸載當前編輯器、不重載、保留「已儲存」提示**；失敗則保留既有快取。編輯器分支的 `onSaved` 呼叫 `refreshTabCache('basic_info')` 後再刷新摘要計數。
- 原理：掛載中的編輯器僅在初次掛載用 `initialFields`，故背景更新快取不擾動當前輸入；新資料只在下次（切分頁返回）重新掛載時被讀取。

## 問題二：舊版於輸入框按 Enter 可保存，新版失效
**重現（Playwright）**：於單行輸入框按 Enter，無任何 `/api/v2/mutate` 送出。

**修法**：
- `BasicInfoEditor` 根節點由 `<div>` 改為原生 `<form onSubmit>`；`onSubmit` 依權限走 `save('direct')`（可編輯）或 `save('proposal')`（可提案），未變更／儲存中／刪除中則不提交。
- 新增一顆視覺隱藏的 `type="submit"` 按鈕作為表單「預設提交鈕」（多輸入框情境下，Enter 觸發原生隱式提交所必需；不可用 `display:none`）；可見動作按鈕維持 `type="button"`，點擊行為不變。
- `textarea` 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不誤觸提交。

## 測試 / 驗證
- Playwright（本機、真實登入編輯權限帳號）：
  - 修復前：切分頁返回顯示舊值；修復後：顯示已存新值（整頁重整亦一致）。
  - Enter：單行輸入框按 Enter 觸發 **一次** `/api/v2/mutate` 並持久化；`textarea` 按 Enter **不**提交。
- `npm run build` 通過。
- 每一環節均經 review agent 與 codex 兩輪審查，皆無嚴重問題。

## 影響面
- 僅改兩個前端元件；`onSaved` 為可選 prop，`BasicInfoEditor` 的其他呼叫端（PersonBrowser／EditV2）不受影響。`refreshTabCache` 僅由編輯器分支觸發（PersonBrowser 不渲染該分支）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)