### PR TITLE
docs(pinyin): Code 表 API 計畫納入 §D-6 保存時 v→ü 歸一化（Phase B 止血）

### DIFF
--- a/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
@@ -14,7 +14,15 @@
   - (b) **zero controller change**: the external script sends `person_id: 0` for code tables (reusing `NianHaoMutationHandler`'s existing approach).
 - **D-4 `ADDRESSES` derived table:** after correcting `ADDR_CODES`, **rebuild** via `cbdb:regenerate-addresses-table` (production, MySQL-only).
 - **D-5 Phase B "what to change" is governed by the scan rule, no human Sheet needed:** code tables are essentially pure pinyin (verified: of 498 `ETHNICITY.c_name` rows, 11 with v are all genuine pinyin, 0 Western; of 173 `CHORONYM` rows, 1 `Vietnam` has no `lv/nv` syllable and is excluded by the rule). So **apply the deterministic `lv/lve/nv/nve` syllable rule directly to both dedicated pinyin columns and romanized-name columns**; the scan command additionally emits a small `[OTHER-v]` list for a human eyeball (safety net). `ADDR_CODES` is confirmed by the read-only scan at Phase B start before any write.
-- **Scope adjustments**: per D-1, remove `SOCIAL_INSTITUTION_ALTNAME_DATA` from this API's target tables; per D-2, add the `CodesController` audit-fix item.
+- **D-6 Save-time v→ü normalization (stop-the-bleed 2.0, mirroring Phase A §D-12): included in this plan.** Phase A already added save-path stop-the-bleed for person names (`PinyinUmlaut::normalizeFields()`, see [PINYIN_SAVE_NORMALIZE_DESIGN.md](./PINYIN_SAVE_NORMALIZE_DESIGN.md)); after the code tables are batch-cleaned, their **manual-input surface** and **external API** would likewise re-accumulate `v`, so this is added too — otherwise the batch fix gets re-polluted by later data entry.
+  - **Hook points (three)**:
+    1. the new **`AbstractCodeTableMutationHandler`** (covers all code-table API writes in one place — cheapest);
+    2. **`CodesController`** write paths (`store`/`update` and the proposal methods; `destroy` deletes a row, so no normalization needed) — `store`/`update` **overlap with §D-2's `audit_log` hook points** (add alongside), while the proposal methods are §D-6-specific (not covered by §D-2, but they persist column values so they need normalization);
+    3. **`AdminBatchLoadBookTitlesController::updatePinyin()`** (book-title inline edit, currently whitespace/case only; its batch `buildPinyin()` already uses `PinyinUmlaut` — this fixes the inline-vs-batch inconsistency).
+  - **Per-table pinyin-column registry = the SAME list as §D-5**: v→ü may only touch columns that are **definitely Hanyu pinyin**, so a "table → pinyin columns" list is required to exclude English translations (e.g. `OFFICE_CODES.c_office_trans`), Chinese columns (`c_*_chn`), and semantically-uncertain alternate-romanization columns. This list **is exactly the "dedicated pinyin / romanized-name columns" list used by §D-5's batch migration** — batch fix and save-time stop-the-bleed **share one registry** to avoid drift. Generic writes (`CodesController` writing arbitrary columns of arbitrary tables) **must** consult the registry first and normalize only matched columns; never blanket-apply (else Wade-Giles / translation columns get corrupted).
+  - **Usually no Tier 2 dialog (difference from Phase A)**: Phase A's `c_alt_name` needed a frontend dialog (Tier 2) because it may contain Western aliases; but §D-5 verified code-table pinyin columns are "essentially pure pinyin, no Western", so code tables use **Tier 1 backend silent conversion** and generally need no dialog. If §D-5's `[OTHER-v]` scan finds real Western text in some column, assess case-by-case; **default is Tier 1**.
+  - **Tests**: per hook point (typing `lv` reads back as `lü`; English-translation / Chinese columns unaffected; columns not in the registry unchanged; book-title inline consistent with batch).
+- **Scope adjustments**: per D-1, remove `SOCIAL_INSTITUTION_ALTNAME_DATA` from this API's target tables; per D-2, add the `CodesController` audit-fix item; per D-6, add save-time v→ü normalization (hooked at `AbstractCodeTableMutationHandler` + `CodesController` + book-title inline, per the shared registry).
 
 ## 0. Background and Motivation
 
@@ -87,6 +95,7 @@
 - This plan is a **prerequisite for Phase B (the other, non-person-name pinyin fields)** of the [pinyin migration plan](./PINYIN_V_TO_UMLAUT_MIGRATION.en.md).
 - Once this API is built, the Phase B code-table pinyin corrections can be done just like Phase A person names: via an **external script + the audited mutation API**.
 - Phase A (person names) does **not** depend on this plan — person names go through the existing `basicinformation` / `altnames` mutation handlers.
+- **Both halves of stop-the-bleed align here**: Phase A's "save-time stop-the-bleed" is covered by [PINYIN_SAVE_NORMALIZE_DESIGN.md](./PINYIN_SAVE_NORMALIZE_DESIGN.md) for person-name save paths; the code-table half (§D-6) is built into this plan (new handler + `CodesController` + book-title inline), sharing §D-5's per-table pinyin-column registry with the batch fix. Together, code tables also stop producing new `v` after Phase B.
 
 ## 8. To-do Ledger
 
@@ -99,4 +108,7 @@
 - [ ] No-PK table `SOCIAL_INSTITUTION_ALTNAME_DATA`: **SKIP — not handled** (§D-1)
 - [ ] Tests (update / audit / composite PK / authorization / modes / compatibility)
 - [ ] **(Required, §D-2)** add `AuditLogService::write()` to the `CodesController` direct-write paths, making UI and API auditing consistent
+- [ ] **(Required, §D-6)** build the "table → Hanyu-pinyin columns" registry (shared with §D-5's batch migration)
+- [ ] **(Required, §D-6)** hook save-time v→ü normalization at three places: `AbstractCodeTableMutationHandler`, `CodesController` (`store`/`update` + proposal methods; `store`/`update` overlap §D-2's hook points), `AdminBatchLoadBookTitlesController::updatePinyin()`; each normalizes only registry-matched columns
+- [ ] **(§D-6)** Tests: per hook point, typing `lv`→`lü` regression, English-translation/Chinese columns unaffected, non-registry columns unchanged, book-title inline consistent with batch
 - [ ] Doc sync: `AGENTS.md` module entry, and `CHANGELOG.md` as needed

--- a/docs/CODE_TABLE_MUTATION_API_PLAN.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.md
@@ -14,7 +14,15 @@
   - (b) **零控制器改動**：外部腳本對 code 表照送 `person_id: 0`（沿用 `NianHaoMutationHandler` 既有做法）。
 - **D-4 `ADDRESSES` 派生表：** 改完 `ADDR_CODES` 後以 `cbdb:regenerate-addresses-table`（生產、MySQL-only）**重建**。
 - **D-5 Phase B 的「改哪些」以掃描規則為準、不需人工 Sheet：** code 表基本純拼音（實測：`ETHNICITY.c_name` 498 列 11 條含 v 全為真拼音、0 西文；`CHORONYM` 173 列 1 條 `Vietnam` 不含 `lv/nv` 音節、規則天然排除）。故**專用拼音欄與 romanized-name 欄一律以確定性 `lv/lve/nv/nve` 音節規則直接替換**；掃描命令另出 `[OTHER-v]` 小清單供人類瞄一眼（安全網）。`ADDR_CODES` 於 Phase B 起步以只讀掃描實錘後再寫。
-- **範圍調整**：因 D-1，本 API 的目標表**移除 `SOCIAL_INSTITUTION_ALTNAME_DATA`**；因 D-2，**加入 `CodesController` 補審計**一項。
+- **D-6 保存時拼音 v→ü 歸一化（止血 2.0，比照階段 A §D-12）：本計畫一併納入。** 階段 A 已對人名**保存路徑**補上手動輸入止血（`PinyinUmlaut::normalizeFields()`，見 [PINYIN_SAVE_NORMALIZE_DESIGN.md](./PINYIN_SAVE_NORMALIZE_DESIGN.md)）；code 表批次清乾淨後，其**手動輸入面**與**外部 API** 同樣會重新累積 `v`，故一併加掛，否則批次修正的成果會被日後錄入重新污染。
+  - **掛點（三處）**：
+    1. 新建的 **`AbstractCodeTableMutationHandler`**（一次覆蓋所有 code 表 API 寫入，最省事）；
+    2. **`CodesController`** 寫入路徑（`store`/`update` 與各 proposal 方法；`destroy` 為刪除、無需歸一化）——其中 `store`/`update` **與 §D-2 補 `audit_log` 的掛點重疊**、可順手一起加，proposal 方法則為 §D-6 專屬（§D-2 未涵蓋、但會持久化欄位值故需歸一化）；
+    3. **`AdminBatchLoadBookTitlesController::updatePinyin()`**（書名內聯編輯，現僅做大小寫／空白；其批次 `buildPinyin()` 已用 `PinyinUmlaut`——此為修正 inline 與 batch 的不一致）。
+  - **每表拼音欄登錄（registry）＝與 §D-5 共用同一份名單**：v→ü 只能套在**確定是漢語拼音的欄**，須有「表→拼音欄」清單以排除英文譯名（如 `OFFICE_CODES.c_office_trans`）、中文欄（`c_*_chn`）、與語義存疑的另種羅馬化欄。此清單**即 §D-5 批次遷移所用的「專用拼音欄／romanized-name 欄」名單**——批次修正與保存止血**共用一個 registry**，避免兩份清單漂移。泛型直寫（`CodesController` 對任意表寫任意欄）**必須**先查 registry、只歸一化命中欄，嚴禁盲套（否則誤傷 Wade-Giles／譯名欄）。
+  - **多半不需 Tier 2 彈窗（與階段 A 的差異）**：階段 A 的 `c_alt_name` 因可能含西文別名而需前端彈窗（Tier 2）；但 §D-5 實測 code 表拼音欄「基本純拼音、無西文」，故 code 表以 **Tier 1 後端靜默轉**即可、一般不需彈窗。若某表某欄經 §D-5 掃描的 `[OTHER-v]` 清單發現確有西文夾雜，再個案評估；**預設 Tier 1**。
+  - **測試**：每個掛點回歸（手打 `lv` 讀回 `lü`；英文譯名／中文欄不受影響；registry 未列的欄不轉；書名 inline 與 batch 行為一致）。
+- **範圍調整**：因 D-1，本 API 的目標表**移除 `SOCIAL_INSTITUTION_ALTNAME_DATA`**；因 D-2，**加入 `CodesController` 補審計**一項；因 D-6，**加入保存時 v→ü 歸一化**一項（掛於 `AbstractCodeTableMutationHandler` + `CodesController` + 書名內聯，依共用 registry）。
 
 ## 0. 背景與動機
 
@@ -87,6 +95,7 @@
 - 本計畫是 [拼音遷移計畫](./PINYIN_V_TO_UMLAUT_MIGRATION.md) **階段 B（其他非人名拼音欄位）的前置依賴**。
 - 完成本 API 後，階段 B 的 code 表拼音修正即可比照階段 A 人名，以**外部腳本 + 受審計 mutation API** 進行。
 - 階段 A（人名）**不依賴**本計畫——人名走既有的 `basicinformation` / `altnames` mutation handler 即可。
+- **止血兩半在此對齊**：階段 A 的「保存時止血」由 [PINYIN_SAVE_NORMALIZE_DESIGN.md](./PINYIN_SAVE_NORMALIZE_DESIGN.md) 覆蓋人名保存路徑；code 表的對應一半（§D-6）內建於本計畫（新 handler + `CodesController` + 書名內聯），與批次修正共用 §D-5 的每表拼音欄 registry。兩者合起來，code 表在階段 B 之後也不再產生新的 `v`。
 
 ## 8. 待辦帳本
 
@@ -99,4 +108,7 @@
 - [ ] 無主鍵表 `SOCIAL_INSTITUTION_ALTNAME_DATA`：**SKIP、不處理**（§D-1）
 - [ ] 測試（update / audit / 複合主鍵 / 授權 / 模式 / 相容）
 - [ ] **（必做，§D-2）** `CodesController` 直寫路徑補 `AuditLogService::write()`，使 UI 與 API 審計一致
+- [ ] **（必做，§D-6）** 建立「表→漢語拼音欄」registry（與 §D-5 批次遷移共用同一份名單）
+- [ ] **（必做，§D-6）** 保存時 v→ü 歸一化加掛三處：`AbstractCodeTableMutationHandler`、`CodesController`（`store`/`update`＋proposal 方法；`store`/`update` 與 §D-2 掛點重疊）、`AdminBatchLoadBookTitlesController::updatePinyin()`；均依 registry 只轉命中欄
+- [ ] **（§D-6）** 測試：每掛點手打 `lv`→`lü` 回歸、英文譯名／中文欄不受影響、registry 未列欄不轉、書名 inline 與 batch 一致
 - [ ] 文件同步：`AGENTS.md` 模組入口、必要時 `CHANGELOG.md`

--- a/docs/PINYIN_SAVE_NORMALIZE_DESIGN.md
+++ b/docs/PINYIN_SAVE_NORMALIZE_DESIGN.md
@@ -143,10 +143,11 @@ flag 已翻 `new`、真正在用的 React／`/api/v2` 人工輸入寫入面**。
 3. **無「重新污染」急迫性**：止血 2.0 的目的是保護 **Phase A 已清乾淨**的資料（人名）。code 表尚未清理，
    談不上「被重新污染」；等 Phase B 一併清理＋建立 API＋建欄位白名單時再納入，最安全。
 
-**於 Phase B 待辦記錄**（並補進 §D-12／CODE_TABLE_MUTATION_API_PLAN）：
-- 建立「表→漢語拼音欄」白名單（隨掃描＋人工複核產出）。
-- `CodesController` 各寫入方法與 `AdminBatchLoadBookTitlesController::updatePinyin()` 依白名單加掛 v→ü。
+**於 Phase B 待辦記錄**（✅ 已鎖進 [CODE_TABLE_MUTATION_API_PLAN.md](./CODE_TABLE_MUTATION_API_PLAN.md) §D-6）：
+- 建立「表→漢語拼音欄」registry——與 §D-5 批次遷移**共用同一份名單**（該計畫實測 code 表拼音欄基本純拼音、無西文）。
+- `CodesController` 各寫入方法（`store`/`update` 與 §D-2 補 audit 掛點重疊，proposal 方法為額外）、新 `AbstractCodeTableMutationHandler`、`AdminBatchLoadBookTitlesController::updatePinyin()` 依 registry 加掛 v→ü。
 - 修正 `updatePinyin` 內聯編輯與其批次 `buildPinyin`（已用 PinyinUmlaut）行為不一致的問題。
+- 因 §D-5 code 表無西文，一般以 **Tier 1 後端靜默轉**即可、不需階段 A 的 Tier 2 彈窗（個案例外循 `[OTHER-v]` 清單評估）。
 
 ## 6. Helper 設計
 


### PR DESCRIPTION
## 目的
把 Phase B 的「保存時止血」另一半鎖進 code 表 API 計畫。Phase A 已為人名保存路徑補上手動輸入止血（§D-12，PR #1127）；code 表在 Phase B 批次清乾淨後，其**手動輸入面**（`/codes` UI、書名內聯）與**外部 API** 同樣會被日後錄入重新污染，故需對應機制。

## 內容（純文件）
新增決策 **§D-6** 於 `CODE_TABLE_MUTATION_API_PLAN.md`（＋英文鏡像），並回填 §7/§8、`PINYIN_SAVE_NORMALIZE_DESIGN.md` §5：
- **掛點三處**：新建的 `AbstractCodeTableMutationHandler`、`CodesController`（`store`/`update` 與 §D-2 補 audit 掛點重疊、proposal 方法為額外；`destroy` 無需轉）、`AdminBatchLoadBookTitlesController::updatePinyin()`（順帶修正 inline 與 batch `buildPinyin` 的不一致）。
- **registry 共用**：每表「漢語拼音欄」清單＝§D-5 批次遷移所用的同一份名單，批次修正與保存止血共用、避免漂移；泛型直寫須先查 registry、只轉命中欄，排除英文譯名（`c_office_trans`）／中文欄／另種羅馬化欄。
- **多半只需 Tier 1**：§D-5 實測 code 表基本純拼音、無西文，故一般以後端靜默轉即可，不需階段 A `c_alt_name` 的 Tier 2 彈窗（例外循 `[OTHER-v]` 清單個案評估）。

## 審查
review agent + codex 各一輪；review agent 揪出「§D-2 掛點」措辭高估重疊（§D-2 為 store/update/destroy，§D-6 需 store/update＋proposal）已修正；codex 複審 **無 SERIOUS/MINOR/NIT**，事實與現況一致、zh/en 無漂移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)