### PR TITLE
fix(name): 中文姓名括號正規化去除鄰接空白，避免破壞搜尋索引

### DIFF
--- a/app/Console/Commands/RebuildNameSearchIndex.php
+++ b/app/Console/Commands/RebuildNameSearchIndex.php
@@ -440,10 +440,11 @@ class RebuildNameSearchIndex extends Command {
             return null;
         }
 
-        // 移除括號符號本身，但保留內容以便搜尋
-        // 例如："宗氏（李白妻）" → "宗氏李白妻"
-        // 這樣搜尋 "李白" 可以找到這條記錄
-        $name = preg_replace('/[()（）]/u', '', $name);
+        // 移除括號符號本身，並移除所有空白（含全形／不斷行空白），但保留內容以便搜尋。
+        // 例如："宗氏（李白妻）" → "宗氏李白妻"、"李白 (青蓮)" → "李白青蓮"。
+        // 中文姓名不含有意義的空白；殘留空白會破壞後綴索引與搜尋比對，
+        // 也會導致全量重建時覆蓋掉增量流程（NameSearchIndexService）已修正的結果。
+        $name = preg_replace('/[()（）\s\p{Zs}]/u', '', $name);
         $name = trim($name);
 
         return $name ?: null;

--- a/app/Services/BracketNormalizer.php
+++ b/app/Services/BracketNormalizer.php
@@ -48,10 +48,16 @@ class BracketNormalizer {
     ];
 
     /**
-     * 僅將全角括號轉為半角，不加空格
+     * 中文欄位括號正規化：全角轉半角，並移除括號內外緊鄰的空白
      *
-     * 適用於中文欄位，避免在中文字之間插入空格，
-     * 同時保持與 NameSearchIndexService 搜尋索引的相容性。
+     * 適用於中文欄位。中文字與括號之間不應留空白，
+     * 否則 NameSearchIndexService::normalizeName() 去除括號符號後會殘留空白，
+     * 破壞搜尋索引（例如「李白 (青蓮)」→ 索引「李白 青蓮」而非「李白青蓮」）。
+     *
+     * 規則：
+     * 1. 全角括號（、）轉為半角括號 (、)
+     * 2. 移除半角括號前後緊鄰的空白（含全形／不斷行空白）
+     *    例如："李白 (青蓮)" → "李白(青蓮)"、"李白( 青蓮 )" → "李白(青蓮)"
      *
      * @param string|null $value 原始值
      * @return string|null 正規化後的值
@@ -61,7 +67,13 @@ class BracketNormalizer {
             return $value;
         }
 
-        return str_replace(['（', '）'], ['(', ')'], $value);
+        // Step 1: 全角括號轉半角
+        $value = str_replace(['（', '）'], ['(', ')'], $value);
+
+        // Step 2: 移除括號內外緊鄰的空白（避免破壞搜尋索引與中文閱讀習慣）
+        $value = preg_replace('/[\s\p{Zs}]*([()])[\s\p{Zs}]*/u', '$1', $value);
+
+        return $value;
     }
 
     /**

--- a/app/Services/NameSearchIndexService.php
+++ b/app/Services/NameSearchIndexService.php
@@ -271,9 +271,10 @@ class NameSearchIndexService {
             return null;
         }
 
-        // 移除括號符號本身，但保留內容以便搜尋
-        // 例如："宗氏（李白妻）" → "宗氏李白妻"
-        $name = preg_replace('/[()（）]/u', '', $name);
+        // 移除括號符號本身，並移除所有空白（含全形／不斷行空白），但保留內容以便搜尋。
+        // 中文姓名不含有意義的空白；若殘留空白會破壞後綴索引與搜尋比對。
+        // 例如："宗氏（李白妻）" → "宗氏李白妻"、"李白 (青蓮)" → "李白青蓮"
+        $name = preg_replace('/[()（）\s\p{Zs}]/u', '', $name);
         $name = trim($name);
 
         return $name ?: null;

--- a/tests/Feature/NameSearchIndexAutoSyncTest.php
+++ b/tests/Feature/NameSearchIndexAutoSyncTest.php
@@ -440,6 +440,57 @@ class NameSearchIndexAutoSyncTest extends TestCase {
     }
 
     #[Test]
+    public function test_person_with_spaced_parentheses_creates_space_free_index(): void {
+        // 使用者輸入帶空白的半角括號（例："李白 (青蓮)"）。
+        // BiogMain::create 走 Eloquent + Observer → NameSearchIndexService，
+        // 索引應與「李白(青蓮)」一致：移除括號與空白後為「李白青蓮」。
+        $person = BiogMain::create([
+            'c_personid' => 3002,
+            'c_name_chn' => '李白 (青蓮)',
+        ]);
+
+        $searchTerms = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 3002)
+            ->pluck('search_term')
+            ->toArray();
+
+        $this->assertContains('李白青蓮', $searchTerms, '應包含移除括號與空白後的完整名稱');
+        $this->assertContains('青蓮', $searchTerms, '應包含括號內容的後綴');
+
+        foreach ($searchTerms as $term) {
+            $this->assertStringNotContainsString(' ', $term, '搜尋詞不應殘留半形空白');
+            $this->assertStringNotContainsString("\u{3000}", $term, '搜尋詞不應殘留全形空白');
+        }
+    }
+
+    #[Test]
+    public function test_altname_with_spaced_parentheses_creates_space_free_index(): void {
+        // 別名路徑（indexAltname → normalizeName）：帶空白的半角括號輸入
+        // 應與「太白(青蓮)」一致，索引移除括號與空白後為「太白青蓮」。
+        BiogMain::create([
+            'c_personid' => 3003,
+            'c_name_chn' => '李白',
+        ]);
+
+        app(\App\Services\NameSearchIndexService::class)
+            ->indexAltname(3003, 4, '太白 (青蓮)');
+
+        $searchTerms = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 3003)
+            ->where('name_type_code', 4)
+            ->pluck('search_term')
+            ->toArray();
+
+        $this->assertContains('太白青蓮', $searchTerms, '別名索引應移除括號與空白後的完整名稱');
+        $this->assertContains('青蓮', $searchTerms, '別名索引應包含括號內容的後綴');
+
+        foreach ($searchTerms as $term) {
+            $this->assertStringNotContainsString(' ', $term, '別名搜尋詞不應殘留半形空白');
+            $this->assertStringNotContainsString("\u{3000}", $term, '別名搜尋詞不應殘留全形空白');
+        }
+    }
+
+    #[Test]
     public function test_index_table_does_not_exist_gracefully_handles(): void {
         // 刪除索引表
         Schema::dropIfExists('CBDB__NAME_FTS');

--- a/tests/Unit/BracketNormalizerTest.php
+++ b/tests/Unit/BracketNormalizerTest.php
@@ -28,6 +28,24 @@ class BracketNormalizerTest extends TestCase {
     }
 
     /**
+     * 中文欄位：移除半角括號前後緊鄰的空白
+     *
+     * 使用者若輸入「李白 (青蓮)」（半角括號帶空格），
+     * 應標準化為「李白(青蓮)」，避免搜尋索引殘留空白。
+     */
+    public function test_chinese_removes_spaces_around_brackets(): void {
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白 (青蓮)'));
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白（青蓮）'));
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白 （青蓮）'));
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白( 青蓮 )'));
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白 ( 青蓮 ) '));
+        // 全形空白 U+3000
+        $this->assertSame('李白(青蓮)', BracketNormalizer::normalizeChineseField('李白　(青蓮)'));
+        // 括號後仍有內容
+        $this->assertSame('升卿(一作陞卿)號', BracketNormalizer::normalizeChineseField('升卿 (一作陞卿) 號'));
+    }
+
+    /**
      * 中文欄位：空值與空字串
      */
     public function test_chinese_null_and_empty(): void {
@@ -214,5 +232,21 @@ class BracketNormalizerTest extends TestCase {
         // 搜尋索引結果應完全一致
         $this->assertSame($originalIndexed, $normalizedIndexed);
         $this->assertSame('宗氏李白妻', $normalizedIndexed);
+    }
+
+    /**
+     * 驗證使用者輸入帶空白的半角括號時，正規化後不會破壞搜尋索引。
+     *
+     * 若未移除空白：「李白 (青蓮)」→ 去括號後「李白 青蓮」（殘留空白，破壞搜尋）。
+     * 正規化後：「李白(青蓮)」→ 去括號後「李白青蓮」（連續 token，可正常搜尋）。
+     */
+    public function test_chinese_space_removal_preserves_search_index_compatibility(): void {
+        $strip = fn ($s) => preg_replace('/[()（）]/u', '', $s);
+
+        $normalized = BracketNormalizer::normalizeChineseField('李白 (青蓮)');
+        $indexed = $strip($normalized);
+
+        $this->assertSame('李白(青蓮)', $normalized);
+        $this->assertSame('李白青蓮', $indexed);
     }
 }

--- a/tests/Unit/RebuildNameSearchIndexTest.php
+++ b/tests/Unit/RebuildNameSearchIndexTest.php
@@ -90,6 +90,21 @@ class RebuildNameSearchIndexTest extends TestCase {
     }
 
     #[Test]
+    public function test_normalizeName_removes_spaces_around_parentheses(): void {
+        // 帶空白的半角括號：空白與括號皆移除，與 NameSearchIndexService 一致
+        // 避免全量重建覆蓋增量流程已修正的無空白索引
+        $this->assertEquals('李白青蓮', $this->invokeNormalizeName('李白 (青蓮)'));
+        $this->assertEquals('李白青蓮', $this->invokeNormalizeName('李白（青蓮）'));
+        $this->assertEquals('李白青蓮', $this->invokeNormalizeName('李白( 青蓮 )'));
+        // 全形空白 U+3000
+        $this->assertEquals('李白青蓮', $this->invokeNormalizeName('李白　(青蓮)'));
+        // 不斷行空白 U+00A0
+        $this->assertEquals('李白青蓮', $this->invokeNormalizeName("李白\u{00A0}(青蓮)"));
+        // 非括號的內部空白亦移除（中文姓名不含有意義空白）
+        $this->assertEquals('李白', $this->invokeNormalizeName('李 白'));
+    }
+
+    #[Test]
     public function test_normalizeName_handles_nested_parentheses(): void {
         // 嵌套括號（雖然實際數據中不太可能出現）
         $result = $this->invokeNormalizeName('王氏（李（白）妻）');


### PR DESCRIPTION
## 問題

輸入含括號的中文姓名時，同一內容的不同輸入形式未被統一標準化：

- `李白（青蓮）`（全角括號）→ 已正確轉成 `李白(青蓮)`
- `李白 (青蓮)`（半角括號帶空白）→ **未處理**，空白保留為 `李白 (青蓮)`

`NameSearchIndexService::normalizeName()` 建索引時只移除括號符號、不移除空白，
因此帶空白的輸入會被索引成 `李白 青蓮`（殘留空白），使用者搜尋 `李白青蓮` 無法命中。
這正是 `BracketNormalizer` 設計註解所要避免的搜尋索引破壞情形。

舊版（原 CBDB 桌面程式）對此類輸入會標準化為半角、無鄰接空白的形式；
本 PR 補齊此行為。

## 修改

- **`BracketNormalizer::normalizeChineseField()`**：全角轉半角後，移除半角括號前後鄰接的空白（含全形／不斷行空白，`[\s\p{Zs}]`）。寫入端正規化，涵蓋 BIOG_MAIN 與 ALTNAME 的直接／提案四條路徑。
- **`NameSearchIndexService::normalizeName()`**：去括號符號同時移除所有空白，作為索引端最終保障（涵蓋既有資料重建與非括號鄰接的內部空白）。
- **`RebuildNameSearchIndex::normalizeName()`**：同步相同規則，避免全量重建覆蓋增量流程（Observer）已修正的無空白索引；兩份索引端實作行為一致。
- **測試**：單元／功能回歸，涵蓋帶空白括號、全形／不斷行空白、別名 `indexAltname` 路徑，並驗證搜尋索引不殘留空白。

`MergePreviewController::normalizeName()` 為合併比對用的大小寫正規化助手，與搜尋索引無關，維持不動。

## 驗證

- 影響範圍測試全綠：`BracketNormalizer` / `NameSearchIndexAutoSync` / `RebuildNameSearchIndex` / `BiogMainNameSearch` / `BasicInformationAltnames`（86 tests, 259 assertions）
- `php-cs-fixer` clean
- 已通過多輪 review agent 與 codex 審查，無 CRITICAL/HIGH issue

## 備註（既有、非本 PR 範圍）

查詢端（`LIKE` 比對）目前不對使用者輸入做同樣的去空白／去括號正規化，
故使用者若「自行」鍵入內部空白或括號（如 `李白 青蓮`、`李白(青蓮)`）仍可能漏查。
本 PR 不改變此既有行為，可另案處理查詢端對稱化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)