### PR TITLE
修正提案路徑可靜默清空姓名的漏洞（改為「不可清空」語義）

### DIFF
--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -35,6 +35,18 @@ class OperationsProposalController extends Controller {
         // 注意：ALTNAME_DATA 使用復合主鍵，不使用 Eloquent，改為手動調用索引服務
     ];
 
+    /**
+     * 核准套用時的「不可清空」欄位守衛（per-table）：payload 將該欄寫成空、而資料列當下有值時，
+     * 擋下核准。兜住「提交端驗證修復前的存量 pending 提案」與 legacy 提交路徑（所有提案核准必經此處）。
+     * 以「當下 DB 現值」而非提案存檔時的 original 比對：提案送出後若他人已補值，清空它的舊提案照樣被擋。
+     */
+    protected const NO_CLEAR_COLUMNS_ON_APPLY = [
+        'BIOG_MAIN' => [
+            'c_mingzi_chn' => '名（中）',
+            'c_mingzi' => '拼音名',
+        ],
+    ];
+
     public function __construct(
         OperationRepository $operationRepository,
         NameSearchIndexService $nameSearchIndexService,
@@ -638,6 +650,23 @@ class OperationsProposalController extends Controller {
         return $this->convertRowToArray($row);
     }
 
+    /**
+     * 「不可清空」守衛：提案 payload 把 NO_CLEAR_COLUMNS_ON_APPLY 所列欄位寫成空白、
+     * 而該列當下（$currentRow）有值時，拒絕核准。原本即為空的欄位不受影響（可維持空）。
+     */
+    protected function assertNoClearColumns(string $table, array $data, array $currentRow): void {
+        foreach (self::NO_CLEAR_COLUMNS_ON_APPLY[$table] ?? [] as $column => $label) {
+            if (!array_key_exists($column, $data)) {
+                continue;
+            }
+            $proposed = trim((string) ($data[$column] ?? ''));
+            $current = trim((string) ($currentRow[$column] ?? ''));
+            if ($proposed === '' && $current !== '') {
+                throw new \RuntimeException("此提案會清空既有的「{$label}」，無法核准。");
+            }
+        }
+    }
+
     protected function applyUpdateProposal(string $table, array $data, array $keyColumns, array $original): array {
         if (empty($original)) {
             throw new \RuntimeException('缺少原始資料，無法更新。');
@@ -653,6 +682,8 @@ class OperationsProposalController extends Controller {
             if (!$model) {
                 throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
             }
+
+            $this->assertNoClearColumns($table, $data, $model->toArray());
 
             foreach ($keyColumns as $column) {
                 if (!array_key_exists($column, $original)) {
@@ -679,6 +710,8 @@ class OperationsProposalController extends Controller {
         if (!$current) {
             throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
         }
+
+        $this->assertNoClearColumns($table, $data, (array) $current);
 
         $updatePayload = $this->buildUpdatePayload($data, $keyColumns, $original);
 

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -90,7 +90,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
             return $this->handleProposalUpdate($personId, $updatedFields, $merged, $original, $meta);
         }
 
-        $validator = Validator::make($merged, $this->validationRules(false), $this->validationMessages());
+        $validator = Validator::make($merged, $this->validationRules($original), $this->validationMessages());
         if ($validator->fails()) {
             return $this->errorResponse('參數校驗失敗', 422, $validator->errors()->toArray());
         }
@@ -133,7 +133,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
 
     protected function handleProposalUpdate(int $personId, array $updatedFields, array $merged, BiogMain $original, array $meta): JsonResponse {
         $proposalData = $this->prepareProposalPayload($merged);
-        $validator = Validator::make($proposalData, $this->validationRules(true), $this->validationMessages());
+        $validator = Validator::make($proposalData, $this->validationRules($original), $this->validationMessages());
         if ($validator->fails()) {
             return $this->errorResponse('參數校驗失敗', 422, $validator->errors()->toArray());
         }
@@ -215,12 +215,16 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         return (new ToolsRepository())->timestamp($payload);
     }
 
-    protected function validationRules(bool $isProposal): array {
+    protected function validationRules(BiogMain $original): array {
         $requestTemplate = new BasicInformationRequest();
         $rules = $requestTemplate->rules();
 
-        if ($isProposal) {
-            unset($rules['c_mingzi_chn'], $rules['c_mingzi']);
+        // 「不可清空」語義（direct 與 proposal 一致）：名（中）／拼音名原值非空才掛 required，
+        // 擋下顯式清空；原本即為空的人物可維持空、照常編輯其他欄位。兩欄獨立判斷。
+        foreach (['c_mingzi_chn', 'c_mingzi'] as $field) {
+            if (trim((string) ($original->{$field} ?? '')) === '') {
+                unset($rules[$field]);
+            }
         }
 
         return $rules;

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -223,17 +223,20 @@ export default function BasicInfoEditor({
     // 回傳 boolean：成功 true、驗證失敗／無變更／出錯 false。供切分頁「儲存並繼續」判斷是否可放行導航。
     const save = async (mode: 'direct' | 'proposal'): Promise<boolean> => {
         setSaving(true); setError(null); setMessage(null);
-        // 名（中）／拼音名必填（僅 direct：proposal 時後端會清掉這兩欄，故不擋提案）。空白即阻擋並提示。
-        if (mode === 'direct') {
-            if (!(fields.c_mingzi_chn ?? '').trim()) { setSaving(false); setError(tr('mingzi_chn_required', '「名（中）」為必填')); return false; }
-            if (!(fields.c_mingzi ?? '').trim()) { setSaving(false); setError(tr('mingzi_required', '「拼音名」為必填')); return false; }
+        const initial: Fields = JSON.parse(savedSnapshot);
+        // 名（中）／拼音名「不可清空」（direct 與 proposal 一致，後端同規則）：
+        // 原值非空、現值清空即阻擋；原本即為空的人物可維持空、照常編輯其他欄位。
+        if ((initial.c_mingzi_chn ?? '').trim() && !(fields.c_mingzi_chn ?? '').trim()) {
+            setSaving(false); setError(tr('mingzi_chn_no_clear', '「名（中）」不可清空')); return false;
+        }
+        if ((initial.c_mingzi ?? '').trim() && !(fields.c_mingzi ?? '').trim()) {
+            setSaving(false); setError(tr('mingzi_no_clear', '「拼音名」不可清空')); return false;
         }
         // 朝代 c_dy 必填（僅此基本資料編輯頁；其他編輯器的朝代維持非必填）。空（''/'0'）即阻擋並提示。
         if (!fields.c_dy || fields.c_dy === '0') {
             setSaving(false); setError(tr('dynasty_required', '朝代為必填欄位，請先選擇朝代')); return false;
         }
         // 只送與初始不同、且非唯讀派生的欄位。
-        const initial: Fields = JSON.parse(savedSnapshot);
         const changes: Record<string, string | null> = {};
         for (const [k, v] of Object.entries(fields)) {
             if (READONLY_DERIVED.includes(k)) continue;

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -70,8 +70,8 @@ return [
     // basic_info dynasty required.
     'required_field' => 'Required',
     'dynasty_required' => 'Dynasty is required — please select a dynasty first.',
-    'mingzi_chn_required' => 'Given name (Chinese) is required',
-    'mingzi_required' => 'Pinyin given name is required',
+    'mingzi_chn_no_clear' => 'Given name (Chinese) cannot be cleared',
+    'mingzi_no_clear' => 'Pinyin given name cannot be cleared',
     'please_select_office' => 'Please select an office',
     'please_select_text' => 'Please select a text',
     // Primary-code required (phase 1): each editor's primary anchor code / target person is required; create rejects empty/Unknown(0).

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -70,8 +70,8 @@ return [
     // basic_info 朝代必填。
     'required_field' => '必填',
     'dynasty_required' => '朝代為必填欄位，請先選擇朝代',
-    'mingzi_chn_required' => '「名（中）」為必填',
-    'mingzi_required' => '「拼音名」為必填',
+    'mingzi_chn_no_clear' => '「名（中）」不可清空',
+    'mingzi_no_clear' => '「拼音名」不可清空',
     'please_select_office' => '請選擇官名',
     'please_select_text' => '請選擇著述',
     // 主碼必填（階段1）：各編輯器主錨碼／對象人物必填，新增時拒絕空值/未詳(0)。

--- a/tests/Feature/ApiV2MutateTest.php
+++ b/tests/Feature/ApiV2MutateTest.php
@@ -568,6 +568,56 @@ class ApiV2MutateTest extends TestCase {
     }
 
     #[Test]
+    public function testBiogMainUpdateRejectsClearingMingziWhenOriginalNonEmpty() {
+        // 「不可清空」語義：名（中）／拼音名原值非空時，direct 與 proposal 清空一律 422（四路徑對齊）。
+        $this->actingAs($this->makeUser(email: 'biog-no-clear@example.com'));
+        $this->seedBiogMain();
+
+        foreach (['direct', 'proposal'] as $mode) {
+            foreach ([['c_mingzi_chn' => ''], ['c_mingzi_chn' => null], ['c_mingzi' => '']] as $changes) {
+                $this->postJson('/api/v2/mutate', [
+                    'resource' => 'basicinformation', 'person_id' => 138841, 'mode' => $mode, 'operation' => 'update',
+                    'target' => ['pk' => ['c_personid' => 138841]],
+                    'changes' => $changes,
+                ])->assertStatus(422);
+            }
+        }
+
+        // 資料未被清空，且未產生任何 pending 提案。
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_mingzi_chn' => '忠', 'c_mingzi' => 'Zhong']);
+        $this->assertDatabaseCount('operations', 0);
+    }
+
+    #[Test]
+    public function testBiogMainUpdateAllowsKeepingMingziEmptyWhenOriginalEmpty() {
+        // 「不可清空」語義的另一半：原本即為空的人物，維持空並編輯其他欄位可照常保存（direct 與 proposal）。
+        $this->actingAs($this->makeUser(email: 'biog-keep-empty@example.com'));
+
+        foreach (['direct', 'proposal'] as $mode) {
+            DB::table('BIOG_MAIN')->where('c_personid', 138841)->delete();
+            $this->seedBiogMain(['c_mingzi_chn' => '', 'c_mingzi' => null, 'c_name_chn' => '張', 'c_name' => 'Zhang']);
+
+            $this->postJson('/api/v2/mutate', [
+                'resource' => 'basicinformation', 'person_id' => 138841, 'mode' => $mode, 'operation' => 'update',
+                'target' => ['pk' => ['c_personid' => 138841]],
+                'changes' => ['c_index_year' => $mode === 'direct' ? 1101 : 1102],
+                ...($mode === 'proposal' ? ['meta' => ['comment' => '僅改指數年']] : []),
+            ])->assertOk();
+
+            $row = DB::table('BIOG_MAIN')->where('c_personid', 138841)->first();
+            $this->assertSame('', trim((string) $row->c_mingzi_chn), $mode.'：名（中）應維持空');
+            if ($mode === 'direct') {
+                $this->assertSame(1101, (int) $row->c_index_year, 'direct：其他欄位應照常寫入');
+            } else {
+                $this->assertDatabaseHas('operations', [
+                    'resource' => 'BIOG_MAIN', 'c_personid' => 138841,
+                    'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+                ]);
+            }
+        }
+    }
+
+    #[Test]
     public function testSessionAuthenticatedUserCanMutateAltnameSequenceViaApiV2Mutate() {
         $user = $this->makeUser();
         $this->actingAs($user);

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -219,6 +219,117 @@ class BiogMainProposalTest extends TestCase {
     }
 
     #[Test]
+    public function testApproveRejectsProposalThatWouldClearExistingMingzi() {
+        // 核准端「不可清空」守衛：payload 把名（中）寫成空、而該列當下有值 → 拒絕核准、資料不變、提案維持 pending。
+        // 模擬「提交端驗證修復前的存量 pending 提案」與 legacy 路徑提交的提案。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $personId = 4;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '王五',
+            'c_surname_chn' => '王',
+            'c_mingzi_chn' => '五',
+            'c_mingzi' => 'Wu',
+            'c_notes' => 'Old notes',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => (string) $personId,
+            'resource_data' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '王',
+                'c_mingzi_chn' => '',
+                'c_name_chn' => '王',
+                'c_notes' => 'New notes',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+            ]),
+            'resource_original' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '王',
+                'c_mingzi_chn' => '五',
+                'c_notes' => 'Old notes',
+            ]),
+        ]);
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'try approve',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertStringContainsString('清空既有的「名（中）」', $flash[0]['message'] ?? '');
+
+        // 資料未變、提案未被標記 approved（交易整筆回滾）。
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_mingzi_chn' => '五',
+            'c_notes' => 'Old notes',
+        ]);
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('pending', $payload['__review_status']);
+        $this->assertDatabaseCount('audit_log', 0);
+    }
+
+    #[Test]
+    public function testApproveAllowsProposalKeepingMingziEmptyWhenRowEmpty() {
+        // 守衛的另一半：該列名（中）當下即為空，提案維持空、只改其他欄位 → 照常核准。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $personId = 5;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '趙',
+            'c_surname_chn' => '趙',
+            'c_mingzi_chn' => '',
+            'c_notes' => 'Old notes',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => (string) $personId,
+            'resource_data' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '趙',
+                'c_mingzi_chn' => '',
+                'c_notes' => 'New notes',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+            ]),
+            'resource_original' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '趙',
+                'c_mingzi_chn' => '',
+                'c_notes' => 'Old notes',
+            ]),
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'ok',
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_mingzi_chn' => '',
+            'c_notes' => 'New notes',
+        ]);
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
     public function testBiogMainProposalDoesNotRewriteMingziFieldsWhenNotChanged() {
         $user = $this->makeActiveUser();
         $this->actingAs($user);


### PR DESCRIPTION
使用者清空「名（中）」→ 點「提交建議」→ 前端放行 → 後端提案驗證放行 → 審核核准（不重驗）→ 姓名被靜默清空，並重算污染 c_name_chn/c_name 等四個派生欄。

direct 路徑會擋、proposal 路徑不擋，違反 AGENTS.md「必填欄位 create/update（含四條路徑）一致」原則。

三個環節逐一失守：
1. BiogMainMutationHandler::validationRules() 對 proposal 模式 unset 掉 c_mingzi_chn/c_mingzi 的 required。其歷史理由是「提案 允許部分欄位更新，不應套用必填限制」——但 v2 流程先經 buildMergedPayload() 把 changes 併回完整原始列後才驗證，部分 更新時名欄保留原值、required 本來就會通過；該 unset 唯一放行 的情境恰是「顯式清空」，前提不成立。
2. 前端 BasicInfoEditor 必填檢查僅在 mode === 'direct' 生效，註解 誤稱「proposal 時後端會清掉這兩欄」——實際值會完整進入提案。
3. 核准端 applyUpdateProposal() 只擋改主鍵，完全信任提交時驗證， 對欄位內容不做任何重驗。

原值非空 → 不准存成空；原值本來即空 → 可維持空、照常編輯其他欄位。相比一律 required 的好處：名欄為空的歷史資料過去連 direct 改其他欄位都被必填擋死，現在恢復可編輯，且兩個名欄獨立判斷。

- 提交端：validationRules() 改依原始列動態掛 required（原值非空 才掛），direct 與 proposal 共用同一套規則，刪除 proposal 特權 分支。
- 前端：BasicInfoEditor 對 direct/proposal 一致檢查，比對 savedSnapshot 原值非空且現值清空才阻擋；修正錯誤註解；翻譯 key 改為 mingzi_chn_no_clear/mingzi_no_clear（zh-TW/en 同步）。
- 核准端（兜底）：OperationsProposalController 新增 NO_CLEAR_COLUMNS_ON_APPLY 登錄表與 assertNoClearColumns() 守 衛，套用前以「該列當下 DB 現值」比對，payload 清空既有值即拋 錯拒絕核准（交易回滾、提案維持 pending）。此層兜住修復前已存 在的 pending 提案與 legacy Blade 路徑提交的提案；因比對當下現 值而非提案快照，亦可擋「提案送出後他人補值、核准舊提案將其清 空」的併發情境。

- 新增 4 個測試：direct/proposal 清空名欄一律 422 且資料不變； 原值為空時維持空可照常保存；核准端擋下清空提案（資料不變、 維持 pending、無 audit_log）；原值為空的提案照常核准。
- 已執行 ./vendor/bin/phpunit（2121 tests 全過； PostingAutofillOfficeMatchTest 6 errors 為容器缺 GEMINI_API_KEY 的環境問題，補 key 後通過，與本改動無關）。
- npm run build 通過；npx tsc --noEmit 無新增錯誤（存量 24 不變）。