### PR TITLE
修正人物編輯頁子資源新增/刪除後分頁徽章數字未即時更新

### DIFF
--- a/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
@@ -252,6 +252,7 @@ export default function PersonEditor() {
                         socialInstEditorIsNew={socialInstEditorIsNew}
                         postCE={summary?.dynasty_start != null && summary.dynasty_start > 0}
                         onBasicInfoSaved={handleBasicInfoSaved}
+                        onSubresourceChanged={handleBasicInfoSaved}
                         onBasicInfoEditorStateChange={setBasicInfoEditorState}
                         onRegisterBasicInfoSaveHandler={registerBasicInfoSaveHandler}
                     />

--- a/resources/js/inertia/Pages/PersonBrowser/Index.tsx
+++ b/resources/js/inertia/Pages/PersonBrowser/Index.tsx
@@ -305,6 +305,13 @@ export default function PersonBrowserIndex() {
         [keyword, dynasty, doSearch, updateUrl],
     );
 
+    // 僅刷新摘要（tab_counts／header），不連動搜尋結果列表。
+    // 12 個子資源分頁新增/刪除記錄不會影響列表欄位顯示，無需重新搜尋（避免不必要的列表閃爍）。
+    const handleSubresourceChanged = useCallback(() => {
+        setSummaryRefreshKey((prev) => prev + 1);
+    }, []);
+
+    // 基本資料儲存後：除刷新摘要外，姓名/朝代等變更可能影響左側列表欄位顯示，需一併重新搜尋。
     const handleBasicInfoSaved = useCallback(() => {
         setSummaryRefreshKey((prev) => prev + 1);
         doSearch(keyword, page, dynasty, sortOrder);
@@ -575,6 +582,7 @@ export default function PersonBrowserIndex() {
                             postCE={summary?.dynasty_start != null && summary.dynasty_start > 0}
                             onSelectPerson={guardedHandleSelect}
                             onBasicInfoSaved={handleBasicInfoSaved}
+                            onSubresourceChanged={handleSubresourceChanged}
                             onBasicInfoEditorStateChange={setBasicInfoEditorState}
                             onRegisterBasicInfoSaveHandler={registerBasicInfoSaveHandler}
                         />

--- a/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
+++ b/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
@@ -44,6 +44,8 @@ interface Props {
     postCE?: boolean;
     onSelectPerson?: (personId: number) => void;
     onBasicInfoSaved?: () => void;
+    /** 12 個子資源分頁新增/刪除成功後呼叫：除刷新該分頁列表外，一併通知上層刷新分頁徽章數字（tab_counts）。 */
+    onSubresourceChanged?: () => void;
     onBasicInfoEditorStateChange?: (state: { editing: boolean; dirty: boolean }) => void;
     onRegisterBasicInfoSaveHandler?: (handler: (() => Promise<boolean>) | null) => void;
 }
@@ -93,6 +95,7 @@ export default function TabContentLoader({
     postCE = false,
     onSelectPerson,
     onBasicInfoSaved,
+    onSubresourceChanged,
     onBasicInfoEditorStateChange,
     onRegisterBasicInfoSaveHandler,
 }: Props) {
@@ -174,6 +177,13 @@ export default function TabContentLoader({
             return next;
         });
         setFetchSeq((s) => s + 1);
+    };
+
+    // 12 個子資源分頁新增/刪除成功後的統一 onRefresh：除重新載入該分頁列表外，
+    // 一併通知上層刷新分頁徽章數字（summary.tab_counts），修正「新增/刪除後分頁數字未即時更新」問題。
+    const refreshTabAndSummary = () => {
+        retryActiveTab();
+        onSubresourceChanged?.();
     };
 
     // 靜默刷新指定分頁的快取資料：於背景重新抓取並就地更新 cache[tabKey].data，
@@ -302,7 +312,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -320,7 +330,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -337,7 +347,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -354,7 +364,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -372,7 +382,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -390,7 +400,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
                 onSelectPerson={onSelectPerson}
             />
         );
@@ -408,7 +418,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
                 onSelectPerson={onSelectPerson}
             />
         );
@@ -426,7 +436,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -443,7 +453,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
                 onSelectPerson={onSelectPerson}
             />
         );
@@ -462,7 +472,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -479,7 +489,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }
@@ -497,7 +507,7 @@ export default function TabContentLoader({
                 createEndpoint={createEndpoint}
                 mutateEndpoint={mutateEndpoint}
                 deleteEndpoint={deleteEndpoint}
-                onRefresh={retryActiveTab}
+                onRefresh={refreshTabAndSummary}
             />
         );
     }


### PR DESCRIPTION
## 摘要

- 人物基本資料頁（`/app/basicinformation/{id}`）與人物瀏覽頁（`/app/person-browser`）的 12 個子資源分頁（親屬、別名、地址、著述、官名、事件、入仕、社會區分、財產、社交機構、社會關係、出處）旁的計數徽章來自 `summary.tab_counts`，僅於頁面初載或 `summaryRefreshKey` 變動時重新抓取
- 先前分頁內就地新增/刪除記錄後，只呼叫 `onRefresh`（`= retryActiveTab`，僅刷新該分頁列表），從未通知上層 bump `summaryRefreshKey`，導致列表已正確更新但徽章數字停留舊值，須整頁重載才正確
- 已用 Playwright 實測重現：在「親屬」分頁刪除唯一一筆記錄後，列表變為「無記錄」，但分頁徽章仍顯示「親屬 1」；重載後才正確消失

## 修正內容

- `TabContentLoader.tsx` 新增 `onSubresourceChanged` prop 與 `refreshTabAndSummary()`（`= retryActiveTab() + onSubresourceChanged?.()`），12 個子資源分頁的 `onRefresh` 統一改用 `refreshTabAndSummary`；`basic_info` 分頁與載入失敗重試鈕維持原邏輯不變
- `PersonEditor.tsx` 沿用既有 `handleBasicInfoSaved`（僅 bump `summaryRefreshKey`）
- `PersonBrowser/Index.tsx` 另外新增 `handleSubresourceChanged`（僅 bump `summaryRefreshKey`，不觸發 `doSearch`），避免子資源新增/刪除誤觸左側人物列表重新搜尋、造成不必要的列表閃爍（`handleBasicInfoSaved` 保留原行為，基本資料儲存後仍需連動搜尋，因姓名/朝代變更可能影響列表欄位顯示）

## 審查過程

- 派出 review agent 進行首輪程式碼審查，發現 `PersonBrowser/Index.tsx` 重用 `handleBasicInfoSaved` 會誤觸左側列表 `doSearch` 重新搜尋（不必要的列表閃爍），已修正為專用的 `handleSubresourceChanged`
- 二輪 review agent 確認修正後無殘留問題
- `codex exec` 獨立審查：確認主邏輯正確，未引入新的 correctness bug；指出既有（非本次改動引入）的 summary/搜尋 fetch race condition，留待後續處理

## 測試計畫

- [x] 建立一次性測試人物（c_personid=999999）與一筆親屬記錄，本地以 `artisan serve` + Vite dev server 啟動，用 Playwright 實測：
  - `/app/basicinformation/999999?tab=kinship` 就地刪除親屬記錄 → 徽章立即從「親屬 1」變為無數字（與整頁重載結果一致）
  - `/app/person-browser?person_id=999999&tab=kinship` 同樣驗證通過，且左側人物列表未觸發不必要的重新搜尋
- [x] 測試完成後已清理測試資料

🤖 Generated with [Claude Code](https://claude.com/claude-code)