### PR TITLE
docs: 技術棧現況盤點與現代化行動手冊（重開自 #1091，續議）

### DIFF
--- a/docs/TECH_DEBT_ASSESSMENT.en.md
+++ b/docs/TECH_DEBT_ASSESSMENT.en.md
@@ -1,0 +1,394 @@
+# Tech-Stack Assessment & Modernization Playbook
+
+> Audit date: 2026-06-29 ｜ Branch: `docs-tech-debt-assessment`
+> 中文版（authoritative source）: [`TECH_DEBT_ASSESSMENT.md`](./TECH_DEBT_ASSESSMENT.md)
+>
+> **What this is**: a **playbook for the team to discuss and act on** — not just a report.
+> Structure = **Assessment (Parts 1–3) + Decisions to settle (Part 3.5) + Per-item action plans (Part 4)**.
+> Every conclusion is backed by evidence (file:line / command output); plans are written to be
+> "pick-up-and-do, no re-scanning needed." Each action lists: goal, prerequisites, step-by-step ops
+> (with commands / config file contents), blast radius, risk, rollback, **Definition of Done (DoD)**,
+> **open decisions**, effort, dependencies.
+>
+> **How to use this (for readers/reviewers)**:
+> 1. Read Part 1 to align (the core stack is actually modern);
+> 2. Skim the Part 2 evidence tables and decide what (if anything) to do;
+> 3. **In the meeting, walk through the Part 3.5 decision list and settle each** (each is tagged with who decides);
+> 4. Once decided, each action = one independent PR, executed per Part 4;
+> 5. This doc only says "what & how"; fill in Owner/schedule in the tracker during discussion.
+
+## Methodology (how this was verified)
+- Read authoritative sources: `package.json`, `composer.json`, `composer.lock`, `package-lock.json`,
+  `vite.config.js`, `tsconfig.json`, `.github/workflows/*`, `routes/*`, `README.md`, `AGENTS.md`.
+- Used `grep`/`find` to count real references — distinguishing "installed" from "actually used."
+- Ran `npx tsc --noEmit` to quantify type errors. Appendix A lists re-runnable commands.
+
+---
+
+# Part 1: Bottom line — the core stack is actually modern
+
+Given it is now 2026-06, the core frameworks are current, even leading-edge. **"Old" is not in the core versions:**
+
+| Component | Installed version (from lockfiles) | Verdict |
+|---|---|---|
+| Laravel Framework | v12.62.0 (`php ^8.2`; CI runs PHP 8.4) | Current |
+| React / React-DOM | 19.2.4 | Current |
+| Inertia (`@inertiajs/react`) | 2.3.18 | Current |
+| Vite | 8.0.16 | Leading-edge |
+| TypeScript | 6.0.2 | Leading-edge |
+| Tailwind CSS | 4.3.1 (`@tailwindcss/vite`) | Leading-edge |
+| lucide-react | 1.21.0 | Works (unusual version, see E3) |
+
+`tsconfig.json` is itself modern and strict (`strict:true`, `noEmit`, `moduleResolution:"bundler"`, `target/module: ESNext`).
+**The real debt is in three places: ① frontend engineering gaps, ② the legacy frontend stack (intentionally retained, pending Phase 7), ③ a few backend structural issues and dead dependencies.**
+
+---
+
+# Part 2: Findings (with evidence)
+
+Severity = risk to quality/maintainability; Effort = rough estimate; "By design" = deliberately kept, not an oversight. Each row maps to a Part 4 plan.
+
+### A. Frontend engineering gaps (incremental, low-risk, highest ROI)
+| ID | Status | Evidence | Severity | Effort | Plan |
+|---|---|---|---|---|---|
+| A1 | No frontend tests (no vitest/jest/playwright) | No JS test config; scripts only `dev`/`build`/`prod`; core React editors have no unit/component tests | High | Med | §P-A1 |
+| A2 | No JS/TS lint/format (no ESLint/Prettier) | `ls .eslintrc* eslint.config.* .prettierrc*` → none; only PHP-side php-cs-fixer | Med | Low | §P-A2 |
+| A3 | TS strict configured but not enforced | `npx tsc --noEmit` reports **21 errors**; CI only runs `npm run prod` (esbuild does no type-checking) | High | Med | §P-A3 |
+| A4 | husky installed but unused | `husky@9` in devDeps, but **no `.husky/`** dir and no `prepare` script | Low | Low | §P-A4 |
+| A5 | No frontend gate in CI | workflows are only `phpunit/php-cs-fixer/codeql`; `phpunit.yml` just builds (`npm run prod`) | Med | Low | §P-A5 |
+
+### B. Legacy frontend stack (**by design**; AGENTS.md states physical removal is Phase 7)
+| ID | Status | Evidence | Severity | Effort | Plan |
+|---|---|---|---|---|---|
+| B1 | AdminLTE 3 + Bootstrap 4 + jQuery 3.5 + DataTables + select2 still wired into legacy `app.js` | Ref counts: `jquery`×22, `select2`×40, `bootstrap`×19, `datatables`×6, `admin-lte`×6; `resources/views` still has **106** `.blade.php`; `axios` is legacy-only (`app.js:228`) | Med (isolated) | Large | §P-B1 |
+| B2 | Vue 3 exists for a single component | Only `resources/js/components/Select.vue` (imported at `app.js:318`, mounted later via `createApp` in app.js); `vue`+`@vitejs/plugin-vue`+`@vue/compiler-sfc` serve only it | Med | Med | §P-B2 |
+
+### C. Backend / infrastructure
+| ID | Status | Evidence | Severity | Effort | Plan |
+|---|---|---|---|---|---|
+| C1 | MariaDB 10.3.39 (EOL) | `README.md:58`, `AGENTS.md:6`; MariaDB 10.3 reached end-of-support 2023-05 | High | Med | §P-C1 |
+| C2 | **Two same-named ApiControllers** (naming confusion, NOT dead code) | Both classes are named `ApiController`: root `app/Http/Controllers/ApiController.php` (43 `'ApiController@'` refs in `api.php`, the select/search/* endpoints) + `app/Http/Controllers/Api/ApiController.php` (**9** `'Api\ApiController@'` refs: OFFICE_CODES, office/entry/place lists, place_belongs_to, etc., resolved via `RouteServiceProvider`'s `App\Http\Controllers` namespace prefix). **Both are live**; only the duplicate name is confusing | Low | Low | §P-C2 |
+| C3 | laravel/ui v4.6.1 (dated auth scaffolding) | `web.php:19 Auth::routes();`, `web.php:26 HomeController@index`; auth pages already migrated to React, but routes still rely on `Auth::routes()` | Med | Med | §P-C3 |
+
+### D. Dead / redundant dependencies (verified removable)
+| ID | Dependency | Evidence | Plan |
+|---|---|---|---|
+| D1 | `sass-loader@12` + `resolve-url-loader@5` | webpack-era loaders; not in `vite.config.js`, and there are **0** `.scss` files | §P-D |
+| D2 | `sass@1.79` | no `.scss` anywhere | §P-D |
+| D3 | `lodash@4.17` | **0** uses in `resources/js` | §P-D |
+| D4 | `husky@9` | no `.husky/`, no `prepare` script | §P-D / §P-A4 |
+
+> `axios` must **not** be listed as dead — legacy `app.js` still uses `window.axios`; handle it in Phase 7.
+
+### E. Code patterns & misc
+| ID | Status | Evidence | Note |
+|---|---|---|---|
+| E1 | Inline `style` with hardcoded hex colors | Recent dark-mode refactor already fixed ~71 files | New components must use token classes; existing ones converge gradually |
+| E2 | Composite PKs via Query Builder (not Eloquent) | Constrained by CBDB schema (`app/Support/CompositePrimaryKey.php`) | "Can't easily change" — record only |
+| E3 | lucide-react version anomaly (1.21.0; upstream mainline is 0.x) | Builds/imports fine | Low priority; verify provenance in §P-D |
+
+---
+
+# Part 3: Recommended priority
+
+1. **A — engineering safety net** (A2/A3 → A1 → A5 → A4): pure addition, doesn't touch features, makes every later change safer.
+2. **D — dead dependencies**: very low risk, quick wins.
+3. **C — backend debt** (C2 → C3 → C1).
+4. **B — legacy stack**: largest but isolated; plan as one batch tied to Phase 7.
+
+---
+
+# Part 3.5: Decisions to settle before starting (walk through in the meeting)
+
+> These are the forks that need someone to decide first; everything else is mechanical once decided.
+
+| # | Decision | Options | Recommendation | Who decides |
+|---|---|---|---|---|
+| Q1 | Adopt the full frontend toolchain (lint/typecheck/test/CI gate)? | All / only lint+typecheck / none | All (A items are highest ROI) | Frontend lead + Tech Lead |
+| Q2 | When to make the CI frontend gate blocking | Block immediately / `continue-on-error` for a week first | Observe a week, then enforce | Tech Lead |
+| Q3 | husky: enable pre-commit vs remove | Enable (§P-A4 option 1) / Remove (option 2) | Enable if adopting A2/A3, else remove | Frontend lead |
+| Q4 | Replacement for `Auth::routes()` | Explicit routes / adopt Fortify | Explicit routes (smaller change, no new dep) | Backend lead |
+| Q5 | MariaDB target version & window | 10.11 LTS / 11.x; maintenance window | 10.11 LTS (stable LTS) | Ops + Tech Lead |
+| Q6 | How to handle `Select.vue` | Retire with Phase 7 (A) / rewrite to React first (B) | Path A (unless that page won't be retired soon) | Frontend lead |
+| Q7 | Start Phase 7 legacy removal? batching? | Start/defer; how to split | Start only after all pages are accepted | Tech Lead + PO |
+| Q8 | `lucide-react@1.21.0` version anomaly | Keep / switch to upstream mainline & pin | Verify provenance first | Frontend lead |
+
+## Action tracker (fill in during discussion)
+| Action | Plan | Effort | Depends on | Owner | Target date | Status |
+|---|---|---|---|---|---|---|
+| ESLint + Prettier | §P-A2 | Low | — | | | TBD |
+| typecheck gate + clear 21 errors | §P-A3 | Med | — | | | TBD |
+| Vitest + RTL | §P-A1 | Med | A2 | | | TBD |
+| husky cleanup | §P-A4 | Low | A2 (option 1) | | | TBD |
+| CI frontend gate | §P-A5 | Low | A1/A2/A3 | | | TBD |
+| Remove dead deps | §P-D | Low | coordinate w/ A4 | | | TBD |
+| Rename ApiController / de-dupe name (**not delete**) | §P-C2 | Low | — | | | TBD |
+| Replace Auth::routes() | §P-C3 | Med | Q4 | | | TBD |
+| MariaDB upgrade | §P-C1 | Med | Q5, Ops | | | TBD |
+| Retire Vue | §P-B2 | Med | Q6, B1 | | | TBD |
+| Phase 7 legacy removal | §P-B1 | Large | Q7, all pages accepted | | | TBD |
+
+---
+
+# Part 4: Detailed action plans
+
+> General rule: each plan = one independent PR/branch; follow the project flow (review agent → codex → then commit/PR/rebase/merge).
+> For any new npm dependency, use "the latest version compatible with the current toolchain" (this repo is in the Vite 8 / TS 6 / ESLint 9 era);
+> after installing, verify with `npm run build` + `npx tsc --noEmit` that the existing build isn't broken.
+
+## §P-A2: Add ESLint + Prettier (do this first; A1/A3/A4 build on it)
+**Goal**: automatic lint/format on the frontend, starting at `warn` (non-blocking), tightening over time.
+**Prereq**: none.
+**Steps**
+1. Install (flat config, ESLint 9 era):
+   ```bash
+   npm i -D eslint @eslint/js typescript-eslint eslint-plugin-react-hooks \
+     eslint-plugin-react-refresh prettier eslint-config-prettier
+   ```
+2. Add `eslint.config.js` (flat config; lint only `resources/js/inertia/**` TS/React, skip legacy `app.js`):
+   ```js
+   import js from '@eslint/js';
+   import tseslint from 'typescript-eslint';
+   import reactHooks from 'eslint-plugin-react-hooks';
+   import reactRefresh from 'eslint-plugin-react-refresh';
+   import prettier from 'eslint-config-prettier';
+
+   export default tseslint.config(
+     { ignores: ['public/**', 'node_modules/**', 'resources/js/app.js', 'resources/js/datatables.js', 'resources/js/historical-maps/**', 'resources/js/chgis-map/**', 'resources/js/components/**'] },
+     js.configs.recommended,
+     ...tseslint.configs.recommended,
+     {
+       files: ['resources/js/inertia/**/*.{ts,tsx}'],
+       plugins: { 'react-hooks': reactHooks, 'react-refresh': reactRefresh },
+       rules: {
+         ...reactHooks.configs.recommended.rules,
+         // start as warn to avoid a huge diff; promote to error once stable
+         '@typescript-eslint/no-explicit-any': 'warn',
+         '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+       },
+     },
+     prettier, // disable formatting rules that conflict with Prettier
+   );
+   ```
+3. Add `.prettierrc.json` (match existing style — 4-space indent, single quotes, semicolons):
+   ```json
+   { "tabWidth": 4, "singleQuote": true, "semi": true, "printWidth": 120, "trailingComma": "all" }
+   ```
+4. Add scripts to `package.json`:
+   ```json
+   "lint": "eslint resources/js/inertia",
+   "lint:fix": "eslint resources/js/inertia --fix",
+   "format": "prettier --write \"resources/js/inertia/**/*.{ts,tsx,css}\""
+   ```
+5. Run `npm run lint`, record the warning count as a baseline; do **not** clear all existing warnings now (avoids a massive diff).
+**Blast radius**: config + scripts only, no runtime code. **Risk**: low.
+**Rollback**: remove config/scripts, `npm uninstall` the packages.
+**DoD**: `npm run lint` runs and only reports warnings; `npm run build` unaffected.
+**Effort**: low (~0.5 day). **Depends**: required by A4/A5.
+
+## §P-A3: Add a type-check gate and clear the existing 21 errors
+**Goal**: `tsc --noEmit` in CI and blocking merges; first clear the existing 21 errors.
+**Prereq**: none (can run parallel to A2).
+**Steps**
+1. Add script: `"typecheck": "tsc --noEmit -p tsconfig.json"`.
+2. Inventory and classify current errors:
+   ```bash
+   npx tsc --noEmit -p tsconfig.json 2>&1 | grep "error TS" | sed -E 's/\(.*//' | sort | uniq -c | sort -rn
+   ```
+   Per this session's observation, they cluster in `PersonBrowser/TabContentLoader.tsx`, `BasicInfoEditor.tsx:99`,
+   `Pages/BasicInformation/{Edit,Show}.tsx`, `SearchByEntry/Index.tsx`, `ViewTables/Show.tsx`,
+   and `utils/*.js` (implicit any, missing `.d.ts`).
+3. Fix file by file (run `npm run typecheck` after each):
+   - `Section[]/Field[]` `value: unknown` → narrow the type or add a type guard at the boundary.
+   - `SetStateAction<Fields>` mismatch (`BasicInfoEditor.tsx:99`) → fix the `Fields` type or the setState callback.
+   - `PageProps` not satisfying the Inertia constraint (`SearchByEntry`, `ViewTables/Show`) → make the interface `extends SharedProps` or add an index signature.
+   - `../../../utils/*.js` (`disableNumberInputWheel`, `sqlFormatter`) implicit any → add matching `.d.ts` or convert to `.ts`.
+4. Once at 0, add the CI gate (see §P-A5).
+**Blast radius**: mostly type annotations; a few may reveal real defects (handle carefully). **Risk**: medium (touches runtime files).
+**Rollback**: keep fixes as small commits, revert individually; the CI gate can start with `continue-on-error`.
+**DoD**: `npm run typecheck` reports 0 errors; `npm run build` green; affected pages' existing PHPUnit pass.
+**Effort**: medium (~1–2 days). **Depends**: A5's typecheck gate depends on this reaching zero.
+
+## §P-A1: Add Vitest + React Testing Library
+**Goal**: testable frontend logic/components.
+**Prereq**: A2 recommended first (shared TS config).
+**Steps**
+1. Install:
+   ```bash
+   npm i -D vitest @testing-library/react @testing-library/jest-dom \
+     @testing-library/user-event jsdom @vitejs/plugin-react
+   ```
+2. Add `vitest.config.ts` (reuse existing alias, jsdom env):
+   ```ts
+   import { defineConfig } from 'vitest/config';
+   import react from '@vitejs/plugin-react';
+   import { fileURLToPath, URL } from 'node:url';
+
+   export default defineConfig({
+     plugins: [react()],
+     test: { environment: 'jsdom', globals: true, setupFiles: ['./resources/js/inertia/test/setup.ts'],
+       include: ['resources/js/inertia/**/*.{test,spec}.{ts,tsx}'] },
+     resolve: { alias: { '@': fileURLToPath(new URL('./resources/js/inertia', import.meta.url)) } },
+   });
+   ```
+3. `resources/js/inertia/test/setup.ts`: `import '@testing-library/jest-dom';`
+4. Add scripts: `"test": "vitest run"`, `"test:watch": "vitest"`.
+5. Start with high-value, low-coupling tests (no backend needed):
+   - `BasicInfoEditor`'s `deriveNames` (pure function) and the "generate pinyin" fill logic (mock `fetch`).
+   - `logCardStyles` / token-class mapping (pure data).
+   - One smoke render test for a key component (e.g. `SelectionDialog` open/close, `Pagination`).
+6. Initial coverage target: prioritize pure functions in `inertia/components`; don't chase a site-wide number.
+**Blast radius**: pure addition. **Risk**: low.
+**Rollback**: remove config/tests, `npm uninstall`.
+**DoD**: `npm run test` green; wired into CI (§P-A5).
+**Effort**: medium (0.5 day setup + ongoing). **Depends**: A5.
+
+## §P-A4: husky cleanup (choose one)
+**Option 1 (recommended if adopting A2/A3): enable pre-commit**
+1. `npm i -D lint-staged`; add `"prepare": "husky"` to `package.json`; run `npm run prepare`.
+2. `npx husky init` generates `.husky/pre-commit` containing:
+   ```sh
+   npx lint-staged
+   ```
+3. Add to `package.json`:
+   ```json
+   "lint-staged": {
+     "resources/js/inertia/**/*.{ts,tsx}": ["eslint --fix", "prettier --write"],
+     "app/**/*.php": ["./vendor/bin/php-cs-fixer fix"]
+   }
+   ```
+**Option 2 (if not adopting hooks now): remove the dependency** — `npm uninstall husky` (see §P-D).
+**Blast radius**: dev workflow. **Risk**: low. **Rollback**: delete `.husky/`, remove prepare/lint-staged.
+**DoD**: an actual commit triggers the hook; CI unaffected. **Effort**: low. **Depends**: option 1 depends on A2.
+
+## §P-A5: Add the frontend CI gate
+**Goal**: PRs block on type/lint/test errors.
+**Steps**: in `.github/workflows/phpunit.yml` (already has Node 22 + `npm install`), after the build step or as a separate job:
+```yaml
+      - name: Frontend checks
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run test
+```
+(Or create `frontend.yml` running in parallel with PHPUnit; same `on:` push/pull_request.)
+**Blast radius**: CI. **Risk**: low, but **only** enable blocking after A3 hits zero and A1/A2 land, otherwise every PR goes red. Consider `continue-on-error: true` for a week first.
+**Rollback**: remove the step. **DoD**: open a PR with a deliberate type error and confirm it's blocked. **Effort**: low. **Depends**: A1/A2/A3.
+
+## §P-D: Remove dead dependencies
+**Goal**: remove `sass-loader`, `resolve-url-loader`, `sass`, `lodash` (husky depends on §P-A4).
+**Prereq**: re-run the Appendix A "D" checks to confirm 0 references.
+**Steps**
+1. Final confirmation:
+   ```bash
+   find resources -name '*.scss' | wc -l                 # expect 0
+   grep -rniE "lodash" resources/js | wc -l              # expect 0
+   grep -rniE "resolve-url-loader|sass-loader|\.scss" vite.config.js resources/js | wc -l   # expect 0
+   ```
+2. Remove: `npm uninstall sass-loader resolve-url-loader sass lodash` (if husky takes option 2, also `npm uninstall husky`).
+3. `npm install` to rebuild the lockfile; `npm run build` and (if present) `npm run test`/`typecheck` all green.
+**Blast radius**: devDeps only. **Risk**: low (0 references proven). **Rollback**: `git checkout package.json package-lock.json && npm install`.
+**DoD**: `npm run build` green; no missing modules in the bundle. **Effort**: low (~0.5 day). **Depends**: coordinate D4 with A4.
+
+## §P-C2: Resolve the "two same-named ApiControllers" confusion (**RENAME, not delete**)
+> ⚠️ Note: `Api/ApiController` is **live code** — `routes/api.php` has **9 routes** pointing to it (see above),
+> so it **must NOT be deleted**. This plan is only "rename to remove the duplicate-name confusion," an optional low-priority readability refactor.
+**Goal**: two classes both named `ApiController` are confusing; rename `Api\ApiController` to something descriptive
+(suggest `CodeLookupApiController` or `OfficeEntryPlaceApiController` per its responsibility) to remove the ambiguity.
+**Prereq**: inventory all references first.
+**Steps**
+1. Inventory references (expect 9 in routes/api.php + the class declaration):
+   ```bash
+   # ⚠️ grep is sensitive to backslash escaping: use -F (fixed string), or "Api\\ApiController@" wrongly returns 0 (the author hit this).
+   grep -Fc 'Api\ApiController@' routes/api.php                          # expect 9 (OFFICE_CODES…entry_list_by_name)
+   php artisan route:list | grep -iE "OFFICE_CODES|post_list|entry_list|place_list|place_belongs_to|office_list_by_name|entry_list_by_name"   # expect 9 rows
+   ```
+2. Rename the class and file (`Api/ApiController.php` → `Api/CodeLookupApiController.php`, class name in sync),
+   and update the 9 `'Api\ApiController@...'` references in `routes/api.php` → `'Api\CodeLookupApiController@...'`.
+3. `composer dump-autoload`; `php artisan route:list` to confirm route count matches before/after.
+**Blast radius**: backend (pure rename, behavior unchanged). **Risk**: low (mechanical rename). **Rollback**: `git revert`.
+**DoD**: `route:list` identical to before (count, URIs, methods unchanged); `./vendor/bin/phpunit` green; no remaining `Api\ApiController` references.
+**Open question**: is it worth doing (pure cosmetics, zero functional gain)? If not, at least add header comments to both files noting their relationship. **Effort**: low.
+
+## §P-C3: Replace laravel/ui's `Auth::routes()` with explicit routes / Fortify
+**Goal**: remove the dated laravel/ui scaffolding; auth is already React/Inertia.
+**Prereq**: first run `php artisan route:list | grep -iE "login|register|password|logout"` to see exactly which routes `Auth::routes()` expands to and their controllers.
+**Steps**
+1. Expand `Auth::routes()` into **explicit** routes (pointing at the existing Inertia/Auth controllers), matching `route:list` one by one: login/logout/register/password.request/password.email/password.reset/password.update (and `verification.*` if used).
+2. Confirm whether `HomeController@index name('home')` is still needed; if the dashboard takes over, adjust the redirect.
+3. Remove `composer remove laravel/ui`; `composer dump-autoload`.
+4. Regression-test the whole auth flow: login/logout/register/forgot-password/reset-password (run existing Feature tests first if any).
+**Blast radius**: auth routes (high-sensitivity). **Risk**: medium (auth). **Rollback**: `git revert` + `composer require laravel/ui`.
+**DoD**: `route:list` identical to before expansion; auth Feature tests green; manually walk all five flows. **Effort**: medium (~1 day).
+
+## §P-C1: MariaDB 10.3.39 → supported version (10.11 LTS or 11.x)
+**Goal**: get off an EOL database. This is **environment-side**; code compatibility is already protected by the migration rules.
+**Prereq**: confirm how prod/test environments are deployed (this repo has no docker-compose version pin; version info is in `README.md:58`).
+**Steps**
+1. Environment inventory: list prod DB actual version, charset (`utf8mb4`), collation, timezone (`DB_TIMEZONE` must align with `APP_TIMEZONE`, see AGENTS high-risk notes).
+2. Stand up the target version in staging (recommend 10.11 LTS), restored from a prod snapshot.
+3. Compatibility checks:
+   - Run `php artisan migrate:status` and the full PHPUnit suite (against MySQL connection, not just SQLite).
+   - Check for DB-specific syntax (README:73 already requires avoiding ngram / proprietary plugins).
+   - Check `sql_mode` (10.11 defaults are stricter: `ONLY_FULL_GROUP_BY`, zero-dates) impact on existing queries.
+4. Roll out gradually: switch staging first, watch query logs and performance, then prod (maintenance window + backup).
+**Blast radius**: the whole data layer. **Risk**: high (environment). **Rollback**: restore DB snapshot + switch back.
+**DoD**: full PHPUnit (MySQL connection) green; key-page queries correct, no performance regression. **Effort**: medium (mostly coordination). **Depends**: Ops.
+
+## §P-B2: Vue `Select.vue` → remove the Vue dependency
+**Goal**: eliminate "carrying a whole Vue runtime for one component."
+**Prereq**: inventory how `Select.vue` is used (the `app.js:318` import / `createApp` mount point, the corresponding Blade pages).
+**Steps (choose one)**
+- **Path A (recommended if that page is legacy Blade)**: fold into §P-B1 Phase 7, retire it together with Blade; don't rewrite separately.
+- **Path B (if that Select is still needed)**: replace with a native `<select>` (or the existing React `Select`), update the `app.js` mount logic; after confirming no other `.vue`, remove `vue`, `@vitejs/plugin-vue`, `@vue/compiler-sfc`, the `vue()` plugin in `vite.config.js`, and `resolve.alias.vue`.
+**Blast radius**: legacy frontend. **Risk**: medium. **Rollback**: `git revert`.
+**DoD**: the page works; `npm run build` green and the bundle no longer contains Vue runtime. **Effort**: medium. **Depends**: coordinate with B1.
+
+## §P-B1: Phase 7 — retire the legacy frontend stack as one batch
+**Goal**: remove AdminLTE/Bootstrap4/jQuery/DataTables/select2/Vue/axios and the 106 Blade views.
+**Prereq (hard requirement)**: every corresponding React/Inertia page has been accepted "page-by-page, compared old vs new like a human tester" (see the project's gate-before-flip rule); all migration flags confirmed permanently `new`, no rollback needed.
+**Steps (batched, not all at once)**
+1. **Freeze rollback**: confirm `config/migration_flags.php` is all `new` and stable for a while; remove the "points to old route" branches before removing the flag mechanism.
+2. **Delete Blade per module**: by module (basicinformation/codes/operations/...), delete `resources/views/**` and the corresponding old controller actions / old routes in batches; run full tests + manual smoke each batch.
+3. **Trim Vite inputs**: remove `app.js`, `datatables.js` from `vite.config.js` `input` (after confirming no page still references them).
+4. **Remove deps**: `npm uninstall admin-lte bootstrap jquery datatables.net datatables.net-bs4 @ttskch/select2-bootstrap4-theme select2 vue @vitejs/plugin-vue @vue/compiler-sfc axios` (each after confirming 0 references).
+5. **Clean layouts/assets**: remove `layouts/dashboard-v3` and related AdminLTE layout CSS/JS.
+**Blast radius**: site-wide (removes the entire legacy world). **Risk**: high (large scope). **Rollback**: batch-by-batch, each independently revertable; keep tags.
+**DoD**: full PHPUnit + manual page-by-page each batch; finally `grep -rniE "jquery|admin-lte|select2"` returns zero. **Effort**: large (multiple PRs, multi-week). **Depends**: all pages accepted.
+
+## §E items (informational, no standalone PR)
+- **E1 inline colors**: new components must not hardcode hex; use `var(--token)` / token classes (the convention is reflected in `docs`/recent commits).
+- **E2 composite PKs**: keep the Query Builder approach, don't change (schema constraint).
+- **E3 lucide-react version**: verify the provenance of `1.21.0` at plan time; if it's not a mainline release, evaluate switching to upstream mainline and pinning.
+
+---
+
+## Appendix A: re-runnable verification commands
+```bash
+# Version snapshot
+grep -A1 '"laravel/framework"' composer.lock | grep version
+node -e "const l=require('./package-lock.json'),p=l.packages||{};for(const k of ['node_modules/vite','node_modules/typescript','node_modules/react','node_modules/tailwindcss','node_modules/@inertiajs/react','node_modules/lucide-react'])p[k]&&console.log(k.replace('node_modules/','')+': '+p[k].version)"
+
+# A3 type-error count and distribution
+npx tsc --noEmit -p tsconfig.json 2>&1 | grep -cE "error TS"
+npx tsc --noEmit -p tsconfig.json 2>&1 | grep "error TS" | sed -E 's/\(.*//' | sort | uniq -c | sort -rn
+
+# A1/A2/A4 toolchain gaps
+ls .eslintrc* eslint.config.* .prettierrc* vitest.config.* jest.config.* playwright.config.* .husky/ 2>/dev/null
+
+# B1 legacy frontend reference counts
+for lib in jquery admin-lte bootstrap datatables select2; do echo "$lib: $(grep -rniE "$lib" resources/js/app.js resources/js/*.js | wc -l)"; done
+find resources/views -name '*.blade.php' | wc -l   # Blade view count
+
+# B2 Vue usage
+find resources -name '*.vue'
+
+# C2 two same-named ApiControllers (both live) — mind grep backslash escaping; use -F for the 2nd
+grep -c "'ApiController@" routes/api.php                             # root ApiController (expect 43)
+grep -Fc 'Api\ApiController@' routes/api.php                         # Api\ApiController (expect 9, not 0!)
+
+# D dead deps
+grep -rniE "lodash" resources/js | wc -l                            # expect 0
+find resources -name '*.scss' | wc -l                               # expect 0
+grep -rniE "resolve-url-loader|sass-loader" vite.config.js           # expect 0
+```

--- a/docs/TECH_DEBT_ASSESSMENT.md
+++ b/docs/TECH_DEBT_ASSESSMENT.md
@@ -1,0 +1,393 @@
+# 技術棧現況盤點與現代化行動手冊
+
+> 盤點日期：2026-06-29 ｜ 分支：`docs-tech-debt-assessment`
+> English version: [`TECH_DEBT_ASSESSMENT.en.md`](./TECH_DEBT_ASSESSMENT.en.md)
+>
+> **本文定位**：一份**供同事討論、可直接據以行動的行動手冊（playbook）**——不是純報告。
+> 結構＝**評估（Part 1–3）＋ 討論前決策清單（Part 3.5）＋ 逐項行動計畫（Part 4）**。
+> 所有結論已附證據（檔案行號／指令結果），計畫力求「拿著就能做、不需再掃描」。
+> 每個行動含：目標、前置、逐步操作（含指令／設定檔內容）、影響面、風險、回退、**驗收標準(DoD)**、
+> **待討論決策點**、工作量、相依。
+>
+> **怎麼用這份手冊（給讀者/評審）**：
+> 1. 先看 Part 1 對齊認知（核心棧其實偏新）；
+> 2. 看 Part 2 證據表，挑要不要做、做哪些；
+> 3. **開會時逐條過 Part 3.5 的決策清單並拍板**（每條都標了需要誰決定）；
+> 4. 拍板後，每個行動 = 一個獨立 PR，照 Part 4 的步驟執行；
+> 5. 本手冊只描述「做什麼、怎麼做」，實際排期與負責人請於討論時填入下表的 Owner/排期欄。
+
+## 方法論（如何驗證）
+- 讀權威來源：`package.json`、`composer.json`、`composer.lock`、`package-lock.json`、`vite.config.js`、
+  `tsconfig.json`、`.github/workflows/*`、`routes/*`、`README.md`、`AGENTS.md`。
+- 以 `grep`/`find` 統計實際引用點，區分「安裝了」與「真的有用」。
+- 跑 `npx tsc --noEmit` 量化型別錯誤。附錄 A 列出可重跑指令。
+
+---
+
+# Part 1：先說結論——核心棧其實偏新
+
+考量現在是 2026-06，核心框架屬當代甚至前沿，**「古老」不在核心版本**：
+
+| 元件 | 已安裝版本（lock 實測） | 評價 |
+|---|---|---|
+| Laravel Framework | v12.62.0（`php ^8.2`，CI 跑 PHP 8.4） | 當代 |
+| React / React-DOM | 19.2.4 | 當代 |
+| Inertia (`@inertiajs/react`) | 2.3.18 | 當代 |
+| Vite | 8.0.16 | 前沿 |
+| TypeScript | 6.0.2 | 前沿 |
+| Tailwind CSS | 4.3.1（`@tailwindcss/vite`） | 前沿 |
+| lucide-react | 1.21.0 | 可用（版號異常，見 E3） |
+
+`tsconfig.json` 現代且嚴格（`strict:true`、`noEmit`、`moduleResolution:"bundler"`、`target/module: ESNext`）。
+**真正的債在三處：① 前端工程化缺口、② 遺留前端棧（設計保留待 Phase 7）、③ 少量後端結構債與死依賴。**
+
+---
+
+# Part 2：發現清單（含證據）
+
+嚴重度＝對品質/維護的風險；工作量＝粗估；「設計保留」＝專案刻意保留、非疏失。各項對應 Part 4 的詳細計畫編號。
+
+### A. 前端工程化缺口（增量補強、低風險、性價比最高）
+| 編號 | 現狀 | 證據 | 嚴重度 | 工作量 | 計畫 |
+|---|---|---|---|---|---|
+| A1 | 前端零測試（無 vitest/jest/playwright） | 無任何 JS 測試設定檔；scripts 僅 `dev`/`build`/`prod`；React 核心編輯器無單元/元件測試 | 高 | 中 | §P-A1 |
+| A2 | 無 JS/TS lint/format（無 ESLint/Prettier） | `ls .eslintrc* eslint.config.* .prettierrc*`→無；只有 PHP 端 php-cs-fixer | 中 | 低 | §P-A2 |
+| A3 | TS strict 配了但未強制 | `npx tsc --noEmit` 回報 **21 個錯誤**；CI 前端只 `npm run prod`（esbuild 不做型別檢查） | 高 | 中 | §P-A3 |
+| A4 | husky 裝了卻沒用 | `husky@9` 在 devDeps，但**無 `.husky/`**、無 `prepare` script | 低 | 低 | §P-A4 |
+| A5 | CI 無前端關卡 | workflows 僅 `phpunit/php-cs-fixer/codeql`；`phpunit.yml` 只 `npm run prod` | 中 | 低 | §P-A5 |
+
+### B. 遺留前端棧（**設計保留**，AGENTS.md 載明 Phase 7 才物理下架）
+| 編號 | 現狀 | 證據 | 嚴重度 | 工作量 | 計畫 |
+|---|---|---|---|---|---|
+| B1 | AdminLTE 3 + Bootstrap 4 + jQuery 3.5 + DataTables + select2 仍接線於 legacy `app.js` | 引用數：`jquery`×22、`select2`×40、`bootstrap`×19、`datatables`×6、`admin-lte`×6；`resources/views` 仍有 **106** 個 `.blade.php`；`axios` 僅 legacy 用（`app.js:228`） | 中（已隔離） | 大 | §P-B1 |
+| B2 | Vue 3 只為 1 個元件存在 | 僅 `resources/js/components/Select.vue`（`app.js:318` import、稍後於 app.js 內 `createApp` 掛載）；`vue`+`@vitejs/plugin-vue`+`@vue/compiler-sfc` 只服務它 | 中 | 中 | §P-B2 |
+
+### C. 後端 / 基礎設施
+| 編號 | 現狀 | 證據 | 嚴重度 | 工作量 | 計畫 |
+|---|---|---|---|---|---|
+| C1 | MariaDB 10.3.39（已 EOL） | `README.md:58`、`AGENTS.md:6`；MariaDB 10.3 官方支援 2023-05 結束 | 高 | 中 | §P-C1 |
+| C2 | **同名雙 ApiController**（命名混淆，非死碼） | 兩個類別都叫 `ApiController`：根命名空間 `app/Http/Controllers/ApiController.php`（`api.php` 43 處 `'ApiController@'`，select/search/* 等）＋ `app/Http/Controllers/Api/ApiController.php`（`api.php` **9 處** `'Api\ApiController@'`：OFFICE_CODES、office/entry/place 清單、place_belongs_to 等，經 `RouteServiceProvider` 的 `App\Http\Controllers` 命名空間前綴解析）。**兩者皆 live**，僅命名重複易混淆 | 低 | 低 | §P-C2 |
+| C3 | laravel/ui\@4.6.1（過時認證腳手架） | `web.php:19 Auth::routes();`、`web.php:26 HomeController@index`；認證頁已遷 React 但路由仍靠 `Auth::routes()` | 中 | 中 | §P-C3 |
+
+### D. 死依賴 / 冗餘（已驗證可移除）
+| 編號 | 依賴 | 證據 | 計畫 |
+|---|---|---|---|
+| D1 | `sass-loader@12` + `resolve-url-loader@5` | webpack 時代 loader；不在 `vite.config.js`，全庫 `.scss` **0** 個 | §P-D |
+| D2 | `sass@1.79` | 無任何 `.scss` | §P-D |
+| D3 | `lodash@4.17` | `resources/js` **0** 次使用 | §P-D |
+| D4 | `husky@9` | 無 `.husky/`、無 `prepare` script | §P-D / §P-A4 |
+
+> `axios` **不可**列死依賴——legacy `app.js` 仍用 `window.axios`；待 Phase 7 一併處理。
+
+### E. 程式模式與其他
+| 編號 | 現狀 | 證據 | 備註 |
+|---|---|---|---|
+| E1 | 內聯 `style` 寫死十六進制色 | 近期深色模式重構已修約 71 檔 | 新元件一律用 token class；存量漸進收斂 |
+| E2 | 複合主鍵走 Query Builder | 受 CBDB schema 限制（`app/Support/CompositePrimaryKey.php`） | 「無法輕易改」類，僅記錄 |
+| E3 | lucide-react 版號異常（1.21.0；上游主線 0.x） | 實測可正常打包 | 低優先；§P-D 附帶查證 |
+
+---
+
+# Part 3：建議優先序
+
+1. **A 類工程化安全網**（A2/A3 → A1 → A5 → A4）：純增量、不動功能，讓後續所有改動更安全。
+2. **D 類死依賴**：風險極低的快速勝利。
+3. **C 類後端債**（C2 → C3 → C1）。
+4. **B 類遺留棧**：最大但已隔離，綁定 Phase 7 整批規劃。
+
+---
+
+# Part 3.5：討論前需拍板的決策清單（開會逐條過）
+
+> 這些是「做之前必須有人拍板」的岔路；其餘步驟一旦決策確定即為機械執行。
+
+| # | 決策題 | 選項 | 建議 | 需誰拍板 |
+|---|---|---|---|---|
+| Q1 | 是否導入前端工程化全套（lint/typecheck/test/CI 關卡） | 全做 / 只做 lint+typecheck / 暫不做 | 全做（A 類性價比最高） | 前端負責人 + Tech Lead |
+| Q2 | CI 前端關卡何時轉「阻擋合併」 | 立即阻擋 / 先 `continue-on-error` 觀察一週 | 先觀察一週再強制 | Tech Lead |
+| Q3 | husky：正式啟用 pre-commit vs 直接移除 | 啟用（§P-A4 選項一）/ 移除（選項二） | 若採 A2/A3 則啟用，否則移除 | 前端負責人 |
+| Q4 | `Auth::routes()` 替代方案 | 顯式路由 / 導入 Fortify | 顯式路由（改動小、無新依賴） | 後端負責人 |
+| Q5 | MariaDB 升級目標版本與窗口 | 10.11 LTS / 11.x；維護窗口時間 | 10.11 LTS（LTS 穩定） | 維運 + Tech Lead |
+| Q6 | `Select.vue` 處理路徑 | 隨 Phase 7 退場(A) / 先改寫成 React(B) | 路徑 A（除非該頁短期不會下架） | 前端負責人 |
+| Q7 | Phase 7 legacy 下架是否啟動、批次切分 | 啟動/暫緩；如何分批 | 待所有頁驗收完成再啟動 | Tech Lead + PO |
+| Q8 | `lucide-react@1.21.0` 版號異常處理 | 維持 / 改上游主線版號並鎖定 | 查證來源後再定 | 前端負責人 |
+
+## 行動追蹤表（討論時填寫）
+| 行動 | 計畫 | 工作量 | 相依 | Owner | 目標排期 | 狀態 |
+|---|---|---|---|---|---|---|
+| ESLint+Prettier | §P-A2 | 低 | — | | | 待討論 |
+| typecheck 關卡 + 清 21 錯 | §P-A3 | 中 | — | | | 待討論 |
+| Vitest + RTL | §P-A1 | 中 | A2 | | | 待討論 |
+| husky 收尾 | §P-A4 | 低 | A2（選項一） | | | 待討論 |
+| CI 前端關卡 | §P-A5 | 低 | A1/A2/A3 | | | 待討論 |
+| 清死依賴 | §P-D | 低 | A4 協調 | | | 待討論 |
+| ApiController 改名／消除同名混淆（**非刪除**） | §P-C2 | 低 | — | | | 待討論 |
+| 取代 Auth::routes() | §P-C3 | 中 | Q4 | | | 待討論 |
+| MariaDB 升級 | §P-C1 | 中 | Q5、維運 | | | 待討論 |
+| Vue 退場 | §P-B2 | 中 | Q6、B1 | | | 待討論 |
+| Phase 7 legacy 下架 | §P-B1 | 大 | Q7、全頁驗收 | | | 待討論 |
+
+---
+
+# Part 4：詳細實作計畫
+
+> 通則：每個計畫獨立成一個 PR/分支；遵循專案流程（review agent → codex → 通過後 commit/PR/rebase/merge）。
+> 凡新增 npm 依賴，版本以「與現有工具鏈相容的最新版」為準（本專案在 Vite 8 / TS 6 / ESLint 9 era），
+> 安裝後以 `npm run build` + `npx tsc --noEmit` 驗證不破壞既有建置。
+
+## §P-A2：導入 ESLint + Prettier（建議最先做，後續 A1/A3/A4 都依賴它）
+**目標**：前端有自動 lint/format，先 `warn` 不阻擋、再逐步收緊。
+**前置**：無。
+**步驟**
+1. 安裝（flat config，ESLint 9 era）：
+   ```bash
+   npm i -D eslint @eslint/js typescript-eslint eslint-plugin-react-hooks \
+     eslint-plugin-react-refresh prettier eslint-config-prettier
+   ```
+2. 新增 `eslint.config.js`（flat config，只掃 `resources/js/inertia/**` 的 TS/React，避開 legacy `app.js`）：
+   ```js
+   import js from '@eslint/js';
+   import tseslint from 'typescript-eslint';
+   import reactHooks from 'eslint-plugin-react-hooks';
+   import reactRefresh from 'eslint-plugin-react-refresh';
+   import prettier from 'eslint-config-prettier';
+
+   export default tseslint.config(
+     { ignores: ['public/**', 'node_modules/**', 'resources/js/app.js', 'resources/js/datatables.js', 'resources/js/historical-maps/**', 'resources/js/chgis-map/**', 'resources/js/components/**'] },
+     js.configs.recommended,
+     ...tseslint.configs.recommended,
+     {
+       files: ['resources/js/inertia/**/*.{ts,tsx}'],
+       plugins: { 'react-hooks': reactHooks, 'react-refresh': reactRefresh },
+       rules: {
+         ...reactHooks.configs.recommended.rules,
+         // 起步階段先降級為 warn，避免一次塞爆；穩定後逐條轉 error
+         '@typescript-eslint/no-explicit-any': 'warn',
+         '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+       },
+     },
+     prettier, // 關掉與 Prettier 衝突的格式規則
+   );
+   ```
+3. 新增 `.prettierrc.json`（對齊現有程式風格——4 空格縮排、單引號、結尾分號）：
+   ```json
+   { "tabWidth": 4, "singleQuote": true, "semi": true, "printWidth": 120, "trailingComma": "all" }
+   ```
+4. `package.json` scripts 增：
+   ```json
+   "lint": "eslint resources/js/inertia",
+   "lint:fix": "eslint resources/js/inertia --fix",
+   "format": "prettier --write \"resources/js/inertia/**/*.{ts,tsx,css}\""
+   ```
+5. 跑 `npm run lint`，記錄 warning 數作為基線；**先不**把既有 warning 清光（避免巨大 diff）。
+**影響面**：僅新增設定檔與 scripts，不改執行程式。**風險**：低。
+**回退**：移除設定檔與 scripts、`npm uninstall` 上述套件。
+**驗證**：`npm run lint` 可執行且只報 warn；`npm run build` 不受影響。
+**工作量**：低（~0.5 天）。**相依**：被 A4/A5 依賴。
+
+## §P-A3：建立型別檢查關卡並清除現有 21 個錯誤
+**目標**：`tsc --noEmit` 進 CI 並阻擋合併；先清掉現存 21 個錯誤。
+**前置**：無（可與 A2 並行）。
+**步驟**
+1. `package.json` 增 script：`"typecheck": "tsc --noEmit -p tsconfig.json"`。
+2. 先盤點現有錯誤並分類：
+   ```bash
+   npx tsc --noEmit -p tsconfig.json 2>&1 | grep "error TS" | sed -E 's/\(.*//' | sort | uniq -c | sort -rn
+   ```
+   依本會話觀察，主要集中在 `PersonBrowser/TabContentLoader.tsx`、`BasicInfoEditor.tsx:99`、
+   `Pages/BasicInformation/{Edit,Show}.tsx`、`SearchByEntry/Index.tsx`、`ViewTables/Show.tsx`、
+   以及 `utils/*.js`（隱式 any，缺 `.d.ts`）。
+3. 逐檔修正（每修一檔即 `npm run typecheck` 收斂）：
+   - `Section[]/Field[]` 的 `value: unknown` → 收斂型別或在邊界做型別守衛。
+   - `SetStateAction<Fields>` 不相容（`BasicInfoEditor.tsx:99`）→ 修正 `Fields` 型別或 setState 回呼。
+   - `PageProps` 不滿足 Inertia 約束（`SearchByEntry`、`ViewTables/Show`）→ 讓 interface `extends SharedProps` 或補索引簽章。
+   - `../../../utils/*.js`（`disableNumberInputWheel`、`sqlFormatter`）隱式 any → 補同名 `.d.ts` 或改 `.ts`。
+4. 全清為 0 後，CI 加關卡（見 §P-A5）。
+**影響面**：多為型別標註修正，少數可能揭露真實缺陷（需小心）。**風險**：中（改到執行檔）。
+**回退**：型別修正分小 commit，可逐一回退；CI 關卡可先設 `continue-on-error` 緩衝。
+**驗證**：`npm run typecheck` 回 0 錯誤；`npm run build` 綠；跑受影響頁的既有 PHPUnit。
+**工作量**：中（~1–2 天，視 21 個錯誤深淺）。**相依**：A5 的 typecheck 關卡依賴本項清零。
+
+## §P-A1：導入 Vitest + React Testing Library
+**目標**：前端關鍵邏輯/元件可測。
+**前置**：建議 A2 先行（共用 TS 設定）。
+**步驟**
+1. 安裝：
+   ```bash
+   npm i -D vitest @testing-library/react @testing-library/jest-dom \
+     @testing-library/user-event jsdom @vitejs/plugin-react
+   ```
+2. 新增 `vitest.config.ts`（重用既有 alias，jsdom 環境）：
+   ```ts
+   import { defineConfig } from 'vitest/config';
+   import react from '@vitejs/plugin-react';
+   import { fileURLToPath, URL } from 'node:url';
+
+   export default defineConfig({
+     plugins: [react()],
+     test: { environment: 'jsdom', globals: true, setupFiles: ['./resources/js/inertia/test/setup.ts'],
+       include: ['resources/js/inertia/**/*.{test,spec}.{ts,tsx}'] },
+     resolve: { alias: { '@': fileURLToPath(new URL('./resources/js/inertia', import.meta.url)) } },
+   });
+   ```
+3. `resources/js/inertia/test/setup.ts`：`import '@testing-library/jest-dom';`
+4. scripts 增：`"test": "vitest run"`、`"test:watch": "vitest"`。
+5. 先寫高價值、低耦合的測試（不需後端）：
+   - `BasicInfoEditor` 的 `deriveNames`（純函式）與「生成拼音」回填邏輯（mock `fetch`）。
+   - `logCardStyles`／token class 對映（純資料）。
+   - 一個關鍵元件 render 冒煙測試（如 `SelectionDialog` 開關、`Pagination`）。
+6. 目標起步覆蓋率：核心 `inertia/components` 純函式優先，不追全站數字。
+**影響面**：純新增。**風險**：低。
+**回退**：移除設定/測試、`npm uninstall`。
+**驗證**：`npm run test` 綠；CI 串接（§P-A5）。
+**工作量**：中（框架 0.5 天 + 持續補測）。**相依**：A5。
+
+## §P-A4：husky 收尾（二擇一）
+**選項一（建議，若採用 A2/A3）：正式啟用 pre-commit**
+1. `npm i -D lint-staged`；`package.json` 增 `"prepare": "husky"`；跑 `npm run prepare`。
+2. `npx husky init` 生成 `.husky/pre-commit`，內容：
+   ```sh
+   npx lint-staged
+   ```
+3. `package.json` 增：
+   ```json
+   "lint-staged": {
+     "resources/js/inertia/**/*.{ts,tsx}": ["eslint --fix", "prettier --write"],
+     "app/**/*.php": ["./vendor/bin/php-cs-fixer fix"]
+   }
+   ```
+**選項二（若暫不導入鉤子）：移除依賴** —— `npm uninstall husky`（見 §P-D）。
+**影響面**：開發流程。**風險**：低。**回退**：刪 `.husky/`、移除 prepare/lint-staged。
+**驗證**：實際 commit 觸發 hook；CI 不受影響。**工作量**：低。**相依**：選項一依賴 A2。
+
+## §P-A5：CI 加前端關卡
+**目標**：PR 阻擋型別/lint/測試錯誤。
+**步驟**：在 `.github/workflows/phpunit.yml`（已裝 Node 22 + `npm install`）的 build 步驟後、或獨立 job 增：
+```yaml
+      - name: Frontend checks
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run test
+```
+（或新建 `frontend.yml`，與 PHPUnit 並行；`on:` 同 push/pull_request。）
+**影響面**：CI。**風險**：低，但**必須**在 A3 清零、A1/A2 落地後才開啟阻擋，否則 PR 全紅。可先 `continue-on-error: true` 觀察一週再轉強制。
+**回退**：移除步驟。**驗證**：開一個故意含型別錯誤的 PR，確認被擋。**工作量**：低。**相依**：A1/A2/A3。
+
+## §P-D：清除死依賴
+**目標**：移除 `sass-loader`、`resolve-url-loader`、`sass`、`lodash`（husky 視 §P-A4 決定）。
+**前置**：再次跑驗證（附錄 A 的 D 區指令）確認 0 引用。
+**步驟**
+1. 最終確認：
+   ```bash
+   find resources -name '*.scss' | wc -l                 # 預期 0
+   grep -rniE "lodash" resources/js | wc -l              # 預期 0
+   grep -rniE "resolve-url-loader|sass-loader|\.scss" vite.config.js resources/js | wc -l   # 預期 0
+   ```
+2. 移除：`npm uninstall sass-loader resolve-url-loader sass lodash`（husky 若採選項二一併 `npm uninstall husky`）。
+3. `npm install` 重建 lockfile；`npm run build` 與（若已有）`npm run test`/`typecheck` 全綠。
+**影響面**：僅 devDeps。**風險**：低（已證 0 引用）。**回退**：`git checkout package.json package-lock.json && npm install`。
+**驗證**：`npm run build` 綠；bundle 不缺檔。**工作量**：低（~0.5 天）。**相依**：D4 與 A4 二選一協調。
+
+## §P-C2：消除「同名雙 ApiController」命名混淆（**改名，非刪除**）
+> ⚠️ 注意：`Api/ApiController` 是 **live 程式碼**——`routes/api.php` 有 **9 個路由**指向它（見上），
+> **絕對不可刪除**。本計畫只做「重新命名以消除同名混淆」，屬可選的低優先 readability 重構。
+**目標**：兩個都叫 `ApiController` 的類別易混淆；把 `Api\ApiController` 改名為描述性名稱（建議
+`CodeLookupApiController` 或 `OfficeEntryPlaceApiController`，依其職責），消除歧義。
+**前置**：先盤點其全部引用點。
+**步驟**
+1. 盤點引用（預期 routes/api.php 9 筆 + 類別宣告）：
+   ```bash
+   # ⚠️ grep 對反斜線轉義敏感：務必用 -F 固定字串，否則 "Api\\ApiController@" 會誤回 0（本手冊作者曾踩此坑）。
+   grep -Fc 'Api\ApiController@' routes/api.php                          # 預期 9（OFFICE_CODES…entry_list_by_name）
+   php artisan route:list | grep -iE "OFFICE_CODES|post_list|entry_list|place_list|place_belongs_to|office_list_by_name|entry_list_by_name"   # 預期 9 條
+   ```
+2. 重新命名類別與檔案（`Api/ApiController.php` → `Api/CodeLookupApiController.php`，class 名同步），
+   同步更新 `routes/api.php` 的 9 處 `'Api\ApiController@...'` → `'Api\CodeLookupApiController@...'`。
+3. `composer dump-autoload`；`php artisan route:list` 比對改名前後路由數一致。
+**影響面**：後端（純改名，行為不變）。**風險**：低（機械改名）。**回退**：`git revert`。
+**驗收標準(DoD)**：`route:list` 與改名前完全一致（路由數、URI、method 不變）；`./vendor/bin/phpunit` 全綠；全庫無殘留 `Api\ApiController` 引用。
+**待討論**：是否值得做（純美化、零功能收益）；若否，至少在兩個檔頭加註解標明彼此關係。**工作量**：低。
+
+## §P-C3：以顯式路由/Fortify 取代 `laravel/ui` 的 `Auth::routes()`
+**目標**：移除過時的 laravel/ui 腳手架；認證已是 React/Inertia。
+**前置**：先 `php artisan route:list | grep -iE "login|register|password|logout"` 盤點 `Auth::routes()` 實際展開了哪些路由與其 controller。
+**步驟**
+1. 將 `Auth::routes()` 展開為**顯式**路由（指向現有 Inertia/Auth controllers），逐條對照 `route:list` 補齊：login/logout/register/password.request/password.email/password.reset/password.update（及 `verification.*` 若有用）。
+2. 確認 `HomeController@index name('home')` 是否仍需要；若 dashboard 已接管，導向調整。
+3. 移除 `composer remove laravel/ui`；`composer dump-autoload`。
+4. 全站認證流程回歸：登入/登出/註冊/忘記密碼/重設密碼（已有對應 Feature 測試者優先跑）。
+**影響面**：認證路由（高敏感）。**風險**：中（認證面）。**回退**：`git revert` + `composer require laravel/ui`。
+**驗證**：`route:list` 與展開前一致；認證 Feature 測試綠；手動走一遍五條流程。**工作量**：中（~1 天）。
+
+## §P-C1：MariaDB 10.3.39 → 受支援版本（10.11 LTS 或 11.x）
+**目標**：脫離 EOL 資料庫。屬**環境面**，程式相容性已被 migration 規範保護。
+**前置**：確認生產/測試環境部署方式（本 repo 無 docker-compose 版本鎖；版本資訊在 `README.md:58`）。
+**步驟**
+1. 環境盤點：列出生產 DB 實際版本、字元集（`utf8mb4`）、collation、timezone 設定（`DB_TIMEZONE` 需與 `APP_TIMEZONE` 對齊，見 AGENTS 高風險備忘）。
+2. 在 staging 起一台目標版本（建議 10.11 LTS），以生產資料快照還原。
+3. 相容性檢查：
+   - 跑 `php artisan migrate:status` 與全套 PHPUnit（針對 MySQL 連線，非僅 SQLite）。
+   - 檢查是否誤用 DB 專屬語法（README:73 已要求避免 ngram/專屬插件）。
+   - 檢查 `sql_mode`（10.11 預設較嚴格，留意 `ONLY_FULL_GROUP_BY`、零日期）對既有查詢影響。
+4. 灰度：先切 staging，觀察查詢日誌與效能，再切生產（維護窗口 + 備援）。
+**影響面**：全站資料層。**風險**：高（環境）。**回退**：DB 快照還原 + 切回舊版本。
+**驗證**：全套 PHPUnit（MySQL 連線）綠；關鍵頁查詢正確、效能無退化。**工作量**：中（環境協調為主）。**相依**：需維運。
+
+## §P-B2：Vue `Select.vue` → 移除 Vue 依賴
+**目標**：消滅「為 1 個元件背整套 Vue」。
+**前置**：盤點 `Select.vue` 的使用情境（`app.js:318` import、稍後於 app.js 內 `createApp` 掛載；對應 Blade 頁）。
+**步驟（二擇一）**
+- **路徑 A（推薦，若該頁屬 legacy Blade）**：併入 §P-B1 Phase 7，隨 Blade 一起退場，不單獨改寫。
+- **路徑 B（若該 Select 仍被需要）**：用原生 `<select>`（或既有 React `Select` 元件）取代，改 `app.js` 掛載邏輯；確認無其他 `.vue` 後，移除 `vue`、`@vitejs/plugin-vue`、`@vue/compiler-sfc`、`vite.config.js` 的 `vue()` plugin 與 `resolve.alias.vue`。
+**影響面**：legacy 前端。**風險**：中。**回退**：`git revert`。
+**驗證**：對應頁功能正常；`npm run build` 綠且 bundle 不再含 Vue runtime。**工作量**：中。**相依**：與 B1 協調。
+
+## §P-B1：Phase 7——legacy 前端棧整批下架
+**目標**：移除 AdminLTE/Bootstrap4/jQuery/DataTables/select2/Vue/axios 與 106 個 Blade 視圖。
+**前置（硬條件）**：對應的每一個 React/Inertia 頁皆已「像人類測試員逐頁對比新舊」驗收通過（見專案 gate-before-flip 規範）；所有 migration flag 確認可永久 `new`、不再需要回退。
+**步驟（分批，非一次性）**
+1. **凍結回退**：確認 `config/migration_flags.php` 全部 `new` 且穩定一段時間；移除 flag 機制前先移除「指向舊路由」的分支。
+2. **逐模組刪 Blade**：依模組（basicinformation/codes/operations/...）分批刪 `resources/views/**` 與對應舊 controller 動作、舊路由；每批跑全測 + 手動冒煙。
+3. **拆 Vite 入口**：從 `vite.config.js` 的 `input` 移除 `app.js`、`datatables.js`（確認無頁面再引用）。
+4. **移除依賴**：`npm uninstall admin-lte bootstrap jquery datatables.net datatables.net-bs4 @ttskch/select2-bootstrap4-theme select2 vue @vitejs/plugin-vue @vue/compiler-sfc axios`（逐一確認 0 引用後）。
+5. **清 layout/資產**：移除 `layouts/dashboard-v3` 等 AdminLTE layout 與相關 CSS/JS。
+**影響面**：全站（移除整個 legacy 世界）。**風險**：高（範圍大）。**回退**：分批進行，每批獨立可 revert；保留 tag。
+**驗證**：每批後全套 PHPUnit + 手動逐頁；最終 `grep -rniE "jquery|admin-lte|select2"` 歸零。**工作量**：大（多個 PR、跨週）。**相依**：所有頁面驗收完成。
+
+## §E 類（記錄性，無獨立 PR）
+- **E1 內聯色**：新元件禁止再寫死 hex，一律 `var(--token)`/token class（規範已在 `docs`/近期 commit 體現）。
+- **E2 複合主鍵**：維持 Query Builder 做法，勿改（schema 限制）。
+- **E3 lucide-react 版號**：plan 階段查證 `1.21.0` 來源；若為非主線發佈，評估改用上游主線並鎖定。
+
+---
+
+## 附錄 A：可重跑的驗證指令
+```bash
+# 版本快照
+grep -A1 '"laravel/framework"' composer.lock | grep version
+node -e "const l=require('./package-lock.json'),p=l.packages||{};for(const k of ['node_modules/vite','node_modules/typescript','node_modules/react','node_modules/tailwindcss','node_modules/@inertiajs/react','node_modules/lucide-react'])p[k]&&console.log(k.replace('node_modules/','')+': '+p[k].version)"
+
+# A3 型別錯誤數與分布
+npx tsc --noEmit -p tsconfig.json 2>&1 | grep -cE "error TS"
+npx tsc --noEmit -p tsconfig.json 2>&1 | grep "error TS" | sed -E 's/\(.*//' | sort | uniq -c | sort -rn
+
+# A1/A2/A4 工具鏈缺口
+ls .eslintrc* eslint.config.* .prettierrc* vitest.config.* jest.config.* playwright.config.* .husky/ 2>/dev/null
+
+# B1 遺留前端引用量
+for lib in jquery admin-lte bootstrap datatables select2; do echo "$lib: $(grep -rniE "$lib" resources/js/app.js resources/js/*.js | wc -l)"; done
+find resources/views -name '*.blade.php' | wc -l   # Blade 視圖數
+
+# B2 Vue 用量
+find resources -name '*.vue'
+
+# C2 同名雙 ApiController（兩者皆 live）— 注意 grep 反斜線轉義，第二條務必用 -F 固定字串
+grep -c "'ApiController@" routes/api.php                             # 根 ApiController（預期 43）
+grep -Fc 'Api\ApiController@' routes/api.php                         # Api\ApiController（預期 9，非 0！）
+
+# D 死依賴
+grep -rniE "lodash" resources/js | wc -l                            # 預期 0
+find resources -name '*.scss' | wc -l                               # 預期 0
+grep -rniE "resolve-url-loader|sass-loader" vite.config.js           # 預期 0
+```


### PR DESCRIPTION
重開自 #1091。原 #1091 於 2026-07-06 被「Rebase and merge」誤合併進 `develop`，已由 #1128 還原。此 PR 重新提出同一份文件供**續議**，暫不合併，待依 @frankslin 的審查意見重整後再定。

## 內容
- `docs/TECH_DEBT_ASSESSMENT.md`
- `docs/TECH_DEBT_ASSESSMENT.en.md`

## 待辦（依 @frankslin 審查意見）
重整優先序：先盤點**資料正確性 / 資料處理流程正確性**（複合主鍵、必填欄位、mutation/proposal/restore、Query Playground 只讀邊界、Person Browser 與各類查詢結果正確性），再談 legacy 前端退場、型別檢查、lint、測試框架、dead dependency 等前端工具鏈與技術債。

（@frankslin 的完整審查意見見下方留言，原文出處：#1091 (comment)。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)