### PR TITLE
fix(font): serif 模式字體棧改用正確族名 Jigmo TC，罕見字回歸 Jigmo 顯示

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -233,7 +233,7 @@
     /* 字體：Source Sans Pro / Noto Sans TC 由模板走 Google Fonts 載入，不進 Vite bundle。 */
     --font-sans: 'Source Sans Pro', 'Noto Sans TC', -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
-    --font-historical-serif: 'Source Serif 4', 'Source Han Serif TC', 'Jigmo', serif;
+    --font-historical-serif: 'Source Serif 4', 'Source Han Serif TC', 'Jigmo TC', serif;
     --font-body: var(--font-sans);
 
     /*

--- a/resources/views/cbdbapi/person.blade.php
+++ b/resources/views/cbdbapi/person.blade.php
@@ -136,7 +136,7 @@
         }
 
         .cbdb-database-text {
-            font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo', serif;
+            font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo TC', serif;
             font-variant-east-asian: traditional;
         }
 

--- a/resources/views/inertia.blade.php
+++ b/resources/views/inertia.blade.php
@@ -16,7 +16,7 @@
     {{-- Google Fonts: Source Sans Pro + Noto Sans TC（與主站 dashboard-v3 對齊；CJK 不進 Vite bundle） --}}
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700&display=fallback">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;700&display=fallback">
-    {{-- CJK serif 備援：serif 模式與人名、地名等歷史文本使用 Source Serif 4 / Source Han Serif TC / Jigmo。 --}}
+    {{-- CJK serif 備援：serif 模式與人名、地名等歷史文本使用 Source Serif 4 / Source Han Serif TC / Jigmo TC。 --}}
     <link rel="stylesheet" href="https://jigmo.digitalhumanities.dev/jigmo-tc.css">
     <title>{{ config('app.name', 'CBDB') }}</title>
     <style>

--- a/tests/Feature/CbdbApiPersonTest.php
+++ b/tests/Feature/CbdbApiPersonTest.php
@@ -360,7 +360,7 @@ class CbdbApiPersonTest extends TestCase {
         $response->assertStatus(200);
         $response->assertSee('person-content');
         $response->assertSee('cbdb-database-text');
-        $response->assertSee("font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo', serif", false);
+        $response->assertSee("font-family: 'Source Serif 4', 'Source Han Serif TC', 'Noto Serif TC', 'Jigmo TC', serif", false);
     }
 
     #[Test]


### PR DESCRIPTION
承接 #1121。修正 serif 模式下罕見字未套用 Jigmo 的問題。

## 問題

#1121 載入的 `https://jigmo.digitalhumanities.dev/jigmo-tc.css` 定義的字型族名為 **`'Jigmo TC'`**，但應用的 serif 字體棧寫成 **`'Jigmo'`**（少了 TC）。CSS 字型族名為**精確比對**，`'Jigmo'` ≠ `'Jigmo TC'`，因此擴展區罕見字（CJK Ext A/B/C，U+3400+、U+20000+）**跳過 Jigmo、掉回系統 `serif`**：

- Windows：微軟正黑體（其實是黑體／無襯線）、SimSun-ExtB（另一套較細的宋體）
- 行動裝置：缺字方塊（豆腐塊）

於是一行內常用字（Source Han Serif TC）與罕見字（系統字型）並排，**筆畫粗細、甚至襯線／非襯線都不一致** —— 即 #1121 討論串中回報的「有些字線條較重、有些較細」。

## 修正

把 serif 字體棧中的 `'Jigmo'` 改為 `'Jigmo TC'`（與 jigmo-tc.css 實際族名一致）：

| 檔案 | 位置 |
|---|---|
| `resources/css/inertia.css` | `--font-historical-serif`（React /app serif 模式）|
| `resources/views/cbdbapi/person.blade.php` | `.cbdb-database-text` |
| `resources/views/inertia.blade.php` | 註解一併更正 |
| `tests/Feature/CbdbApiPersonTest.php` | 斷言同步 |

## 驗證（Chrome DevTools Protocol `CSS.getPlatformFontsForNode`，實測實際渲染字型）

| 字符 | 修正前（`'Jigmo'`）| 修正後（`'Jigmo TC'`）|
|---|---|---|
| 常用「好」 | Source Han Serif TC | Source Han Serif TC（不變）|
| Ext A U+3400 / U+4DB5 | 微軟正黑體（系統字）| **Jigmo TC**（webfont）|
| Ext B U+20000 / U+2A6B2 | SimSun-ExtB（系統字）| **Jigmo TC** |
| Ext C U+2A700 | SimSun-ExtB | **Jigmo TC** |
| 兼容 U+2F81A | 微軟正黑體 | **Jigmo TC** |

常用字維持 Source Han Serif TC；罕見字修正後改由 Jigmo TC 渲染，粗細／風格恢復一致。

`CbdbApiPersonTest` 16/16 綠；`npm run build` 通過；php-cs-fixer clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)