### PR TITLE
修正 React 編輯器輸入框缺少 name/id 導致瀏覽器自動完成記憶失效

### DIFF
--- a/resources/js/inertia/components/AddressEditor.tsx
+++ b/resources/js/inertia/components/AddressEditor.tsx
@@ -188,12 +188,12 @@ export default function AddressEditor({
 
     const numRow = (key: string, label: string, code?: string, required = false, maxLength?: number) => (
         gridCell(label, { code, required }, (
-            <input type="number" value={fields[key] ?? ''} disabled={!editable} required={required} maxLength={maxLength}
+            <input type="number" name={key} id={key} value={fields[key] ?? ''} disabled={!editable} required={required} maxLength={maxLength}
                 onChange={(e) => set(key, e.target.value)} style={{ ...gInputStyle, ...(!editable ? gReadonlyStyle : {}) }} />
         ))
     );
     const textRow = (key: string, label: string, code?: string, highlight = false) => (
-        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
     return (
@@ -229,7 +229,7 @@ export default function AddressEditor({
                         onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
                 {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {gridCell(tr('maiden_addr', '祖籍'), { code: 'c_natal' },
                     <select value={fields.c_natal ?? ''} onChange={(e) => set('c_natal', e.target.value)} disabled={!editable} style={gInputStyle}>
@@ -256,7 +256,7 @@ export default function AddressEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -166,7 +166,7 @@ export default function AltnameEditor({
     };
 
     const textRow = (key: string, label: string, code?: string, type = 'text', highlight = false, required = false) => (
-        gridCell(label, { code, required }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), type, disabled: !editable, highlight }))
+        gridCell(label, { code, required }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), type, disabled: !editable, highlight, name: key }))
     );
 
     return (
@@ -194,7 +194,7 @@ export default function AltnameEditor({
                     {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', 'text', sourceHighlight)}
                 </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -214,7 +214,7 @@ export default function AltnameEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -431,7 +431,7 @@ export default function AssocEditor({
     };
 
     const textRow = (key: string, label: string, code: string, highlight = false, hint?: string) => (
-        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
     const searchRow = (key: string, label: string, code: string, endpoint: string, highlight = false, sentinel = '0', required = false, sentinelLabel?: string, extraQuery?: Record<string, string>) => (
         gridCell(label, { code, required },
@@ -563,12 +563,12 @@ export default function AssocEditor({
                 <div style={gGrid}>
                     {/* 作品標題自成一行（與「出處＋頁碼」非同類）；出處與頁碼成對同行（#121） */}
                     {gridCell(tr('text_title_field', '作品標題'), { code: 'c_text_title', full: true },
-                        gridInput({ value: fields.c_text_title ?? '', onChange: (v) => set('c_text_title', v), disabled: !editable }))}
+                        gridInput({ value: fields.c_text_title ?? '', onChange: (v) => set('c_text_title', v), disabled: !editable, name: 'c_text_title' }))}
                     {gridCell(tr('source_field', '出處'), { code: 'c_source' },
                         <CodeAutocomplete mode="search" endpoint="/api/select/search/text" value={fields.c_source ?? '0'} initialLabel={labels.c_source ?? ''} disabled={!editable} onChange={(v, l) => { set('c_source', v || '0'); setLabel('c_source', l); }} />)}
                     {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
                     {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                        <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                        <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
                 </div>
                 <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
             </GridSection>
@@ -588,7 +588,7 @@ export default function AssocEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }} placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }} placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}
 

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -332,7 +332,7 @@ export default function BasicInfoEditor({
     const gText = (key: string, label: string, code?: string, opts: { readonly?: boolean; hint?: string; full?: boolean; required?: boolean } = {}) => (
         <div style={opts.full ? gFull : undefined}>
             {fLabel(label, code, opts.required)}
-            <input type="text" value={fields[key] ?? ''} readOnly={opts.readonly} disabled={opts.readonly}
+            <input type="text" name={key} id={key} value={fields[key] ?? ''} readOnly={opts.readonly} disabled={opts.readonly}
                 onChange={(e) => set(key, e.target.value)}
                 style={{ ...gInputStyle, ...(opts.readonly ? gReadonlyStyle : {}) }} />
             {opts.hint ? <span style={gHintStyle}>{opts.hint}</span> : null}
@@ -490,7 +490,7 @@ export default function BasicInfoEditor({
             {block(tr('block_notes', '備註'), (
                 <div style={gGrid}>
                     <div style={gFull}>{fLabel(tr('notes_field', '備註'), 'c_notes')}
-                        <textarea value={fields.c_notes ?? ''} disabled={!canEdit && !canPropose} rows={5}
+                        <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!canEdit && !canPropose} rows={5}
                             onChange={(e) => set('c_notes', e.target.value)} style={{ ...gInputStyle, height: 'auto' }} /></div>
                 </div>
             ))}
@@ -499,7 +499,7 @@ export default function BasicInfoEditor({
             {(canEdit || canPropose) ? (
                 <div style={{ marginBottom: 16 }}>
                     {fLabel(tr('modification_note_label', '修改說明'))}
-                    <textarea value={comment} rows={3} onChange={(e) => setComment(e.target.value)}
+                    <textarea name="modification_note" id="modification_note" value={comment} rows={3} onChange={(e) => setComment(e.target.value)}
                         placeholder={tr('modification_note_placeholder', '請說明修改原因')} style={{ ...gInputStyle, height: 'auto' }} />
                     <span style={gHintStyle}>{tr('modification_note_hint', '此說明將記錄於操作歷史中（提交建議時附帶）')}</span>
                 </div>

--- a/resources/js/inertia/components/EntryEditor.tsx
+++ b/resources/js/inertia/components/EntryEditor.tsx
@@ -218,7 +218,7 @@ export default function EntryEditor({
     };
 
     const textRow = (key: string, label: string, code?: string, highlight = false, hint?: string) => (
-        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
     return (
@@ -235,7 +235,7 @@ export default function EntryEditor({
 
                 {/* 次序非重點，置於入仕途徑右側（#102）；label 用「次序」而非地址用語「遷徙次序」 */}
                 {gridCell(tr('sequence', '次序'), { code: 'c_sequence', required: mode === 'create' },
-                    <input type="number" value={fields.c_sequence ?? ''} disabled={!editable} required maxLength={4}
+                    <input type="number" name="c_sequence" id="c_sequence" value={fields.c_sequence ?? ''} disabled={!editable} required maxLength={4}
                         onChange={(e) => set('c_sequence', e.target.value)} style={{ ...gInputStyle, ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {gridCell(tr('entry_year_field', '入仕年'), { code: 'c_year', full: true },
@@ -293,7 +293,7 @@ export default function EntryEditor({
                     {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
                 </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -313,7 +313,7 @@ export default function EntryEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/EventEditor.tsx
+++ b/resources/js/inertia/components/EventEditor.tsx
@@ -211,7 +211,7 @@ export default function EventEditor({
     };
 
     const textRow = (key: string, label: string, code: string, highlight = false) => (
-        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
     return (
@@ -261,10 +261,10 @@ export default function EventEditor({
                 {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
 
                 {gridCell(tr('major_event', '重大事件'), { code: 'c_event', full: true },
-                    <textarea value={fields.c_event ?? ''} disabled={!editable} onChange={(e) => set('c_event', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_event" id="c_event" value={fields.c_event ?? ''} disabled={!editable} onChange={(e) => set('c_event', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -284,7 +284,7 @@ export default function EventEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/KinEditor.tsx
+++ b/resources/js/inertia/components/KinEditor.tsx
@@ -323,13 +323,13 @@ export default function KinEditor({
                     <CodeAutocomplete mode="search" endpoint="/api/select/search/text" value={fields.c_source ?? '0'} initialLabel={labels.c_source ?? ''} disabled={!editable} onChange={(v, l) => { set('c_source', v || '0'); setLabel('c_source', l); }} />)}
 
                 {gridCell(tr('pages_entries', '頁碼'), { code: 'c_pages' },
-                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight }))}
+                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight, name: 'c_pages' }))}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {gridCell('c_autogen_notes', { full: true },
-                    <textarea value={fields.c_autogen_notes ?? ''} disabled={!editable} onChange={(e) => set('c_autogen_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_autogen_notes" id="c_autogen_notes" value={fields.c_autogen_notes ?? ''} disabled={!editable} onChange={(e) => set('c_autogen_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -349,7 +349,7 @@ export default function KinEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }} placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }} placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}
 

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -288,7 +288,7 @@ export default function OfficeEditor({
     };
 
     const textRow = (key: string, label: string, code: string, highlight = false, hint?: string) => (
-        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
     const listRow = (key: string, label: string, code: string, model: string, idKey: string, labelKeys: string[]) => (
         gridCell(label, { code },
@@ -359,7 +359,7 @@ export default function OfficeEditor({
                 {listRow('c_dy', tr('dynasty', '朝代'), 'dy', 'dynasty', 'c_dy', ['c_dynasty_chn', 'c_dynasty'])}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {/* 出處 / 頁碼（與下方「候選出處與頁數」對應）（#101） */}
                 {gridCell(tr('source_field', '出處'), { code: 'c_source' },
@@ -387,7 +387,7 @@ export default function OfficeEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -810,6 +810,8 @@ function renderInputControl(
     if (field.input === 'textarea') {
         return (
             <textarea
+                name={field.key}
+                id={field.key}
                 value={value}
                 style={{
                     ...textareaStyle,
@@ -840,6 +842,8 @@ function renderInputControl(
             }}>
                 <input
                     type="checkbox"
+                    name={field.key}
+                    id={field.key}
                     checked={value === '1'}
                     style={checkboxInputStyle}
                     onChange={(event) => onChange(field.key, event.target.checked ? '1' : '0')}
@@ -852,6 +856,8 @@ function renderInputControl(
     return (
         <input
             type={field.input === 'number' ? 'number' : 'text'}
+            name={field.key}
+            id={field.key}
             value={value}
             style={{
                 ...inputStyle,

--- a/resources/js/inertia/components/PersonEditorShared/grid.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/grid.tsx
@@ -85,6 +85,9 @@ export interface GridInputOpts {
     highlight?: boolean;
     placeholder?: string;
     maxLength?: number;
+    /** 欄位技術碼（如 c_pages）。傳入後同時設為 input 的 name/id，讓瀏覽器原生表單記憶
+     * （點擊即彈出曾手動輸入過的值）能以此為 key 生效；不傳則維持匿名 input（如僅供單次輸入的欄位）。 */
+    name?: string;
 }
 
 /** 純文字/數字輸入（取代各編輯器的 textRow/numRow 內層 input）。value/onChange 由呼叫端綁定其 fields/set。 */
@@ -92,6 +95,8 @@ export function gridInput(o: GridInputOpts): React.ReactElement {
     return (
         <input
             type={o.type ?? 'text'}
+            name={o.name}
+            id={o.name}
             value={o.value}
             disabled={o.disabled || o.readonly}
             readOnly={o.readonly}

--- a/resources/js/inertia/components/PossessionEditor.tsx
+++ b/resources/js/inertia/components/PossessionEditor.tsx
@@ -186,7 +186,7 @@ export default function PossessionEditor({
     };
 
     const textRow = (key: string, label: string, code?: string) => (
-        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable }))
+        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, name: key }))
     );
 
     return (
@@ -209,7 +209,7 @@ export default function PossessionEditor({
 
                 {gridCell(tr('quantity', '數量'), { code: 'c_quantity', full: true },
                     <div style={{ display: 'flex', gap: 8 }}>
-                        <input type="text" value={fields.c_quantity ?? ''} disabled={!editable} onChange={(e) => set('c_quantity', e.target.value)} style={{ ...gInputStyle, width: 100, ...(!editable ? gReadonlyStyle : {}) }} />
+                        <input type="text" name="c_quantity" id="c_quantity" value={fields.c_quantity ?? ''} disabled={!editable} onChange={(e) => set('c_quantity', e.target.value)} style={{ ...gInputStyle, width: 100, ...(!editable ? gReadonlyStyle : {}) }} />
                         <div style={{ flex: 1, minWidth: 0 }}>
                             <CodeAutocomplete mode="list" model="measure" idKey="c_measure_code" labelKeys={['c_measure_desc_chn', 'c_measure_desc']}
                                 value={fields.c_measure_code ?? ''} initialLabel={labels.c_measure_code ?? ''} disabled={!editable} placeholder={tr('unit', '單位')}
@@ -245,10 +245,10 @@ export default function PossessionEditor({
                         onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
 
                 {gridCell(tr('pages_entries', '頁碼'), {},
-                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight }))}
+                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight, name: 'c_pages' }))}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -268,7 +268,7 @@ export default function PossessionEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/SocialInstEditor.tsx
+++ b/resources/js/inertia/components/SocialInstEditor.tsx
@@ -228,10 +228,10 @@ export default function SocialInstEditor({
                         onChange={(v, l) => { set('c_source', v); setLabel('c_source', l); }} />)}
 
                 {gridCell(tr('pages_entries', '頁碼'), {},
-                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight }))}
+                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, highlight: sourceHighlight, name: 'c_pages' }))}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -251,7 +251,7 @@ export default function SocialInstEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/SourceEditor.tsx
+++ b/resources/js/inertia/components/SourceEditor.tsx
@@ -208,7 +208,7 @@ export default function SourceEditor({
                         onChange={(v, l) => { set('c_textid', v); setLabel('c_textid', l); }} />)}
 
                 {gridCell(tr('pages_entries', '頁數/條目'), { code: 'c_pages' },
-                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable }))}
+                    gridInput({ value: fields.c_pages ?? '', onChange: (v) => set('c_pages', v), disabled: !editable, name: 'c_pages' }))}
 
                 {gridCell(tr('options', '選項'), { full: true },
                     <>
@@ -225,7 +225,7 @@ export default function SourceEditor({
                     </>)}
 
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={5}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={5}
                         style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
@@ -244,7 +244,7 @@ export default function SourceEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/StatusEditor.tsx
+++ b/resources/js/inertia/components/StatusEditor.tsx
@@ -218,7 +218,7 @@ export default function StatusEditor({
     };
 
     const textRow = (key: string, label: string, code?: string, highlight = false, placeholder?: string) => (
-        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, placeholder }))
+        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, placeholder, name: key }))
     );
 
     return (
@@ -250,7 +250,7 @@ export default function StatusEditor({
 
                 {/* 次序非重點，置於社會區分右側（#103） */}
                 {gridCell(tr('sequence', '次序'), { code: 'c_sequence', required: true },
-                    <input type="number" value={fields.c_sequence ?? ''} disabled={!editable} required maxLength={4}
+                    <input type="number" name="c_sequence" id="c_sequence" value={fields.c_sequence ?? ''} disabled={!editable} required maxLength={4}
                         onChange={(e) => set('c_sequence', e.target.value)} style={{ ...gInputStyle, ...(!editable ? gReadonlyStyle : {}) }} />)}
 
                 {textRow('c_supplement', tr('supplement_text', '補充說明'), 'c_supplement', false, tr('supplement_placeholder', ''))}
@@ -268,7 +268,7 @@ export default function StatusEditor({
                         onChange={(v, l) => { set('c_source', v || '0'); setLabel('c_source', l); }} />)}
                 {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -288,7 +288,7 @@ export default function StatusEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}

--- a/resources/js/inertia/components/TextEditor.tsx
+++ b/resources/js/inertia/components/TextEditor.tsx
@@ -158,7 +158,7 @@ export default function TextEditor({
     };
 
     const textRow = (key: string, label: string, code?: string, highlight = false) => (
-        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight }))
+        gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
     return (
@@ -188,7 +188,7 @@ export default function TextEditor({
                     {textRow('c_pages', tr('pages_entries', '頁碼'), 'c_pages', sourceHighlight)}
                 </div>
                 {gridCell(tr('notes_field', '備註'), { code: 'c_notes', full: true },
-                    <textarea value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
+                    <textarea name="c_notes" id="c_notes" value={fields.c_notes ?? ''} disabled={!editable} onChange={(e) => set('c_notes', e.target.value)} rows={4} style={{ ...gInputStyle, height: 'auto', ...(!editable ? gReadonlyStyle : {}) }} />)}
             </div>
 
             <TextpersonPair personId={personId} label={tr('candidate_source_title', '候選出處')} onPick={onPickTextperson} disabled={!editable} />
@@ -208,7 +208,7 @@ export default function TextEditor({
             {(canEdit || canPropose) && (
                 <div style={{ marginBottom: 16 }}>
                     <GridLabel label={tr('modification_note_label', '修改說明')} />
-                    <textarea value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
+                    <textarea name="modification_note" id="modification_note" value={comment} onChange={(e) => setComment(e.target.value)} rows={3} style={{ ...gInputStyle, height: 'auto' }}
                         placeholder={tr('modification_note_placeholder', '提案時請說明修改原因')} />
                 </div>
             )}


### PR DESCRIPTION
## 問題

使用者反映：舊版 Blade 表單中，「頁數/條目」等欄位點擊一下就會彈出瀏覽器記住的曾手動輸入過的值，很方便；新版 React 編輯器裡同一欄位完全不會彈出候選，只能逐字手動輸入。

## 根因

舊版 Blade 的 `<input name="c_pages" ...>` 帶有 `name` 屬性，瀏覽器原生表單自動完成機制以此為 key 記住歷史輸入值。React 重寫後，共用的 `gridInput()` 元件（`resources/js/inertia/components/PersonEditorShared/grid.tsx`）以及各編輯器手寫的 `<input>`/`<textarea>` 都完全沒有 `name`/`id` 屬性，導致這個瀏覽器原生記憶功能全面失效。

## 修正範圍

- `gridInput()` 新增可選 `name` 參數，同時設為 input 的 `name`/`id`。
- 13 個複合主鍵子資源編輯器（Address / Altname / Assoc / Entry / Event / Kin / Office / Possession / SocialInst / Source / Status / Text）呼叫 `gridInput()` 時傳入對應欄位鍵作為 `name`。
- 各編輯器手寫、繞過 `gridInput()` 的欄位（`c_notes` 備註、`c_event`、`c_sequence`、`c_quantity` 等）補上對應 `name`/`id`。
- 每個編輯器共通的「修改說明 / 提案理由」欄位統一補上 `name="modification_note" id="modification_note"`。
- `BasicInfoEditor.tsx`（人物基本資料編輯器本體）與 `PersonBrowser/BasicInfoView.tsx`（人物瀏覽器基本資料分頁）比照補齊，確保行為與子資源編輯器一致。

**刻意不動的部分**：`CodeAutocomplete` / `EnumAutocompleteField` 等自訂搜尋型下拉選擇器（如出處、地名、朝代等欄位）維持匿名 input——這類欄位本身已有自己的下拉候選 UI，若疊加瀏覽器原生自動完成候選清單，兩者視覺上會互相干擾；`readOnly`/`disabled` 的建檔／更新稽核展示欄位也未補，因為瀏覽器不會對唯讀欄位提供自動完成。

## 驗證

- `npm run build` 通過。
- `php artisan serve` + Playwright 手動驗證（使用真實資料庫資料，測試後已清除建立的測試帳號、未提交任何欄位變更）：
  - `/app/basicinformation/{id}/sources/edit-v2` 的「頁數/條目」（c_pages）輸入框確認帶有 `name="c_pages" id="c_pages"`，值正確載入，頁面渲染正常。
  - `/app/basicinformation/{id}/edit-v2` 的姓名等欄位、`c_notes` 備註欄、修改說明欄位皆確認帶有對應 `name`/`id`。
  - 無因本次改動新增的 console 錯誤。
- 三輪 code review（獨立 review agent + `codex exec` CLI 交叉驗證）確認無阻擋性問題。

## Test plan

- [x] `npm run build`
- [x] Playwright 手動驗證子資源編輯器與基本資料編輯器欄位屬性、頁面渲染
- [ ] Merge 後於瀏覽器實際測試：對同一欄位分別輸入兩次不同值儲存後，第三次點擊欄位應能看到瀏覽器彈出的歷史候選