### PR TITLE
fix(sidebar): React 側邊欄修正僅以 query 區分的選單項同時高亮（#1109）

### DIFF
--- a/resources/js/inertia/components/shell/Sidebar.tsx
+++ b/resources/js/inertia/components/shell/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { usePage } from '@inertiajs/react';
 import type { NavNode, SharedProps } from '../../types/page';
-import SidebarNode from './SidebarNode';
+import SidebarNode, { buildActiveContext } from './SidebarNode';
 
 interface SidebarProps {
     collapsed: boolean;
@@ -16,7 +16,8 @@ export default function Sidebar({ collapsed }: SidebarProps) {
     const nav: NavNode[] = page.props.nav ?? [];
     // 與舊 Blade 側邊欄（sidebar-v3）一致：讀 config('app.name')，未設定時回退 'CBDB'。
     const appName = page.props.app?.name ?? 'CBDB';
-    const currentPath = (page.url.split('?')[0] || '/').replace(/\/$/, '') || '/';
+    // active 比對上下文：路徑 + 顯著 query 簽章（讓僅以 query 區分的同路徑選單項不再同時高亮，#1109）。
+    const ctx = buildActiveContext(nav, page.url);
 
     return (
         <aside
@@ -34,7 +35,7 @@ export default function Sidebar({ collapsed }: SidebarProps) {
             <nav className="sidebar-scroll flex-1 overflow-y-auto px-2 py-3">
                 <ul className="space-y-1">
                     {nav.map((node) => (
-                        <SidebarNode key={node.key} node={node} currentPath={currentPath} />
+                        <SidebarNode key={node.key} node={node} ctx={ctx} />
                     ))}
                 </ul>
             </nav>

--- a/resources/js/inertia/components/shell/SidebarNode.tsx
+++ b/resources/js/inertia/components/shell/SidebarNode.tsx
@@ -2,6 +2,14 @@ import React, { useEffect, useState } from 'react';
 import type { NavNode } from '../../types/page';
 import { cn } from '../../lib/utils';
 
+/** active 比對上下文：目前路徑、目前 URL 的「顯著 query 簽章」、以及此路徑上有意義的 query key。 */
+export interface ActiveContext {
+    currentPath: string;
+    currentSig: string;
+    /** 僅「與 currentPath 同路徑的選單項」所使用的 query key；用於區分同路徑但不同 query 的選單項。 */
+    sigKeys: string[];
+}
+
 /** 取 href 的 pathname（去掉 origin 與 query），用於 active 比對。 */
 function pathOf(href: string | null): string | null {
     if (!href || href === '#') {
@@ -15,53 +23,144 @@ function pathOf(href: string | null): string | null {
     }
 }
 
+/** 取 href 的 query 字串（不含開頭的 '?'）。 */
+function searchOf(href: string | null): string {
+    if (!href || href === '#') {
+        return '';
+    }
+    try {
+        return new URL(href, window.location.origin).search.replace(/^\?/, '');
+    } catch {
+        const i = href.indexOf('?');
+        return i >= 0 ? href.slice(i + 1) : '';
+    }
+}
+
 function normalize(path: string): string {
     return path.replace(/\/$/, '') || '/';
 }
 
 /**
- * 節點自身是否對應目前路徑。葉節點採精確比對（避免 /codes 在 /codes/X 上誤亮）。
+ * 只保留指定的 query key，組成可比對的正規化簽章（key 排序後 key=value 串接）。
  *
- * 註：React 端以 href 路徑判定 active（後端 nav 的 active.patterns 為 route 名稱
- * glob，僅供 Blade 以 request()->routeIs() 使用；React 無 route 名稱對照表，故改用
- * href 路徑比對，見遷移計畫附錄 D 決策記錄）。
+ * 忽略分頁／篩選等未列入 keys 的參數（如 page、editor、op_type），避免細項頁改變
+ * 分頁時 active 消失；同時讓「僅以 query 區分的同路徑選單項」（如 /app/operations 與
+ * /app/operations?proposals_only=1）各自精確命中，不再同時高亮（#1109）。
  */
-function isSelfActive(node: NavNode, currentPath: string): boolean {
-    const p = pathOf(node.href);
-    return p !== null && p === currentPath;
+function querySignature(search: string, keys: string[]): string {
+    if (keys.length === 0) {
+        return '';
+    }
+    const params = new URLSearchParams(search);
+    const parts: string[] = [];
+    for (const key of [...keys].sort()) {
+        if (params.has(key)) {
+            parts.push(key + '=' + (params.get(key) ?? ''));
+        }
+    }
+    return parts.join('&');
 }
 
-/** 父節點是否落在目前路徑的祖先（href 為 currentPath 的前綴段）。 */
-function isAncestorOf(node: NavNode, currentPath: string): boolean {
+/**
+ * 蒐集「與 currentPath 同路徑」的選單項所使用的 query key。
+ *
+ * 只取同路徑的 key（而非整棵樹），避免把某頁的 query key 變成所有路徑的 active
+ * 比對條件——否則未來別的選單項引入同名參數，可能讓不相關的頁面在帶上該參數時反而不高亮。
+ *
+ * 設計前提：active 比對本以「pathname + 顯著 query」進行，因此「共用同一 pathname 的選單項」
+ * 天生就是同一個需要以 query 區分的群組（目前僅 operations / proposals 這組）；各項只會用
+ * 自己宣告的 key 產生簽章，故同路徑多項可各自精確命中。跨區段若未來共用同一 pathname，
+ * 仍屬同一群組、行為一致。
+ */
+function collectQueryKeysForPath(nodes: NavNode[], currentPath: string): string[] {
+    const acc = new Set<string>();
+    const walk = (list: NavNode[]) => {
+        for (const node of list) {
+            if (pathOf(node.href) === currentPath) {
+                const s = searchOf(node.href);
+                if (s) {
+                    new URLSearchParams(s).forEach((_value, key) => acc.add(key));
+                }
+            }
+            if (node.children.length) {
+                walk(node.children);
+            }
+        }
+    };
+    walk(nodes);
+
+    return [...acc];
+}
+
+/** 依目前 page.url 與 nav 樹建立 active 比對上下文。 */
+export function buildActiveContext(nav: NavNode[], pageUrl: string): ActiveContext {
+    let currentPath: string;
+    let currentSearch: string;
+    try {
+        // page.url 通常為相對路徑（含 query），以目前 origin 解析可穩健處理 fragment / 編碼。
+        const u = new URL(pageUrl, window.location.origin);
+        currentPath = normalize(u.pathname);
+        currentSearch = u.search.replace(/^\?/, '');
+    } catch {
+        const [pathPart, searchPart = ''] = pageUrl.split('?');
+        currentPath = normalize(pathPart || '/');
+        currentSearch = searchPart;
+    }
+
+    const sigKeys = collectQueryKeysForPath(nav, currentPath);
+    const currentSig = querySignature(currentSearch, sigKeys);
+
+    return { currentPath, currentSig, sigKeys };
+}
+
+/**
+ * 節點自身是否對應目前路徑。葉節點採精確比對（避免 /codes 在 /codes/X 上誤亮），
+ * 並比對「顯著 query 簽章」，讓僅以 query 區分的同路徑選單項各自精確命中（#1109）。
+ *
+ * 註：React 端以 href 路徑 + 顯著 query 判定 active（後端 nav 的 active.patterns 為
+ * route 名稱 glob，僅供 Blade 以 request()->routeIs() 使用；React 無 route 名稱對照表，
+ * 見遷移計畫附錄 D 決策記錄）。
+ */
+function isSelfActive(node: NavNode, ctx: ActiveContext): boolean {
     const p = pathOf(node.href);
-    return p !== null && p !== '/' && (currentPath === p || currentPath.startsWith(p + '/'));
+    if (p === null || p !== ctx.currentPath) {
+        return false;
+    }
+
+    return querySignature(searchOf(node.href), ctx.sigKeys) === ctx.currentSig;
+}
+
+/** 父節點是否落在目前路徑的祖先（href 為 currentPath 的前綴段；query 不影響祖先判定）。 */
+function isAncestorOf(node: NavNode, ctx: ActiveContext): boolean {
+    const p = pathOf(node.href);
+    return p !== null && p !== '/' && (ctx.currentPath === p || ctx.currentPath.startsWith(p + '/'));
 }
 
 /**
  * 節點是否應高亮 / 父節點是否應展開：自身精確命中，或任一子孫命中，
  * 或（針對有子節點的區段）目前路徑落在其 href 之下（細項頁高亮其區段）。
  */
-export function isBranchActive(node: NavNode, currentPath: string): boolean {
-    if (isSelfActive(node, currentPath)) {
+export function isBranchActive(node: NavNode, ctx: ActiveContext): boolean {
+    if (isSelfActive(node, ctx)) {
         return true;
     }
-    if (node.children.length > 0 && isAncestorOf(node, currentPath)) {
+    if (node.children.length > 0 && isAncestorOf(node, ctx)) {
         return true;
     }
-    return node.children.some((child) => isBranchActive(child, currentPath));
+    return node.children.some((child) => isBranchActive(child, ctx));
 }
 
 interface SidebarNodeProps {
     node: NavNode;
-    currentPath: string;
+    ctx: ActiveContext;
     depth?: number;
 }
 
-export default function SidebarNode({ node, currentPath, depth = 0 }: SidebarNodeProps) {
+export default function SidebarNode({ node, ctx, depth = 0 }: SidebarNodeProps) {
     // label/badge.label 已由後端 Navigation 解析為當前語系字串，直接顯示。
     const hasChildren = node.children.length > 0;
-    const branchActive = isBranchActive(node, currentPath);
-    const selfActive = isSelfActive(node, currentPath);
+    const branchActive = isBranchActive(node, ctx);
+    const selfActive = isSelfActive(node, ctx);
     const [open, setOpen] = useState<boolean>(branchActive);
 
     // 導覽後若此分支變為 active 但仍收合（持久化 layout 不會 remount），自動展開。
@@ -124,7 +223,7 @@ export default function SidebarNode({ node, currentPath, depth = 0 }: SidebarNod
                             <SidebarNode
                                 key={child.key}
                                 node={child}
-                                currentPath={currentPath}
+                                ctx={ctx}
                                 depth={depth + 1}
                             />
                         ))}


### PR DESCRIPTION
Closes #1109

## 問題

新版（React/Inertia）側邊欄有時會同時高亮兩個選單項。實測可穩定重現：
「最近操作記錄」（`/app/operations`）與「最近提案列表」（`/app/operations?proposals_only=1`）兩項會同時亮起。

## 根因

兩個葉節點只差在 query 參數 `proposals_only`。原本 active 比對（`SidebarNode.tsx`）
會把 query 去掉、只比 pathname，兩者都命中 `/app/operations`，於是 `isSelfActive`
對兩項都回傳 true，導致同時高亮。兩個 URL 也都渲染同一個 Inertia 元件
（`Admin/Operations/Index`），故無法靠 `page.component` 區分——唯一區別就是 query。

## 修改（僅 React，前端）

改為 **query-aware，但只針對「與目前 pathname 相同的選單項」實際使用的 query key**
（此處為 `proposals_only`）建立正規化簽章比對：

- `SidebarNode.tsx`：新增 `searchOf()`、`querySignature()`、`collectQueryKeysForPath()`、
  `buildActiveContext()`；`isSelfActive` 改以「pathname 相同且顯著 query 簽章相符」判定；
  `isAncestorOf`／`isBranchActive` 改吃 `ActiveContext`（祖先／父節點維持 path-only，
  不受 query 影響）。
- `Sidebar.tsx`：以 `buildActiveContext(nav, page.url)` 預先計算一次上下文再往下傳。

分頁／篩選等未被選單區分的參數（`page`、`editor`、`op_type`…）一律忽略，
避免細項頁改變分頁時 active 消失。significant query key 只取「同 pathname 群組」，
不是整棵樹，避免某頁的 query key 汙染其他路徑的比對。

## 驗證（Playwright，實登入實測）

| URL | 高亮項 |
|---|---|
| `/app/operations` | 只有「最近操作記錄」 |
| `/app/operations?proposals_only=1` | 只有「最近提案列表」 |
| `/app/operations?proposals_only=1&page=2` | 只有「最近提案列表」（分頁參數忽略） |
| `/app/operations?page=2` | 只有「最近操作記錄」 |
| `/app/dashboard` | 只有「系統總覽」 |
| `/app/basicinformation` | 只有「人物編輯」 |
| `/app/codes` | 「全部表格」+「全部表格首頁」（父子同亮，既有行為不變） |

其他：`npm run build` 通過；`tsc` 對本次兩檔無型別錯誤；`NavigationSchemaTest` 10/10 綠；
無 PHP 變更（php-cs-fixer 無需修正）。

備註：Blade 舊側邊欄以 `page_title`（`NewUpdate`／`OperationsProposals`）區分，
本就無此問題，且為 flag-gated 舊版，故不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)