### PR TITLE
feat(codetable-api): code 表拼音 v→ü 批次遷移指令＋掃描器（Phase B 里程碑 4）

### DIFF
--- a/app/Console/Commands/MigrateCodeTablePinyinV.php
+++ b/app/Console/Commands/MigrateCodeTablePinyinV.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Pinyin\CodeTablePinyinScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Code 表拼音 v→ü 批次遷移（Phase B）。預設 dry-run，只掃描不寫入。
+ *
+ * 機制（見 docs/CODE_TABLE_MUTATION_API_PLAN.md §D-5/§D-6）：
+ *   - 掃描每張表的 Tier 1／Tier 2 拼音欄（config/code_table_mutations.php），套確定性規則
+ *     {@see \App\Support\PinyinUmlaut::normalize()}。
+ *   - **Tier 1**（純拼音）：`--execute` 時直接寫入。
+ *   - **Tier 2**（可能含西文，如 ADDR_CODES.c_name）：**預設不寫**——僅列出命中供人眼複核；
+ *     確認無誤傷後再以 `--tier=tier2`（或 `--tier=all`）寫入。
+ *   - `otherVs`（含 v 但規則未命中，如 Vietnam/Bavard）：一律輸出安全網清單、絕不改。
+ *
+ * 寫入一律走受審計 `/api/v2/mutate`（mode:direct、person_id:0），逐筆有 audit/operations 可回退。
+ * Token 只從環境變數 `CBDB_MIGRATE_TOKEN` 讀，絕不接受 CLI 參數、絕不輸出。
+ */
+class MigrateCodeTablePinyinV extends Command {
+    /** @var string */
+    protected $signature = 'cbdb:migrate-code-pinyin-v
+                            {--tables=all : all｜逗號分隔的 resource（如 office_codes,ganzhi_codes）}
+                            {--tier=tier1 : 處理哪層欄位 tier1｜tier2｜all（tier2 含西文，需人工複核後才寫）}
+                            {--out-dir= : 產物輸出目錄（預設 storage/app/code-pinyin-migration）}
+                            {--execute : 實際寫入（走 /api/v2/mutate）；省略＝dry-run 只掃描}
+                            {--base-url=http://localhost : --execute 時的 API base URL}';
+
+    /** @var string */
+    protected $description = 'Code 表拼音 v→ü 批次遷移：掃描 Tier 1/2 拼音欄、確定性規則，預設 dry-run。Tier 1 可 --execute 寫入（審計 API）；Tier 2 需人工複核。';
+
+    public function handle(CodeTablePinyinScanner $scanner): int {
+        $tier = (string) $this->option('tier');
+        if (!in_array($tier, ['tier1', 'tier2', 'all'], true)) {
+            $this->error('--tier 只能是 tier1｜tier2｜all');
+
+            return self::FAILURE;
+        }
+        $execute = (bool) $this->option('execute');
+        $outDir = (string) ($this->option('out-dir') ?: storage_path('app/code-pinyin-migration'));
+        if (!is_dir($outDir) && !@mkdir($outDir, 0775, true) && !is_dir($outDir)) {
+            $this->error("無法建立輸出目錄：{$outDir}");
+
+            return self::FAILURE;
+        }
+
+        $token = null;
+        if ($execute) {
+            $token = getenv('CBDB_MIGRATE_TOKEN') ?: null;
+            if (!$token) {
+                $this->error('--execute 需要環境變數 CBDB_MIGRATE_TOKEN（Bearer token）；token 不接受 CLI 參數。');
+
+                return self::FAILURE;
+            }
+        }
+
+        $definitions = $this->selectedDefinitions((string) $this->option('tables'));
+        if ($definitions === null) {
+            return self::FAILURE;
+        }
+
+        $this->info('Code 表拼音 v→ü 遷移 — '.($execute ? '**寫入模式（--execute）**' : 'dry-run（只掃描、不寫入）')."；tier={$tier}");
+
+        $totalMutations = 0;
+        $totalOtherV = 0;
+        $applyFailures = 0;
+
+        foreach ($definitions as $def) {
+            $columns = $this->columnsForTier($def, $tier);
+            if ($columns === []) {
+                continue;
+            }
+            // 掃描須與 API 寫入同一連線（基底 handler 用預設連線 DB::table），故用預設連線（null）。
+            $result = $scanner->scan($def['table'], $def['key_columns'], $columns, null);
+            $this->reportTable($def, $columns, $result, $outDir);
+            $totalMutations += count($result['mutations']);
+            $totalOtherV += count($result['otherVs']);
+
+            if ($execute && $result['mutations'] !== []) {
+                $applyFailures += $this->applyMutations($def, $result['mutations'], (string) $this->option('base-url'), (string) $token, $outDir);
+            }
+        }
+
+        $this->newLine();
+        $this->line("合計預定變更 {$totalMutations} 筆、[OTHER-v] 安全網 {$totalOtherV} 筆。產物於：{$outDir}");
+        if (!$execute) {
+            $this->line('這是 dry-run；加 --execute 並設 CBDB_MIGRATE_TOKEN 才會實際寫入。Tier 2 需 --tier=tier2/all 且已人工複核 [OTHER-v] 清單。');
+        }
+
+        if ($applyFailures > 0) {
+            $this->error("有 {$applyFailures} 筆寫入失敗（詳見 *-apply-failures.json）。");
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * 依 --tables 選出要處理的 config 定義。
+     *
+     * @return list<array<string,mixed>>|null  null＝參數錯誤
+     */
+    private function selectedDefinitions(string $tablesOpt): ?array {
+        $all = config('code_table_mutations.tables', []);
+        if ($tablesOpt === 'all') {
+            return array_values($all);
+        }
+        $wanted = array_filter(array_map('trim', explode(',', $tablesOpt)));
+        $byResource = [];
+        foreach ($all as $def) {
+            $byResource[$def['resource']] = $def;
+        }
+        $selected = [];
+        foreach ($wanted as $r) {
+            if (!isset($byResource[$r])) {
+                $this->error("未知 resource：{$r}（見 config/code_table_mutations.php）");
+
+                return null;
+            }
+            $selected[] = $byResource[$r];
+        }
+
+        return $selected;
+    }
+
+    /** @param array<string,mixed> $def @return list<string> */
+    private function columnsForTier(array $def, string $tier): array {
+        $t1 = $def['tier1_fields'] ?? [];
+        $t2 = $def['tier2_fields'] ?? [];
+
+        return match ($tier) {
+            'tier1' => array_values($t1),
+            'tier2' => array_values($t2),
+            default => array_values(array_merge($t1, $t2)),
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $def
+     * @param array{mutations:array,otherVs:array,scannedRows:int} $result
+     * @param list<string> $columns
+     */
+    private function reportTable(array $def, array $columns, array $result, string $outDir): void {
+        $this->newLine();
+        $this->info(sprintf(
+            '%s（%s）：掃描 %d 列、命中(可轉) %d、[OTHER-v] %d',
+            $def['table'],
+            implode(',', $columns),
+            $result['scannedRows'],
+            count($result['mutations']),
+            count($result['otherVs'])
+        ));
+
+        $samples = array_slice($result['mutations'], 0, 8);
+        if ($samples !== []) {
+            $this->table(['pk', 'column', 'from', 'to'], array_map(static fn ($m) => [
+                json_encode($m['pk'], JSON_UNESCAPED_UNICODE),
+                $m['column'],
+                $m['from'],
+                $m['to'],
+            ], $samples));
+        }
+
+        foreach (['mutations', 'otherVs'] as $bucket) {
+            file_put_contents(
+                $outDir.DIRECTORY_SEPARATOR.$def['resource'].'-'.$bucket.'.json',
+                json_encode($result[$bucket], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+        }
+    }
+
+    /**
+     * 送出變更（走 /api/v2/mutate，mode:direct）。同一列多欄命中合併為一次請求。Token 僅用於 header。
+     *
+     * @param array<string,mixed> $def
+     * @param list<array{pk:array,column:string,from:string,to:string}> $mutations
+     * @return int 失敗筆數
+     */
+    private function applyMutations(array $def, array $mutations, string $baseUrl, string $token, string $outDir): int {
+        $endpoint = rtrim($baseUrl, '/').'/api/v2/mutate';
+
+        // 依 pk 合併同列的多欄變更
+        $byPk = [];
+        foreach ($mutations as $m) {
+            $key = json_encode($m['pk'], JSON_UNESCAPED_UNICODE);
+            if (!isset($byPk[$key])) {
+                $byPk[$key] = ['pk' => $m['pk'], 'changes' => []];
+            }
+            $byPk[$key]['changes'][$m['column']] = $m['to'];
+        }
+
+        $ok = 0;
+        $fail = 0;
+        $failures = [];
+        foreach ($byPk as $entry) {
+            $resp = Http::withToken($token)->acceptJson()->post($endpoint, [
+                'resource' => $def['resource'],
+                'mode' => 'direct',
+                'person_id' => 0,
+                'target' => ['pk' => $entry['pk']],
+                'changes' => $entry['changes'],
+            ]);
+            if ($resp->successful()) {
+                $ok++;
+            } else {
+                $fail++;
+                // 防禦性：--base-url 為呼叫端可控，惡意/誤設端點可能把 Authorization 反射進 body。
+                // 落檔前把 token 字串一律塗掉，確保 token 絕不寫入磁碟（即使被反射）。
+                $failures[] = [
+                    'pk' => $entry['pk'],
+                    'status' => $resp->status(),
+                    'body' => $this->redactToken($resp->json() ?? $resp->body(), $token),
+                ];
+            }
+        }
+
+        $this->line("  送出 {$def['table']}：成功 {$ok}、失敗 {$fail}");
+        if ($failures !== []) {
+            file_put_contents(
+                $outDir.DIRECTORY_SEPARATOR.$def['resource'].'-apply-failures.json',
+                json_encode($failures, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+        }
+
+        return $fail;
+    }
+
+    /**
+     * 遞迴把 token 明文從（字串／陣列）回應內容中塗掉，確保 token 不隨失敗紀錄落檔。
+     */
+    private function redactToken(mixed $data, string $token): mixed {
+        if ($token === '') {
+            return $data;
+        }
+        if (is_string($data)) {
+            return str_replace($token, '[REDACTED]', $data);
+        }
+        if (is_array($data)) {
+            $out = [];
+            foreach ($data as $key => $value) {
+                // 連 key 也塗（惡意端點若把 token 反射成 JSON key）
+                $safeKey = is_string($key) ? str_replace($token, '[REDACTED]', $key) : $key;
+                $out[$safeKey] = $this->redactToken($value, $token);
+            }
+
+            return $out;
+        }
+
+        return $data;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends ConsoleKernel {
         \App\Console\Commands\FetchChgisMap::class,
         \App\Console\Commands\RebuildPersonChangeIndex::class,
         \App\Console\Commands\MigratePinyinV::class,
+        \App\Console\Commands\MigrateCodeTablePinyinV::class,
     ];
 
     /**

--- a/app/Services/Pinyin/CodeTablePinyinScanner.php
+++ b/app/Services/Pinyin/CodeTablePinyinScanner.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services\Pinyin;
+
+use App\Support\PinyinUmlaut;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Code 表拼音 v→ü 批次掃描器（Phase B）。
+ *
+ * 對一張表的指定欄位掃描含 `v/V` 的列，套用確定性規則 {@see PinyinUmlaut::normalize()}，
+ * 分類為：
+ *   - mutations：規則命中（值會改變，如 `Lvchuan`→`Lüchuan`）→ 遷移候選。
+ *   - otherVs：含 v 但規則未命中（如 `Vietnam`、`Bavard`）→ 安全網清單，供人眼確認無誤傷。
+ *
+ * 純讀取、不寫入（寫入由指令走受審計 API）。與 §D-5 掃描規則、§D-6 Tier 登錄一致。
+ */
+class CodeTablePinyinScanner {
+    /**
+     * @param  list<string>  $keyColumns  主鍵欄（構成每列 pk）
+     * @param  list<string>  $columns     要掃描的欄位
+     * @return array{mutations: list<array{pk:array<string,mixed>,column:string,from:string,to:string}>, otherVs: list<array{pk:array<string,mixed>,column:string,value:string}>, scannedRows:int}
+     */
+    public function scan(string $table, array $keyColumns, array $columns, ?string $connection = null): array {
+        if ($columns === []) {
+            return ['mutations' => [], 'otherVs' => [], 'scannedRows' => 0];
+        }
+
+        $db = DB::connection($connection);
+        $select = array_values(array_unique(array_merge($keyColumns, $columns)));
+
+        // 預篩含 v/V 的列（LIKE 於 SQLite/MySQL 預設對 ASCII 大小寫不敏感，v 與 V 皆命中）；
+        // 逐欄 orWhere，任一欄含 v 即取回，再於 PHP 端逐欄精確判定。
+        $query = $db->table($table)->select($select)->where(function ($q) use ($columns) {
+            foreach ($columns as $c) {
+                $q->orWhere($c, 'like', '%v%');
+            }
+        });
+
+        $mutations = [];
+        $otherVs = [];
+        $scannedRows = 0;
+
+        foreach ($query->cursor() as $row) {
+            $scannedRows++;
+            $rowArr = (array) $row;
+            $pk = [];
+            foreach ($keyColumns as $k) {
+                $pk[$k] = $rowArr[$k] ?? null;
+            }
+            foreach ($columns as $c) {
+                $val = $rowArr[$c] ?? null;
+                if (!is_string($val) || $val === '' || !preg_match('/[Vv]/', $val)) {
+                    continue;
+                }
+                $norm = PinyinUmlaut::normalize($val);
+                if ($norm !== $val) {
+                    $mutations[] = ['pk' => $pk, 'column' => $c, 'from' => $val, 'to' => $norm];
+                } else {
+                    $otherVs[] = ['pk' => $pk, 'column' => $c, 'value' => $val];
+                }
+            }
+        }
+
+        return ['mutations' => $mutations, 'otherVs' => $otherVs, 'scannedRows' => $scannedRows];
+    }
+}

--- a/docs/PINYIN_V_TO_UMLAUT_MIGRATION.en.md
+++ b/docs/PINYIN_V_TO_UMLAUT_MIGRATION.en.md
@@ -230,8 +230,8 @@ Therefore **only these four substrings need conversion** (handle each case separ
 - [x] **(Phase A, §D-8)** Search compatibility: query expansion on the pinyin LIKE query side (a typed `v` searches both `v` and `ü`) (§3) — M3 PR #1099
 - [ ] ~~confirm/create `ALTNAME_CODES` code 22, then add aliases~~ **(not doing it — see §D-1)**
 - [ ] Communicate with downstream systems and the Access edition, recommending they match both `v` and `ü` forms at query time
-- [ ] Phase B prerequisite: build the code-table audited write API per the [Code-Table Audited Mutation API Construction Plan](./CODE_TABLE_MUTATION_API_PLAN.en.md)
-- [ ] Phase B: once the API is ready, scan and correct other pinyin fields in batches (including the `TEXT_INSTANCE_DATA` composite PK and the `ADDRESSES` rebuild; `SOCIAL_INSTITUTION_ALTNAME_DATA` is **SKIPPED, see §D-9a**)
+- [x] Phase B prerequisite: the code-table audited write API is built ([plan](./CODE_TABLE_MUTATION_API_PLAN.en.md) milestones 1-3: base + config-driven 13-table update + §D-6 save normalization)
+- [~] Phase B: the batch migration tool is built (`cbdb:migrate-code-pinyin-v`: scans Tier 1/2 pinyin columns, deterministic rule, dry-run by default, `--execute` goes through the audited API). **Local CBDB-copy dry-run: ~1460 planned changes** (mostly Tier 1: `TEXT_CODES.c_title` 824, `OFFICE_CODES` 522, `TEXT_INSTANCE_DATA` 77, `SOCIAL_INSTITUTION_NAME_CODES` 8…; Tier 2: `ADDR_CODES.c_name` 16, `ETHNICITY.c_romanized` 2), plus 393 `[OTHER-v]` safety-net rows. **Production `--execute` is a human-gated step** (Tier 1 automatic; Tier 2 needs prior review of `[OTHER-v]`/hits); rebuild `ADDRESSES` after `ADDR_CODES`; `SOCIAL_INSTITUTION_ALTNAME_DATA` is **SKIPPED** (§D-9a)
 - [ ] Regression tests (generation / normalization / person-name correction / audit / Western-name exclusion; mind the SQLite collation difference)
 - [ ] Doc sync: `CHANGELOG.md`, and `DATABASE.md` / `README.md` as needed
 - [ ] **Final step (§D-10)**: remove `'pinyin'` from `ui_hidden` in `config/codes.php` to re-expose the surname-pinyin table in the codes UI

--- a/docs/PINYIN_V_TO_UMLAUT_MIGRATION.md
+++ b/docs/PINYIN_V_TO_UMLAUT_MIGRATION.md
@@ -230,8 +230,8 @@ CBDB 拼音規範長期以 `v` 代替 `ü`（如 `呂 = Lv`、`閭丘 = Lvqiu`�
 - [x] **（Phase A，§D-8）** 搜尋兼容：拼音 LIKE 查詢端查詢展開（輸入 `v` 同查 `v` 與 `ü`）（§3）——M3 PR #1099
 - [ ] ~~確認／建立 `ALTNAME_CODES` 代碼 22 並補別名~~ **（不做，見 §D-1）**
 - [ ] 溝通下游系統與 Access 版，建議查詢時同時匹配 `v` 與 `ü` 形式
-- [ ] 階段 B 前置：依 [Code 表受審計寫入 API 建設計畫](./CODE_TABLE_MUTATION_API_PLAN.md) 建立 code 表受審計寫入 API
-- [ ] 階段 B：API 就緒後，分批掃描修正其他拼音欄位（含 `TEXT_INSTANCE_DATA` 複合主鍵、`ADDRESSES` 重建；`SOCIAL_INSTITUTION_ALTNAME_DATA` **SKIP，見 §D-9a**）
+- [x] 階段 B 前置：code 表受審計寫入 API 已建（[計畫](./CODE_TABLE_MUTATION_API_PLAN.md) 里程碑 1-3：基底＋config 驅動 13 表 update＋§D-6 保存歸一化）
+- [~] 階段 B：批次遷移工具已建（`cbdb:migrate-code-pinyin-v`：掃描 Tier 1/2 拼音欄、確定性規則、預設 dry-run、`--execute` 走審計 API）。**本機 CBDB 副本 dry-run 實測：預定變更約 1460 筆**（Tier 1 為主：`TEXT_CODES.c_title` 824、`OFFICE_CODES` 522、`TEXT_INSTANCE_DATA` 77、`SOCIAL_INSTITUTION_NAME_CODES` 8…；Tier 2：`ADDR_CODES.c_name` 16、`ETHNICITY.c_romanized` 2），`[OTHER-v]` 安全網 393 筆。**生產 `--execute` 為人工把關步驟**（Tier 1 可自動、Tier 2 需先複核 `[OTHER-v]`／命中）；`ADDRESSES` 於 `ADDR_CODES` 改後重建；`SOCIAL_INSTITUTION_ALTNAME_DATA` **SKIP**（§D-9a）
 - [ ] 回歸測試（生成 / 正規化 / 人名修正 / audit / 西文名排除；注意 SQLite collation 差異）
 - [ ] 文件同步：`CHANGELOG.md`、必要時 `DATABASE.md` / `README.md`
 - [ ] **最後環節（§D-10）**：自 `config/codes.php` 的 `ui_hidden` 移除 `'pinyin'`，於 codes 介面重新顯示姓氏拼音對照表

--- a/tests/Feature/MigrateCodeTablePinyinVTest.php
+++ b/tests/Feature/MigrateCodeTablePinyinVTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\Pinyin\CodeTablePinyinScanner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Code 表拼音 v→ü 批次遷移的掃描器與 dry-run 指令（Phase B）。
+ */
+class MigrateCodeTablePinyinVTest extends TestCase {
+    private string $outDir;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('GANZHI_CODES', function (Blueprint $table) {
+            $table->integer('c_ganzhi_code')->primary();
+            $table->string('c_ganzhi_chn')->nullable();
+            $table->string('c_ganzhi_py')->nullable();
+        });
+        Schema::create('ADDR_CODES', function (Blueprint $table) {
+            $table->integer('c_addr_id')->primary();
+            $table->string('c_name')->nullable();
+            $table->string('c_name_chn')->nullable();
+        });
+        Schema::create('OFFICE_CODES', function (Blueprint $table) {
+            $table->integer('c_office_id')->primary();
+            $table->string('c_office_pinyin')->nullable();
+            $table->string('c_office_pinyin_alt')->nullable();
+            $table->string('c_office_trans')->nullable();
+        });
+        Schema::create('TEXT_INSTANCE_DATA', function (Blueprint $table) {
+            $table->integer('c_textid');
+            $table->integer('c_text_edition_id');
+            $table->integer('c_text_instance_id');
+            $table->string('c_instance_title')->nullable();
+            $table->primary(['c_textid', 'c_text_edition_id', 'c_text_instance_id']);
+        });
+
+        $this->outDir = storage_path('framework/testing/code-pinyin-'.uniqid());
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('GANZHI_CODES');
+        Schema::dropIfExists('ADDR_CODES');
+        Schema::dropIfExists('OFFICE_CODES');
+        Schema::dropIfExists('TEXT_INSTANCE_DATA');
+        if (is_dir($this->outDir)) {
+            File::deleteDirectory($this->outDir);
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function testScannerClassifiesMutationsAndOtherVs(): void {
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 1, 'c_name' => 'Lvchuan'],          // 命中 → Lüchuan
+            ['c_addr_id' => 2, 'c_name' => 'Vietnam'],          // 含 v、規則未命中 → otherV
+            ['c_addr_id' => 3, 'c_name' => 'Soviet Far East'],  // 含 v、規則未命中 → otherV
+            ['c_addr_id' => 4, 'c_name' => 'Beijing'],          // 無 v → 不掃
+            ['c_addr_id' => 5, 'c_name' => 'Yanlv'],            // 命中 → Yanlü
+        ]);
+
+        $scanner = new CodeTablePinyinScanner();
+        $result = $scanner->scan('ADDR_CODES', ['c_addr_id'], ['c_name']);
+
+        $muts = collect($result['mutations']);
+        $this->assertCount(2, $muts);
+        $this->assertEqualsCanonicalizing(
+            [['from' => 'Lvchuan', 'to' => 'Lüchuan'], ['from' => 'Yanlv', 'to' => 'Yanlü']],
+            $muts->map(fn ($m) => ['from' => $m['from'], 'to' => $m['to']])->all()
+        );
+        $this->assertSame(['c_addr_id' => 1], $muts->firstWhere('from', 'Lvchuan')['pk']);
+
+        $otherVals = collect($result['otherVs'])->pluck('value')->all();
+        $this->assertEqualsCanonicalizing(['Vietnam', 'Soviet Far East'], $otherVals);
+    }
+
+    #[Test]
+    public function testScannerReturnsEmptyForNoColumns(): void {
+        $result = (new CodeTablePinyinScanner())->scan('ADDR_CODES', ['c_addr_id'], []);
+        $this->assertSame(['mutations' => [], 'otherVs' => [], 'scannedRows' => 0], $result);
+    }
+
+    #[Test]
+    public function testDryRunTier1WritesReportsAndDoesNotTouchDb(): void {
+        DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 1, 'c_ganzhi_chn' => '呂', 'c_ganzhi_py' => 'lv']);
+
+        $this->artisan('cbdb:migrate-code-pinyin-v', [
+            '--tables' => 'ganzhi_codes',
+            '--tier' => 'tier1',
+            '--out-dir' => $this->outDir,
+        ])->assertExitCode(0);
+
+        // dry-run 不改資料
+        $this->assertDatabaseHas('GANZHI_CODES', ['c_ganzhi_code' => 1, 'c_ganzhi_py' => 'lv']);
+
+        // 產物 JSON：mutations 含 lv→lü
+        $mutations = json_decode(File::get($this->outDir.'/ganzhi_codes-mutations.json'), true);
+        $this->assertCount(1, $mutations);
+        $this->assertSame('lv', $mutations[0]['from']);
+        $this->assertSame('lü', $mutations[0]['to']);
+    }
+
+    #[Test]
+    public function testTier1DoesNotScanTier2Columns(): void {
+        // ADDR_CODES.c_name 為 Tier 2；--tier=tier1 時該表無 Tier 1 欄 → 略過、不產出 mutations 檔
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 1, 'c_name' => 'Lvchuan']);
+
+        $this->artisan('cbdb:migrate-code-pinyin-v', [
+            '--tables' => 'addr_codes',
+            '--tier' => 'tier1',
+            '--out-dir' => $this->outDir,
+        ])->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->outDir.'/addr_codes-mutations.json');
+    }
+
+    #[Test]
+    public function testTier2ScanReportsMixedColumnHitsAndOtherV(): void {
+        DB::table('ADDR_CODES')->insert([
+            ['c_addr_id' => 1, 'c_name' => 'Lvchuan'],
+            ['c_addr_id' => 2, 'c_name' => 'Vietnam'],
+        ]);
+
+        $this->artisan('cbdb:migrate-code-pinyin-v', [
+            '--tables' => 'addr_codes',
+            '--tier' => 'tier2',
+            '--out-dir' => $this->outDir,
+        ])->assertExitCode(0);
+
+        $mutations = json_decode(File::get($this->outDir.'/addr_codes-mutations.json'), true);
+        $otherVs = json_decode(File::get($this->outDir.'/addr_codes-otherVs.json'), true);
+        $this->assertSame('Lüchuan', $mutations[0]['to']);
+        $this->assertSame('Vietnam', $otherVs[0]['value']);
+    }
+
+    #[Test]
+    public function testScannerHandlesCompositeKey(): void {
+        DB::table('TEXT_INSTANCE_DATA')->insert([
+            'c_textid' => 100, 'c_text_edition_id' => 2, 'c_text_instance_id' => 3, 'c_instance_title' => 'Lvshi Chunqiu',
+        ]);
+        $result = (new CodeTablePinyinScanner())->scan('TEXT_INSTANCE_DATA', ['c_textid', 'c_text_edition_id', 'c_text_instance_id'], ['c_instance_title']);
+
+        $this->assertCount(1, $result['mutations']);
+        $this->assertSame(['c_textid' => 100, 'c_text_edition_id' => 2, 'c_text_instance_id' => 3], $result['mutations'][0]['pk']);
+        $this->assertSame('Lüshi Chunqiu', $result['mutations'][0]['to']);
+    }
+
+    #[Test]
+    public function testDryRunSendsNoHttp(): void {
+        Http::fake();
+        DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 1, 'c_ganzhi_py' => 'lv']);
+
+        $this->artisan('cbdb:migrate-code-pinyin-v', [
+            '--tables' => 'ganzhi_codes',
+            '--out-dir' => $this->outDir,
+        ])->assertExitCode(0);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function testExecuteGroupsMultiColumnAndSendsBearerTokenNoLeak(): void {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+        // 同一列兩個 Tier 1 欄皆命中 → 應合併為一次請求
+        DB::table('OFFICE_CODES')->insert(['c_office_id' => 10, 'c_office_pinyin' => 'Lv Bu', 'c_office_pinyin_alt' => 'Nvguan', 'c_office_trans' => 'x']);
+
+        $prev = getenv('CBDB_MIGRATE_TOKEN');
+        putenv('CBDB_MIGRATE_TOKEN=SECRET-TOKEN-XYZ');
+
+        try {
+            $this->artisan('cbdb:migrate-code-pinyin-v', [
+                '--tables' => 'office_codes',
+                '--tier' => 'tier1',
+                '--execute' => true,
+                '--base-url' => 'http://localhost',
+                '--out-dir' => $this->outDir,
+            ])->assertExitCode(0);
+        } finally {
+            putenv($prev === false ? 'CBDB_MIGRATE_TOKEN' : 'CBDB_MIGRATE_TOKEN='.$prev);
+        }
+
+        Http::assertSentCount(1);
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return str_ends_with($request->url(), '/api/v2/mutate')
+                && $request->hasHeader('Authorization', 'Bearer SECRET-TOKEN-XYZ')
+                && $body['resource'] === 'office_codes'
+                && $body['person_id'] === 0
+                && $body['target']['pk'] === ['c_office_id' => 10]
+                // 兩欄合併為一次 changes
+                && $body['changes'] === ['c_office_pinyin' => 'Lü Bu', 'c_office_pinyin_alt' => 'Nüguan'];
+        });
+    }
+
+    #[Test]
+    public function testExecuteFailureWritesFailuresJsonWithoutToken(): void {
+        // 模擬「反射端點」：把 Authorization 明文回填進 body，驗證落檔前一律塗掉 token。
+        Http::fake(['*' => Http::response(['ok' => false, 'echo' => 'got header Bearer SECRET-TOKEN-XYZ'], 422)]);
+        DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 1, 'c_ganzhi_py' => 'lv']);
+
+        $prev = getenv('CBDB_MIGRATE_TOKEN');
+        putenv('CBDB_MIGRATE_TOKEN=SECRET-TOKEN-XYZ');
+
+        try {
+            $this->artisan('cbdb:migrate-code-pinyin-v', [
+                '--tables' => 'ganzhi_codes',
+                '--tier' => 'tier1',
+                '--execute' => true,
+                '--out-dir' => $this->outDir,
+            ])->assertExitCode(1); // 有寫入失敗
+        } finally {
+            putenv($prev === false ? 'CBDB_MIGRATE_TOKEN' : 'CBDB_MIGRATE_TOKEN='.$prev);
+        }
+
+        $failFile = $this->outDir.'/ganzhi_codes-apply-failures.json';
+        $this->assertFileExists($failFile);
+        $raw = File::get($failFile);
+        $this->assertStringContainsString('"status": 422', $raw);
+        // 即使端點把 token 反射進 body，落檔前也已塗掉：token 絕不落檔、且已 [REDACTED]。
+        $this->assertStringNotContainsString('SECRET-TOKEN-XYZ', $raw);
+        $this->assertStringContainsString('[REDACTED]', $raw);
+    }
+
+    #[Test]
+    public function testUnknownResourceFails(): void {
+        $this->artisan('cbdb:migrate-code-pinyin-v', [
+            '--tables' => 'not_a_table',
+            '--out-dir' => $this->outDir,
+        ])->assertExitCode(1);
+    }
+
+    #[Test]
+    public function testExecuteWithoutTokenFails(): void {
+        $prev = getenv('CBDB_MIGRATE_TOKEN');
+        putenv('CBDB_MIGRATE_TOKEN');  // 清空
+
+        try {
+            $this->artisan('cbdb:migrate-code-pinyin-v', [
+                '--tables' => 'ganzhi_codes',
+                '--execute' => true,
+                '--out-dir' => $this->outDir,
+            ])->assertExitCode(1);
+        } finally {
+            if ($prev !== false) {
+                putenv('CBDB_MIGRATE_TOKEN='.$prev);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 目的（Phase B 里程碑 4）
Phase B 的**實際資料修正工具**：掃描 code 表拼音欄、套確定性 v→ü 規則、預設 dry-run，`--execute` 走 M1-M3 的受審計 API。

## 內容
- **`CodeTablePinyinScanner`**：掃一張表指定欄，`LIKE '%v%'` 預篩＋`PinyinUmlaut` 判定，分類 `mutations`（規則命中、會改）與 `otherVs`（含 v 但未命中，如 `Vietnam`/`Bavard`，安全網、不改）；支援複合主鍵。
- **`cbdb:migrate-code-pinyin-v`**：讀 `config/code_table_mutations.php`，`--tables=all|csv`、`--tier=tier1|tier2|all`（預設 `tier1`）、`--execute`、`--base-url`、`--out-dir`。輸出 `{resource}-mutations.json`／`-otherVs.json`；`--execute` 把同列多欄合併為一次 `/api/v2/mutate`（direct、`person_id 0`）。
- **Tier 2 閘**：混西文欄（`ADDR_CODES.c_name` 等）預設不寫，需顯式 `--tier=tier2/all`（人工複核 `[OTHER-v]` 後）。
- **Token 安全**：只從 env `CBDB_MIGRATE_TOKEN` 讀、只用於 Authorization header、不印不記；失敗落檔前 `redactToken()` 遞迴塗掉 token（含 array key／value）——防惡意/誤設端點反射 header 導致 token 落盤。

## dry-run 實測（本機 CBDB 全量副本）
約 **1460 筆**預定變更（`TEXT_CODES.c_title` 824、`OFFICE_CODES` 522、`TEXT_INSTANCE_DATA` 77…；Tier 2：`ADDR_CODES.c_name` 16、`ETHNICITY.c_romanized` 2），`[OTHER-v]` 安全網 393。抽樣命中全為正字拼音（`Lvshi→Lüshi`、`funv→funü`、`Jilve→Jilüe`）。**生產 `--execute` 為人工把關步驟**。

## 測試（11 項）
掃描分類／空欄／複合鍵、dry-run 不寫庫且不發 HTTP、Tier 分流、多欄合併＋Bearer header、**失敗落檔不含 token（模擬反射端點證明 redaction）**、未知 resource／缺 token 失敗。

## 審查
review agent + codex 各一輪。codex 揪出「失敗 body 反射可致 token 落盤」**SERIOUS** → 已補 `redactToken`（含 key）並以反射端點測試證明；dry-run 零寫入、Tier 2 顯式閘、掃描/合併正確——**現無 SERIOUS/MINOR**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)