### PR TITLE
年號/朝代選單加上起止年以區分同朝代重複年號

### DIFF
--- a/app/Repositories/DynastyRepository.php
+++ b/app/Repositories/DynastyRepository.php
@@ -10,9 +10,22 @@
 namespace App\Repositories;
 
 use App\Models\Dynasty;
+use App\Support\HistoricalYearRangeFormatter;
 
 class DynastyRepository {
     public function dynasties() {
-        return Dynasty::select(['c_dy', 'c_dynasty_chn', 'c_dynasty', 'c_start', 'c_end'])->get();
+        $dynasties = Dynasty::select(['c_dy', 'c_dynasty_chn', 'c_dynasty', 'c_start', 'c_end'])->get();
+
+        return $dynasties->map(function ($item) {
+            return [
+                'c_dy' => $item->c_dy,
+                'c_dynasty_chn' => $item->c_dynasty_chn,
+                'c_dynasty' => $item->c_dynasty,
+                'c_start' => $item->c_start,
+                'c_end' => $item->c_end,
+                // 供下拉選單標示起止年，幫助使用者辨識朝代時間範圍。
+                'c_year_range' => HistoricalYearRangeFormatter::format($item->c_start, $item->c_end),
+            ];
+        });
     }
 }

--- a/app/Repositories/NianHaoRepository.php
+++ b/app/Repositories/NianHaoRepository.php
@@ -10,6 +10,7 @@
 namespace App\Repositories;
 
 use App\Models\NianHao;
+use App\Support\HistoricalYearRangeFormatter;
 
 class NianHaoRepository {
     public function nianhaos() {
@@ -22,6 +23,8 @@ class NianHaoRepository {
                 'c_str' => "[".$item->c_firstyear."]~[".$item->c_lastyear."]",
                 'c_firstyear' => $item->c_firstyear,
                 'c_lastyear' => $item->c_lastyear,
+                // 供下拉選單標示起止年以區分同朝代重複年號（如元朝兩筆「至元」）；c_str 保留給既有解析邏輯用。
+                'c_year_range' => HistoricalYearRangeFormatter::format($item->c_firstyear, $item->c_lastyear),
             ];
         });
     }

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -523,42 +523,28 @@ class PostingAutofillService {
 
                 // 特殊處理：年號欄位可能返回名稱而非 ID，需要轉換
                 if (in_array($fieldName, ['c_fy_nh_code', 'c_ly_nh_code']) && !is_numeric($value)) {
-                    // AI 返回的是年號名稱（如"雍正"），需要查詢 ID
+                    // AI 返回的是年號名稱（如"雍正"），需要查詢 ID。
+                    // 同一朝代內可能有同名年號重複（如元朝兩筆「至元」：1264–1294 與 1335–1340），
+                    // 以同一欄位群組已提取的西元年（c_firstyear/c_lastyear）作為 tiebreaker 消歧，
+                    // 避免同名但年份差距懸殊時靜默選錯（見 resolveNianhaoId）。
+                    $yearHintKey = $fieldName === 'c_fy_nh_code' ? 'c_firstyear' : 'c_lastyear';
+                    $yearHint = $aiData[$yearHintKey] ?? null;
+
                     Log::info("[AI Autofill] 查詢年號", [
                         'field' => $fieldName,
                         'name' => $value,
                         'dynasty' => $effectiveDynasty,
+                        'year_hint' => $yearHint,
                     ]);
 
-                    $nianhaoQuery = DB::table('NIAN_HAO')
-                        ->where('c_nianhao_chn', $value);
+                    $nianhaoId = $this->resolveNianhaoId((string) $value, $effectiveDynasty, $yearHint);
 
-                    // 按朝代過濾（避免跨朝代的同名年號混淆）
-                    if ($effectiveDynasty !== null) {
-                        $nianhaoQuery->where('c_dy', $effectiveDynasty);
-                    }
-
-                    $nianhaoId = $nianhaoQuery->value('c_nianhao_id');
-
-                    Log::info("[AI Autofill] 年號查詢結果（按朝代過濾）", [
+                    Log::info("[AI Autofill] 年號查詢結果", [
                         'field' => $fieldName,
                         'name' => $value,
                         'dynasty' => $effectiveDynasty,
                         'found_id' => $nianhaoId,
                     ]);
-
-                    // 如果沒找到，嘗試不限制朝代再查一次
-                    if (!$nianhaoId) {
-                        $nianhaoId = DB::table('NIAN_HAO')
-                            ->where('c_nianhao_chn', $value)
-                            ->value('c_nianhao_id');
-
-                        Log::info("[AI Autofill] 年號查詢結果（不限朝代）", [
-                            'field' => $fieldName,
-                            'name' => $value,
-                            'found_id' => $nianhaoId,
-                        ]);
-                    }
 
                     if ($nianhaoId) {
                         $value = $nianhaoId;
@@ -1440,6 +1426,59 @@ class PostingAutofillService {
         }
 
         return $dynastyRangesCache[$dynastyCode] ?? null;
+    }
+
+    /**
+     * 依年號中文名解析出 c_nianhao_id。同一朝代內可能有同名年號重複
+     * （如元朝「至元」：c_nianhao_id=623 為 1264–1294，=635 為 1335–1340），
+     * 僅按名稱＋朝代過濾無法消歧，須靠西元年 tiebreaker，否則兩者相差 70 年、
+     * 選錯會寫入明顯錯誤的資料。
+     *
+     * 策略：
+     *   1. 按朝代過濾候選；若無候選且有指定朝代，退而不限朝代重試（沿用既有行為，
+     *      因朝代判斷本身可能不準）。
+     *   2. 候選恰好 1 筆 → 直接採用（絕大多數年號皆屬此情況）。
+     *   3. 候選 > 1 筆（真正重複）→ 若有西元年提示（$yearHint，來自同一欄位群組已提取的
+     *      c_firstyear/c_lastyear），優先取「西元年落在該筆 [c_firstyear, c_lastyear] 範圍內」
+     *      者；篩選後恰好剩 1 筆才採用。
+     *   4. 其餘情況（無候選、或候選 >1 且年份提示無法唯一消歧）→ 回傳 null，
+     *      交由呼叫端轉入 suggested（不可靜默猜一筆）。
+     *
+     * @param string $name 年號中文名
+     * @param int|null $dynasty 朝代代碼（$effectiveDynasty）
+     * @param int|null $yearHint 同一欄位群組已提取的西元年（c_fy_nh_code 對應 c_firstyear，
+     *                           c_ly_nh_code 對應 c_lastyear），用於候選 >1 時消歧
+     * @return int|null 解析出的 c_nianhao_id；無法確定時回傳 null
+     */
+    protected function resolveNianhaoId(string $name, ?int $dynasty, ?int $yearHint): ?int {
+        $query = DB::table('NIAN_HAO')->where('c_nianhao_chn', $name);
+        if ($dynasty !== null) {
+            $query->where('c_dy', $dynasty);
+        }
+        $candidates = $query->get(['c_nianhao_id', 'c_firstyear', 'c_lastyear']);
+
+        if ($candidates->isEmpty() && $dynasty !== null) {
+            // 按朝代過濾找不到時，退而不限朝代重試（沿用既有行為）。
+            $candidates = DB::table('NIAN_HAO')
+                ->where('c_nianhao_chn', $name)
+                ->get(['c_nianhao_id', 'c_firstyear', 'c_lastyear']);
+        }
+
+        if ($candidates->count() === 1) {
+            return $candidates->first()->c_nianhao_id;
+        }
+
+        if ($candidates->count() > 1 && $yearHint !== null) {
+            $inRange = $candidates->filter(function ($row) use ($yearHint) {
+                return $row->c_firstyear !== null && $row->c_lastyear !== null
+                    && $yearHint >= $row->c_firstyear && $yearHint <= $row->c_lastyear;
+            });
+            if ($inRange->count() === 1) {
+                return $inRange->first()->c_nianhao_id;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Support/HistoricalYearRangeFormatter.php
+++ b/app/Support/HistoricalYearRangeFormatter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * 統一年號/朝代等代碼表的起止年顯示格式，供下拉選單標示以區分同名重複代碼
+ * （例如元朝有兩筆「至元」年號，分屬 1264–1294 與 1335–1340）。
+ */
+class HistoricalYearRangeFormatter {
+    /** CBDB 慣用「未詳」哨兵值：0 與 -9999。 */
+    private const SENTINELS = [0, -9999];
+
+    /**
+     * @return string|null 例如 "(1264–1294)"；起訖任一為 null 或哨兵值時回傳 null（不顯示區間）。
+     */
+    public static function format(?int $first, ?int $last): ?string {
+        if ($first === null || $last === null) {
+            return null;
+        }
+        if (in_array($first, self::SENTINELS, true) || in_array($last, self::SENTINELS, true)) {
+            return null;
+        }
+
+        return "({$first}–{$last})";
+    }
+}

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -442,7 +442,7 @@ export default function BasicInfoEditor({
                         </select>
                     </div>
                     {gCode('c_ethnicity_code', tr('tribe', '族群/部族'), 'c_ethnicity_code', 'ethnicity', 'c_ethnicity_code', ['c_ethnicity_code', 'c_name_chn', 'c_name'])}
-                    {gCode('c_dy', tr('dynasty', '朝代'), 'c_dy', 'dynasty', 'c_dy', ['c_dy', 'c_dynasty_chn', 'c_dynasty'], true)}
+                    {gCode('c_dy', tr('dynasty', '朝代'), 'c_dy', 'dynasty', 'c_dy', ['c_dy', 'c_dynasty_chn', 'c_dynasty', 'c_year_range'], true)}
                 </div>
             ))}
 

--- a/resources/js/inertia/components/EraTimeField.tsx
+++ b/resources/js/inertia/components/EraTimeField.tsx
@@ -209,7 +209,8 @@ export default function EraTimeField({
                         mode="list"
                         model="nianhao"
                         idKey="c_nianhao_id"
-                        labelKeys={['c_nianhao_chn']}
+                        // c_year_range（如 "(1264–1294)"）用於區分同朝代重複年號（如元朝兩筆「至元」）。
+                        labelKeys={['c_nianhao_chn', 'c_year_range']}
                         value={values.nhCode}
                         initialLabel={values.nhCodeLabel}
                         disabled={disabled}

--- a/tests/Feature/AiPostingAutofillTest.php
+++ b/tests/Feature/AiPostingAutofillTest.php
@@ -440,6 +440,96 @@ class AiPostingAutofillTest extends TestCase {
     }
 
     /**
+     * 測試同朝代內重複年號（如元朝兩筆「至元」：1264–1294 與 1335–1340）：
+     * 有西元年提示時應正確消歧為對應的那一筆，而非靜默選錯（可能相差 70 年）。
+     */
+    public function test_duplicate_nianhao_in_same_dynasty_disambiguated_by_year_hint() {
+        DB::table('NIAN_HAO')->insert([
+            ['c_nianhao_id' => 623, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1264, 'c_lastyear' => 1294],
+            ['c_nianhao_id' => 635, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1335, 'c_lastyear' => 1340],
+        ]);
+
+        $user = User::factory()->create(['is_active' => 1, 'is_admin' => 1]);
+
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [[
+                    'message' => [
+                        'content' => json_encode(['postings' => [[
+                            'title_str' => '知縣',
+                            'addr_str' => null,
+                            'c_firstyear' => 1336, // 落在第二筆「至元」(1335–1340) 範圍內
+                            'c_fy_nh_code' => '至元',
+                            'c_fy_nh_year' => 2,
+                            'c_fy_range' => null, 'c_fy_intercalary' => false,
+                            'c_fy_month' => null, 'c_fy_day' => null, 'c_fy_day_gz' => null,
+                            'c_lastyear' => null, 'c_ly_nh_code' => null, 'c_ly_nh_year' => null,
+                            'c_ly_range' => null, 'c_ly_intercalary' => null,
+                            'c_ly_month' => null, 'c_ly_day' => null, 'c_ly_day_gz' => null,
+                            'c_appt_code' => null, 'c_assume_office_code' => null,
+                        ]]]),
+                    ],
+                ]],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '至元二年知某縣',
+            'person_id' => 1,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true])
+            ->assertJsonPath('data.matched_fields.c_fy_nh_code.value', 635)
+            ->assertJsonPath('data.matched_fields.c_fy_nh_code.text', '至元');
+    }
+
+    /**
+     * 測試同朝代內重複年號、且無西元年提示可消歧時：不可靜默選其中一筆，
+     * 應轉為 suggested（待人工確認），避免可能相差 70 年的錯誤資料被直接採用。
+     */
+    public function test_duplicate_nianhao_without_year_hint_falls_back_to_suggested() {
+        DB::table('NIAN_HAO')->insert([
+            ['c_nianhao_id' => 623, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1264, 'c_lastyear' => 1294],
+            ['c_nianhao_id' => 635, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1335, 'c_lastyear' => 1340],
+        ]);
+
+        $user = User::factory()->create(['is_active' => 1, 'is_admin' => 1]);
+
+        Http::fake([
+            'https://example.com/api' => Http::response([
+                'choices' => [[
+                    'message' => [
+                        'content' => json_encode(['postings' => [[
+                            'title_str' => '知縣',
+                            'addr_str' => null,
+                            'c_firstyear' => null, // 無西元年提示 → 無法消歧
+                            'c_fy_nh_code' => '至元',
+                            'c_fy_nh_year' => 2,
+                            'c_fy_range' => null, 'c_fy_intercalary' => false,
+                            'c_fy_month' => null, 'c_fy_day' => null, 'c_fy_day_gz' => null,
+                            'c_lastyear' => null, 'c_ly_nh_code' => null, 'c_ly_nh_year' => null,
+                            'c_ly_range' => null, 'c_ly_intercalary' => null,
+                            'c_ly_month' => null, 'c_ly_day' => null, 'c_ly_day_gz' => null,
+                            'c_appt_code' => null, 'c_assume_office_code' => null,
+                        ]]]),
+                    ],
+                ]],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/ai/posting/extract', [
+            'source_text' => '至元某年知某縣',
+            'person_id' => 1,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['success' => true])
+            ->assertJsonMissingPath('data.matched_fields.c_fy_nh_code')
+            ->assertJsonPath('data.suggested_fields.c_fy_nh_code.ai_extracted', '至元');
+    }
+
+    /**
      * 測試無具體年份時，地址按朝代範圍交集過濾，且優先選重疊最多的同名地址
      *
      * 場景：明代人物，AI 提取「禹州」但無年份信息。

--- a/tests/Feature/ApiSelectNianhaoDynastyYearRangeTest.php
+++ b/tests/Feature/ApiSelectNianhaoDynastyYearRangeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * /api/select/nianhao 與 /api/select/dynasty 新增 c_year_range 欄位（如 "(1264–1294)"），
+ * 供前端下拉選單標示起止年以區分同朝代重複年號（如元朝兩筆「至元」）。
+ */
+class ApiSelectNianhaoDynastyYearRangeTest extends TestCase {
+    use RefreshDatabase;
+
+    #[Test]
+    public function nianhao_endpoint_includes_formatted_year_range(): void {
+        DB::table('DYNASTIES')->insert([
+            'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_dynasty' => 'Yuan', 'c_start' => 1234, 'c_end' => 1367, 'c_sort' => 18,
+        ]);
+        DB::table('NIAN_HAO')->insert([
+            ['c_nianhao_id' => 623, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1264, 'c_lastyear' => 1294],
+            ['c_nianhao_id' => 635, 'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_nianhao_chn' => '至元', 'c_firstyear' => 1335, 'c_lastyear' => 1340],
+        ]);
+
+        $response = $this->getJson('/api/select/nianhao');
+
+        $response->assertOk();
+        $rows = collect($response->json())->keyBy('c_nianhao_id');
+
+        $this->assertSame('(1264–1294)', $rows[623]['c_year_range']);
+        $this->assertSame('(1335–1340)', $rows[635]['c_year_range']);
+        // c_str 為既有解析用欄位，格式不受本次改動影響。
+        $this->assertSame('[1264]~[1294]', $rows[623]['c_str']);
+    }
+
+    #[Test]
+    public function nianhao_endpoint_omits_year_range_when_years_are_sentinel_or_missing(): void {
+        DB::table('DYNASTIES')->insert([
+            'c_dy' => 0, 'c_dynasty_chn' => '未詳', 'c_dynasty' => 'unknown', 'c_start' => 0, 'c_end' => 0, 'c_sort' => 0,
+        ]);
+        DB::table('NIAN_HAO')->insert([
+            ['c_nianhao_id' => 0, 'c_dy' => 0, 'c_dynasty_chn' => '未詳', 'c_nianhao_chn' => '未詳', 'c_firstyear' => null, 'c_lastyear' => null],
+        ]);
+
+        $response = $this->getJson('/api/select/nianhao');
+
+        $response->assertOk();
+        $rows = collect($response->json())->keyBy('c_nianhao_id');
+
+        $this->assertNull($rows[0]['c_year_range']);
+    }
+
+    #[Test]
+    public function dynasty_endpoint_includes_formatted_year_range(): void {
+        DB::table('DYNASTIES')->insert([
+            'c_dy' => 18, 'c_dynasty_chn' => '元', 'c_dynasty' => 'Yuan', 'c_start' => 1234, 'c_end' => 1367, 'c_sort' => 18,
+        ]);
+
+        $response = $this->getJson('/api/select/dynasty');
+
+        $response->assertOk();
+        $rows = collect($response->json())->keyBy('c_dy');
+
+        $this->assertSame('(1234–1367)', $rows[18]['c_year_range']);
+    }
+
+    #[Test]
+    public function dynasty_endpoint_omits_year_range_for_sentinel_placeholder(): void {
+        DB::table('DYNASTIES')->insert([
+            'c_dy' => 999, 'c_dynasty_chn' => '未詳', 'c_dynasty' => 'unknown', 'c_start' => 0, 'c_end' => 0, 'c_sort' => 999,
+        ]);
+
+        $response = $this->getJson('/api/select/dynasty');
+
+        $response->assertOk();
+        $rows = collect($response->json())->keyBy('c_dy');
+
+        $this->assertNull($rows[999]['c_year_range']);
+    }
+}


### PR DESCRIPTION
## 背景

Email 回報：CBDB 元朝有兩筆「至元」年號（1264–1294、1335–1340），在網站年號選單中無法區分。

實際確認：`NIAN_HAO` 有 6 組同朝代內重複年號名稱（上元、至元、永安、中平、永興、大慶）；`DYNASTIES` 85 筆朝代名稱本身則 0 重複。

## 修正內容

- 新增 `app/Support/HistoricalYearRangeFormatter.php`：統一格式化起止年為 `(1264–1294)`，`null`／哨兵值（`0`、`-9999`，對齊前端 `formatters.ts` 既有 `isValidYear` 邏輯）時回傳 `null` 不顯示
- `NianHaoRepository`／`DynastyRepository` 新增 `c_year_range` 欄位（不動既有 `c_str`，該欄位仍供 `eraConversion.ts` 解析用）
- `EraTimeField.tsx` 年號選單、`BasicInfoEditor.tsx` 朝代選單 `labelKeys` 加入 `c_year_range`
- **順便修復審查中發現的正確性 bug**：`PostingAutofillService.php` 的 AI 自動填年號功能，原本只用朝代過濾＋取第一筆（無 tiebreaker），遇到「至元」這類同朝代重複年號可能靜默選錯（差 70 年）。新增 `resolveNianhaoId()`：候選恰好 1 筆才直接採用；候選 >1 筆時以同一欄位群組已提取的西元年（`c_firstyear`/`c_lastyear`）篩選範圍內恰好 1 筆才採用，否則回傳 `null` 轉為 `suggested`，交由人工確認

## 審查過程

- Review agent 全面檢查程式碼與測試，確認無嚴重問題
- `codex exec` 獨立審查：確認 `resolveNianhaoId()` 的 fallback 邏輯正確保留既有單一候選情境行為，僅修正真正重複時的靜默猜錯問題；哨兵值處理與前端一致；`c_str` 未受影響

## 測試計畫

- [x] `./vendor/bin/phpunit tests/Feature/ApiSelectNianhaoDynastyYearRangeTest.php`（新增，涵蓋 `c_year_range` 輸出與哨兵值處理）
- [x] `./vendor/bin/phpunit tests/Feature/AiPostingAutofillTest.php`（新增兩個測試涵蓋重複年號消歧與無法消歧時轉 suggested）
- [x] `./vendor/bin/phpunit tests/Feature/PostingAutofillOfficeMatchTest.php`
- [x] `./vendor/bin/php-cs-fixer fix`（0 檔案需要調整）
- [x] 本地以 Playwright 實測：年號選單輸入「至元」正確顯示「至元 (1264–1294)」與「至元 (1335–1340)」兩個可區分選項；朝代選單顯示「15宋 Song (960–1279)」

🤖 Generated with [Claude Code](https://claude.com/claude-code)