### PR TITLE
feat(codetable-api): 抽出 AbstractCodeTableMutationHandler 基底（Phase B 起手）

### DIFF
--- a/app/Services/Mutations/AbstractCodeTableMutationHandler.php
+++ b/app/Services/Mutations/AbstractCodeTableMutationHandler.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace App\Services\Mutations;
+
+use App\Models\Operation;
+use App\Repositories\OperationRepository;
+use App\Services\AuditLogService;
+use App\Support\CompositePrimaryKey;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Code／lookup 表受審計更新 handler 的共用基底。
+ *
+ * 整合交易、`audit_log`、`operations`、複合主鍵驗證、欄位白名單、變更偵測與 direct/proposal 兩模式；
+ * 具體每表 handler 只需實作 tableName／resourceName／resourceAliases／displayName／keyColumns／allowedFields
+ * 少量方法（見 CODE_TABLE_MUTATION_API_PLAN.md §4）。
+ *
+ * code 表為全域代碼、非人物子資源，故 `operations.c_personid` 一律設為 0（不受呼叫端 person_id 控制；
+ * 呼叫端仍須依 MutationController 契約傳 person_id，通常為 0）。
+ */
+abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler {
+    protected OperationRepository $operationRepository;
+    protected AuditLogService $auditLogService;
+
+    public function __construct(
+        OperationRepository $operationRepository,
+        AuditLogService $auditLogService
+    ) {
+        $this->operationRepository = $operationRepository;
+        $this->auditLogService = $auditLogService;
+    }
+
+    /** 實際資料表名（＝ audit_log／operations 的 table 值、CompositePrimaryKey::SCHEMAS 鍵）。 */
+    abstract protected function tableName(): string;
+
+    /** 回應與提案 meta 使用的正規 resource 名（須包含於 resourceAliases()）。 */
+    abstract protected function resourceName(): string;
+
+    /** supports() 接受的 resource 別名清單。 */
+    abstract protected function resourceAliases(): array;
+
+    /** 提案 meta 顯示名（如「年號」）。 */
+    abstract protected function displayName(): string;
+
+    /** 主鍵欄位（單鍵或複合鍵，順序需與 CompositePrimaryKey::SCHEMAS 一致）。 */
+    abstract protected function keyColumns(): array;
+
+    /** 允許更新的欄位白名單。 */
+    abstract protected function allowedFields(): array;
+
+    public function supports(string $resource, string $mode, string $operation): bool {
+        return in_array($resource, $this->resourceAliases(), true)
+            && in_array($mode, ['direct', 'proposal'], true)
+            && $operation === 'update';
+    }
+
+    public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
+        if ($authorizationError) {
+            return $authorizationError;
+        }
+
+        $table = $this->tableName();
+
+        try {
+            CompositePrimaryKey::validateOrFail($targetPk, $table);
+        } catch (\Throwable $e) {
+            return $this->errorResponse('主鍵格式不正確', 422, ['pk' => [$e->getMessage()]]);
+        }
+
+        // 防呆：keyColumns() 必須與 CompositePrimaryKey::SCHEMAS 登錄的主鍵完全一致（順序＋欄名）。
+        // validateOrFail 依 SCHEMAS 驗證「全鍵存在且非 null」；若子類 keyColumns() 為 SCHEMAS 的真子集，
+        // 驗證仍會通過、但 whereByPk 只用部分鍵→UPDATE 可能命中多列。此處硬擋子類設定錯誤（500）。
+        $schemaKeys = CompositePrimaryKey::getSchema($table);
+        if ($schemaKeys === null || $this->keyColumns() !== $schemaKeys) {
+            return $this->errorResponse($table . ' 主鍵宣告與登錄不一致（handler 設定錯誤）', 500, ['pk' => ['schema_mismatch']]);
+        }
+
+        if (empty($changes)) {
+            return $this->errorResponse('changes 不可為空', 422, ['changes' => ['empty']]);
+        }
+
+        // 依 keyColumns 取出主鍵（已驗證＝SCHEMAS、全鍵存在且非 null）
+        $pk = [];
+        foreach ($this->keyColumns() as $col) {
+            $pk[$col] = $targetPk[$col];
+        }
+
+        $original = $this->findByPk($pk);
+        if (!$original) {
+            return $this->errorResponse($table . ' 記錄不存在', 404);
+        }
+
+        $allowed = $this->allowedFields();
+
+        // 拒絕白名單外的欄位
+        $disallowedFields = array_diff(array_keys($changes), $allowed);
+        if (!empty($disallowedFields)) {
+            return $this->errorResponse('包含不允許更新的欄位', 422, [
+                'changes' => ['disallowed_fields: ' . implode(', ', $disallowedFields)],
+            ]);
+        }
+
+        $updateData = array_intersect_key($changes, array_flip($allowed));
+        if (empty($updateData)) {
+            return $this->errorResponse('changes 至少需包含一個可更新欄位', 422, [
+                'changes' => ['no_supported_fields'],
+            ]);
+        }
+
+        // 驗證欄位值
+        $validationErrors = $this->validateFields($updateData);
+        if (!empty($validationErrors)) {
+            return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
+        }
+
+        // 檢查是否有實際變更
+        $originalArray = $this->auditLogService->normalizeRow($original);
+        $hasEffectiveChange = false;
+        foreach ($updateData as $field => $value) {
+            if (($originalArray[$field] ?? null) !== $value) {
+                $hasEffectiveChange = true;
+
+                break;
+            }
+        }
+        if (!$hasEffectiveChange) {
+            return $this->errorResponse('未偵測到任何修改內容', 422, [
+                'changes' => ['no_effective_changes'],
+            ]);
+        }
+
+        $resourceId = CompositePrimaryKey::buildStoredResourceId($pk);
+        $comment = is_string($meta['comment'] ?? null) ? trim($meta['comment']) : '';
+
+        // code 表為全域代碼，c_personid 一律設為 0，不受呼叫端控制
+        $operationPersonId = 0;
+
+        if ($mode === 'proposal') {
+            return $this->handleProposal($operationPersonId, $pk, $resourceId, $updateData, $originalArray, $comment);
+        }
+
+        return $this->handleDirect($operationPersonId, $pk, $resourceId, $updateData, $originalArray, $comment);
+    }
+
+    protected function handleDirect(int $personId, array $pk, string $resourceId, array $updateData, array $originalArray, string $comment): JsonResponse {
+        $table = $this->tableName();
+        $operationId = (string) Str::ulid();
+
+        /** @var \App\Models\Operation|null $operation */
+        $operation = null;
+        $newArray = [];
+
+        DB::transaction(function () use ($table, $pk, $resourceId, $updateData, $originalArray, $comment, $operationId, $personId, &$operation, &$newArray) {
+            $this->whereByPk(DB::table($table), $pk)->update($updateData);
+
+            $updatedRow = $this->findByPk($pk);
+            $newArray = $this->auditLogService->normalizeRow($updatedRow);
+
+            $resourceData = array_merge($newArray, ['__operation_id' => $operationId]);
+            if ($comment !== '') {
+                $resourceData['__note'] = $comment;
+            }
+
+            $operation = $this->operationRepository->store(
+                Auth::id(),
+                $personId,
+                Operation::TYPE_UPDATE,
+                $table,
+                $resourceId,
+                $resourceData,
+                $originalArray
+            );
+
+            $this->auditLogService->write(
+                $table,
+                'UPDATE',
+                $pk,
+                $originalArray,
+                $newArray,
+                'user',
+                (string) Auth::id(),
+                $operationId
+            );
+        });
+
+        return response()->json([
+            'ok' => true,
+            'resource' => $this->resourceName(),
+            'mode' => 'direct',
+            'operation' => 'update',
+            'result' => [
+                'pk' => $pk,
+                'updated_fields' => array_keys($updateData),
+                'operation_id' => $operation?->id,
+                'row' => $newArray,
+            ],
+        ]);
+    }
+
+    protected function handleProposal(int $personId, array $pk, string $resourceId, array $updateData, array $originalArray, string $comment): JsonResponse {
+        $proposalData = array_merge($originalArray, $updateData, [
+            '__proposal_meta' => [
+                'action' => 'update',
+                'resource_type' => $this->resourceName(),
+                'table' => $this->tableName(),
+                'display_name' => $this->displayName(),
+                'submitted_by' => Auth::user()->name ?? Auth::id(),
+                'submitted_by_id' => Auth::id(),
+                'submitted_at' => Carbon::now()->format('Y-m-d H:i:s'),
+                'comment' => $comment,
+            ],
+            '__review_status' => 'pending',
+            '__key_columns' => $this->keyColumns(),
+        ]);
+
+        $operation = $this->operationRepository->store(
+            Auth::id(),
+            $personId,
+            Operation::TYPE_PROPOSAL_UPDATE,
+            $this->tableName(),
+            $resourceId,
+            $proposalData,
+            $originalArray
+        );
+
+        return response()->json([
+            'ok' => true,
+            'resource' => $this->resourceName(),
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'result' => [
+                'pk' => $pk,
+                'updated_fields' => array_keys($updateData),
+                'status' => 'proposal_updated',
+                'operation_id' => $operation?->id,
+            ],
+        ]);
+    }
+
+    /**
+     * 欄位值校驗：預設對每個白名單欄做「字串或 null、長度 ≤ 255」檢查。
+     * 需要更嚴格規則的表可覆寫。
+     */
+    protected function validateFields(array $data): array {
+        $errors = [];
+        foreach ($data as $field => $value) {
+            if ($value !== null && !is_string($value)) {
+                $errors[$field] = [$field . ' 必須為字串或 null'];
+            } elseif (is_string($value) && mb_strlen($value) > 255) {
+                $errors[$field] = [$field . ' 長度不可超過 255 字元'];
+            }
+        }
+
+        return $errors;
+    }
+
+    /** 以主鍵定位單列。 */
+    protected function findByPk(array $pk): ?object {
+        return $this->whereByPk(DB::table($this->tableName()), $pk)->first();
+    }
+
+    /** 把主鍵條件套到 query builder。 */
+    protected function whereByPk(\Illuminate\Database\Query\Builder $query, array $pk): \Illuminate\Database\Query\Builder {
+        foreach ($pk as $col => $value) {
+            $query->where($col, $value);
+        }
+
+        return $query;
+    }
+}

--- a/app/Services/Mutations/NianHaoMutationHandler.php
+++ b/app/Services/Mutations/NianHaoMutationHandler.php
@@ -2,223 +2,34 @@
 
 namespace App\Services\Mutations;
 
-use App\Models\Operation;
-use App\Repositories\OperationRepository;
-use App\Services\AuditLogService;
-use App\Support\CompositePrimaryKey;
-use Carbon\Carbon;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
-
-class NianHaoMutationHandler extends AbstractMutationHandler {
-    /**
-     * 允許更新的欄位白名單（僅拼音相關）
-     */
-    protected const ALLOWED_FIELDS = [
-        'c_nianhao_pin',
-    ];
-
-    protected OperationRepository $operationRepository;
-    protected AuditLogService $auditLogService;
-
-    public function __construct(
-        OperationRepository $operationRepository,
-        AuditLogService $auditLogService
-    ) {
-        $this->operationRepository = $operationRepository;
-        $this->auditLogService = $auditLogService;
+/**
+ * 年號（NIAN_HAO）拼音更新 handler。
+ *
+ * 為 {@see AbstractCodeTableMutationHandler} 的第一個使用者；僅宣告表名／resource／主鍵／白名單，
+ * 交易・審計・變更偵測・direct/proposal 邏輯全由基底提供。
+ */
+class NianHaoMutationHandler extends AbstractCodeTableMutationHandler {
+    protected function tableName(): string {
+        return 'NIAN_HAO';
     }
 
-    public function supports(string $resource, string $mode, string $operation): bool {
-        return in_array($resource, ['nianhao', 'nian_hao'], true)
-            && in_array($mode, ['direct', 'proposal'], true)
-            && $operation === 'update';
+    protected function resourceName(): string {
+        return 'nianhao';
     }
 
-    public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
-        $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
-        if ($authorizationError) {
-            return $authorizationError;
-        }
-
-        try {
-            CompositePrimaryKey::validateOrFail($targetPk, 'NIAN_HAO');
-        } catch (\Throwable $e) {
-            return $this->errorResponse('主鍵格式不正確', 422, ['pk' => [$e->getMessage()]]);
-        }
-
-        if (empty($changes)) {
-            return $this->errorResponse('changes 不可為空', 422, ['changes' => ['empty']]);
-        }
-
-        $nianhaoId = $targetPk['c_nianhao_id'] ?? null;
-
-        $original = DB::table('NIAN_HAO')->where('c_nianhao_id', $nianhaoId)->first();
-        if (!$original) {
-            return $this->errorResponse('NIAN_HAO 記錄不存在', 404);
-        }
-
-        // 過濾出允許更新的欄位
-        $updateData = array_intersect_key($changes, array_flip(self::ALLOWED_FIELDS));
-
-        // 拒絕白名單外的欄位
-        $disallowedFields = array_diff(array_keys($changes), self::ALLOWED_FIELDS);
-        if (!empty($disallowedFields)) {
-            return $this->errorResponse('包含不允許更新的欄位', 422, [
-                'changes' => ['disallowed_fields: ' . implode(', ', $disallowedFields)],
-            ]);
-        }
-
-        if (empty($updateData)) {
-            return $this->errorResponse('changes 至少需包含一個可更新欄位', 422, [
-                'changes' => ['no_supported_fields'],
-            ]);
-        }
-
-        // 驗證欄位值
-        $validationErrors = $this->validateFields($updateData);
-        if (!empty($validationErrors)) {
-            return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
-        }
-
-        // 檢查是否有實際變更
-        $originalArray = $this->auditLogService->normalizeRow($original);
-        $hasEffectiveChange = false;
-        foreach ($updateData as $field => $value) {
-            if (($originalArray[$field] ?? null) !== $value) {
-                $hasEffectiveChange = true;
-
-                break;
-            }
-        }
-        if (!$hasEffectiveChange) {
-            return $this->errorResponse('未偵測到任何修改內容', 422, [
-                'changes' => ['no_effective_changes'],
-            ]);
-        }
-
-        $pk = ['c_nianhao_id' => $nianhaoId];
-        $resourceId = CompositePrimaryKey::buildStoredResourceId($pk);
-        $comment = is_string($meta['comment'] ?? null) ? trim($meta['comment']) : '';
-
-        // NIAN_HAO 為全域代碼表，c_personid 一律設為 0，不受呼叫端控制
-        $operationPersonId = 0;
-
-        if ($mode === 'proposal') {
-            return $this->handleProposal($operationPersonId, $pk, $resourceId, $updateData, $originalArray, $comment);
-        }
-
-        return $this->handleDirect($operationPersonId, $nianhaoId, $pk, $resourceId, $updateData, $originalArray, $comment);
+    protected function resourceAliases(): array {
+        return ['nianhao', 'nian_hao'];
     }
 
-    protected function handleDirect(int $personId, int $nianhaoId, array $pk, string $resourceId, array $updateData, array $originalArray, string $comment): JsonResponse {
-        $operationId = (string) Str::ulid();
-
-        /** @var \App\Models\Operation|null $operation */
-        $operation = null;
-        $newArray = [];
-
-        DB::transaction(function () use ($nianhaoId, $pk, $resourceId, $updateData, $originalArray, $comment, $operationId, $personId, &$operation, &$newArray) {
-            DB::table('NIAN_HAO')->where('c_nianhao_id', $nianhaoId)->update($updateData);
-
-            $updatedRow = DB::table('NIAN_HAO')->where('c_nianhao_id', $nianhaoId)->first();
-            $newArray = $this->auditLogService->normalizeRow($updatedRow);
-
-            $resourceData = array_merge($newArray, ['__operation_id' => $operationId]);
-            if ($comment !== '') {
-                $resourceData['__note'] = $comment;
-            }
-
-            $operation = $this->operationRepository->store(
-                Auth::id(),
-                $personId,
-                Operation::TYPE_UPDATE,
-                'NIAN_HAO',
-                $resourceId,
-                $resourceData,
-                $originalArray
-            );
-
-            $this->auditLogService->write(
-                'NIAN_HAO',
-                'UPDATE',
-                $pk,
-                $originalArray,
-                $newArray,
-                'user',
-                (string) Auth::id(),
-                $operationId
-            );
-        });
-
-        return response()->json([
-            'ok' => true,
-            'resource' => 'nianhao',
-            'mode' => 'direct',
-            'operation' => 'update',
-            'result' => [
-                'pk' => $pk,
-                'updated_fields' => array_keys($updateData),
-                'operation_id' => $operation?->id,
-                'row' => $newArray,
-            ],
-        ]);
+    protected function displayName(): string {
+        return '年號';
     }
 
-    protected function handleProposal(int $personId, array $pk, string $resourceId, array $updateData, array $originalArray, string $comment): JsonResponse {
-        $proposalData = array_merge($originalArray, $updateData, [
-            '__proposal_meta' => [
-                'action' => 'update',
-                'resource_type' => 'nianhao',
-                'table' => 'NIAN_HAO',
-                'display_name' => '年號',
-                'submitted_by' => Auth::user()->name ?? Auth::id(),
-                'submitted_by_id' => Auth::id(),
-                'submitted_at' => Carbon::now()->format('Y-m-d H:i:s'),
-                'comment' => $comment,
-            ],
-            '__review_status' => 'pending',
-            '__key_columns' => ['c_nianhao_id'],
-        ]);
-
-        $operation = $this->operationRepository->store(
-            Auth::id(),
-            $personId,
-            Operation::TYPE_PROPOSAL_UPDATE,
-            'NIAN_HAO',
-            $resourceId,
-            $proposalData,
-            $originalArray
-        );
-
-        return response()->json([
-            'ok' => true,
-            'resource' => 'nianhao',
-            'mode' => 'proposal',
-            'operation' => 'update',
-            'result' => [
-                'pk' => $pk,
-                'updated_fields' => array_keys($updateData),
-                'status' => 'proposal_updated',
-                'operation_id' => $operation?->id,
-            ],
-        ]);
+    protected function keyColumns(): array {
+        return ['c_nianhao_id'];
     }
 
-    protected function validateFields(array $data): array {
-        $errors = [];
-
-        if (array_key_exists('c_nianhao_pin', $data)) {
-            $value = $data['c_nianhao_pin'];
-            if ($value !== null && !is_string($value)) {
-                $errors['c_nianhao_pin'] = ['c_nianhao_pin 必須為字串或 null'];
-            } elseif (is_string($value) && mb_strlen($value) > 255) {
-                $errors['c_nianhao_pin'] = ['c_nianhao_pin 長度不可超過 255 字元'];
-            }
-        }
-
-        return $errors;
+    protected function allowedFields(): array {
+        return ['c_nianhao_pin'];
     }
 }


### PR DESCRIPTION
## 目的（Phase B 里程碑 1／基礎）
Code 表受審計寫入 API 的第一步：把 `NianHaoMutationHandler` 的樣板邏輯（交易・`audit_log`・`operations`・複合主鍵驗證・欄位白名單・變更偵測・direct/proposal）抽到共用基底 **`AbstractCodeTableMutationHandler`**，讓後續每張 code 表 handler 只需宣告 `tableName`／`resourceName`／`resourceAliases`／`displayName`／`keyColumns`／`allowedFields`。對應 `CODE_TABLE_MUTATION_API_PLAN.md` §4/§5 步驟 3-4。

## 重點
- **行為對 NIAN_HAO 完全等價**——22 個 `ApiV2MutateNianHaoTest` 全數不變通過。
- **泛化支援複合主鍵**：`whereByPk` 對全部主鍵欄 AND（供日後 `TEXT_INSTANCE_DATA` 等 3 鍵表）。
- **防呆（review agent 揪出的 future footgun）**：`keyColumns()` 必須與 `CompositePrimaryKey::SCHEMAS` 登錄的主鍵完全一致，否則 500——杜絕子類宣告「部分鍵」時 `validateOrFail` 仍過、但 UPDATE 命中多列的資料損壞風險。
- code 表 `c_personid` 一律 0（沿用 NianHao 既有做法，**`MutationController` 零改動**，§D-3 選項 b）。

## 審查
review agent + codex 各一輪，逐項對照舊 `NianHaoMutationHandler`（`git show develop:...`）確認等價、guard 有效、複合鍵安全、DI 無誤——**均無 SERIOUS/MINOR/NIT**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)