### PR TITLE
feat(codetable-api): §D-6 code 表 API 保存時 Tier 1 拼音 v→ü 歸一化（Phase B 里程碑 3）

### DIFF
--- a/app/Services/Mutations/AbstractCodeTableMutationHandler.php
+++ b/app/Services/Mutations/AbstractCodeTableMutationHandler.php
@@ -118,6 +118,9 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
             return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
         }
 
+        // 保存前處理（如 §D-6 Tier 1 拼音 v→ü 歸一化）；於變更偵測前，確保冪等（已是 ü→不觸發更新）。
+        $updateData = $this->preprocessUpdateData($updateData);
+
         // 檢查是否有實際變更
         $originalArray = $this->auditLogService->normalizeRow($original);
         $hasEffectiveChange = false;
@@ -257,6 +260,17 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
         }
 
         return $errors;
+    }
+
+    /**
+     * 寫入前對 updateData 的最後加工（預設為 no-op）。
+     * 子類可覆寫以套用 §D-6 保存時拼音 v→ü 歸一化等。於變更偵測前呼叫。
+     *
+     * @param array<string,mixed> $updateData
+     * @return array<string,mixed>
+     */
+    protected function preprocessUpdateData(array $updateData): array {
+        return $updateData;
     }
 
     /** 以主鍵定位單列。 */

--- a/app/Services/Mutations/ConfigCodeTableMutationHandler.php
+++ b/app/Services/Mutations/ConfigCodeTableMutationHandler.php
@@ -4,6 +4,7 @@ namespace App\Services\Mutations;
 
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Support\PinyinUmlaut;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -83,5 +84,15 @@ class ConfigCodeTableMutationHandler extends AbstractCodeTableMutationHandler {
 
     protected function allowedFields(): array {
         return $this->active['allowed_fields'];
+    }
+
+    /**
+     * §D-6 保存止血：對本表的 **Tier 1** 拼音欄靜默套用 v→ü 歸一化。
+     * Tier 2（混西文）欄**不**在此轉——由前端 altname 式彈窗讓使用者決定（後端原樣寫入）。
+     */
+    protected function preprocessUpdateData(array $updateData): array {
+        $tier1 = $this->active['tier1_fields'] ?? [];
+
+        return PinyinUmlaut::normalizeFields($updateData, $tier1);
     }
 }

--- a/config/code_table_mutations.php
+++ b/config/code_table_mutations.php
@@ -12,6 +12,9 @@
  *   - display_name：提案 meta 顯示名。
  *   - key_columns：主鍵欄（順序須與 CompositePrimaryKey::SCHEMAS 完全一致；基底有 500 防呆）。
  *   - allowed_fields：允許更新的欄位白名單（Phase B 首要為拼音／羅馬字欄，見 §D-6 Tier 登錄表）。
+ *   - tier1_fields：保存時**後端靜默** v→ü 歸一化的欄（定義上即漢語拼音、無西文）。
+ *   - tier2_fields：**可能含西文**的混合欄——後端**不**靜默轉（由前端 altname 式彈窗讓使用者決定）。
+ *     tier1_fields ∪ tier2_fields 必等於 allowed_fields。依 §D-6 Tier 登錄表（實測定案）。
  *
  * 目前僅 update；c_personid 一律 0（code 表為全域代碼）。
  */
@@ -25,6 +28,8 @@ return [
             'display_name' => '年號',
             'key_columns' => ['c_nianhao_id'],
             'allowed_fields' => ['c_nianhao_pin'],
+            'tier1_fields' => ['c_nianhao_pin'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'office_codes',
@@ -33,6 +38,8 @@ return [
             'display_name' => '官職代碼',
             'key_columns' => ['c_office_id'],
             'allowed_fields' => ['c_office_pinyin', 'c_office_pinyin_alt'],
+            'tier1_fields' => ['c_office_pinyin', 'c_office_pinyin_alt'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'dynasties',
@@ -41,6 +48,8 @@ return [
             'display_name' => '朝代',
             'key_columns' => ['c_dy'],
             'allowed_fields' => ['c_dynasty'],
+            'tier1_fields' => [],
+            'tier2_fields' => ['c_dynasty'],
         ],
         [
             'resource' => 'choronym_codes',
@@ -49,6 +58,8 @@ return [
             'display_name' => '郡望代碼',
             'key_columns' => ['c_choronym_code'],
             'allowed_fields' => ['c_choronym_desc'],
+            'tier1_fields' => [],
+            'tier2_fields' => ['c_choronym_desc'],
         ],
         [
             'resource' => 'ethnicity_tribe_codes',
@@ -57,6 +68,8 @@ return [
             'display_name' => '民族部族代碼',
             'key_columns' => ['c_ethnicity_code'],
             'allowed_fields' => ['c_name', 'c_romanized', 'c_surname'],
+            'tier1_fields' => ['c_name'],
+            'tier2_fields' => ['c_romanized', 'c_surname'],
         ],
         [
             'resource' => 'text_codes',
@@ -65,6 +78,8 @@ return [
             'display_name' => '文獻代碼',
             'key_columns' => ['c_textid'],
             'allowed_fields' => ['c_title'],
+            'tier1_fields' => ['c_title'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'text_instance_data',
@@ -73,6 +88,8 @@ return [
             'display_name' => '文獻版本',
             'key_columns' => ['c_textid', 'c_text_edition_id', 'c_text_instance_id'],
             'allowed_fields' => ['c_instance_title'],
+            'tier1_fields' => ['c_instance_title'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'text_biblcat_codes',
@@ -81,6 +98,8 @@ return [
             'display_name' => '文獻分類代碼',
             'key_columns' => ['c_text_cat_code'],
             'allowed_fields' => ['c_text_cat_pinyin'],
+            'tier1_fields' => ['c_text_cat_pinyin'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'ganzhi_codes',
@@ -89,6 +108,8 @@ return [
             'display_name' => '干支代碼',
             'key_columns' => ['c_ganzhi_code'],
             'allowed_fields' => ['c_ganzhi_py'],
+            'tier1_fields' => ['c_ganzhi_py'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'social_institution_name_codes',
@@ -97,6 +118,8 @@ return [
             'display_name' => '社會機構名稱代碼',
             'key_columns' => ['c_inst_name_code'],
             'allowed_fields' => ['c_inst_name_py'],
+            'tier1_fields' => ['c_inst_name_py'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'social_institution_types',
@@ -105,6 +128,8 @@ return [
             'display_name' => '社會機構類型',
             'key_columns' => ['c_inst_type_code'],
             'allowed_fields' => ['c_inst_type_py'],
+            'tier1_fields' => ['c_inst_type_py'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'admin_cat_codes',
@@ -113,6 +138,8 @@ return [
             'display_name' => '行政類別代碼',
             'key_columns' => ['c_admin_cat_code'],
             'allowed_fields' => ['c_admin_cat_py'],
+            'tier1_fields' => ['c_admin_cat_py'],
+            'tier2_fields' => [],
         ],
         [
             'resource' => 'addr_codes',
@@ -121,6 +148,8 @@ return [
             'display_name' => '地址代碼',
             'key_columns' => ['c_addr_id'],
             'allowed_fields' => ['c_name'],
+            'tier1_fields' => [],
+            'tier2_fields' => ['c_name'],
         ],
     ],
 ];

--- a/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
@@ -124,7 +124,7 @@
 - [ ] No-PK table `SOCIAL_INSTITUTION_ALTNAME_DATA`: **SKIP — not handled** (§D-1)
 - [x] Tests (`ApiV2MutateCodeTablesTest`: single/multi/triple-column & composite-3-key update, audit, person_id=0, whitelist rejection, proposal, 404, 403; `ApiV2MutateNianHaoTest` 22 unchanged)
 - [ ] **(Required, §D-2)** add `AuditLogService::write()` to the `CodesController` direct-write paths, making UI and API auditing consistent
-- [ ] **(Required, §D-6)** build the "table → Hanyu-pinyin columns" registry (shared with §D-5's batch migration)
-- [ ] **(Required, §D-6)** hook save-time v→ü normalization at three places: `AbstractCodeTableMutationHandler`, `CodesController` (`store`/`update` + proposal methods; `store`/`update` overlap §D-2's hook points), `AdminBatchLoadBookTitlesController::updatePinyin()`; each normalizes only registry-matched columns
-- [ ] **(§D-6)** Tests: Tier-1 columns typing `lv`→`lü` regression; **Tier-2 columns trigger the dialog, convert/keep both work, "keep" is not overwritten by the backend (no silent convert)**; English-translation/Chinese columns unaffected, non-registry columns unchanged, book-title inline consistent with batch
+- [x] **(§D-6)** "table → pinyin-column Tier" registry — lives in `config/code_table_mutations.php` as each table's `tier1_fields`/`tier2_fields` (subset of allowed_fields; same source as §D-5)
+- [~] **(§D-6)** save-time v→ü normalization at three hooks: **(1) `AbstractCodeTableMutationHandler`/`ConfigCodeTableMutationHandler` done** (Tier 1 silent, Tier 2 not converted by backend); (2) `CodesController` (`store`/`update` + proposal, overlapping §D-2) and (3) `AdminBatchLoadBookTitlesController::updatePinyin()` **in a later milestone**
+- [~] **(§D-6)** Tests: **API-handler Tier-1 silent / Tier-2 not-converted / idempotence (normalize before change detection) done** (`ApiV2MutateCodeTablesTest`); `CodesController` / book-title inline / frontend Tier-2 dialog tests pending
 - [ ] Doc sync: `AGENTS.md` module entry, and `CHANGELOG.md` as needed

--- a/docs/CODE_TABLE_MUTATION_API_PLAN.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.md
@@ -124,7 +124,7 @@
 - [ ] 無主鍵表 `SOCIAL_INSTITUTION_ALTNAME_DATA`：**SKIP、不處理**（§D-1）
 - [x] 測試（`ApiV2MutateCodeTablesTest`：單鍵/多欄/三欄/複合三鍵 update・audit・person_id=0・白名單拒絕・proposal・404・403；`ApiV2MutateNianHaoTest` 22 項不變）
 - [ ] **（必做，§D-2）** `CodesController` 直寫路徑補 `AuditLogService::write()`，使 UI 與 API 審計一致
-- [ ] **（必做，§D-6）** 建立「表→漢語拼音欄」registry（與 §D-5 批次遷移共用同一份名單）
-- [ ] **（必做，§D-6）** 保存時 v→ü 歸一化加掛三處：`AbstractCodeTableMutationHandler`、`CodesController`（`store`/`update`＋proposal 方法；`store`/`update` 與 §D-2 掛點重疊）、`AdminBatchLoadBookTitlesController::updatePinyin()`；均依 registry 只轉命中欄
-- [ ] **（§D-6）** 測試：Tier 1 欄手打 `lv`→`lü` 回歸；**Tier 2 欄觸發彈窗、選轉/保留生效、選保留後端不覆寫（不 silent 轉）**；英文譯名／中文欄不受影響、registry 未列欄不轉、書名 inline 與 batch 一致
+- [x] **（§D-6）** 「表→拼音欄 Tier」registry——落於 `config/code_table_mutations.php` 每表的 `tier1_fields`／`tier2_fields`（與 allowed_fields 一致；與 §D-5 名單同源）
+- [~] **（§D-6）** 保存時 v→ü 歸一化三掛點：**(1) `AbstractCodeTableMutationHandler`／`ConfigCodeTableMutationHandler` 已加**（Tier 1 靜默轉、Tier 2 後端不轉）；(2) `CodesController`（`store`/`update`＋proposal，與 §D-2 掛點重疊）、(3) `AdminBatchLoadBookTitlesController::updatePinyin()` **待後續里程碑**
+- [~] **（§D-6）** 測試：**API handler 的 Tier 1 靜默轉／Tier 2 不轉／冪等（變更偵測前歸一化）已補**（`ApiV2MutateCodeTablesTest`）；`CodesController`／書名 inline／前端 Tier 2 彈窗測試待後續
 - [ ] 文件同步：`AGENTS.md` 模組入口、必要時 `CHANGELOG.md`

--- a/tests/Feature/ApiV2MutateCodeTablesTest.php
+++ b/tests/Feature/ApiV2MutateCodeTablesTest.php
@@ -267,6 +267,59 @@ class ApiV2MutateCodeTablesTest extends TestCase {
         $this->assertDatabaseHas('TEXT_INSTANCE_DATA', ['c_textid' => 100, 'c_text_instance_id' => 9, 'c_instance_title' => 'other']);
     }
 
+    // ── §D-6 保存止血：Tier 1 靜默轉、Tier 2 後端不轉 ────────
+
+    #[Test]
+    public function testTier1ColumnSilentlyNormalizedOnSave(): void {
+        $this->actingAs($this->makeUser(email: 'ethnicity-tier1@example.com'));
+        DB::table('ETHNICITY_TRIBE_CODES')->insert(['c_ethnicity_code' => 20, 'c_name_chn' => '女真', 'c_name' => null, 'c_romanized' => null, 'c_surname' => null]);
+
+        // c_name 為 Tier 1：手打 Nvzhen（nv+z）→ 靜默轉 Nüzhen
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'ethnicity_tribe_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_ethnicity_code' => 20]],
+            'changes' => ['c_name' => 'Nvzhen'],
+        ])->assertOk();
+        $this->assertDatabaseHas('ETHNICITY_TRIBE_CODES', ['c_ethnicity_code' => 20, 'c_name' => 'Nüzhen']);
+    }
+
+    #[Test]
+    public function testTier2ColumnNotNormalizedByBackend(): void {
+        $this->actingAs($this->makeUser(email: 'ethnicity-tier2@example.com'));
+        DB::table('ETHNICITY_TRIBE_CODES')->insert(['c_ethnicity_code' => 21, 'c_name_chn' => '契丹', 'c_name' => null, 'c_romanized' => null, 'c_surname' => null]);
+
+        // c_romanized 為 Tier 2（可能含西文）：後端原樣寫入、不轉（交前端 altname 式彈窗）
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'ethnicity_tribe_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_ethnicity_code' => 21]],
+            'changes' => ['c_romanized' => 'Kitan-Yelv'],
+        ])->assertOk();
+        $this->assertDatabaseHas('ETHNICITY_TRIBE_CODES', ['c_ethnicity_code' => 21, 'c_romanized' => 'Kitan-Yelv']);
+    }
+
+    #[Test]
+    public function testTier1NormalizationIsIdempotentWithChangeDetection(): void {
+        $this->actingAs($this->makeUser(email: 'ganzhi-idem@example.com'));
+        // 現庫已是 ü；手打 lv 經歸一化＝lü＝原值→無實質變更→422（證明歸一化在變更偵測之前、冪等）
+        DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 30, 'c_ganzhi_chn' => '呂', 'c_ganzhi_py' => 'lü']);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'ganzhi_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_ganzhi_code' => 30]],
+            'changes' => ['c_ganzhi_py' => 'lv'],
+        ])->assertStatus(422);
+        $this->assertDatabaseHas('GANZHI_CODES', ['c_ganzhi_code' => 30, 'c_ganzhi_py' => 'lü']);
+    }
+
     // ── proposal 模式 ───────────────────────────────────────
 
     #[Test]


### PR DESCRIPTION
## 目的（Phase B 里程碑 3）
在 code 表更新 API（M2 的 config 驅動 handler）加上 **§D-6 保存止血的第一掛點**：Tier 1 純拼音欄**後端靜默** v→ü；Tier 2 混西文欄**後端不轉**（留給前端 altname 式彈窗）。

## 內容
- **`config/code_table_mutations.php`**：每表新增 `tier1_fields`／`tier2_fields`（＝ `allowed_fields` 的分割，依 §D-6 實測登錄表）。Tier 2 集合＝`ADDR_CODES.c_name`、`ETHNICITY.c_romanized`/`c_surname`、`DYNASTIES.c_dynasty`、`CHORONYM.c_choronym_desc`；其餘 Tier 1。
- **`AbstractCodeTableMutationHandler`**：新增 `preprocessUpdateData()` 掛點（預設 no-op），於 `validateFields` 之後、**變更偵測與寫入之前**呼叫。
- **`ConfigCodeTableMutationHandler`**：覆寫該掛點，只對本表 `tier1_fields` 套 `PinyinUmlaut::normalizeFields`；Tier 2 欄原樣寫入。
- **冪等**：歸一化在變更偵測「之前」→ 現庫已 `ü`、送 `lv` 歸一化後＝原值→ 422 無變更、不重複寫。DB／`audit_log`／`operations`／proposal payload 皆存歸一化值。

## 測試
Tier 1 靜默轉（`Nvzhen→Nüzhen`）、Tier 2 verbatim（`Kitan-Yelv` 不轉，若轉會變 `Yelü`→強測）、冪等（seed `lü` 送 `lv`→422、列不變）。mutation+pinyin 回歸 368 綠；NIAN_HAO 22 不變。

## 審查
review agent + codex 各一輪：13 表 tier 分割 `∪==allowed_fields`、Tier 2 集合＝規定 5 欄、掛點順序/冪等/不洩漏未歸一化值、`normalizeFields` 只碰字串欄、NIAN_HAO 不受影響——**均無 SERIOUS/MINOR/NIT**。

> §D-6 尚餘掛點 (2) `CodesController`（＋§D-2 audit）、(3) 書名 inline、以及前端 Tier 2 彈窗——後續里程碑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)