### PR TITLE
修正親屬關係拼音優先沿用存檔英文姓名

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -644,12 +644,13 @@ class ApiController extends Controller {
         if (preg_match('/^\s*[（(]\s*(.+?)\s*('.$titlesPattern.')\s*[）)]\s*$/u', $word, $matches) === 1) {
             $targetChn = $matches[1] ?? '';
             // 親屬守衛：括號內之人不在此人親屬名單中 → 判為別名，退回一般轉換並標記提示。
-            if (!$this->personHasKinNamed($personId, $targetChn)) {
+            $kinMatch = $this->resolveKinMatch($personId, $targetChn);
+            if (!$kinMatch['matched']) {
                 $kinshipUnmatched = true;
 
                 return null;
             }
-            $target = $this->buildPinyinWord($targetChn, $split);
+            $target = $kinMatch['c_name'] ?? $this->buildPinyinWord($targetChn, $split);
             $phrase = $this->relationshipPhrases()[$matches[2]] ?? null;
 
             return $phrase ? '('.$phrase.' '.trim($target).')' : null;
@@ -658,13 +659,14 @@ class ApiController extends Controller {
         // 特例 2：例如「宗氏（李白妻）」→「Zong Shi (Wife of Li Bai)」
         if (preg_match('/^(.*?)[（(]\s*(.+?)\s*('.$titlesPattern.')\s*[）)]\s*$/u', $word, $matches) === 1) {
             $targetChn = $matches[2] ?? '';
-            if (!$this->personHasKinNamed($personId, $targetChn)) {
+            $kinMatch = $this->resolveKinMatch($personId, $targetChn);
+            if (!$kinMatch['matched']) {
                 $kinshipUnmatched = true;
 
                 return null;
             }
             $prefix = $this->buildPinyinWord($matches[1] ?? '', $split);
-            $target = $this->buildPinyinWord($targetChn, $split);
+            $target = $kinMatch['c_name'] ?? $this->buildPinyinWord($targetChn, $split);
             $phrase = $this->relationshipPhrases()[$matches[3]] ?? null;
 
             return $phrase ? trim($prefix).' ('.$phrase.' '.trim($target).')' : null;
@@ -674,29 +676,49 @@ class ApiController extends Controller {
     }
 
     /**
-     * 快速判斷此人（$personId）的親屬名單中，是否有「中文姓名等於 $targetNameChn」的親屬。
+     * 判斷此人（$personId）的親屬名單中，是否有「中文姓名等於 $targetNameChn」的親屬，
+     * 若有，一併取回該親屬存檔的英文姓名（BIOG_MAIN.c_name）。
      * 供關係拼音守衛使用：偵測到關係稱謂（如「（靖江女）」）時，若括號內之人不在此人親屬中，
      * 多半是別名而非真實親屬關係，應改走一般拼音轉換。
      *
-     * 無 person 上下文（$personId 為 null）或空目標時回傳 true（不做守衛，維持既有行為、向後相容）。
+     * 無 person 上下文（$personId 為 null）或空目標時視為「已匹配但無姓名」（不做守衛，維持既有行為、向後相容）。
      *
      * 限制（刻意的「快速匹配」）：僅比對親屬中文姓名是否相等，不驗證關係方向／稱謂互逆
      * （如「（靖江女）」代表本人為靖江之女，靖江在本人親屬中應記為「父」）。因此：
      *   - 偽陰性（真親屬但存檔姓名寫法不同）→ 退回一般轉換並提示，屬保守可接受；
      *   - 偽陽性（同名親屬但實際關係不符，或同名多人）→ 仍會套用關係轉換。
      * 這符合使用者「親屬名單中查無此人才不套用」的訴求；若日後需更精準，可加入互逆稱謂比對。
+     *
+     * @return array{matched: bool, c_name: ?string} matched 為 false 時 c_name 恆為 null；
+     *                                                matched 為 true 時，若同名親屬存檔的非空 c_name
+     *                                                恰好只有一種取值，直接沿用（避免對「劉汝彬」這類
+     *                                                姓氏偵測易誤判的姓名重新盲轉拼音、產生「Liurubin」
+     *                                                等未拆分姓名）；若同名親屬有多筆且 c_name 取值不一致
+     *                                                （無法確定該用哪一筆），或皆為空，則回傳 null 交由
+     *                                                呼叫端退回一般拼音轉換，避免任意挑選造成不穩定輸出。
      */
-    private function personHasKinNamed(?int $personId, string $targetNameChn): bool {
+    private function resolveKinMatch(?int $personId, string $targetNameChn): array {
         $target = trim($targetNameChn);
         if ($personId === null || $target === '') {
-            return true;
+            return ['matched' => true, 'c_name' => null];
         }
 
-        return DB::table('KIN_DATA')
+        $rows = DB::table('KIN_DATA')
             ->join('BIOG_MAIN', 'BIOG_MAIN.c_personid', '=', 'KIN_DATA.c_kin_id')
             ->where('KIN_DATA.c_personid', $personId)
             ->where('BIOG_MAIN.c_name_chn', $target)
-            ->exists();
+            ->pluck('BIOG_MAIN.c_name');
+
+        if ($rows->isEmpty()) {
+            return ['matched' => false, 'c_name' => null];
+        }
+
+        // 注意：去重前不可先濾掉空值——若同名親屬中一筆有 c_name、另一筆為空，
+        // 仍代表「不確定該用哪一筆姓名」，須視為歧義並回傳 null（而非誤用那筆非空值）。
+        $distinctNames = $rows->map(static fn ($name) => trim((string) ($name ?? '')))->unique();
+        $resolvedName = $distinctNames->count() === 1 ? $distinctNames->first() : '';
+
+        return ['matched' => true, 'c_name' => $resolvedName !== '' ? $resolvedName : null];
     }
 
     /**

--- a/tests/Feature/ApiSearchPinyinTest.php
+++ b/tests/Feature/ApiSearchPinyinTest.php
@@ -36,6 +36,7 @@ class ApiSearchPinyinTest extends TestCase {
         Schema::create('BIOG_MAIN', function (Blueprint $table) {
             $table->integer('c_personid')->primary();
             $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
         });
     }
 
@@ -251,6 +252,60 @@ class ApiSearchPinyinTest extends TestCase {
 
         $response->assertOk();
         $this->assertSame('(Wife of Li Bai)', trim($response->getContent()));
+        $response->assertHeaderMissing('X-Pinyin-Kinship-Unmatched');
+    }
+
+    #[Test]
+    public function search_pinyin_uses_matched_kin_stored_english_name_instead_of_blind_pinyin(): void {
+        // 「劉」易被姓氏偵測誤判，若對「劉汝彬」盲轉拼音會產生「Liurubin」（未拆分姓名）。
+        // 親屬守衛已確認括號內之人是本人親屬，且該親屬存檔中已有正確英文姓名「Liu Rubin」，
+        // 應直接沿用，而非重新盲轉拼音。
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 200, 'c_name_chn' => '劉汝彬', 'c_name' => 'Liu Rubin']);
+        DB::table('KIN_DATA')->insert(['c_personid' => 100, 'c_kin_id' => 200, 'c_kin_code' => 1]);
+
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('氏（劉汝彬妻）').'&person_id=100');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertStringContainsString('Wife of Liu Rubin', $content);
+        $this->assertStringNotContainsString('Liurubin', $content);
+        $response->assertHeaderMissing('X-Pinyin-Kinship-Unmatched');
+    }
+
+    #[Test]
+    public function search_pinyin_falls_back_to_pinyin_when_multiple_kin_share_name_with_different_c_name(): void {
+        // 同一人親屬名單中有兩筆中文姓名皆為「劉汝彬」但存檔英文姓名不同 → 無法確定該用哪一筆，
+        // 應退回一般拼音轉換（deterministic），而非任意挑選其中一筆（依資料庫回傳順序不穩定）。
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 200, 'c_name_chn' => '劉汝彬', 'c_name' => 'Liu Rubin']);
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 201, 'c_name_chn' => '劉汝彬', 'c_name' => 'Liu Rubin (II)']);
+        DB::table('KIN_DATA')->insert(['c_personid' => 100, 'c_kin_id' => 200, 'c_kin_code' => 1]);
+        DB::table('KIN_DATA')->insert(['c_personid' => 100, 'c_kin_id' => 201, 'c_kin_code' => 1]);
+
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('氏（劉汝彬妻）').'&person_id=100');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertStringNotContainsString('Liu Rubin', $content);
+        $response->assertHeaderMissing('X-Pinyin-Kinship-Unmatched');
+    }
+
+    #[Test]
+    public function search_pinyin_falls_back_to_pinyin_when_one_of_multiple_same_name_kin_has_no_c_name(): void {
+        // 同一人親屬名單中有兩筆中文姓名皆為「劉汝彬」，其中一筆有存檔英文姓名、另一筆為空 →
+        // 仍屬「不確定該用哪一筆」的歧義情境，不可誤用那筆非空值，應退回一般拼音轉換。
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 200, 'c_name_chn' => '劉汝彬', 'c_name' => 'Liu Rubin']);
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 201, 'c_name_chn' => '劉汝彬', 'c_name' => null]);
+        DB::table('KIN_DATA')->insert(['c_personid' => 100, 'c_kin_id' => 200, 'c_kin_code' => 1]);
+        DB::table('KIN_DATA')->insert(['c_personid' => 100, 'c_kin_id' => 201, 'c_kin_code' => 1]);
+
+        $response = $this->get('/api/select/search/pinyin?q='.urlencode('氏（劉汝彬妻）').'&person_id=100');
+
+        $response->assertOk();
+        $content = trim($response->getContent());
+
+        $this->assertStringNotContainsString('Liu Rubin', $content);
         $response->assertHeaderMissing('X-Pinyin-Kinship-Unmatched');
     }
 


### PR DESCRIPTION
## 摘要

- 「氏（劉汝彬妻）」等關係拼音轉換，先前即使已透過 `KIN_DATA` 確認括號內之人是本人真實親屬，仍會捨棄該筆比對結果、重新對中文姓名盲轉拼音。「劉」易被姓氏偵測誤判，導致產出 `Liurubin`（未拆分姓名）而非 `Liu Rubin`
- 修正為 `resolveKinMatch()` 一併取回該親屬存檔的 `BIOG_MAIN.c_name`：
  - 若同名親屬僅有一種非空取值，直接沿用該英文姓名
  - 若同名親屬有多筆且取值不一致（含其中一筆為空的情況），視為歧義，退回原本的盲轉拼音以維持穩定輸出（避免依資料庫回傳順序任意挑選）

## 審查過程

- 已派出 review agent 檢查程式碼與測試，確認無嚴重問題
- 已用 `codex exec` 進行三輪獨立審查：
  1. 指出多筆同名親屬但 `c_name` 不同時 `first()` 會產生不確定輸出 → 改為判斷 distinct 值
  2. 指出去重前濾掉空值會把「一筆有值、一筆為空」誤判為 unambiguous → 改為去重前不濾空值
  3. 確認修正後語意自洽，無殘留問題

## 測試計畫

- [x] `./vendor/bin/phpunit tests/Feature/ApiSearchPinyinTest.php`（17 tests, 82 assertions）
- [x] `./vendor/bin/phpunit tests/Feature/ApiSearchPinyinTest.php tests/Feature/PersonBrowserTest.php`（72 tests, 710 assertions）
- [x] `./vendor/bin/php-cs-fixer fix`（僅本次改動檔案，無格式問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)