### PR TITLE
修正人物列表頁搜尋按鈕與輸入框高度不齊

### DIFF
--- a/resources/js/inertia/Pages/BasicInformation/Index.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/Index.tsx
@@ -91,7 +91,7 @@ export default function PersonIndex() {
                             ))}
                         </Select>
                     )}
-                    <Button type="submit" variant="secondary" size="sm">
+                    <Button type="submit" variant="secondary" size="icon" title={tc('search')} aria-label={tc('search')}>
                         <i className="fas fa-search" aria-hidden />
                     </Button>
                 </form>


### PR DESCRIPTION
## 摘要

- 使用者回報 `/app/basicinformation?q=26114` 的搜尋列，輸入框與搜尋按鈕大小看起來不太匹配。
- 調查確認：`Input`/`Select` 元件固定 `h-9`（36px），搜尋按鈕原用 `size="sm"`（`h-8`，32px），純圖示按鈕比旁邊欄位矮 4px，視覺不對齊。
- 設計面：`Button.tsx` 已內建 `size="icon"`（`h-9 w-9`）變體，本就是為「純圖示按鈕、需與預設 h-9 欄位等高」設計，但先前全專案未使用過。改用此變體即可讓搜尋鈕與輸入框/下拉選單完全等高，且不需更動 Input/Select 的預設樣式。
- 附帶修正：純圖示按鈕原本沒有可見文字，補上 `title`/`aria-label`，比照專案內其他純圖示按鈕的無障礙慣例。

## 測試計畫

- [x] `npx tsc --noEmit`：無新增錯誤
- [x] `npm run build`：成功
- [x] review agent 審查一輪：無嚴重問題
- [x] `codex exec` 審查一輪：無嚴重問題
- [ ] 建議上線後於 `/app/basicinformation` 實際頁面肉眼確認搜尋鈕與輸入框/下拉選單已等高對齊

🤖 Generated with [Claude Code](https://claude.com/claude-code)