### PR TITLE
feat(font): 新增全站襯線字體切換，並由 CDN 載入 Jigmo 罕見字型

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -233,6 +233,8 @@
     /* 字體：Source Sans Pro / Noto Sans TC 由模板走 Google Fonts 載入，不進 Vite bundle。 */
     --font-sans: 'Source Sans Pro', 'Noto Sans TC', -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
+    --font-historical-serif: 'Source Serif 4', 'Source Han Serif TC', 'Jigmo', serif;
+    --font-body: var(--font-sans);
 
     /*
      * 正文字級對齊 AdminLTE 16px 基準。
@@ -253,8 +255,29 @@
     body {
         background-color: var(--background);
         color: var(--foreground);
-        font-family: var(--font-sans);
+        font-family: var(--font-body);
     }
+
+    html.font-serif-mode {
+        --font-body: var(--font-historical-serif);
+    }
+
+    button,
+    input,
+    select,
+    textarea {
+        font-family: inherit;
+    }
+}
+
+.cbdb-historical-text,
+.chgis-place-link {
+    font-variant-east-asian: traditional;
+}
+
+.cbdb-historical-name {
+    font-weight: 600;
+    letter-spacing: 0;
 }
 
 /* 深色側邊欄細捲軸：取代深色背景上突兀的預設白色捲軸（Firefox + WebKit） */

--- a/resources/js/inertia/Layouts/DashboardLayout.tsx
+++ b/resources/js/inertia/Layouts/DashboardLayout.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { usePage } from '@inertiajs/react';
 import type { SharedProps } from '../types/page';
 import { useDarkMode } from '../hooks/useDarkMode';
+import { useFontMode } from '../hooks/useFontMode';
 import Sidebar from '../components/shell/Sidebar';
 import Navbar from '../components/shell/Navbar';
 import FlashMessages from '../components/shell/FlashMessages';
@@ -38,6 +39,7 @@ interface DashboardLayoutProps {
 export default function DashboardLayout({ children, title, description, breadcrumbs, disableContentPadding, headerAlign = 'left' }: DashboardLayoutProps) {
     const { app } = usePage<SharedProps>().props;
     const { isDark, toggle } = useDarkMode();
+    const { fontMode, toggle: toggleFontMode } = useFontMode();
     const [collapsed, setCollapsed] = useState(false);
     const version = app?.version ?? 'unknown';
 
@@ -50,6 +52,8 @@ export default function DashboardLayout({ children, title, description, breadcru
                     onToggleSidebar={() => setCollapsed((v) => !v)}
                     isDark={isDark}
                     onToggleDark={toggle}
+                    fontMode={fontMode}
+                    onToggleFontMode={toggleFontMode}
                     breadcrumbs={breadcrumbs}
                 />
 
@@ -57,7 +61,7 @@ export default function DashboardLayout({ children, title, description, breadcru
                     {/* 麵包屑改渲染於頂部導覽列「首頁」同一行（見 Navbar，#113）；此處僅保留標題/描述。 */}
                     {(title || description) && (
                         <div className="mb-4 flex flex-col gap-1 border-b border-border pb-3">
-                            {title && <h1 className={`text-xl font-semibold${headerAlign === 'center' ? ' text-center' : ''}`}>{title}</h1>}
+                            {title && <h1 className={`text-xl font-semibold${headerAlign === 'center' ? ' text-center cbdb-historical-name' : ''}`}>{title}</h1>}
                             {description && <p className={`text-sm text-muted-foreground${headerAlign === 'center' ? ' text-center' : ''}`}>{description}</p>}
                         </div>
                     )}

--- a/resources/js/inertia/Pages/BasicInformation/Index.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/Index.tsx
@@ -126,7 +126,7 @@ export default function PersonIndex() {
                                 <tr key={row.c_personid} className="border-t border-border hover:bg-muted/30">
                                     {COLUMNS.map((c) => (
                                         <td key={c.key} className="px-3 py-1.5">
-                                            <a href={editUrl(row.c_personid)} target="_blank" rel="noreferrer" className="text-primary hover:underline">
+                                            <a href={editUrl(row.c_personid)} target="_blank" rel="noreferrer" className="cbdb-historical-text text-primary hover:underline">
                                                 {c.render ? c.render(row) : (row[c.key] ?? '')}
                                             </a>
                                         </td>

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -342,7 +342,7 @@ export default function BasicInfoEditor({
     const gRO = (key: string, label: string, code?: string, opts: { hint?: string; full?: boolean } = {}) => (
         <div style={opts.full ? gFull : undefined}>
             {fLabel(label, code)}
-            <input type="text" value={labels[key] || fields[key] || ''} readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }} />
+            <input className="cbdb-historical-text" type="text" value={labels[key] || fields[key] || ''} readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }} />
             {opts.hint ? <span style={gHintStyle}>{opts.hint}</span> : null}
         </div>
     );
@@ -434,7 +434,7 @@ export default function BasicInfoEditor({
                 <div style={gGrid}>
                     <div>
                         {fLabel(tr('gender', '性別'), 'c_female')}
-                        <select value={fields.c_female ?? ''} disabled={!canEdit && !canPropose}
+                        <select className="cbdb-historical-text" value={fields.c_female ?? ''} disabled={!canEdit && !canPropose}
                             onChange={(e) => set('c_female', e.target.value)} style={gInputStyle}>
                             <option value="">{tr('please_select', 'NULL')}</option>
                             <option value="0">0-{tr('male', '男')}</option>
@@ -511,10 +511,10 @@ export default function BasicInfoEditor({
                     <div style={gridSectionHeadStyle}>{tr('create_or_modify', '建檔 / 更新資訊')}</div>
                     <div style={gGrid}>
                         <div>{fLabel(tr('audit_created', '建檔'))}
-                            <input type="text" readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }}
+                            <input className="cbdb-historical-text" type="text" readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }}
                                 value={auditValue(fields.c_created_by, fields.c_created_date)} /></div>
                         <div>{fLabel(tr('audit_updated', '更新'))}
-                            <input type="text" readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }}
+                            <input className="cbdb-historical-text" type="text" readOnly disabled style={{ ...gInputStyle, ...gReadonlyStyle }}
                                 value={auditValue(fields.c_modified_by, fields.c_modified_date)} /></div>
                     </div>
                 </div>

--- a/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
+++ b/resources/js/inertia/components/PersonBrowser/BasicInfoView.tsx
@@ -1341,6 +1341,7 @@ function ReadOnlyField({
         >
             <div style={{ ...fieldLabelStyle, ...(dirty ? dirtyFieldLabelStyle : {}) }}>{label}</div>
             <div
+                className="cbdb-historical-text"
                 style={{
                     ...fieldValueBoxStyle,
                     ...(muted ? mutedValueBoxStyle : {}),

--- a/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PeopleList.tsx
@@ -79,8 +79,8 @@ export default function PeopleList({ people, pagination, selectedId, loading, so
                         <div style={topRowStyle}>
                             <span style={idBadgeStyle}>#{p.c_personid}</span>
                             <div style={nameBlockStyle}>
-                                <strong style={chnNameStyle}>{p.c_name_chn || '—'}</strong>
-                                {p.c_name && <span style={romanNameStyle}>{p.c_name}</span>}
+                                <strong className="cbdb-historical-name" style={chnNameStyle}>{p.c_name_chn || '—'}</strong>
+                                {p.c_name && <span className="cbdb-historical-text" style={romanNameStyle}>{p.c_name}</span>}
                             </div>
                         </div>
                         <div style={tagRowStyle}>
@@ -144,7 +144,7 @@ function MiniTag({ label, value }: { label: string; value: string | null | undef
     return (
         <span style={miniTagStyle}>
             <span style={miniTagLabelStyle}>{label}</span>
-            <span style={miniTagValueStyle}>{value}</span>
+            <span className="cbdb-historical-text" style={miniTagValueStyle}>{value}</span>
         </span>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
+++ b/resources/js/inertia/components/PersonBrowser/PersonSummaryPanel.tsx
@@ -64,11 +64,11 @@ export default function PersonSummaryPanel({ summary, loading, error }: Props) {
         <div style={boxStyle}>
             <div style={headerStyle}>
                 <div style={nameRowStyle}>
-                    <div style={mainNameStyle}>{summary.c_name_chn || '—'}</div>
+                    <div className="cbdb-historical-name" style={mainNameStyle}>{summary.c_name_chn || '—'}</div>
                     {secondaryNames.length > 0 && (
                         <div style={secondaryNameBlockStyle}>
                             {secondaryNames.map((name) => (
-                                <div key={name} style={secondaryNameStyle}>{name}</div>
+                                <div key={name} className="cbdb-historical-text" style={secondaryNameStyle}>{name}</div>
                             ))}
                         </div>
                     )}
@@ -105,7 +105,7 @@ function Tag({ label, value }: { label: string; value: React.ReactNode }) {
     return (
         <span style={tagStyle}>
             <span style={tagLabelStyle}>{label}</span>
-            <span style={tagValueStyle}>{value}</span>
+            <span className="cbdb-historical-text" style={tagValueStyle}>{value}</span>
         </span>
     );
 }

--- a/resources/js/inertia/components/PersonBrowser/shared/AddressDisplayWithMap.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/AddressDisplayWithMap.tsx
@@ -39,7 +39,7 @@ export default function AddressDisplayWithMap({
     if (latitude !== null && longitude !== null && personId != null) {
         return (
             <a
-                className="chgis-place-link"
+                className="chgis-place-link cbdb-historical-text"
                 role="button"
                 tabIndex={0}
                 data-person-id={personId}
@@ -53,5 +53,5 @@ export default function AddressDisplayWithMap({
         );
     }
 
-    return <span>{label}</span>;
+    return <span className="cbdb-historical-text">{label}</span>;
 }

--- a/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
@@ -238,6 +238,7 @@ export default function CodeAutocomplete(props: Props) {
     return (
         <div ref={containerRef} style={wrapStyle}>
             <input
+                className="cbdb-historical-text"
                 id={id}
                 type="text"
                 disabled={disabled}

--- a/resources/js/inertia/components/PersonEditorShared/SubresourceTable.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/SubresourceTable.tsx
@@ -44,7 +44,7 @@ export default function SubresourceTable<T>({ columns, items, rowKey, actions, a
                         items.map((item, i) => (
                             <tr key={rowKey(item, i)}>
                                 {columns.map((c, ci) => (
-                                    <td key={ci} style={tdStyle}>{c.render(item, i)}</td>
+                                    <td key={ci} className="cbdb-historical-text" style={tdStyle}>{c.render(item, i)}</td>
                                 ))}
                                 {actions ? <td style={tdStyle}>{actions(item)}</td> : null}
                             </tr>

--- a/resources/js/inertia/components/PersonEditorShared/grid.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/grid.tsx
@@ -94,6 +94,7 @@ export interface GridInputOpts {
 export function gridInput(o: GridInputOpts): React.ReactElement {
     return (
         <input
+            className="cbdb-historical-text"
             type={o.type ?? 'text'}
             name={o.name}
             id={o.name}

--- a/resources/js/inertia/components/shell/Navbar.tsx
+++ b/resources/js/inertia/components/shell/Navbar.tsx
@@ -10,6 +10,8 @@ interface NavbarProps {
     onToggleSidebar: () => void;
     isDark: boolean;
     onToggleDark: () => void;
+    fontMode: 'sans' | 'serif';
+    onToggleFontMode: () => void;
     /** 麵包屑：渲染於頂部導覽列「首頁」之後（同一行），對齊 legacy header-v3 的頂端麵包屑。 */
     breadcrumbs?: Crumb[];
 }
@@ -18,7 +20,7 @@ interface NavbarProps {
  * 頂部導覽列：pushmenu 切換、首頁、深色模式、語言切換、使用者下拉/登入註冊。
  * 對齊舊 header-v3.blade.php 的功能與行為（含語言切換的未存變更確認）。
  */
-export default function Navbar({ onToggleSidebar, isDark, onToggleDark, breadcrumbs }: NavbarProps) {
+export default function Navbar({ onToggleSidebar, isDark, onToggleDark, fontMode, onToggleFontMode, breadcrumbs }: NavbarProps) {
     const { auth, locale, locale_url, shell } = usePage<SharedProps>().props;
     const tNav = useTranslation('nav');
     const tCommon = useTranslation('common');
@@ -43,6 +45,9 @@ export default function Navbar({ onToggleSidebar, isDark, onToggleDark, breadcru
     const langLabel = currentLocale === 'zh-TW'
         ? tNav('language_switch_to_en')
         : tNav('language_switch_to_zh');
+    const fontToggleTitle = currentLocale === 'zh-TW'
+        ? (fontMode === 'serif' ? '切換為無襯線字體' : '切換為襯線字體')
+        : (fontMode === 'serif' ? 'Switch to sans serif' : 'Switch to serif');
 
     return (
         <nav className="flex h-14 items-center gap-2 border-b border-border bg-card px-3 text-card-foreground">
@@ -86,6 +91,17 @@ export default function Navbar({ onToggleSidebar, isDark, onToggleDark, breadcru
                     onClick={onToggleDark}
                 >
                     <i className={cn('fas', isDark ? 'fa-sun' : 'fa-moon')} aria-hidden />
+                </button>
+                <button
+                    type="button"
+                    className="flex items-center gap-1 rounded px-2 py-1 text-sm font-semibold hover:bg-muted"
+                    title={fontToggleTitle}
+                    aria-label={fontToggleTitle}
+                    aria-pressed={fontMode === 'serif'}
+                    onClick={onToggleFontMode}
+                >
+                    <i className="fas fa-font" aria-hidden />
+                    <span className="hidden sm:inline">{fontMode === 'serif' ? 'Serif' : 'Sans'}</span>
                 </button>
                 <button
                     type="button"

--- a/resources/js/inertia/hooks/useFontMode.ts
+++ b/resources/js/inertia/hooks/useFontMode.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type FontMode = 'sans' | 'serif';
+
+const STORAGE_KEY = 'fontMode';
+const SERIF_CLASS = 'font-serif-mode';
+
+function readInitial(): FontMode {
+    if (typeof window === 'undefined') {
+        return 'sans';
+    }
+    return window.localStorage.getItem(STORAGE_KEY) === 'serif' ? 'serif' : 'sans';
+}
+
+function applyToDocument(mode: FontMode): void {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    document.documentElement.classList.toggle(SERIF_CLASS, mode === 'serif');
+}
+
+export function useFontMode(): { fontMode: FontMode; toggle: () => void } {
+    const [fontMode, setFontMode] = useState<FontMode>(readInitial);
+
+    useEffect(() => {
+        applyToDocument(fontMode);
+    }, [fontMode]);
+
+    const toggle = useCallback(() => {
+        setFontMode((prev) => {
+            const next: FontMode = prev === 'serif' ? 'sans' : 'serif';
+            try {
+                window.localStorage.setItem(STORAGE_KEY, next);
+            } catch {
+                // localStorage 不可用時靜默忽略（仍套用於本次 session）。
+            }
+            return next;
+        });
+    }, []);
+
+    return { fontMode, toggle };
+}

--- a/resources/views/cbdbapi/person.blade.php
+++ b/resources/views/cbdbapi/person.blade.php
@@ -10,6 +10,8 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&display=fallback" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@400;600&family=Noto+Serif+TC:wght@400;600&display=fallback" rel="stylesheet">
+    <link rel="stylesheet" href="https://jigmo.digitalhumanities.dev/jigmo-tc.css">
 
     <style>
         * {
@@ -131,6 +133,11 @@
 
         .info-value {
             color: #333;
+        }
+
+        .cbdb-database-text {
+            font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo', serif;
+            font-variant-east-asian: traditional;
         }
 
         .item-box {
@@ -299,7 +306,7 @@
             <div>
                 @foreach($searchResults as $result)
                     <a href="#" class="person-link person-search-result" data-person-id="{{ $result['id'] }}">
-                        {{ e($result['label']) }} <span class="badge">{{ $result['id'] }}</span>
+                        <span class="cbdb-database-text">{{ e($result['label']) }}</span> <span class="badge">{{ $result['id'] }}</span>
                     </a>
                 @endforeach
             </div>
@@ -442,14 +449,26 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             .replace(/'/g, '&#39;');
     }
 
+    function dbHtml(value) {
+        return '<span class="cbdb-database-text">' + (value || '') + '</span>';
+    }
+
+    function dbText(value) {
+        return dbHtml(escapeHtml(value));
+    }
+
+    function dbStrong(value) {
+        return '<strong class="cbdb-database-text">' + escapeHtml(value) + '</strong>';
+    }
+
     function formatIdLabel(label, id) {
         if (!label && !id) {
             return '';
         }
         if (label && id) {
-            return escapeHtml(label) + ' <span class="badge">ID: ' + escapeHtml(id) + '</span>';
+            return dbText(label) + ' <span class="badge">ID: ' + escapeHtml(id) + '</span>';
         }
-        return escapeHtml(label || id || '');
+        return dbText(label || id || '');
     }
 
     function joinParts(parts, separator) {
@@ -458,7 +477,11 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
     }
 
     function line(label, value) {
-        return '<div class="info-row"><span class="info-label">' + label + '：</span><span class="info-value">' + (value || '<span class="empty">' + cbdbI18n.empty + '</span>') + '</span></div>';
+        var output = value || '<span class="empty">' + cbdbI18n.empty + '</span>';
+        if (value && value !== cbdbI18n.unknown && String(value).indexOf('<') === -1) {
+            output = dbHtml(value);
+        }
+        return '<div class="info-row"><span class="info-label">' + label + '：</span><span class="info-value">' + output + '</span></div>';
     }
 
     function isValidValue(val) {
@@ -473,7 +496,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         html += line(cbdbI18n.fieldIndexYear, isValidValue(info.IndexYear) ? escapeHtml(info.IndexYear) : cbdbI18n.unknown);
         var indexAddrHtml = '';
         if (info.IndexAddr) {
-            indexAddrHtml = escapeHtml(info.IndexAddr);
+            indexAddrHtml = dbText(info.IndexAddr);
         }
         if (info.IndexAddrId) {
             indexAddrHtml += ' <a href="/codes/ADDR_CODES?search=' + encodeURIComponent(info.IndexAddrId) + '" target="_blank" rel="noopener noreferrer">';
@@ -514,8 +537,8 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             }
             if (info.Source || info.SourcePages) {
                 html += line(cbdbI18n.fieldSourceLink,
-                    (info.Source ? escapeHtml(info.Source) : '<span class="empty">' + cbdbI18n.empty + '</span>') +
-                    (info.SourcePages ? cbdbI18n.pagesComma + escapeHtml(info.SourcePages) : ''));
+                    (info.Source ? dbText(info.Source) : '<span class="empty">' + cbdbI18n.empty + '</span>') +
+                    (info.SourcePages ? cbdbI18n.pagesComma + dbText(info.SourcePages) : ''));
             }
         }
 
@@ -532,7 +555,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             var itemHtml = '<div class="item-box">';
             var pieces = [];
             if (item.Source) {
-                var sourceLabel = escapeHtml(item.Source);
+                var sourceLabel = dbText(item.Source);
                 if (item.SourceId) {
                     sourceLabel += ' <span class="badge">ID: ' + escapeHtml(item.SourceId) + '</span>';
                 }
@@ -542,14 +565,14 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
                 if (item.UrlApi) {
                     var urlPart = encodeURIComponent(item.Pages);
                     var fullUrl = item.UrlApi + urlPart + (item.UrlApiCoda || '');
-                    pieces.push(cbdbI18n.pagesPrefix + '<a href="' + escapeHtml(fullUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(item.Pages) + '</a>');
+                    pieces.push(cbdbI18n.pagesPrefix + '<a href="' + escapeHtml(fullUrl) + '" target="_blank" rel="noopener noreferrer">' + dbText(item.Pages) + '</a>');
                 } else {
-                    pieces.push(cbdbI18n.pagesPrefix + escapeHtml(item.Pages));
+                    pieces.push(cbdbI18n.pagesPrefix + dbText(item.Pages));
                 }
             }
             itemHtml += (pieces.length ? pieces.join('，') : '<span class="empty">' + cbdbI18n.empty + '</span>');
             if (item.Notes) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + escapeHtml(item.Notes) + '</div>';
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + dbText(item.Notes) + '</div>';
             }
             itemHtml += '</div>';
             html += itemHtml;
@@ -566,14 +589,14 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         items.forEach(function (item) {
             var parts = [];
             if (item.AliasType) {
-                var aliasType = '<strong>' + escapeHtml(item.AliasType) + '</strong>';
+                var aliasType = dbStrong(item.AliasType);
                 if (item.AliasTypeId) {
                     aliasType += ' <span class="badge">ID: ' + escapeHtml(item.AliasTypeId) + '</span>';
                 }
                 parts.push(aliasType);
             }
             if (item.AliasName) {
-                parts.push(escapeHtml(item.AliasName));
+                parts.push(dbText(item.AliasName));
             }
             if (parts.length > 0) {
                 html += '<div class="item-box">' + parts.join('：') + '</div>';
@@ -589,7 +612,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         }
         var addr = '';
         if (item.AddrName) {
-            addr = escapeHtml(item.AddrName);
+            addr = dbText(item.AddrName);
         }
         if (item.AddrId) {
             var addrLink = '<a href="/codes/ADDR_CODES?search=' + encodeURIComponent(item.AddrId) + '" target="_blank" rel="noopener noreferrer">';
@@ -607,7 +630,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         items.forEach(function (item) {
             var itemHtml = '<div class="item-box">';
             if (item.AddrType) {
-                var typeLabel = '<strong>' + escapeHtml(item.AddrType) + '</strong>';
+                var typeLabel = dbStrong(item.AddrType);
                 if (item.AddrTypeId !== undefined) {
                     typeLabel += ' <span class="badge">ID: ' + escapeHtml(item.AddrTypeId) + '</span>';
                 }
@@ -619,26 +642,26 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             }
             var extra = [];
             if (item.MoveCount) {
-                extra.push(cbdbI18n.sequenceLabel + escapeHtml(item.MoveCount));
+                extra.push(cbdbI18n.sequenceLabel + dbText(item.MoveCount));
             }
             if (item.FirstYear && isValidValue(item.FirstYear)) {
-                extra.push(cbdbI18n.startYearLabel + escapeHtml(item.FirstYear));
+                extra.push(cbdbI18n.startYearLabel + dbText(item.FirstYear));
             }
             if (item.LastYear && isValidValue(item.LastYear)) {
-                extra.push(cbdbI18n.endYearLabel + escapeHtml(item.LastYear));
+                extra.push(cbdbI18n.endYearLabel + dbText(item.LastYear));
             }
             if (extra.length) {
                 itemHtml += '<div class="small-text mt-2">' + extra.join('，') + '</div>';
             }
             if (item.Source) {
-                var src = cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                var src = cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    src += cbdbI18n.pagesComma + escapeHtml(item.Pages);
+                    src += cbdbI18n.pagesComma + dbText(item.Pages);
                 }
                 itemHtml += '<div class="small-text mt-1">' + src + '</div>';
             }
             if (item.Notes) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + escapeHtml(item.Notes) + '</div>';
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + dbText(item.Notes) + '</div>';
             }
             itemHtml += '</div>';
             html += itemHtml;
@@ -656,14 +679,14 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             var itemHtml = '<div class="item-box">';
             var pieces = [];
             if (item.EntryType) {
-                var entry = '<strong>' + escapeHtml(item.EntryType) + '</strong>';
+                var entry = dbStrong(item.EntryType);
                 if (item.EntryTypeId) {
                     entry += ' <span class="badge">ID: ' + escapeHtml(item.EntryTypeId) + '</span>';
                 }
                 pieces.push(entry);
             }
             if (item.EntryCode) {
-                var code = escapeHtml(item.EntryCode);
+                var code = dbText(item.EntryCode);
                 if (item.EntryCodeId) {
                     code += ' <span class="badge">' + escapeHtml(item.EntryCodeId) + '</span>';
                 }
@@ -672,23 +695,23 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             itemHtml += pieces.join('：');
             var tail = [];
             if (item.RuShiYear && isValidValue(item.RuShiYear)) {
-                tail.push(cbdbI18n.yearLabel + escapeHtml(item.RuShiYear));
+                tail.push(cbdbI18n.yearLabel + dbText(item.RuShiYear));
             }
             if (item.RuShiAge && isValidValue(item.RuShiAge)) {
-                tail.push(cbdbI18n.ageLabel + escapeHtml(item.RuShiAge));
+                tail.push(cbdbI18n.ageLabel + dbText(item.RuShiAge));
             }
             if (tail.length) {
                 itemHtml += '<div class="small-text mt-2">' + tail.join('，') + '</div>';
             }
             if (item.Source) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    itemHtml += cbdbI18n.pagesComma + escapeHtml(item.Pages);
+                    itemHtml += cbdbI18n.pagesComma + dbText(item.Pages);
                 }
                 itemHtml += '</div>';
             }
             if (item.Notes) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + escapeHtml(item.Notes) + '</div>';
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + dbText(item.Notes) + '</div>';
             }
             itemHtml += '</div>';
             html += itemHtml;
@@ -708,7 +731,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
 
             // 官职名称
             if (item.OfficeName) {
-                itemHtml += '<strong>' + escapeHtml(item.OfficeName) + '</strong>';
+                itemHtml += dbStrong(item.OfficeName);
             }
 
             var details = [];
@@ -716,42 +739,42 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             // 起始年
             var startParts = [];
             if (item.FirstYearNianhao && isValidValue(item.FirstYearNianhao)) {
-                startParts.push(escapeHtml(item.FirstYearNianhao));
+                startParts.push(dbText(item.FirstYearNianhao));
             }
             if (item.FirstYearNiaohaoYear && isValidValue(item.FirstYearNiaohaoYear)) {
-                startParts.push(escapeHtml(item.FirstYearNiaohaoYear) + cbdbI18n.yearSuffix);
+                startParts.push(dbText(item.FirstYearNiaohaoYear) + cbdbI18n.yearSuffix);
             }
             if (item.FirstYear && isValidValue(item.FirstYear)) {
-                startParts.push('(' + escapeHtml(item.FirstYear) + ')');
+                startParts.push('(' + dbText(item.FirstYear) + ')');
             }
             var startYearText = startParts.length > 0 ? startParts.join(' ') : cbdbI18n.unknown;
             // 只有当年份不是未詳时，才添加年份限定詞
             if (startParts.length > 0 && item.FirstYearRange && isValidValue(item.FirstYearRange)) {
-                startYearText += '   ' + cbdbI18n.yearQualifierLabel + escapeHtml(item.FirstYearRange);
+                startYearText += '   ' + cbdbI18n.yearQualifierLabel + dbText(item.FirstYearRange);
             }
             details.push(cbdbI18n.startYearLabel + startYearText);
 
             // 終止年
             var endParts = [];
             if (item.LastYearNianhao && isValidValue(item.LastYearNianhao)) {
-                endParts.push(escapeHtml(item.LastYearNianhao));
+                endParts.push(dbText(item.LastYearNianhao));
             }
             if (item.LastYearNianhaoYear && isValidValue(item.LastYearNianhaoYear)) {
-                endParts.push(escapeHtml(item.LastYearNianhaoYear) + cbdbI18n.yearSuffix);
+                endParts.push(dbText(item.LastYearNianhaoYear) + cbdbI18n.yearSuffix);
             }
             if (item.LastYear && isValidValue(item.LastYear)) {
-                endParts.push('(' + escapeHtml(item.LastYear) + ')');
+                endParts.push('(' + dbText(item.LastYear) + ')');
             }
             var endYearText = endParts.length > 0 ? endParts.join(' ') : cbdbI18n.unknown;
             // 只有当年份不是未詳时，才添加年份限定詞
             if (endParts.length > 0 && item.LastYearRange && isValidValue(item.LastYearRange)) {
-                endYearText += '   ' + cbdbI18n.yearQualifierLabel + escapeHtml(item.LastYearRange);
+                endYearText += '   ' + cbdbI18n.yearQualifierLabel + dbText(item.LastYearRange);
             }
             details.push(cbdbI18n.endYearLabel + endYearText);
 
             // 地點
             if (item.AddrName || item.AddrId) {
-                var addrHtml = cbdbI18n.locationLabel + '<strong>' + escapeHtml(item.AddrName || '') + '</strong>';
+                var addrHtml = cbdbI18n.locationLabel + dbStrong(item.AddrName || '');
                 if (item.AddrId) {
                     addrHtml += ' <a href="/codes/ADDR_CODES?search=' + encodeURIComponent(item.AddrId) + '" target="_blank" rel="noopener noreferrer">';
                     addrHtml += '<span class="badge">' + escapeHtml(item.AddrId) + '</span></a>';
@@ -761,16 +784,16 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
 
             // 出處
             if (item.Source) {
-                var src = cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                var src = cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    src += cbdbI18n.pagesComma + escapeHtml(item.Pages);
+                    src += cbdbI18n.pagesComma + dbText(item.Pages);
                 }
                 details.push(src);
             }
 
             // 註
             if (item.Notes) {
-                details.push(cbdbI18n.noteLabel + escapeHtml(item.Notes));
+                details.push(cbdbI18n.noteLabel + dbText(item.Notes));
             }
 
             itemHtml += '<div class="small-text mt-2">' + details.join('<br>') + '</div>';
@@ -789,17 +812,17 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
         items.forEach(function (item) {
             var text = [];
             if (item.StatusName) {
-                var label = '<strong>' + escapeHtml(item.StatusName) + '</strong>';
+                var label = dbStrong(item.StatusName);
                 if (item.StatusId) {
                     label += ' <span class="badge">ID: ' + escapeHtml(item.StatusId) + '</span>';
                 }
                 text.push(label);
             }
             if (item.FirstYear && isValidValue(item.FirstYear)) {
-                text.push(cbdbI18n.startYearLabel + escapeHtml(item.FirstYear));
+                text.push(cbdbI18n.startYearLabel + dbText(item.FirstYear));
             }
             if (item.LastYear && isValidValue(item.LastYear)) {
-                text.push(cbdbI18n.endYearLabel + escapeHtml(item.LastYear));
+                text.push(cbdbI18n.endYearLabel + dbText(item.LastYear));
             }
             html += '<div class="item-box">' + (text.length ? text.join('，') : '<span class="empty">' + cbdbI18n.empty + '</span>') + '</div>';
         });
@@ -816,17 +839,17 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             var itemHtml = '<div class="item-box">';
             var relation = item.KinRelName || item.KinRel || cbdbI18n.kinshipDefault;
             var person = item.KinPersonName || '';
-            itemHtml += '<strong>' + escapeHtml(relation) + '：</strong>' + escapeHtml(person);
+            itemHtml += dbStrong(relation) + '：' + (person ? dbText(person) : '');
             var extras = [];
             if (item.Source) {
-                var src = cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                var src = cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    src += '（' + cbdbI18n.pagesPrefix + escapeHtml(item.Pages) + '）';
+                    src += '（' + cbdbI18n.pagesPrefix + dbText(item.Pages) + '）';
                 }
                 extras.push(src);
             }
             if (item.Notes) {
-                extras.push(cbdbI18n.noteLabel + escapeHtml(item.Notes));
+                extras.push(cbdbI18n.noteLabel + dbText(item.Notes));
             }
             if (extras.length) {
                 itemHtml += '<div class="small-text mt-1">' + extras.join('； ') + '</div>';
@@ -847,13 +870,13 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             var itemHtml = '<div class="item-box">';
             var base = [];
             if (item.AssocName) {
-                base.push('<strong>' + escapeHtml(item.AssocName) + '</strong>');
+                base.push(dbStrong(item.AssocName));
             }
             if (item.AssocPersonName) {
-                base.push(escapeHtml(item.AssocPersonName));
+                base.push(dbText(item.AssocPersonName));
             }
             if (item.TextTitle) {
-                base.push('【' + escapeHtml(item.TextTitle) + '】');
+                base.push('【' + dbText(item.TextTitle) + '】');
             }
             if (item.Year && isValidValue(item.Year)) {
                 base.push('<span class="badge">' + cbdbI18n.yearLabel + escapeHtml(item.Year) + '</span>');
@@ -861,14 +884,14 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             itemHtml += base.join(' ');
             var extras = [];
             if (item.Source) {
-                var src = cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                var src = cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    src += '（' + cbdbI18n.pagesPrefix + escapeHtml(item.Pages) + '）';
+                    src += '（' + cbdbI18n.pagesPrefix + dbText(item.Pages) + '）';
                 }
                 extras.push(src);
             }
             if (item.Notes) {
-                extras.push(cbdbI18n.noteLabel + escapeHtml(item.Notes));
+                extras.push(cbdbI18n.noteLabel + dbText(item.Notes));
             }
             if (extras.length) {
                 itemHtml += '<div class="small-text mt-1">' + extras.join('； ') + '</div>';
@@ -889,28 +912,28 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
             var itemHtml = '<div class="item-box">';
             var line = [];
             if (item.TextName) {
-                var name = '<strong>' + escapeHtml(item.TextName) + '</strong>';
+                var name = dbStrong(item.TextName);
                 if (item.TextId) {
                     name += ' <span class="badge">ID: ' + escapeHtml(item.TextId) + '</span>';
                 }
                 line.push(name);
             }
             if (item.Year && isValidValue(item.Year)) {
-                line.push(cbdbI18n.workYearLabel + escapeHtml(item.Year));
+                line.push(cbdbI18n.workYearLabel + dbText(item.Year));
             }
             if (item.Role) {
-                line.push(cbdbI18n.roleLabel + escapeHtml(item.Role));
+                line.push(cbdbI18n.roleLabel + dbText(item.Role));
             }
             itemHtml += line.join('，');
             if (item.Source) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.sourceLabel + escapeHtml(item.Source);
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.sourceLabel + dbText(item.Source);
                 if (item.Pages) {
-                    itemHtml += cbdbI18n.pagesComma + escapeHtml(item.Pages);
+                    itemHtml += cbdbI18n.pagesComma + dbText(item.Pages);
                 }
                 itemHtml += '</div>';
             }
             if (item.Notes) {
-                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + escapeHtml(item.Notes) + '</div>';
+                itemHtml += '<div class="small-text mt-1">' + cbdbI18n.noteLabel + dbText(item.Notes) + '</div>';
             }
             itemHtml += '</div>';
             html += itemHtml;
@@ -949,7 +972,7 @@ var hasValidationErrors = @json(isset($validationErrors) && !empty($validationEr
                     return;
                 }
                 var label = key;
-                segments.push(escapeHtml(label) + '：' + escapeHtml(value));
+                segments.push(escapeHtml(label) + '：' + dbText(value));
             });
             html += '<div class="item-box">' + (segments.length ? segments.join('； ') : '<span class="empty">' + cbdbI18n.empty + '</span>') + '</div>';
         });

--- a/resources/views/inertia.blade.php
+++ b/resources/views/inertia.blade.php
@@ -4,9 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script>
+        try {
+            if (window.localStorage.getItem('fontMode') === 'serif') {
+                document.documentElement.classList.add('font-serif-mode');
+            }
+        } catch (error) {
+            // localStorage 不可用時保留預設 sans 模式。
+        }
+    </script>
     {{-- Google Fonts: Source Sans Pro + Noto Sans TC（與主站 dashboard-v3 對齊；CJK 不進 Vite bundle） --}}
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;700&display=fallback">
+    {{-- CJK serif 備援：serif 模式與人名、地名等歷史文本使用 Source Serif 4 / Source Han Serif TC / Jigmo。 --}}
+    <link rel="stylesheet" href="https://jigmo.digitalhumanities.dev/jigmo-tc.css">
     <title>{{ config('app.name', 'CBDB') }}</title>
     <style>
         html, body {

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -359,6 +359,8 @@ class CbdbApiPersonTest extends TestCase {
 
         $response->assertStatus(200);
         $response->assertSee('person-content');
+        $response->assertSee('cbdb-database-text');
+        $response->assertSee("font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo', serif", false);
     }
 
     #[Test]


### PR DESCRIPTION
Serif 模式使用了 Source Serif 4 + Source Han Serif TC + Jigmo TC。後者由本人基於 Jigmo + GlyphWiki 公开字型（CC0）制作。

詳細介紹見 https://jigmo.digitalhumanities.dev/ 及 https://github.com/frankslin/jigmo-webfonts。

## 顯示效果示例：

### 開啟 Serif 模式（罕見字的顯示風格更統一）

<img width="754" height="584" alt="image" src="https://github.com/user-attachments/assets/25d38b85-dec4-4cad-b236-e83a29b52a8e" />

### 未開啟 - Noto Sans（罕見字使用了系统中的 fallback 字型，手機上顯示為「豆腐塊」）

<img width="790" height="442" alt="image" src="https://github.com/user-attachments/assets/7ede601b-c09e-422d-b4ed-ec708e9f9403" />
