### PR TITLE
fix(person): 人物編輯分頁曾選過殘留邊框（只保留選中/未選中兩態）

### DIFF
--- a/resources/js/inertia/components/PersonEditorShared/PersonBanner.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/PersonBanner.tsx
@@ -127,9 +127,14 @@ const historyLinkStyle: React.CSSProperties = {
     borderRadius: 4, border: '1px solid var(--border)', background: 'var(--secondary)', color: 'var(--secondary-foreground)', textDecoration: 'none',
 };
 const navStyle: React.CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: 2, borderBottom: '1px solid var(--border)', paddingBottom: 0 };
+// 用 border 長寫（borderColor 而非 border 簡寫）：active 樣式只覆寫 borderColor，
+// 若基底用 `border` 簡寫、active 用 `borderColor` 長寫，React 在分頁由 active→inactive
+// 時只會「移除」borderColor 長寫而非重設為 transparent，導致曾選過的分頁殘留邊框（只剩
+// 當前選中／未選中兩態才對）。基底顯式給 borderColor: 'transparent' 可讓 React 乾淨重設。
 const tabStyle: React.CSSProperties = {
     display: 'inline-flex', alignItems: 'center', gap: 2, padding: '8px 12px',
-    border: '1px solid transparent', borderTopLeftRadius: 6, borderTopRightRadius: 6,
+    borderWidth: '1px', borderStyle: 'solid', borderColor: 'transparent',
+    borderTopLeftRadius: 6, borderTopRightRadius: 6,
     background: 'none', color: 'var(--primary)', fontSize: '0.95rem', cursor: 'pointer',
     marginBottom: -1, textDecoration: 'none',
 };


### PR DESCRIPTION
## 問題

人物編輯頁（`/app/basicinformation/{id}/edit?tab=…` 等 editv2 頁）的分頁列，**點過的分頁會殘留邊框**：切到別的分頁後，先前點過的分頁仍保有選中時的灰色邊框，看起來像多出「曾經選過」的第三種狀態。分頁應只有「當前選中／未選中」兩態。

元件：`resources/js/inertia/components/PersonEditorShared/PersonBanner.tsx`（分頁為 `<a role="tab">`）。React 版（`BrowserTabs`）無此問題。

## 根因（Playwright 實測 + inline style 檢查確認）

分頁樣式為 `{...tabStyle, ...(active ? tabActiveStyle : {})}`：
- 基底 `tabStyle` 用 CSS `border` **簡寫**（`'1px solid transparent'`）
- `tabActiveStyle` 只覆寫 `borderColor` **長寫**（`'var(--border) var(--border) var(--card)'`）

點分頁走 Inertia SPA 導航（`router.visit`，不整頁重載）→ 重渲染。當某分頁由 active→inactive，React 比對 inline style：`border` 簡寫字串前後相同（不重套），而 `borderColor` 這個 key 從 active 樣式消失 → React **移除**該長寫（實測：失活分頁 inline `borderColor` 變空字串），使 border-color 未回到 transparent，**殘留 active 邊框色**。

## 修正

基底 `tabStyle` 由 `border` 簡寫改為長寫 `borderWidth/borderStyle/borderColor`（`borderColor:'transparent'`），讓基底一律明確帶 `borderColor`。如此 active→inactive 時 React 會把 `borderColor` 重設為 `transparent`（真正 diff），乾淨回到兩態。

```diff
-    border: '1px solid transparent', borderTopLeftRadius: 6, borderTopRightRadius: 6,
+    borderWidth: '1px', borderStyle: 'solid', borderColor: 'transparent',
+    borderTopLeftRadius: 6, borderTopRightRadius: 6,
```

## 驗證（Playwright）

| | 非選中分頁殘留邊框數 |
|---|---|
| 修正前（點過 別名→著述→入仕）| **3**（地址、別名、著述）|
| 修正後（同操作）| **0**（僅選中的入仕有邊框）|

active 分頁邊框樣式值等價、**無視覺回歸**。`npm run build` 通過。已掃描其他分頁/切換元件（BrowserTabs、SearchByEntry、AiCodeLookupPanel、ModeTabs、BasicInfoView），**無相同 anti-pattern**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)