### PR TITLE
fix(font): 從 Vite 中移除 Noto Sans TC 字型；改由 Google Fonts 加載

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "cbdb-online-main-server",
       "dependencies": {
-        "@fontsource/noto-sans-tc": "^5.2.9",
         "@inertiajs/react": "^2.3.18",
         "@radix-ui/react-dialog": "^1.1.17",
         "@radix-ui/react-label": "^2.1.10",
@@ -178,15 +177,6 @@
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT"
-    },
-    "node_modules/@fontsource/noto-sans-tc": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-tc/-/noto-sans-tc-5.2.9.tgz",
-      "integrity": "sha512-Z+pXTvXYrip79lPV9X1lCYO3UTys55P25VqcifDStIzdZ86I4R6t8dz+NhGd09YdbvHWvOCB5Icw1m7glKHPNQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
     },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@fontsource/noto-sans-tc": "^5.2.9",
     "@inertiajs/react": "^2.3.18",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-label": "^2.1.10",

--- a/public/cbdbapi/index.html
+++ b/public/cbdbapi/index.html
@@ -9,7 +9,7 @@
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=fallback" rel="stylesheet">
 
     <style>
         * {

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -230,7 +230,7 @@
     --radius-md: var(--radius);
     --radius-lg: calc(var(--radius) + 2px);
 
-    /* 字體：沿用主站 Source Sans Pro / Noto Sans TC（見近期 commit） */
+    /* 字體：Source Sans Pro / Noto Sans TC 由模板走 Google Fonts 載入，不進 Vite bundle。 */
     --font-sans: 'Source Sans Pro', 'Noto Sans TC', -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,11 +8,6 @@
 // Import AdminLTE v3 CSS from NPM
 import 'admin-lte/dist/css/adminlte.min.css';
 
-// Self-hosted Noto Sans TC (weights matching Source Sans Pro) — no Google CDN dependency
-import '@fontsource/noto-sans-tc/300.css';
-import '@fontsource/noto-sans-tc/400.css';
-import '@fontsource/noto-sans-tc/700.css';
-
 // Import jQuery and expose globally before any plugins run
 import $ from './jquery-global';
 

--- a/resources/js/inertia/app.tsx
+++ b/resources/js/inertia/app.tsx
@@ -2,12 +2,8 @@ import { createInertiaApp } from '@inertiajs/react';
 import { createRoot } from 'react-dom/client';
 // Tailwind v4 + 設計 token（僅此 inertia bundle 載入，不影響 Blade/AdminLTE）
 import '../../css/inertia.css';
-// 字體與主站對齊：Noto Sans TC 自托管（@fontsource，與 app.js 一致），修正 zh-TW 偏細；
-// Source Sans Pro 由 inertia.blade.php 的 Google Font link 載入（與 dashboard-v3 同法）。
-// 先前 /app 只在 inertia.css 宣告字體名卻未載入字體，導致中文掉回系統 CJK（偏細）。
-import '@fontsource/noto-sans-tc/300.css';
-import '@fontsource/noto-sans-tc/400.css';
-import '@fontsource/noto-sans-tc/700.css';
+// Source Sans Pro / Noto Sans TC 由 inertia.blade.php 的 Google Fonts link 載入（與 dashboard-v3 同法）；
+// 不再由 @fontsource 進入 Vite bundle，避免每次 build 產生大量 hashed Noto webfont。
 import { installNumberInputWheelGuard } from '../utils/disableNumberInputWheel';
 
 installNumberInputWheelGuard();

--- a/resources/views/cbdbapi/person.blade.php
+++ b/resources/views/cbdbapi/person.blade.php
@@ -9,7 +9,7 @@
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=fallback" rel="stylesheet">
 
     <style>
         * {

--- a/resources/views/inertia.blade.php
+++ b/resources/views/inertia.blade.php
@@ -4,8 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    {{-- Google Font: Source Sans Pro（與主站 dashboard-v3 對齊；Noto Sans TC 由 inertia bundle 自托管） --}}
+    {{-- Google Fonts: Source Sans Pro + Noto Sans TC（與主站 dashboard-v3 對齊；CJK 不進 Vite bundle） --}}
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;700&display=fallback">
     <title>{{ config('app.name', 'CBDB') }}</title>
     <style>
         html, body {

--- a/resources/views/layouts/dashboard-v3.blade.php
+++ b/resources/views/layouts/dashboard-v3.blade.php
@@ -12,8 +12,9 @@
     <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-    <!-- Google Font: Source Sans Pro -->
+    <!-- Google Fonts: Source Sans Pro + Noto Sans TC（CJK 走 Google Fonts，不進 Vite bundle） -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;700&display=fallback">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <!-- Ionicons -->


### PR DESCRIPTION
移除 @fontsource/noto-sans-tc 依賴，以及 app.js / Inertia app.tsx 中的 300、400、700 weight CSS import。這批字型原本由 Vite 打包成大量 hashed woff/woff2，導致每次 release 都產生新的字型檔名稱與 manifest 資產列表。

此舉並非移除 CJK webfont：主站與 Inertia 模板仍透過 Google Fonts 載入 Noto Sans TC，CSS 字體棧也保留 Source Sans Pro + Noto Sans TC。CBDB API 頁面同樣保留 Google Fonts 的 Noto Sans TC 載入。

頁面不會因為移除 @fontsource 而無法載入：Noto Sans TC 仍由 Google Fonts 提供；若外部字型未載入，瀏覽器仍會回退到系統 sans 字型。npm run build 已確認通過，Vite 產物中不再出現 noto-sans-tc-* hashed 字型資產。

此改動會大幅減少編譯產物體積，並減少訪問 CBDB 站的網路帶寬。