### PR TITLE
feat(codes): §D-2 /codes 直寫路徑補寫 audit_log（Phase B 里程碑 7）

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Operation;
 use App\Repositories\CodesRepository;
 use App\Repositories\OperationRepository;
+use App\Services\AuditLogService;
 use App\Support\ColumnFilterExpression;
 use App\Support\ColumnFilterParseException;
 use App\Support\PinyinUmlaut;
@@ -246,14 +247,18 @@ class CodesController extends Controller {
 
     protected ColumnFilterExpression $columnFilterExpression;
 
+    protected AuditLogService $auditLogService;
+
     public function __construct(
         CodesRepository $codesRepository,
         OperationRepository $operationRepository,
-        ?ColumnFilterExpression $columnFilterExpression = null
+        ?ColumnFilterExpression $columnFilterExpression = null,
+        ?AuditLogService $auditLogService = null
     ) {
         $this->codesrepostory = $codesRepository;
         $this->operationRepository = $operationRepository;
         $this->columnFilterExpression = $columnFilterExpression ?? new ColumnFilterExpression();
+        $this->auditLogService = $auditLogService ?? app(AuditLogService::class);
         $this->allowedTables = $this->codesrepostory->allowedTables();
 
         // 直接从配置构建大小写映射，避免 SHOW TABLES 查询
@@ -2047,7 +2052,7 @@ class CodesController extends Controller {
             $resourceId = $this->buildCompositeId($keyColumns, $original);
         }
 
-        $this->operationRepository->store(
+        $operation = $this->operationRepository->store(
             Auth::id(),
             0,
             $type,
@@ -2056,6 +2061,35 @@ class CodesController extends Controller {
             $data,
             $original
         );
+
+        // §D-2：/codes 直寫路徑補 audit_log，使 UI 與 v2 API 審計一致（先前只寫 operations）。
+        // 僅 direct 寫入（INSERT/UPDATE/DELETE）；提案（recordProposalOperation）不落表、於核准時才審計。
+        // 注意：performUpdate 傳的是 TYPE_UPDATE_FULL(2)（Put），非 TYPE_UPDATE(3)；兩者皆映射為 UPDATE。
+        $auditOp = match ($type) {
+            Operation::TYPE_CREATE => 'INSERT',
+            Operation::TYPE_UPDATE_FULL, Operation::TYPE_UPDATE => 'UPDATE',
+            Operation::TYPE_DELETE => 'DELETE',
+            default => null,
+        };
+        if ($auditOp !== null && Schema::hasTable('audit_log')) {
+            $pkSource = !empty($data) ? $data : $original;
+            $rowPk = [];
+            foreach ($keyColumns as $col) {
+                if (array_key_exists($col, $pkSource)) {
+                    $rowPk[$col] = $pkSource[$col];
+                }
+            }
+            $this->auditLogService->write(
+                $table,
+                $auditOp,
+                $rowPk,
+                $auditOp === 'INSERT' ? null : ($original ?: null),
+                $auditOp === 'DELETE' ? null : ($data ?: null),
+                'user',
+                (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+        }
     }
 
     protected function convertRowToArray($row): array {

--- a/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.en.md
@@ -123,7 +123,7 @@
 - [x] `person_id` contract: §D-3 option b (handler forces 0 internally, **`MutationController` unchanged**)
 - [ ] No-PK table `SOCIAL_INSTITUTION_ALTNAME_DATA`: **SKIP — not handled** (§D-1)
 - [x] Tests (`ApiV2MutateCodeTablesTest`: single/multi/triple-column & composite-3-key update, audit, person_id=0, whitelist rejection, proposal, 404, 403; `ApiV2MutateNianHaoTest` 22 unchanged)
-- [ ] **(Required, §D-2)** add `AuditLogService::write()` to the `CodesController` direct-write paths, making UI and API auditing consistent
+- [x] **(§D-2)** add `AuditLogService::write()` to the `CodesController` direct-write paths, making UI and API auditing consistent
 - [x] **(§D-6)** "table → pinyin-column Tier" registry — lives in `config/code_table_mutations.php` as each table's `tier1_fields`/`tier2_fields` (subset of allowed_fields; same source as §D-5)
 - [x] **(§D-6)** save-time v→ü normalization — **all three backend hooks done**: (1) `AbstractCodeTableMutationHandler`/`ConfigCodeTableMutationHandler` (v2 API); (2) `CodesController` (`store`/`update` / proposal store+update+updateExisting; normalizes only config `tier1_fields`, leaves Tier 2, untouched for non-Phase-B tables); (3) `AdminBatchLoadBookTitlesController::updatePinyin()` (book-title `c_title`, Tier 1).
 - [x] **(§D-6)** **Frontend Tier-2 dialog done**: the generic `/codes` editor (`Codes/Create`, `Codes/Edit`) detects rule-hits in the table's `tier2_fields` (a controller-supplied prop) before save and pops a dialog (`PinyinUmlautConfirmDialog`, reusing `pinyinUmlaut.ts`) for convert/keep; `form.transform` guarantees the submit sends the chosen value.

--- a/docs/CODE_TABLE_MUTATION_API_PLAN.md
+++ b/docs/CODE_TABLE_MUTATION_API_PLAN.md
@@ -123,7 +123,7 @@
 - [x] `person_id` 契約：採 §D-3 選項 b（handler 內部固定 0、**`MutationController` 零改動**）
 - [ ] 無主鍵表 `SOCIAL_INSTITUTION_ALTNAME_DATA`：**SKIP、不處理**（§D-1）
 - [x] 測試（`ApiV2MutateCodeTablesTest`：單鍵/多欄/三欄/複合三鍵 update・audit・person_id=0・白名單拒絕・proposal・404・403；`ApiV2MutateNianHaoTest` 22 項不變）
-- [ ] **（必做，§D-2）** `CodesController` 直寫路徑補 `AuditLogService::write()`，使 UI 與 API 審計一致
+- [x] **（§D-2）** `CodesController` 直寫路徑補 `AuditLogService::write()`，使 UI 與 API 審計一致——統一掛於 `recordOperation()`（涵蓋 store/update/destroy＝INSERT/UPDATE/DELETE），rowPk 由 `getKeyColumns` 構建、`operation_id` 連結 operations；提案於核准時才審計；`Schema::hasTable` 守衛使無 audit_log 的測試不受影響。測試 `CodesControllerAuditTest`
 - [x] **（§D-6）** 「表→拼音欄 Tier」registry——落於 `config/code_table_mutations.php` 每表的 `tier1_fields`／`tier2_fields`（與 allowed_fields 一致；與 §D-5 名單同源）
 - [x] **（§D-6）** 保存時 v→ü 歸一化**後端三掛點全數完成**：(1) `AbstractCodeTableMutationHandler`／`ConfigCodeTableMutationHandler`（v2 API）；(2) `CodesController`（`store`/`update`／proposal store/update/updateExisting，依 config tier1_fields 只轉 Tier 1、Tier 2 不動、非 Phase B 表不動）；(3) `AdminBatchLoadBookTitlesController::updatePinyin()`（書名 c_title Tier 1）。
 - [x] **（§D-6）** **前端 Tier 2 彈窗完成**：通用 `/codes` 編輯器（`Codes/Create`、`Codes/Edit`）於保存前對本表 `tier2_fields`（controller 傳入之 prop）以規則偵測 v→ü，命中才彈窗（`PinyinUmlautConfirmDialog`，復用 `pinyinUmlaut.ts`）由使用者「轉換／保留」；`form.transform` 保證提交送出選定值。

--- a/tests/Feature/CodesControllerAuditTest.php
+++ b/tests/Feature/CodesControllerAuditTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * §D-2：/codes 直寫路徑（store/update/destroy）補寫 audit_log，使 UI 與 v2 API 審計一致。
+ */
+class CodesControllerAuditTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiled = sys_get_temp_dir().'/cbdb-test-views-codes-audit';
+        if (!is_dir($compiled)) {
+            mkdir($compiled, 0777, true);
+        }
+        config(['view.compiled' => $compiled]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+        config(['codes.tables' => ['TEST_AUDIT_CODES' => '審計測試代碼']]);
+
+        Schema::create('users', function ($t) {
+            $t->increments('id');
+            $t->string('name');
+            $t->string('email')->unique();
+            $t->string('password');
+            $t->string('confirmation_token')->nullable();
+            $t->tinyInteger('is_active')->default(0);
+            $t->tinyInteger('is_admin')->default(0);
+            $t->timestamps();
+        });
+        Schema::create('TEST_AUDIT_CODES', function ($t) {
+            $t->integer('code_id')->primary();
+            $t->string('description')->nullable();
+        });
+        Schema::create('operations', function ($t) {
+            $t->increments('id');
+            $t->unsignedBigInteger('user_id')->nullable();
+            $t->integer('c_personid')->default(0);
+            $t->string('resource')->nullable();
+            $t->text('resource_id')->nullable();
+            $t->string('op_type')->nullable();
+            $t->longText('resource_data')->nullable();
+            $t->longText('resource_original')->nullable();
+            $t->integer('crowdsourcing_status')->default(0);
+            $t->timestamps();
+        });
+        Schema::create('audit_log', function ($t) {
+            $t->bigIncrements('id');
+            $t->dateTime('occurred_at');
+            $t->dateTime('created_at');
+            $t->string('table_name', 64);
+            $t->string('operation', 16);
+            $t->string('actor_type', 32);
+            $t->string('actor_id', 128);
+            $t->string('operation_id', 64);
+            $t->text('row_pk');
+            $t->string('row_pk_text', 512)->nullable();
+            $t->longText('old_data')->nullable();
+            $t->longText('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        foreach (['audit_log', 'operations', 'TEST_AUDIT_CODES', 'users'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    private function activeUser(): User {
+        return User::create([
+            'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    #[Test]
+    public function store_writes_audit_log_insert(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/TEST_AUDIT_CODES', ['code_id' => 7, 'description' => 'hello']);
+
+        $audit = DB::table('audit_log')->where('table_name', 'TEST_AUDIT_CODES')->first();
+        $this->assertNotNull($audit);
+        $this->assertSame('INSERT', $audit->operation);
+        $this->assertSame('user', $audit->actor_type);
+        $this->assertNull($audit->old_data);
+        $this->assertSame('hello', json_decode($audit->new_data, true)['description']);
+        $this->assertSame(['code_id' => 7], json_decode($audit->row_pk, true));
+    }
+
+    #[Test]
+    public function update_writes_audit_log_update_with_old_and_new(): void {
+        $this->actingAs($this->activeUser());
+        DB::table('TEST_AUDIT_CODES')->insert(['code_id' => 8, 'description' => 'before']);
+
+        $this->put('/codes/TEST_AUDIT_CODES/8', ['code_id' => 8, 'description' => 'after']);
+
+        $audit = DB::table('audit_log')->where('operation', 'UPDATE')->first();
+        $this->assertNotNull($audit);
+        $this->assertSame('TEST_AUDIT_CODES', $audit->table_name);
+        $this->assertSame('before', json_decode($audit->old_data, true)['description']);
+        $this->assertSame('after', json_decode($audit->new_data, true)['description']);
+    }
+
+    #[Test]
+    public function destroy_writes_audit_log_delete(): void {
+        $this->actingAs($this->activeUser());
+        DB::table('TEST_AUDIT_CODES')->insert(['code_id' => 9, 'description' => 'doomed']);
+
+        $this->delete('/codes/TEST_AUDIT_CODES/9');
+
+        $audit = DB::table('audit_log')->where('operation', 'DELETE')->first();
+        $this->assertNotNull($audit);
+        $this->assertSame('TEST_AUDIT_CODES', $audit->table_name);
+        $this->assertSame('doomed', json_decode($audit->old_data, true)['description']);
+        $this->assertNull($audit->new_data);
+    }
+}


### PR DESCRIPTION
## 目的（Phase B 里程碑 7｜最後一個 必做 程式項）
`/codes` 通用編輯的直寫（新增/修改/刪除）先前**只寫 `operations`、不寫 `audit_log`**，與 v2 mutation API 不一致。本項於共用的 `recordOperation()` 補上 `AuditLogService::write()`，一處涵蓋三路徑。

## 內容
- **`recordOperation()`**：`operationRepository->store()` 後補 `auditLogService->write()`。op 型別 `match`：`TYPE_CREATE(1)→INSERT`、`TYPE_UPDATE_FULL(2)`/`TYPE_UPDATE(3)→UPDATE`（**注意 `performUpdate` 傳 2、非 3**）、`TYPE_DELETE(4)→DELETE`。`rowPk` 由 `getKeyColumns` 構建（含複合鍵）；`old`：INSERT 為 null 否則 `$original`；`new`：DELETE 為 null 否則 `$data`；`operation_id` 連結 `operations.id`。以 **`Schema::hasTable('audit_log')` 守衛**——無 audit_log 的既有測試不受影響、生產一律寫入。
- 提案（`recordProposalOperation`）**不在此審計**（實際落庫於核准時，另有審計）。
- 建構子新增可選 `AuditLogService`（autowire），不影響既有 DI。

## 測試
`CodesControllerAuditTest`（真 SQLite）：store/update/destroy 各驗 `audit_log` 的 operation、old/new、rowPk；既有 Codes+Operations 回歸 **207 綠**。

## 審查
review agent + codex 各一輪：op 型別映射（避 **2-vs-3** 陷阱）、`rowPk` 複合鍵/DELETE 完整、old/new 語意、`afterCommit` 對非人物表 no-op 且不會失敗請求、提案未動、無雙重審計/回歸——**均無 SERIOUS/MINOR**。

> 至此 `CODE_TABLE_MUTATION_API_PLAN` 全部程式項（§D-2 + §D-6 + 受審計寫入 API + 批次遷移工具）完成；剩生產 `--execute` 為人工把關步驟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)