### PR TITLE
修正人物編輯頁標題儲存後未更新（切分頁再切回仍是舊名）

### DIFF
--- a/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
@@ -190,9 +190,26 @@ export default function PersonEditor() {
         pendingNavigationRef.current = null;
     }, []);
 
+    // 標題（h1）改以 summary 為準：summary 於基本資料儲存後會重新抓取（handleBasicInfoSaved 觸發 summaryRefreshKey），
+    // 故改名存檔後標題即時更新，不再停留在頁面初載的舊 person_label（切分頁再切回仍是舊值、須整頁重載才更新的問題）。
+    // summary 未載入（初載中／載入失敗）時退回伺服器提供的 person_label。
+    // 格式須與後端 buildPersonViewProps 的 person_label 一致：「{id} · {中文名} ({拼音}) · {朝代}」。
+    const displayLabel = (() => {
+        if (!summary) return person_label;
+        let label = String(summary.c_personid ?? personId);
+        const nameChn = summary.c_name_chn ?? '';
+        const name = summary.c_name ?? '';
+        if (nameChn || name) {
+            label += ' · ' + nameChn;
+            if (name) label += ' (' + name + ')';
+        }
+        if (summary.dynasty_chn) label += ' · ' + summary.dynasty_chn;
+        return label;
+    })();
+
     return (
         <DashboardLayout
-            title={person_label}
+            title={displayLabel}
             headerAlign="center"
             breadcrumbs={[
                 // 首段「人物記錄」連到「這個人的基本資料」（詳情中樞，預設 basic_info 分頁），


### PR DESCRIPTION
## 問題（Playwright 已重現）
承 PR #1113（修正儲存後切分頁再切回顯示舊「欄位內容」）——**標題 h1** 仍有殘留舊資訊的情況。

`/app/basicinformation/{id}/edit` 的標題 `person_label`（格式「{id} · 中文名 (拼音) · 朝代」，如 `123508 · 某氏 (盱眙女郎) (Mou Shi (Xuyinülang)) · 清`）是**頁面初載時**由伺服器算好的 Inertia prop。改名並儲存（前端走 `/api/v2/mutate`，不整頁重載）後，標題不更新；切分頁再切回仍是舊名，**須整頁重載才更新**。

實測（person 118873「趙女」）：改名為「趙女測」存檔 → 標題仍「趙女」→ 切分頁再切回仍「趙女」→ 整頁重載才變「趙女測」。

## 修法
標題改由 **summary 推導**（`resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx`）：
- `summary` 於基本資料存檔後會重新抓取（`handleBasicInfoSaved` 觸發 `summaryRefreshKey`，useEffect 重抓），因此改名後標題即時更新。
- 以 `summary` 的 `c_personid / c_name_chn / c_name / dynasty_chn` 組出標題，格式與後端 `buildPersonViewProps` 的 `person_label` **逐欄一致**（同樣來自 BIOG_MAIN + DYNASTIES join）。
- `summary` 未載入（初載中／載入失敗）時退回伺服器 `person_label`；初載時兩者一致，無閃動。
- **不額外增加請求**（summary 本就於存檔後重抓）。

## 驗證
- Playwright（本機真實登入編輯權限帳號，改動後即以 DB 還原 person 118873）：改名存檔後標題由「趙女」即時更新為「趙女測」（免重載），切分頁維持更新。
- `npm run build` 通過。
- 經 review agent 與 codex 兩輪審查，皆無嚴重問題（格式逐欄比對一致、無初載閃動、fallback 正確、僅影響本頁）。

## 影響面
- 僅改 `PersonEditor.tsx` 一個檔案。唯讀詳情頁 `Show.tsx` 無頁內存檔、標題不會過期，無需處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)