### PR TITLE
修正 12 個子資源編輯器輸入框按 Enter 不觸發保存

### DIFF
--- a/resources/js/inertia/components/AddressEditor.tsx
+++ b/resources/js/inertia/components/AddressEditor.tsx
@@ -9,7 +9,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -196,8 +196,22 @@ export default function AddressEditor({
         gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('address_create', '新增地址') : tr('address_edit', '編輯地址')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -270,7 +284,7 @@ export default function AddressEditor({
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -7,7 +7,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -169,8 +169,22 @@ export default function AltnameEditor({
         gridCell(label, { code, required }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), type, disabled: !editable, highlight, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('altname_create', '新增別名') : tr('altname_edit', '編輯別名')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -228,7 +242,7 @@ export default function AltnameEditor({
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -14,7 +14,7 @@ import { useOppositeEdgeDetection } from './PersonEditorShared/useOppositeEdgeDe
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gHintStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, GridSection, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, GridSection, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -464,8 +464,22 @@ export default function AssocEditor({
         </>)
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('assoc_create', '新增社會關係') : tr('assoc_edit', '編輯社會關係')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -624,7 +638,7 @@ export default function AssocEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/EntryEditor.tsx
+++ b/resources/js/inertia/components/EntryEditor.tsx
@@ -8,7 +8,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -221,8 +221,22 @@ export default function EntryEditor({
         gridCell(label, { code, hint }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('entry_create', '新增入仕') : tr('entry_edit', '編輯入仕')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -328,7 +342,7 @@ export default function EntryEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/EventEditor.tsx
+++ b/resources/js/inertia/components/EventEditor.tsx
@@ -8,7 +8,7 @@ import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -214,8 +214,22 @@ export default function EventEditor({
         gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('event_create', '新增事件') : tr('event_edit', '編輯事件')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -299,7 +313,7 @@ export default function EventEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/KinEditor.tsx
+++ b/resources/js/inertia/components/KinEditor.tsx
@@ -13,7 +13,7 @@ import { useOppositeEdgeDetection } from './PersonEditorShared/useOppositeEdgeDe
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gHintStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -287,8 +287,22 @@ export default function KinEditor({
                 onChange={(v, l) => { set(key, v || sentinel); setLabel(key, l); }} />)
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('kinship_create', '新增親屬關係') : tr('kinship_edit', '編輯親屬關係')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -396,7 +410,7 @@ export default function KinEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -9,7 +9,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gSuccessBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -297,8 +297,22 @@ export default function OfficeEditor({
                 onChange={(v, l) => { set(key, v); setLabel(key, l); }} />)
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('office_create', '新增任官') : tr('office_edit', '編輯任官')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -403,7 +417,7 @@ export default function OfficeEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
@@ -251,6 +251,22 @@ export default function CodeAutocomplete(props: Props) {
                     setQuery(e.target.value);
                     setOpen(true);
                 }}
+                // 編輯器根節點現為 <form>（支援 Enter 保存）：下拉開啟時本元件無「目前反白候選」概念，
+                // Enter 若不攔截會被表單當成隱式提交，使用者尚未點選候選就誤觸儲存。開啟中吞掉 Enter，
+                // 迫使使用者以滑鼠點選候選、或按 Esc 關閉下拉後再以 Enter 送出表單。
+                // isComposing 排除：中文輸入法選字用的 Enter 屬合成事件，不可攔截，否則無法確認候選字。
+                onKeyDown={(e) => {
+                    // keyCode 229 後備判斷：部分瀏覽器/輸入法組合在確認字詞當下 isComposing 已回報 false。
+                    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+                    if (e.key === 'Escape' && open) {
+                        e.preventDefault();
+                        setOpen(false);
+                        return;
+                    }
+                    if (e.key === 'Enter' && open) {
+                        e.preventDefault();
+                    }
+                }}
                 style={{
                     ...inputStyle,
                     ...(ariaInvalid ? invalidStyle : {}),

--- a/resources/js/inertia/components/PersonEditorShared/grid.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/grid.tsx
@@ -26,6 +26,10 @@ export const gInputStyle: React.CSSProperties = { width: '100%', height: 40, pad
 export const gHintStyle: React.CSSProperties = { display: 'block', marginTop: 4, fontSize: '0.8rem', color: 'var(--muted-foreground)' };
 export const gReadonlyStyle: React.CSSProperties = { background: 'var(--muted)', cursor: 'not-allowed' };
 export const gAuditWrapStyle: React.CSSProperties = { marginTop: 16, paddingTop: 12, borderTop: '1px solid var(--border)' };
+// 隱藏提交鈕：讓編輯器根 <form> 具備「預設提交按鈕」，使單行輸入框按 Enter 觸發原生隱式提交（復刻 legacy Blade 行為）。
+// 可見動作按鈕皆為 type="button"（點擊行為不變）；此鈕僅供 Enter，並以 tabIndex=-1／aria-hidden 排除於鍵盤焦點與無障礙。
+// 不可用 display:none／hidden，否則部分瀏覽器不觸發隱式提交。
+export const gHiddenSubmitStyle: React.CSSProperties = { position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, border: 0, overflow: 'hidden', clip: 'rect(0 0 0 0)' };
 
 // 動作列：主要動作靠左、危險/另存靠右。
 export const gSubmitRow: React.CSSProperties = { display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap', alignItems: 'center' };

--- a/resources/js/inertia/components/PossessionEditor.tsx
+++ b/resources/js/inertia/components/PossessionEditor.tsx
@@ -8,7 +8,7 @@ import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -189,8 +189,22 @@ export default function PossessionEditor({
         gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('possession_create', '新增財產記錄') : tr('possession_edit', '編輯財產記錄')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -283,7 +297,7 @@ export default function PossessionEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/SocialInstEditor.tsx
+++ b/resources/js/inertia/components/SocialInstEditor.tsx
@@ -8,7 +8,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -198,8 +198,22 @@ export default function SocialInstEditor({
         } finally { setDeleting(false); }
     };
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('socialinst_create', '新增社會機構') : tr('socialinst_edit', '編輯社會機構')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -266,7 +280,7 @@ export default function SocialInstEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/SourceEditor.tsx
+++ b/resources/js/inertia/components/SourceEditor.tsx
@@ -6,7 +6,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle, gWarnStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -190,8 +190,22 @@ export default function SourceEditor({
         } finally { setDeleting(false); }
     };
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('source_create', '新增出處') : tr('source_edit', '編輯出處')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -259,7 +273,7 @@ export default function SourceEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/StatusEditor.tsx
+++ b/resources/js/inertia/components/StatusEditor.tsx
@@ -9,7 +9,7 @@ import AiCodeLookupPanel, { AiCandidate } from './PersonEditorShared/AiCodeLooku
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -221,8 +221,22 @@ export default function StatusEditor({
         gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, placeholder, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('status_create', '新增社會區分') : tr('status_edit', '編輯社會區分')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -303,7 +317,7 @@ export default function StatusEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
-        </div>
+        </form>
     );
 }
 

--- a/resources/js/inertia/components/TextEditor.tsx
+++ b/resources/js/inertia/components/TextEditor.tsx
@@ -7,7 +7,7 @@ import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import {
     gridCardStyle, gGrid, gPairRow, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
     gSubmitRow, gBtnGroupRight, gPrimaryBtn, gInfoBtn, gDangerBtn, gCancelBtn,
-    gAuditWrapStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
+    gAuditWrapStyle, gHiddenSubmitStyle, gridSectionHeadStyle, GridLabel, gridCell, gridInput,
 } from './PersonEditorShared/grid';
 
 /**
@@ -161,8 +161,22 @@ export default function TextEditor({
         gridCell(label, { code }, gridInput({ value: fields[key] ?? '', onChange: (v) => set(key, v), disabled: !editable, highlight, name: key }))
     );
 
+    // 回車保存（復刻舊版 Blade：表單內於單行輸入框按 Enter 觸發提交）。以原生 <form> 實現，
+    // 因此 textarea 換行、輸入法（IME）選字用的 Enter 皆為瀏覽器原生行為、不會誤觸提交；
+    // 表單內按鈕皆為 type="button" 不隱式提交。canEdit → 直接保存；否則可提案者 → 提交建議。
+    const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (saving || deleting || (mode === 'edit' && !dirty)) return;
+        if (canEdit) {
+            void save('direct');
+        } else if (canPropose) {
+            void save('proposal');
+        }
+    };
+
     return (
-        <div style={gridCardStyle}>
+        <form style={gridCardStyle} onSubmit={onFormSubmit}>
+            <button type="submit" aria-hidden="true" tabIndex={-1} style={gHiddenSubmitStyle} />
             <h3 style={titleStyle}>{mode === 'create' ? tr('text_create', '新增著述') : tr('text_edit', '編輯著述')}</h3>
             {message ? <div style={gOkStyle}>{message}</div> : null}
             {error ? <div style={gErrStyle}>{error}</div> : null}
@@ -222,7 +236,7 @@ export default function TextEditor({
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
-        </div>
+        </form>
     );
 }
 


### PR DESCRIPTION
## 摘要

- 使用者回報 altnames 編輯頁 (`/app/basicinformation/34246/altnames/edit-v2`) 在輸入框（不含選擇框）按 Enter 無法觸發保存；basic_info 編輯頁先前已修過同類問題（commit 7f8d7a81：根節點改為原生 `<form>` + 隱藏 `type=submit` 按鈕）。
- 確認後發現同樣問題存在於全部 12 個 person-browser 子資源編輯器（address / altname / assoc / entry / event / kin / office / possession / socialinst / source / status / text），只有 basic_info 編輯器修過。
- 比照 basic_info 的修法套用到這 12 個編輯器：根節點改為 `<form>`、新增共用 `gHiddenSubmitStyle`（`PersonEditorShared/grid.tsx`）。
- 附帶修正：`CodeAutocomplete`（12 個編輯器共用的下拉選擇元件）一 focus 就展開下拉，改成 `<form>` 後若不攔截會被誤判為隱式提交，導致使用者尚未選取候選就誤觸儲存；補上下拉展開中攔截 Enter、Esc 關閉下拉，並排除中文輸入法選字用的 Enter（`isComposing` / `keyCode 229`），避免影響中文輸入。

## 測試計畫

- [x] `npx tsc --noEmit`：無新增錯誤（既有錯誤與本次改動檔案無關）
- [x] `npm run build`：成功
- [x] code-reviewer 子代理審查兩輪：無嚴重問題
- [x] `codex exec` 審查三輪（含發現並修正 CodeAutocomplete Enter/IME 問題後再次確認）：無阻擋合併問題
- [ ] 建議上線後於實際頁面手動測試：一般輸入框按 Enter 觸發保存、下拉選擇展開時按 Enter 不誤觸提交、中文輸入法選字按 Enter 正常運作、textarea 換行不誤觸提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)