### PR TITLE
新增 ON DELETE CASCADE 風險說明與去級聯改造路線圖文件

### DIFF
--- a/docs/ON_DELETE_CASCADE_RISK.en.md
+++ b/docs/ON_DELETE_CASCADE_RISK.en.md
@@ -2,11 +2,11 @@
 
 > 中文版（權威版本）: [ON_DELETE_CASCADE_RISK.md](./ON_DELETE_CASCADE_RISK.md) — this is a translation; in case of discrepancy the Chinese version prevails.
 >
-> Written: 2026-07-07 ｜ Revised: 2026-07-16 (added §6, the implementation design following the team's decisions); 2026-07-28 (backfilled §6.1 execution details from the MariaDB 10.3 results of the Phase 1 batch rollout, see the correction note below) ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
+> Written: 2026-07-07 ｜ Revised: 2026-07-16 (added §6, the implementation design following the team's decisions); 2026-07-28 (backfilled §6.1 execution details from the MariaDB 10.3 results of the Phase 1 batch rollout, see the correction note below); 2026-08-03 (**Phase 1 complete** — status and figures corrected) ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
 >
 > **Purpose of this document**: to show that this project's schema currently sits in the combination most dangerous to a data asset — "physical delete × cascading delete" — and to explain the principled risk (which should be common knowledge in database practice); to present the escape matrix — **what de-cascading (RESTRICT) and soft deletion (deprecate) each solve, and why the two are complementary rather than either/or** — and to lay out an executable migration roadmap.
 >
-> **Status (2026-07-28)**: §6.1 Phase 1 has been rolled out through batch 4 (all code-table inbound FKs flipped; only `BIOG_MAIN`/`POSTING_DATA`/`POSSESSION_DATA`, 28 FKs, remain — application-layer prep is done and the flip is in its observation window). Per-batch mechanics, MariaDB 10.3 test results, and the batch-by-batch rollout log live in
+> **Status (2026-08-03): §6.1 Phase 1 is complete.** All five batches (66 + 32 + 52 + 10 + 28 = 188 FKs) have been flipped, and **there is no `ON DELETE CASCADE` left in the database** — measured: `CASCADE 0` / `NO ACTION 188` / `RESTRICT 1` / `SET NULL 1` (190 total; the single `SET NULL`, `fk_merged_person_source`, was correct to begin with). The disaster scenario in §2 is **no longer possible** on the current schema: deleting a referenced parent row is blocked by the database with error 1451 (fail-closed). The matrix position therefore moves from ① (physical delete × CASCADE) to ② (physical delete × RESTRICT); ④ still awaits Phase 2/3. Also: production has been confirmed to run **MariaDB 10.11.14** (the earlier "10.3" was wrong); every batch was verified on the *stricter* 10.3, so what passes on 10.3 passes on 10.11 and the shipped migrations are unaffected. Per-batch mechanics, MariaDB 10.3 test results, and the batch-by-batch rollout log live in
 > [docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md](./CASCADE_TO_RESTRICT_MIGRATION_NOTES.md), which is
 > the authoritative execution record for this document's §6.1 — where the two disagree, that file wins.
 >
@@ -16,13 +16,13 @@
 
 ## TL;DR
 
-1. This project's schema contains **186 `ON DELETE CASCADE` foreign keys** (plus 187 `ON UPDATE CASCADE`), spread across all core tables. The vast majority sit on **reference relationships** from "biographical data → code tables"; meanwhile the application layer performs **physical deletes** on code tables (and most paths do no reference checking).
+1. This project's schema **used to contain 186 `ON DELETE CASCADE` foreign keys** (188 counting those added by later migrations; plus 190 `ON UPDATE CASCADE`) — **all of them flipped to `RESTRICT` as of 2026-08-03** (see Status above; what follows describes the pre-flip state and its underlying principle, which remains the basis for why Phase 2/3 are needed), spread across all core tables. The vast majority sit on **reference relationships** from "biographical data → code tables"; meanwhile the application layer performs **physical deletes** on code tables (and most paths do no reference checking).
 2. The consequence of this combination: **deleting one code-table record (a reign period, a dynasty, a book title) silently cascades away all biographical data that references it** — including the persons themselves in `BIOG_MAIN`, and then everything belonging to those persons. The application layer's auditing (audit_log), operation records (operations), proposal review, and restore mechanisms are **all completely blind** to it.
 3. The escape matrix (the core argument of this document):
 
    | | `ON DELETE CASCADE` | `RESTRICT` |
    |---|---|---|
-   | **Physical delete** | **Status quo: disaster** (one DELETE silently guts the database) | Acceptable (with reference checks and migration tooling) |
+   | **Physical delete** | ~~Status quo~~ **(pre-flip): disaster** (one DELETE silently guts the database) | **Current state (since 2026-08-03)**: acceptable (with reference checks and migration tooling) |
    | **Soft delete / deprecate** | A live trap (protected only by convention; one violation is a disaster) | **Target state** |
 
    At least one factor must be broken; breaking both is the complete solution. **De-cascading is the fuse (it caps the consequences when something goes wrong); soft deletion is the product semantics (deletion no longer happens on the normal path) — they operate at different layers and complement rather than replace each other.**
@@ -222,7 +222,7 @@ Deliverable: a decision table (one row per constraint: current → target rule �
 3. **Merge + redirect tool**: re-point all references from entry A to entry B in bulk — audited, restorable, A retired with a redirect left behind. This is also the isomorphic foundation for future "person merge."
 4. **Explicit cascade-deletion service**: covering the few relationships Step 1 labels "composition" (following the current `OfficePostingRepository` pattern, adding snapshots and same-operation_id grouping).
 
-**Step 3: Flip the constraints (bleeding-stop migration, run in a maintenance window)**
+**Step 3: Flip the constraints (bleeding-stop migration, run in a maintenance window)** ✅ **Done (2026-07-20 – 2026-08-03, in five batches)**
 Execute in batches per Step 1's decision table:
 
 ```sql
@@ -238,14 +238,14 @@ ALTER TABLE ALTNAME_DATA
 - Prioritize by incoming-edge count: `NIAN_HAO` (24), `YEAR_RANGE_CODES` (23), `TEXT_CODES` (22), `ADDR_CODES` (11), `GANZHI_CODES`/`DYNASTIES` (9), then the rest.
 - Update `import_cbdb_schema.php` (or add a migration) in the same change, keeping fresh installs consistent.
 
-**Step 4: Verification and regression (same window as Step 3)**
+**Step 4: Verification and regression (same window as Step 3)** ✅ **Done with each batch** (full `migrate` on a clean MariaDB 10.3 container + behavioral spot checks + rollback verification; per-batch results in `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §9–§9.4)
 - Live test on staging: delete a referenced reign period → expect the application layer to block it (or the DB to raise error 1451), with not one row of biographical data lost; retire a reign period → it disappears from selectors while existing records display as usual;
 - Check `information_schema`: `DELETE_RULE='CASCADE'` drops to zero within the target batch;
 - After the production run, perform the same check plus spot tests.
 
 **Step 5: Wrap-up and long-term items**
 - **Orphan-scan schedule**: periodic referential-integrity checks as defense in depth (covering constraint gaps and historical leftovers).
-- **`ON UPDATE CASCADE` (187 of them) as a separate project**: key-change propagation does not destroy data and is one grade less dangerous, but it bypasses auditing all the same. Long term, "code-table key changes" should be absorbed into an audited application-layer operation and then flipped to RESTRICT; until then, document and surface the current behavior in docs and UI.
+- **`ON UPDATE CASCADE` (190 measured) as a separate project**: key-change propagation does not destroy data and is one grade less dangerous, but it bypasses auditing all the same. Long term, "code-table key changes" should be absorbed into an audited application-layer operation and then flipped to RESTRICT; until then, document and surface the current behavior in docs and UI.
 - **The test-environment gap as a separate project**: SQLite having no foreign keys means CI can never test any behavior in this document; MariaDB constraint-related changes need dedicated integration verification (e.g. CI spinning up a MariaDB container to run constraint tests).
 
 ### 5.2 Effort and Dependency Overview
@@ -311,7 +311,7 @@ This also revises §5.1's ordering argument ("application layer first, constrain
 
 | Phase | Content | Value delivered |
 |---|---|---|
-| **Phase 1: shim + flip** | Delete paths catch 1451 → friendly error "still referenced in N places"; every delete writes operations/audit_log + a required reason first; abolish `deleteBatch`'s deletion of operations records; then flip in batches (below) | The disaster scenario is gone; zero-reference deletes are restorable; decisions 1/2/3 fully satisfied |
+| **Phase 1: shim + flip** ✅ **Complete (2026-08-03)** | Delete paths catch 1451 → friendly error "still referenced in N places"; every delete writes operations/audit_log + a required reason first; abolish `deleteBatch`'s deletion of operations records; then flip in batches (below) | The disaster scenario is gone (no CASCADE left in the database); zero-reference deletes are restorable; decisions 1/2 satisfied, decision 3 (required reason) lands with the delete-flow rebuild in Phase 2 |
 | **Phase 2: merge + redirect tool** | Audited bulk re-pointing + physical delete once references reach zero | A proper outlet for erroneous/duplicate entries (the dominant need); also the isomorphic foundation for person merge |
 | **Phase 3: lifecycle registry (on demand)** | §6.2–§6.3 | Started only when the "retired but still referenced" need is validated in practice |
 
@@ -322,7 +322,8 @@ This also revises §5.1's ordering argument ("application layer first, constrain
    **two separate `ALTER` statements** (DROP first, then ADD; **correction**: doing DROP + ADD of a
    same-named constraint within one `ALTER` fails on MariaDB 10.3 with
    `ERROR 1826 (HY000): Duplicate FOREIGN KEY constraint name`, splitting into two statements works;
-   whether prod is 10.3 or 10.11 is still unconfirmed, but two separate `ALTER`s are safe on both, so
+   production was confirmed on 2026-08-03 to be **10.11.14** (every batch was nevertheless verified on the
+   stricter 10.3); two separate `ALTER`s are safe on both, so
    that's what we always use — see `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §2 for the test); with
    `foreign_key_checks = 0`, ADD FK does not scan existing data (consistency is already guaranteed by
    the original constraint), so each `ALTER` is near-instant with only a brief metadata lock; measure
@@ -346,7 +347,7 @@ This also revises §5.1's ordering argument ("application layer first, constrain
 4. **Observation period** (1–2 weeks before the next batch): monitor for 1451 (`Cannot delete or update a parent row`) — an occurrence means a hard-delete path slipped through: fail-closed, zero loss, fix the application layer;
 5. **Rollback plan**: the reverse `ALTER` back to CASCADE — one statement, no data risk.
 
-Other points: RESTRICT and NO ACTION are equivalent in InnoDB — write `RESTRICT` explicitly and uniformly; each batch ships with its migration (fresh installs stay consistent); the SQLite test environment has no foreign keys, so verification must run on MariaDB (a MariaDB container in CI is the long-term item, §5 Step 5); **the `operations` table itself has a CASCADE pointing at `BIOG_MAIN`** (a person's operation records vanish with a cascade-deleted person — the audit trail itself is unprotected), flipped together with the `BIOG_MAIN` batch; **`ON UPDATE CASCADE` (187 of them) is retained at this stage** (separate project, §5 Step 5).
+Other points: RESTRICT and NO ACTION are equivalent in InnoDB — write `RESTRICT` explicitly and uniformly; each batch ships with its migration (fresh installs stay consistent); the SQLite test environment has no foreign keys, so verification must run on MariaDB (a MariaDB container in CI is the long-term item, §5 Step 5); **the `operations` table itself has a CASCADE pointing at `BIOG_MAIN`** (a person's operation records vanish with a cascade-deleted person — the audit trail itself is unprotected), flipped together with the `BIOG_MAIN` batch; **`ON UPDATE CASCADE` (190 measured) is retained at this stage** (separate project, §5 Step 5).
 
 ### 6.2 Phase 3 Design Study: How to Store the Soft-Delete State
 
@@ -363,7 +364,7 @@ Requirements (from the decisions and §4): **R1** a state flag for pick endpoint
 **E's three costs, assessed**:
 
 1. **Filtering cost**: the affected surface is small — only the **pick surface** needs filtering (selectors/autocomplete/new-reference write validation, a single-digit number of endpoints); display JOINs, biographical-data queries, and research SQL via Query Playground do **not** filter by design (a deprecated-but-referenced entry must stay visible). The deprecated key set is a 10⁰–10³-scale, low-churn governance artifact; with `LifecycleService` caching it, the filter degenerates to `WHERE pk NOT IN (short list)` — same order as B/C's `WHERE c_deprecated = 0`, no actual JOIN needed.
-2. **No true foreign key**: a registry row pointing at a vanished row is harmless (orphan scan cleans it up); a target-row **key change** (the 187 `ON UPDATE CASCADE`s) silently detaches the flag (fail-open) — any key-change tool must update the registry in the same transaction, and the orphan scan checks registry keys for existence.
+2. **No true foreign key**: a registry row pointing at a vanished row is harmless (orphan scan cleans it up); a target-row **key change** (the 190 `ON UPDATE CASCADE`s) silently detaches the flag (fail-open) — any key-change tool must update the registry in the same transaction, and the orphan scan checks registry keys for existence.
 3. **Discoverability**: hand-written raw SQL sees no retirement state in the code table. A **second-order** problem: the dangerous operation (DELETE) is backstopped by RESTRICT at the DB layer; the worst outcome of missing the state is a mildly skewed analysis or a new reference to a retired entry (repairable with the merge tool) — no data loss. And per decisions 2/5, the released databases carry no retirement state under **any** option, so the gap exists only for internal users. Mitigations: internal views (no base-table change, not exported) + everything through `LifecycleService` (an endpoint bypassing the service is the same engineering-discipline issue as a forgotten `WHERE` under B/C — code review and regression tests).
 
 **Why not reuse the existing `audit_log` / `operations`**: those are **event logs** ("what happened"); the registry is **current state** ("what is the status now"). Deriving the current key set from a log means aggregating to the latest event per key — exactly the expensive scan; the registry is that derivation materialized. Deprecating changes no column of the target row, so audit_log (whose contract is old/new row images) has no natural entry to record, and there is no column for reason/redirect; operations is a person-centric workflow queue (`c_personid` NOT NULL, and that FK is itself a CASCADE). Every registry row carries an `operation_id` linking back to the logs — history stays with the existing machinery; this is not duplication. The partial exception is the tombstone (`deleted`): a physical delete already leaves a DELETE event with old_data in audit_log, missing only the reason — which is exactly why Phase 1 needs no registry; the registry's necessity comes from the current state of deprecated/merged.

--- a/docs/ON_DELETE_CASCADE_RISK.en.md
+++ b/docs/ON_DELETE_CASCADE_RISK.en.md
@@ -2,9 +2,13 @@
 
 > 中文版（權威版本）: [ON_DELETE_CASCADE_RISK.md](./ON_DELETE_CASCADE_RISK.md) — this is a translation; in case of discrepancy the Chinese version prevails.
 >
-> Written: 2026-07-07 ｜ Revised: 2026-07-16 (added §6, the implementation design following the team's decisions) ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
+> Written: 2026-07-07 ｜ Revised: 2026-07-16 (added §6, the implementation design following the team's decisions); 2026-07-28 (backfilled §6.1 execution details from the MariaDB 10.3 results of the Phase 1 batch rollout, see the correction note below) ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
 >
 > **Purpose of this document**: to show that this project's schema currently sits in the combination most dangerous to a data asset — "physical delete × cascading delete" — and to explain the principled risk (which should be common knowledge in database practice); to present the escape matrix — **what de-cascading (RESTRICT) and soft deletion (deprecate) each solve, and why the two are complementary rather than either/or** — and to lay out an executable migration roadmap.
+>
+> **Status (2026-07-28)**: §6.1 Phase 1 has been rolled out through batch 4 (all code-table inbound FKs flipped; only `BIOG_MAIN`/`POSTING_DATA`/`POSSESSION_DATA`, 28 FKs, remain — application-layer prep is done and the flip is in its observation window). Per-batch mechanics, MariaDB 10.3 test results, and the batch-by-batch rollout log live in
+> [docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md](./CASCADE_TO_RESTRICT_MIGRATION_NOTES.md), which is
+> the authoritative execution record for this document's §6.1 — where the two disagree, that file wins.
 >
 > Every number in this document can be re-verified with the commands in Appendix A.
 
@@ -314,19 +318,31 @@ This also revises §5.1's ordering argument ("application layer first, constrain
 **Execution details for the Phase 1 flip** (refining §5.1 Step 3) — batch unit = referenced table, ordered by §1's incoming-edge counts: `NIAN_HAO` (24) → `YEAR_RANGE_CODES` (23) → `TEXT_CODES` (22) → `ADDR_CODES` (11) → `GANZHI_CODES`/`DYNASTIES` (9 each) → the remaining code tables → finally `BIOG_MAIN`'s 25 incoming edges (whose counterpart is the explicit cascade-deletion service and the existing person soft delete, §4.4). Per batch:
 
 1. **Gate**: shim in place, staging walkthrough passed;
-2. **Execution** (maintenance window): MariaDB cannot modify a foreign key's behavior in place — DROP + ADD within one `ALTER`; with `foreign_key_checks = 0`, ADD FK does not scan existing data (consistency is already guaranteed by the original constraint), so the `ALTER` is near-instant with only a brief metadata lock; measure the largest tables on staging first:
+2. **Execution** (maintenance window): MariaDB cannot modify a foreign key's behavior in place —
+   **two separate `ALTER` statements** (DROP first, then ADD; **correction**: doing DROP + ADD of a
+   same-named constraint within one `ALTER` fails on MariaDB 10.3 with
+   `ERROR 1826 (HY000): Duplicate FOREIGN KEY constraint name`, splitting into two statements works;
+   whether prod is 10.3 or 10.11 is still unconfirmed, but two separate `ALTER`s are safe on both, so
+   that's what we always use — see `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §2 for the test); with
+   `foreign_key_checks = 0`, ADD FK does not scan existing data (consistency is already guaranteed by
+   the original constraint), so each `ALTER` is near-instant with only a brief metadata lock; measure
+   the largest tables on staging first:
 
    ```sql
    SET SESSION foreign_key_checks = 0;
+   ALTER TABLE BIOG_MAIN DROP FOREIGN KEY BIOG_MAIN_ibfk_2;
    ALTER TABLE BIOG_MAIN
-     DROP FOREIGN KEY BIOG_MAIN_ibfk_2,
      ADD CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
          REFERENCES NIAN_HAO (c_nianhao_id)
          ON DELETE RESTRICT ON UPDATE CASCADE;   -- leave UPDATE behavior alone at this stage
    SET SESSION foreign_key_checks = 1;
    ```
 
-3. **Verification**: the Appendix B query confirms every `DELETE_RULE` in the batch is `RESTRICT`; spot-test "delete a referenced entry → blocked, not one row of data lost";
+3. **Verification**: the Appendix B query confirms every `DELETE_RULE` in the batch is `RESTRICT`
+   (**correction**: on MariaDB 10.3, `information_schema.REFERENTIAL_CONSTRAINTS.DELETE_RULE` reports
+   an explicitly-written `RESTRICT` as `NO ACTION` — the two are equivalent in InnoDB, so the check
+   should be `DELETE_RULE IN ('RESTRICT','NO ACTION')`, or verify behavior directly); spot-test "delete
+   a referenced entry → blocked, not one row of data lost";
 4. **Observation period** (1–2 weeks before the next batch): monitor for 1451 (`Cannot delete or update a parent row`) — an occurrence means a hard-delete path slipped through: fail-closed, zero loss, fix the application layer;
 5. **Rollback plan**: the reverse `ALTER` back to CASCADE — one statement, no data risk.
 

--- a/docs/ON_DELETE_CASCADE_RISK.en.md
+++ b/docs/ON_DELETE_CASCADE_RISK.en.md
@@ -2,7 +2,7 @@
 
 > 中文版（權威版本）: [ON_DELETE_CASCADE_RISK.md](./ON_DELETE_CASCADE_RISK.md) — this is a translation; in case of discrepancy the Chinese version prevails.
 >
-> Written: 2026-07-07 ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
+> Written: 2026-07-07 ｜ Revised: 2026-07-16 (added §6, the implementation design following the team's decisions) ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
 >
 > **Purpose of this document**: to show that this project's schema currently sits in the combination most dangerous to a data asset — "physical delete × cascading delete" — and to explain the principled risk (which should be common knowledge in database practice); to present the escape matrix — **what de-cascading (RESTRICT) and soft deletion (deprecate) each solve, and why the two are complementary rather than either/or** — and to lay out an executable migration roadmap.
 >
@@ -22,7 +22,7 @@
    | **Soft delete / deprecate** | A live trap (protected only by convention; one violation is a disaster) | **Target state** |
 
    At least one factor must be broken; breaking both is the complete solution. **De-cascading is the fuse (it caps the consequences when something goes wrong); soft deletion is the product semantics (deletion no longer happens on the normal path) — they operate at different layers and complement rather than replace each other.**
-4. Migration path: flip the constraints first (one migration, the cheapest bleeding-stop), then introduce the code-table lifecycle (deprecate as the primary path, merge for duplicates, physical delete only at zero references). The two steps reinforce each other: once soft deletion is universal there is no legitimate hard-delete flow left, so flipping to RESTRICT meets zero resistance; once RESTRICT is in place, violations of the soft-delete convention hit a backstop. See §5.
+4. Migration path: flip the constraints first (one migration, the cheapest bleeding-stop), then introduce the code-table lifecycle (deprecate as the primary path, merge for duplicates, physical delete only at zero references). The two steps reinforce each other: once soft deletion is universal there is no legitimate hard-delete flow left, so flipping to RESTRICT meets zero resistance; once RESTRICT is in place, violations of the soft-delete convention hit a backstop. See §5; **the implementation design following the July 2026 team decisions is in §6 (three phases: RESTRICT first, the merge tool second, the lifecycle registry deferred until demanded)**.
 
 ---
 
@@ -214,7 +214,7 @@ Deliverable: a decision table (one row per constraint: current → target rule �
 
 **Step 2: Application-layer catch-up (one independent PR each)**
 1. **Reference-check service**: input (code table, key value); output per-referencing-table counts and samples — the data source is exactly Step 0's foreign-key list, drivable directly from `information_schema`, no hand-maintained mapping needed.
-2. **Code-table lifecycle**: add a `c_deprecated` status column to the code tables (code tables only, not data tables; **adding a column requires prior discussion by the executive committee; the alignment rules for the offline release and the export update are in §5.3, and the export update ships in the same milestone as this column**); selector/search endpoints filter retired entries while display JOINs do not; `/codes` "delete" becomes "retire," with physical deletion available only at zero references; abolish `deleteBatch`'s deletion of `operations` records.
+2. **Code-table lifecycle** (**per the July 2026 decisions, this whole item is deferred until demanded — see §6.1 Phase 3**; if started, storage uses the centralized lifecycle sidecar table of §6.3, with no column added to the code tables): selector/search endpoints filter retired entries while display JOINs do not; `/codes` "delete" becomes "retire," with physical deletion available only at zero references. Abolishing `deleteBatch`'s deletion of `operations` records is **pulled forward into Phase 1** (§6.1). Offline-release alignment rules are in §5.3 and §6.3; the executive committee discussion remains a prerequisite (topic in §6.4).
 3. **Merge + redirect tool**: re-point all references from entry A to entry B in bulk — audited, restorable, A retired with a redirect left behind. This is also the isomorphic foundation for future "person merge."
 4. **Explicit cascade-deletion service**: covering the few relationships Step 1 labels "composition" (following the current `OfficePostingRepository` pattern, adding snapshots and same-operation_id grouping).
 
@@ -259,7 +259,9 @@ No step on this route is a "big bang": the application-layer PRs are independent
 
 ### 5.3 Offline Releases (SQLite / Access) and Governance Alignment
 
-The online system and the offline releases are structurally separated, with the export function guaranteeing that released versions stay consistent with the Access schema. When `c_deprecated` lands, two things about the offline release must be handled in lockstep:
+> **July 2026 update**: this section was written under the assumption that the deprecated state would live in a `c_deprecated` column on the code tables. Per the team decisions and the design in §6, the state now lives in a **purely internal lifecycle sidecar table** and no column is added to any shared conceptual table — so point (1)'s "export without the `c_deprecated` column" is achieved automatically, and point (2)'s discussion topic shifts from a schema change to a policy change. **The two-tier export rule by reference count remains in force** (updated version in §6.3); this section is kept as the full argument for that rule.
+
+The online system and the offline releases are structurally separated, with the export function guaranteeing that released versions stay consistent with the Access schema. When the deprecated state lands, two things about the offline release must be handled in lockstep:
 
 **(1) Export exclusion rules — deprecated codes are structurally different from the person soft delete, and cannot be excluded wholesale the same way.**
 
@@ -277,6 +279,108 @@ The export update ships **in the same milestone** as the `c_deprecated` column i
 **(2) Governance prerequisite — adding a column requires executive committee discussion.**
 
 Any new column in the online system must first be discussed by the executive committee. Since `c_deprecated` exists only in the online system and — per the table above — is **not exported to Access**, for the committee this is not a change to the shared schema but a **change to the code-table lifecycle policy** ("delete" becomes "deprecate / merge," plus the inclusion rules for released versions). For the discussion, prepare a one-page brief: the semantics of `c_deprecated`, the export rules above, and confirmation that released Access versions keep an unchanged schema. This discussion is a prerequisite for Step 2 milestone 2.
+
+## 6. Implementation Design (per the July 2026 Team Decisions)
+
+> Written 2026-07-16. The team has reached decisions on direction (§6.0). This section lays out the delivery plan: **a three-phase route (§6.1) — RESTRICT first, the merge tool second, the lifecycle registry deferred until demanded** — plus the design study for the third phase (§6.2 storage-option comparison, §6.3 registry draft and export rules). Where this section differs from §5, this section prevails (delta list in §6.4).
+
+### 6.0 Team Decisions (Boundary Conditions for This Design)
+
+1. **Move away from `ON DELETE CASCADE` step by step**, using each database system's appropriate schema syntax or management tooling.
+2. **The end user's database schema and behavior stay unchanged**: no new fields, and no extra rows that were supposed to be deleted.
+3. **The "deletion reason" must be preserved in a form we can later refer back to**, so it is possible to understand why a record is gone.
+4. **Design principle: separate the internal maintenance model from the public data model.**
+5. **The online editing system must contain the additional metadata needed for auditing, recovery, and historical reconstruction**; the released Access and SQLite databases continue to present and export the same conceptual model to end users.
+
+### 6.1 The Three-Phase Route: RESTRICT First, Deprecation Deferred Until Demanded
+
+Examined in isolation, the RESTRICT flip removes most of the concern single-handedly:
+
+- **Data safety**: deleting a still-referenced code entry is blocked by the DB with error 1451 (fail-closed); the matrix drops from ① straight to ②, and the disaster scenario no longer exists;
+- **Recoverability**: the only deletes that can succeed are **zero-reference rows**; with delete paths writing audit_log (full old_data image) + operations before deleting, restoration is re-inserting one row — the deleted row had no referrers, so re-insertion faces no foreign-key obstacle;
+- **Deletion reason (decision 3)**: the minimal landing spot is a required reason on the deletion's operations/audit record — no new table needed;
+- **Erroneous/duplicate entries** (the dominant trigger of "delete this entry," §4.2): fully solved by "merge + redirect → references reach zero → physical delete (with reason)"; no deprecated state needed anywhere along the way.
+
+**Deprecation's unique increment therefore narrows to one scenario: "retired but existing references preserved"** — existing references are historically correct and must not be re-pointed, yet new references are forbidden (true authority-file deprecation), with the side benefit of governance timing ("selectors clean immediately, references cleaned up at leisure"). How often this arises in CBDB practice is an empirical question — **do not build it before it is validated**; the registry is purely additive (touches no shared table, changes nothing the first two phases deliver), so deferring it has zero migration cost.
+
+This also revises §5.1's ordering argument ("application layer first, constraints last"): avoiding the behavioral cliff requires only a thin shim, not all of Step 2.
+
+| Phase | Content | Value delivered |
+|---|---|---|
+| **Phase 1: shim + flip** | Delete paths catch 1451 → friendly error "still referenced in N places"; every delete writes operations/audit_log + a required reason first; abolish `deleteBatch`'s deletion of operations records; then flip in batches (below) | The disaster scenario is gone; zero-reference deletes are restorable; decisions 1/2/3 fully satisfied |
+| **Phase 2: merge + redirect tool** | Audited bulk re-pointing + physical delete once references reach zero | A proper outlet for erroneous/duplicate entries (the dominant need); also the isomorphic foundation for person merge |
+| **Phase 3: lifecycle registry (on demand)** | §6.2–§6.3 | Started only when the "retired but still referenced" need is validated in practice |
+
+**Execution details for the Phase 1 flip** (refining §5.1 Step 3) — batch unit = referenced table, ordered by §1's incoming-edge counts: `NIAN_HAO` (24) → `YEAR_RANGE_CODES` (23) → `TEXT_CODES` (22) → `ADDR_CODES` (11) → `GANZHI_CODES`/`DYNASTIES` (9 each) → the remaining code tables → finally `BIOG_MAIN`'s 25 incoming edges (whose counterpart is the explicit cascade-deletion service and the existing person soft delete, §4.4). Per batch:
+
+1. **Gate**: shim in place, staging walkthrough passed;
+2. **Execution** (maintenance window): MariaDB cannot modify a foreign key's behavior in place — DROP + ADD within one `ALTER`; with `foreign_key_checks = 0`, ADD FK does not scan existing data (consistency is already guaranteed by the original constraint), so the `ALTER` is near-instant with only a brief metadata lock; measure the largest tables on staging first:
+
+   ```sql
+   SET SESSION foreign_key_checks = 0;
+   ALTER TABLE BIOG_MAIN
+     DROP FOREIGN KEY BIOG_MAIN_ibfk_2,
+     ADD CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
+         REFERENCES NIAN_HAO (c_nianhao_id)
+         ON DELETE RESTRICT ON UPDATE CASCADE;   -- leave UPDATE behavior alone at this stage
+   SET SESSION foreign_key_checks = 1;
+   ```
+
+3. **Verification**: the Appendix B query confirms every `DELETE_RULE` in the batch is `RESTRICT`; spot-test "delete a referenced entry → blocked, not one row of data lost";
+4. **Observation period** (1–2 weeks before the next batch): monitor for 1451 (`Cannot delete or update a parent row`) — an occurrence means a hard-delete path slipped through: fail-closed, zero loss, fix the application layer;
+5. **Rollback plan**: the reverse `ALTER` back to CASCADE — one statement, no data risk.
+
+Other points: RESTRICT and NO ACTION are equivalent in InnoDB — write `RESTRICT` explicitly and uniformly; each batch ships with its migration (fresh installs stay consistent); the SQLite test environment has no foreign keys, so verification must run on MariaDB (a MariaDB container in CI is the long-term item, §5 Step 5); **the `operations` table itself has a CASCADE pointing at `BIOG_MAIN`** (a person's operation records vanish with a cascade-deleted person — the audit trail itself is unprotected), flipped together with the `BIOG_MAIN` batch; **`ON UPDATE CASCADE` (187 of them) is retained at this stage** (separate project, §5 Step 5).
+
+### 6.2 Phase 3 Design Study: How to Store the Soft-Delete State
+
+Requirements (from the decisions and §4): **R1** a state flag for pick endpoints to filter on (display JOINs do not filter); **R2** the reason; **R3** when/who, linkable to operations/audit_log; **R4** the merge-redirect pointer; **R5** public model unchanged; **R6** fits the Query Builder + composite-key architecture (Eloquent SoftDeletes largely unavailable).
+
+| Option | Mechanism | Assessment |
+|---|---|---|
+| **A Name marker** | Hijack a data column with a magic string (the current `BIOG_MAIN.c_name_chn='<待删除>'`) | Zero schema change, but it occupies a **display column** (referencing pages show garbage), R2/R3/R4 cannot be stored, unindexable. Legacy only — never extend; long term migrate BIOG_MAIN to E |
+| **B Boolean column** | Add `c_deprecated` per code table | Simplest filtering, but R2–R4 missing (yet another mechanism needed); one migration per code table; online and released schemas diverge, export must strip the column table by table; each shared-table column needs committee review |
+| **C Timestamp column** | Add `c_deprecated_at` per table, NULL = active | Encodes when in addition to B; all other drawbacks identical; Laravel SoftDeletes' convention dividend is unavailable here (R6); `deleted_at`-style naming misleads — the entry is retired, not deleted |
+| **D Full status column set** | status/reason/redirect columns per table | Satisfies R2–R4 but with the largest schema intrusion and export-stripping surface; when/who duplicates audit_log |
+| **E Centralized sidecar table (recommended)** | One purely internal table registering any row of any table | **R5 guaranteed by construction**: zero change to shared tables, zero export stripping, the committee topic becomes pure policy; R2–R4 are columns of this table; the addressing scheme `(table_name, row_pk)` is isomorphic to audit_log (R6) |
+
+**E's three costs, assessed**:
+
+1. **Filtering cost**: the affected surface is small — only the **pick surface** needs filtering (selectors/autocomplete/new-reference write validation, a single-digit number of endpoints); display JOINs, biographical-data queries, and research SQL via Query Playground do **not** filter by design (a deprecated-but-referenced entry must stay visible). The deprecated key set is a 10⁰–10³-scale, low-churn governance artifact; with `LifecycleService` caching it, the filter degenerates to `WHERE pk NOT IN (short list)` — same order as B/C's `WHERE c_deprecated = 0`, no actual JOIN needed.
+2. **No true foreign key**: a registry row pointing at a vanished row is harmless (orphan scan cleans it up); a target-row **key change** (the 187 `ON UPDATE CASCADE`s) silently detaches the flag (fail-open) — any key-change tool must update the registry in the same transaction, and the orphan scan checks registry keys for existence.
+3. **Discoverability**: hand-written raw SQL sees no retirement state in the code table. A **second-order** problem: the dangerous operation (DELETE) is backstopped by RESTRICT at the DB layer; the worst outcome of missing the state is a mildly skewed analysis or a new reference to a retired entry (repairable with the merge tool) — no data loss. And per decisions 2/5, the released databases carry no retirement state under **any** option, so the gap exists only for internal users. Mitigations: internal views (no base-table change, not exported) + everything through `LifecycleService` (an endpoint bypassing the service is the same engineering-discipline issue as a forgotten `WHERE` under B/C — code review and regression tests).
+
+**Why not reuse the existing `audit_log` / `operations`**: those are **event logs** ("what happened"); the registry is **current state** ("what is the status now"). Deriving the current key set from a log means aggregating to the latest event per key — exactly the expensive scan; the registry is that derivation materialized. Deprecating changes no column of the target row, so audit_log (whose contract is old/new row images) has no natural entry to record, and there is no column for reason/redirect; operations is a person-centric workflow queue (`c_personid` NOT NULL, and that FK is itself a CASCADE). Every registry row carries an `operation_id` linking back to the logs — history stays with the existing machinery; this is not duplication. The partial exception is the tombstone (`deleted`): a physical delete already leaves a DELETE event with old_data in audit_log, missing only the reason — which is exactly why Phase 1 needs no registry; the registry's necessity comes from the current state of deprecated/merged.
+
+### 6.3 Registry Draft and Export Rules (Applicable When Phase 3 Starts)
+
+`record_lifecycle` (draft; naming follows `audit_log` conventions):
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | bigint PK | — |
+| `table_name` | varchar(64) | Target table |
+| `row_pk` / `row_pk_text` | json / varchar(512) | Target row's primary key (composite keys supported, as in `audit_log`); unique index on `(table_name, row_pk_text)` — one current state per row |
+| `status` | varchar(16) | `deprecated` (retired: row remains, hidden in pickers, displayed as usual) / `merged` (references re-pointed to `redirect_pk`; this row is the redirect record) / `deleted` (tombstone: row physically deleted, this row keeps the reason, the image is in audit_log.old_data) |
+| `reason` | text | The reason, **required** (where decision 3 lands) |
+| `redirect_pk` | json NULL | For `merged`: the key references were re-pointed to |
+| `operation_id` / `actor_id` / `created_at` | — | Links back to operations/audit_log |
+
+Supporting machinery: a single `LifecycleService` encapsulating register/withdraw/query/filter (with the cached key set), every pick endpoint goes through it; the registry is **purely internal and never exported** (which satisfies decision 2); the current `<待删除>` marker on `BIOG_MAIN` stays untouched for now, listed as a long-term migration item.
+
+Export rules: §5.3's two-tier rule by reference count stands, with the mechanism simplified — `deprecated`/`merged` with **zero references** → the code row is excluded; **still referenced** → exported as-is (the online code table has no extra column, nothing to strip, naturally transparent to Access); `deleted` rows no longer exist. The 8930d73 pattern carries over (filtering centralized at query construction, fail-closed, regression tests); the export update ships in the same milestone as the registry.
+
+### 6.4 Delta List Against the §5 Roadmap
+
+| §5 original | Updated by this section to |
+|---|---|
+| §5.1 ordering: "application layer first, constraints last," with all of Step 2 as a flip prerequisite | A thin shim (1451 friendly error + audit/reason before delete) suffices to flip (§6.1 Phase 1); Step 2's deeper machinery comes later |
+| Step 2-2: add a `c_deprecated` status column to code tables | The whole item is deferred to Phase 3 on demand; if started, use the `record_lifecycle` registry (§6.3), zero change to shared tables |
+| Step 2-2 prerequisite: committee discussion of "adding a column" | The topic becomes **pure policy** ("delete" becomes "deprecate/merge," plus release inclusion rules); still a Phase 3 prerequisite |
+| §5.3(1): still-referenced entries exported "without the `c_deprecated` column" | Achieved automatically — the column never exists; the two-tier rule itself is unchanged (§6.3) |
+| Decision 3, "deletion reason" (not covered by §5) | From Phase 1: a required reason on deletion records; from Phase 3: stored uniformly in the registry |
+
+The remaining steps (Step 0 / 1 / 4 / 5) are unchanged.
 
 ---
 

--- a/docs/ON_DELETE_CASCADE_RISK.en.md
+++ b/docs/ON_DELETE_CASCADE_RISK.en.md
@@ -1,0 +1,356 @@
+# "Physical Delete × ON DELETE CASCADE" Is the One Unacceptable Combination
+
+> 中文版（權威版本）: [ON_DELETE_CASCADE_RISK.md](./ON_DELETE_CASCADE_RISK.md) — this is a translation; in case of discrepancy the Chinese version prevails.
+>
+> Written: 2026-07-07 ｜ Based on: `database/migrations/2025_01_01_000000_import_cbdb_schema.php` (the source from which the production MariaDB schema was imported)
+>
+> **Purpose of this document**: to show that this project's schema currently sits in the combination most dangerous to a data asset — "physical delete × cascading delete" — and to explain the principled risk (which should be common knowledge in database practice); to present the escape matrix — **what de-cascading (RESTRICT) and soft deletion (deprecate) each solve, and why the two are complementary rather than either/or** — and to lay out an executable migration roadmap.
+>
+> Every number in this document can be re-verified with the commands in Appendix A.
+
+---
+
+## TL;DR
+
+1. This project's schema contains **186 `ON DELETE CASCADE` foreign keys** (plus 187 `ON UPDATE CASCADE`), spread across all core tables. The vast majority sit on **reference relationships** from "biographical data → code tables"; meanwhile the application layer performs **physical deletes** on code tables (and most paths do no reference checking).
+2. The consequence of this combination: **deleting one code-table record (a reign period, a dynasty, a book title) silently cascades away all biographical data that references it** — including the persons themselves in `BIOG_MAIN`, and then everything belonging to those persons. The application layer's auditing (audit_log), operation records (operations), proposal review, and restore mechanisms are **all completely blind** to it.
+3. The escape matrix (the core argument of this document):
+
+   | | `ON DELETE CASCADE` | `RESTRICT` |
+   |---|---|---|
+   | **Physical delete** | **Status quo: disaster** (one DELETE silently guts the database) | Acceptable (with reference checks and migration tooling) |
+   | **Soft delete / deprecate** | A live trap (protected only by convention; one violation is a disaster) | **Target state** |
+
+   At least one factor must be broken; breaking both is the complete solution. **De-cascading is the fuse (it caps the consequences when something goes wrong); soft deletion is the product semantics (deletion no longer happens on the normal path) — they operate at different layers and complement rather than replace each other.**
+4. Migration path: flip the constraints first (one migration, the cheapest bleeding-stop), then introduce the code-table lifecycle (deprecate as the primary path, merge for duplicates, physical delete only at zero references). The two steps reinforce each other: once soft deletion is universal there is no legitimate hard-delete flow left, so flipping to RESTRICT meets zero resistance; once RESTRICT is in place, violations of the soft-delete convention hit a backstop. See §5.
+
+---
+
+## 1. Current State (Evidence)
+
+Foreign-key behavior statistics in `import_cbdb_schema.php`:
+
+| ON DELETE behavior | Count |
+|---|---|
+| `CASCADE` | **186** |
+| `SET NULL` | 1 (`fk_merged_person_source`, a newer table — done correctly) |
+| `RESTRICT` / `NO ACTION` | 0 |
+
+Most-referenced target tables (incoming edges):
+
+| Referenced table | Incoming CASCADE FKs | Nature |
+|---|---|---|
+| `BIOG_MAIN` | 25 | Person master table |
+| `NIAN_HAO` | 24 | Code table (reign periods) |
+| `YEAR_RANGE_CODES` | 23 | Code table |
+| `TEXT_CODES` | 22 | Code table (bibliography) |
+| `ADDR_CODES` | 11 | Code table (places) |
+| `GANZHI_CODES` / `DYNASTIES` | 9 each | Code tables |
+
+Note in particular: **`BIOG_MAIN` itself has 13 CASCADE foreign keys pointing at code tables** (`BIOG_MAIN_ibfk_1`–`13`, pointing at `NIAN_HAO`×4, `YEAR_RANGE_CODES`×3, `GANZHI_CODES`×2, `DYNASTIES`, `CHORONYM_CODES`, `ETHNICITY_TRIBE_CODES`, `HOUSEHOLD_STATUS_CODES`).
+
+At the same time, the application layer's "delete" on code tables is currently a **physical DELETE**: the `/codes` editor and `AdminBatchLoadBookTitlesController::deleteBatch` hard-delete `TEXT_CODES` with no reference check beforehand — both conditions of the matrix's top-left cell hold simultaneously.
+
+### 1.1 Historical Context: a Deliberate Trade-off, Not an Oversight
+
+"Physical delete × CASCADE" was a conscious time-saving choice in the original design: CBDB's code tables were not built entry by entry with dictionary-grade verification, but accumulated **in bulk, with an accepted error rate** — so "physical delete × CASCADE" became the low-cost way to clean up codes together with the data referencing them. This document does not dispute that the trade-off was reasonable at the time; it argues that the cost structure the trade-off rested on has changed:
+
+- With agent assistance, the development cost of moving the cleanup logic carried by the foreign-key mechanism into application code (reference checks, merge-and-redirect, explicit cascades) is now manageable;
+- The project's traceability goal is shifting from **discrete traceability** (publishing discrete versions, with the differences between versions unrecoverable) to **linear traceability** (operations / audit_log capture the complete logs between every pair of versions; Phase B has already added audit_log coverage to the `/codes` direct-write path). DB-level cascades are a structural blind spot on that line (§3.3) — without removing them, linear traceability is mechanically impossible;
+- The online system and the offline release (Michael's Access database) are structurally separated, with the export function guaranteeing that released versions stay consistent with the Access schema (§5.3) — so the evolution of the online schema (e.g. adding a `c_deprecated` column) is no longer constrained by the release format.
+
+## 2. A Concrete Disaster Scenario
+
+Take `NIAN_HAO` (the reign-period code table) and run one apparently harmless statement:
+
+```sql
+DELETE FROM NIAN_HAO WHERE c_nianhao_id = 630;   -- delete one "duplicate" reign period
+```
+
+What InnoDB actually executes:
+
+1. Delete the reign period;
+2. **Cascade-delete every `BIOG_MAIN` row whose `c_by_nh_code` / `c_dy_nh_code` / `c_fl_ey_nh_code` / `c_fl_ly_nh_code` references it** — i.e. every **person** whose birth/death or floruit years were recorded with that reign period;
+3. For each deleted person, cascade onward and delete all of their records across 25 tables: alternate names, kinship, social associations, office postings (including posting addresses), writings, entry into office, events, property…;
+4. The mirror rows of kinship/association relations touch **other persons'** data pages;
+5. Throughout: the application layer sees affected rows = `1` from step 1 only; **not a single extra row** appears in `operations` or `audit_log`; the proposal-review flow is never triggered; there is no restorable snapshot of any kind.
+
+In other words: **one DELETE can silently erase the complete biographies of hundreds of people, with no way to know afterwards that it ever happened**.
+
+> This sounds unbelievable, so a minimal reproduction was run on a real MariaDB 10.11 with constraints taken verbatim from this schema (Appendix C):
+> deleting 1 reign period, `ROW_COUNT()` reports **1**, while 8 rows actually vanish (2 whole persons plus their alt-name/kinship records), the cascade propagates two levels deep,
+> and the second-level deletions correspond to no DELETE statement whatsoever that the application layer could intercept.
+
+This is not purely theoretical. The complete accident chain already exists in current code:
+
+- The `/codes` editor and `AdminBatchLoadBookTitlesController::deleteBatch` hard-delete `TEXT_CODES` **with no reference check of any kind before deleting**;
+- `TEXT_CODES` has 22 incoming CASCADE edges (`ALTNAME_DATA.c_source`, `BIOG_SOURCE_DATA.c_textid`, `TEXT_DATA`, `KIN_DATA.c_source`… even a `TEXT_CODES` self-reference); deleting one book title silently deletes the alt-name, source, and writing records that reference it;
+- `deleteBatch` additionally deletes the corresponding `operations` records — erasing the only remaining trace.
+
+Moreover, **tests are completely unable to catch this class of problem**: the local and CI test environment is SQLite, whose table definitions contain none of these foreign keys (`PRAGMA foreign_keys` is 0 as well); the cascade behavior exists only on production MariaDB. A green test suite proves nothing.
+
+## 3. Why "Physical Delete × CASCADE" Is Dangerous — Principles
+
+### 3.1 It Mistakes "Reference" for "Ownership"
+
+Cascading deletion has exactly one legitimate semantics: **composition** — where a child record is meaningless apart from its parent, as order lines are to an order. Deleting the order deletes the lines; perfectly proper.
+
+But CBDB's foreign keys are almost entirely **references**: an alt-name record "cites" a book as its source; that does not make the alt-name "belong to" the book. Fixing a mistyped book-title entry is code-table maintenance; destroying hundreds of biographical facts along the way is a data disaster. Code tables are **vocabulary**; biographical data is the **asset**. Editing vocabulary should never carry the power to destroy assets.
+
+A useful test: ask "if the referenced entry is deleted, does the historical fact carried by the referencing record still hold?" — the fact "Zhang San's alternate name appears in such-and-such book" does not cease to exist because the book's code entry was deleted. If the fact still stands, the record should not be deleted. Of CBDB's 186 CASCADEs, those that pass the composition test can be counted on one hand (e.g. `POSTED_TO_ADDR_DATA` relative to `POSTED_TO_OFFICE_DATA`).
+
+### 3.2 It Is an Unbounded Amplifier
+
+CASCADE is a **transitive closure**: code table → `BIOG_MAIN` → 25 child tables → mirror rows. The actual blast radius of one DELETE depends on the whole foreign-key graph and the data distribution at that moment; the person (or code) issuing the DELETE **cannot tell from the statement itself** how much will be deleted. The amount of destruction is completely decoupled from the intent of the operation — violating the most basic predictability principle of data manipulation.
+
+### 3.3 It Is Entirely Invisible to the Application Layer
+
+This point is fatal for this project. We have invested heavily in data-protection machinery — `operations` records, `audit_log` before/after images, proposal review (propose/approve), restore — all of which operates at the **application layer**. DB cascades happen at the **storage-engine layer**:
+
+- Rows deleted by cascade get no image in `audit_log` and no record in `operations`;
+- Proposal review becomes theater: a single-row edit must pass review, while one code-table DELETE bypasses everything;
+- The goal "every operation is restorable" becomes mathematically unattainable — you cannot replay deletions you never saw.
+
+**As long as CASCADE exists, every application-level audit and undo mechanism has a structural skylight.**
+
+### 3.4 The Failure Modes Are Asymmetric
+
+When choosing a mechanism, engineering compares not "which is more convenient when things go right" but "what does it cost when things go wrong":
+
+| | Failure scenario | Consequence | Visibility | Recoverability |
+|---|---|---|---|---|
+| `RESTRICT` | App layer forgets to handle references before deleting | **Error; operation refused** | Immediate, explicit | Total (nothing happened) |
+| `CASCADE` | App layer issues one wrong DELETE | **Data silently destroyed** | Possibly months later | Permanently lost once backups rotate |
+
+RESTRICT's failure mode is "annoying but harmless" (fail-closed); CASCADE's failure mode is "quiet but devastating." CASCADE is safe only under the premise that "the application layer will never issue a wrong DELETE" — a premise that holds in no real system, and this project's `deleteBatch` is a ready-made counterexample. **Note that this argument does not depend on how the application layer intends to delete: whether it uses physical deletion or a soft-delete convention, as long as CASCADE remains, the price of a violation or a bug is a gutted database. This is why the matrix's bottom-left cell in §4 remains unacceptable.**
+
+### 3.5 Why This Counts as Industry Consensus
+
+- Nearly every domain that treats data as an asset (finance, healthcare, archives) has database standards that prohibit or strictly limit cascading deletes, precisely for the reasons in 3.3/3.4: audit integrity requires every change to pass through the application layer.
+- Mainstream ORMs (Laravel/Eloquent, Rails, Django, Hibernate) all offer **application-level cascading** as the recommended path, because only application-level cascades trigger hooks, observers, auditing, and business validation; Eloquent model events do not fire at all under DB cascades — which is exactly the mechanism behind this project's audit blindness.
+- The accepted use case for `ON DELETE CASCADE` is generally confined to: pure compositional ownership + no application-level audit requirements + a predictable deletion scope. Of CBDB's 186, almost none satisfies all three.
+
+Incidentally, the schema's lone exception, `fk_merged_person_source` (`ON DELETE SET NULL`), comes from recent work — showing that someone inside the project has already made the right call on a new table; what is needed now is to extend that judgment back over the legacy stock.
+
+## 4. The Escape Matrix: What De-cascading and Soft Deletion Each Solve
+
+### 4.1 The Three Conflict Resolutions Under Physical Deletion
+
+The invariant guaranteed by foreign-key constraints is **referential integrity**: no dangling references. When you **physically delete** a target that is still referenced, that invariant is threatened, and mathematically there are only three resolutions:
+
+1. **Refuse** (RESTRICT): the delete is not allowed; go deal with the references first;
+2. **Nullify** (SET NULL): set the referencing column to NULL (only for columns where the reference is optional);
+3. **Propagate** (CASCADE): delete the referencing rows too.
+
+**All three preserve exactly the same invariant.** Cascade provides no additional consistency whatsoever — it merely picks the option that "automatically destroys the most data," without asking anyone. So "how do we keep consistency without cascade?" is a pseudo-question: after switching to RESTRICT, the database still **enforces** the absence of dangling references; the only change is that the conflict is thrown to the application layer and to humans to decide.
+
+### 4.2 The Fourth Option: Don't Physically Delete (Soft Delete / Deprecate)
+
+The three-way choice above presupposes that "deletion must happen." The standard practice of modern data-asset systems dissolves that premise: **code-table entries are never physically deleted; they are retired (deprecated)**. This is exactly the universal practice of authority-file systems (library authority files, SNOMED, MeSH) — entries never disappear; they are merely flagged "no new references allowed." CBDB's code tables are, in essence, authority files.
+
+After adding a status column to the code tables (semantically `c_deprecated` is recommended over `deleted_at` — the entry has not been deleted, only retired):
+
+- Selectors/search endpoints filter out retired entries, achieving the business purpose of "deletion";
+- Foreign keys from existing biographical data remain valid — **no dangling references are created**;
+- The historical fact "this person's alternate name appears in this book" is preserved.
+
+Two necessary details:
+
+- **Visibility is contextual, not a global switch**: hide in selectors, but when biographical pages JOIN the code table for display labels, it **must display as usual** (otherwise the reign periods/book titles on old records all go blank). In implementation, only the "pick" endpoints change; the work is bounded.
+- **Deprecate solves "retirement"; it does not solve "errors and duplicates"**: in practice the most frequent trigger for "delete this entry" is a typo entry or a duplicate entry (like the duplicated "Zhiyuan 至元"). There the old references point at a **wrong record** — keeping it preserves not history but error: references end up split between the correct and the wrong entry, and retrieval by the correct entry misses that batch forever. The right answer there is **merge + redirect** (re-point the references in bulk to the correct entry; retire the wrong entry and leave a redirect). So a "reference migration tool" is not complexity imposed by the de-cascading plan — it is a requirement of data-quality governance itself, which a soft-delete plan needs just the same.
+
+### 4.3 Why Soft Deletion Cannot Replace De-cascading — the Matrix
+
+Crossing the two dimensions yields this document's core conclusion:
+
+| | `ON DELETE CASCADE` | `RESTRICT` |
+|---|---|---|
+| **Physical delete** | **① Status quo: disaster.** One DELETE silently guts the database; audits are blind; unrecoverable | **② Acceptable.** Needs reference checks and migration tooling; forgetting them yields an error, not data loss |
+| **Soft delete / deprecate** | **③ A live trap.** The normal path is safe, but the protection rests only on "convention"; any violating DELETE (script, migration, bug) triggers the same devastation as ① | **④ Target state.** No deletion on the normal path; fail-closed on violations |
+
+The key is ③: **soft deletion is an application-layer convention; the constraint is a database-layer fuse — different layers**. Convention governs "what to do normally"; the fuse governs "what happens when something goes wrong." Choosing soft deletion while keeping CASCADE is like removing the smoke detector and promising "I won't start a fire" — `deleteBatch` has already demonstrated that conventions get violated. The failure-mode argument of §3.4 applies verbatim to a soft-delete plan.
+
+Conversely, the two reinforce each other:
+
+- **Once soft deletion is universal, flipping to RESTRICT costs zero** — no legitimate hard-delete flow remains, the constraint blocks no normal feature, and it becomes pure mistake-proofing;
+- **Once RESTRICT is flipped, the soft-delete convention has a backstop** — a newcomer who doesn't know the convention, or an old script that wasn't updated, gets an error, not a silent disaster.
+
+So this document's claim is not "de-cascade vs. soft delete, pick one," but: **break at least one factor of the matrix (flipping the constraints is the bleeding-stop achievable with a single migration), with ④ as the target state.**
+
+### 4.4 The Full Strategy per Relationship Type
+
+| Relationship type | Example | DB constraint | Application-layer responsibility |
+|---|---|---|---|
+| **Code-table reference** (vast majority) | `ALTNAME_DATA.c_source → TEXT_CODES`, `BIOG_MAIN.c_dy → DYNASTIES` | `RESTRICT` | Entry lifecycle: **deprecate as the primary path** (retired; hidden in selectors, displayed as usual); **merge + redirect** for errors/duplicates; **true deletion only for zero-reference** entries |
+| **Compositional ownership** (few) | `POSTED_TO_ADDR_DATA → POSTED_TO_OFFICE_DATA` | `RESTRICT` (backstop) | **Explicit cascade** at the application layer: within one transaction, expand the child-record set, snapshot each row into audit_log (same operation_id), then delete; UI announces "will also delete N rows" beforehand |
+| **Peer mirrors** | `KIN_DATA` / `ASSOC_DATA` reverse rows | `RESTRICT` | Application-layer paired handling + the existing mirror-conflict detection |
+| **Optional reference** | `fk_merged_person_source` | `SET NULL` acceptable | Already the correct current template |
+
+"Application-level explicit cascade" is not a new invention — `OfficePostingRepository` already explicitly deletes `POSTED_TO_ADDR_DATA` within the transaction when removing a posting; that is the ready-made correct pattern. The last line of defense is a **periodic orphan scan** (defense in depth, not the primary mechanism).
+
+### 4.5 "But 'Deleting' Becomes a Hassle" — Yes; That Is the Point
+
+After the migration, "deleting" a reign period that is still referenced is no longer one casual click: retire it, or migrate the references away first. **Destroying (or hiding) a code entry still referenced by hundreds of biographical records should never have been an operation you can complete casually.** The hassle does not disappear; it merely moves from "investigating afterwards where the data went" to "two extra clicks beforehand" — the trade-off every data-asset system makes.
+
+## 5. Migration Roadmap
+
+### 5.0 Target State (Matrix ④)
+
+- **A code-table entry lifecycle replaces "deletion"**: normal retirement goes through **deprecate** (hidden in selectors, displayed as usual, existing references untouched); errors/duplicates go through **merge + redirect** (audited bulk re-pointing; the wrong entry retired); **physical deletion only for entries with zero references**, confirmed by a reference check.
+- **Deleting owned records** (posting → posting address and other true compositions): a unified deletion service — within one transaction, expand child records, snapshot each row into `audit_log` (same operation_id), delete, restorable as a group.
+- **DB constraints uniformly `RESTRICT`**: when any layer above is bypassed, the result is an error rather than data loss. Every write has operations/audit records and is replayable.
+
+### 5.1 Migration Steps
+
+> The order is deliberately "application layer first, DB constraints last": if the constraints were flipped to RESTRICT first, the deletion paths that currently rely implicitly on cascades would immediately start returning 500s. Fill in the application layer first, then flip the constraints — no behavioral cliff anywhere along the way.
+
+**Step 0: Verify the production database (half a day)**
+Run the Appendix B query on production MariaDB and export the list of constraints actually in effect. This document is based on the migration file; **production is authoritative**.
+Deliverable: `cascade_inventory.csv` (constraint name, table, column, target table, DELETE_RULE, UPDATE_RULE).
+
+**Step 1: Classification and impact inventory (1–2 days)**
+Label every CASCADE foreign key with its relationship type (the four classes of §4.4); simultaneously grep all deletion code paths (controllers/repositories/commands) and flag those that **implicitly rely on DB cascades** to clean up references (known: `/codes` deletion, `AdminBatchLoadBookTitlesController::deleteBatch`; a full sweep is needed).
+Deliverable: a decision table (one row per constraint: current → target rule → code paths depending on it → application-layer changes required).
+
+**Step 2: Application-layer catch-up (one independent PR each)**
+1. **Reference-check service**: input (code table, key value); output per-referencing-table counts and samples — the data source is exactly Step 0's foreign-key list, drivable directly from `information_schema`, no hand-maintained mapping needed.
+2. **Code-table lifecycle**: add a `c_deprecated` status column to the code tables (code tables only, not data tables; **adding a column requires prior discussion by the executive committee; the alignment rules for the offline release and the export update are in §5.3, and the export update ships in the same milestone as this column**); selector/search endpoints filter retired entries while display JOINs do not; `/codes` "delete" becomes "retire," with physical deletion available only at zero references; abolish `deleteBatch`'s deletion of `operations` records.
+3. **Merge + redirect tool**: re-point all references from entry A to entry B in bulk — audited, restorable, A retired with a redirect left behind. This is also the isomorphic foundation for future "person merge."
+4. **Explicit cascade-deletion service**: covering the few relationships Step 1 labels "composition" (following the current `OfficePostingRepository` pattern, adding snapshots and same-operation_id grouping).
+
+**Step 3: Flip the constraints (bleeding-stop migration, run in a maintenance window)**
+Execute in batches per Step 1's decision table:
+
+```sql
+ALTER TABLE ALTNAME_DATA
+  DROP FOREIGN KEY ALTNAME_DATA_ibfk_3,
+  ADD CONSTRAINT ALTNAME_DATA_ibfk_3 FOREIGN KEY (c_source)
+      REFERENCES TEXT_CODES (c_textid)
+      ON DELETE RESTRICT ON UPDATE CASCADE;   -- leave the UPDATE behavior alone at this stage
+```
+
+- Only the constraint behavior changes; table structures and data are untouched. Rebuilding an FK requires a validation scan — measure execution time on large tables against a staging replica first, and decide whether to skip validation with `SET foreign_key_checks=0` (existing data consistency is already guaranteed by the original constraint).
+- Execute in batches (one group of tables per batch), revertible between batches: the rollback is simply flipping that batch's constraints back to CASCADE — one ALTER, no data risk.
+- Prioritize by incoming-edge count: `NIAN_HAO` (24), `YEAR_RANGE_CODES` (23), `TEXT_CODES` (22), `ADDR_CODES` (11), `GANZHI_CODES`/`DYNASTIES` (9), then the rest.
+- Update `import_cbdb_schema.php` (or add a migration) in the same change, keeping fresh installs consistent.
+
+**Step 4: Verification and regression (same window as Step 3)**
+- Live test on staging: delete a referenced reign period → expect the application layer to block it (or the DB to raise error 1451), with not one row of biographical data lost; retire a reign period → it disappears from selectors while existing records display as usual;
+- Check `information_schema`: `DELETE_RULE='CASCADE'` drops to zero within the target batch;
+- After the production run, perform the same check plus spot tests.
+
+**Step 5: Wrap-up and long-term items**
+- **Orphan-scan schedule**: periodic referential-integrity checks as defense in depth (covering constraint gaps and historical leftovers).
+- **`ON UPDATE CASCADE` (187 of them) as a separate project**: key-change propagation does not destroy data and is one grade less dangerous, but it bypasses auditing all the same. Long term, "code-table key changes" should be absorbed into an audited application-layer operation and then flipped to RESTRICT; until then, document and surface the current behavior in docs and UI.
+- **The test-environment gap as a separate project**: SQLite having no foreign keys means CI can never test any behavior in this document; MariaDB constraint-related changes need dedicated integration verification (e.g. CI spinning up a MariaDB container to run constraint tests).
+
+### 5.2 Effort and Dependency Overview
+
+| Step | Effort | Depends on | Risk |
+|---|---|---|---|
+| 0 Verify | Half a day | Read-only access to production | None |
+| 1 Classify | 1–2 days | Step 0 | None (pure analysis) |
+| 2 App-layer catch-up | Medium (4 small PRs) | Step 1 | Low; each item independently revertible |
+| 3 Flip constraints | Low (migration) + maintenance window | Step 2 complete | Medium; staging measurement + batching + single-ALTER rollback |
+| 4 Verify | Half a day | Step 3 | None |
+| 5 Long-term items | Separate projects each | — | — |
+
+No step on this route is a "big bang": the application-layer PRs are independent, and the constraint flips are batched and revertible batch by batch. Once complete, the system lands in matrix cell ④ (soft delete × RESTRICT): "deletion" no longer happens on the normal path, and on abnormal paths the cost is capped at an error — only then does "every operation is restorable" become mechanically possible for the first time. Until then, the skylight of DB cascades voids the guarantees of any audit/undo engineering — which is why this document's conclusion is: **breaking the "physical delete × CASCADE" combination must come before all other data-safety engineering.**
+
+### 5.3 Offline Releases (SQLite / Access) and Governance Alignment
+
+The online system and the offline releases are structurally separated, with the export function guaranteeing that released versions stay consistent with the Access schema. When `c_deprecated` lands, two things about the offline release must be handled in lockstep:
+
+**(1) Export exclusion rules — deprecated codes are structurally different from the person soft delete, and cannot be excluded wholesale the same way.**
+
+The existing precedent is the export exclusion of soft-deleted BIOG_MAIN persons (commit 8930d73, see `docs/SQLITE_DATA_RELEASE.md`): a deleted person is excluded **as a whole group** — the person row, all of their data rows, and the relationship rows in other people's records that mention them (via FK columns dynamically detected through `information_schema`) all disappear together, leaving no dangling references in the exported file; if the `information_schema` query fails, the entire export aborts fail-closed, with dedicated regression tests. That **pattern** (filtering centralized at query construction, fail-closed, regression tests) is worth reusing.
+
+But the **semantics** of deprecation are the opposite of the person soft delete: existing references are preserved, and only new references are forbidden. The rows referencing a deprecated code all belong to normal persons' normal data and must not be excluded by association; if deprecated codes were excluded wholesale from the export, those data rows would carry dangling foreign-key values (pointing to codes absent from the Access/SQLite file), and JOINs on the Access side would silently drop data. The export rule therefore splits by reference count:
+
+| References to the deprecated code | Export behavior | Notes |
+|---|---|---|
+| **Zero** | Excluded from the export | Equivalent to "deleted" from Access's perspective, consistent with current expectations |
+| **Still referenced** | Exported as an ordinary code row (**without the `c_deprecated` column**) | Fully transparent to Access; no dangling references; on the governance side, merge + redirect (Step 2-3) gradually migrates the references away, and once the count reaches zero the code naturally disappears from the next release |
+
+The export update ships **in the same milestone** as the `c_deprecated` column itself; no window is allowed where the column exists but the export hasn't caught up.
+
+**(2) Governance prerequisite — adding a column requires executive committee discussion.**
+
+Any new column in the online system must first be discussed by the executive committee. Since `c_deprecated` exists only in the online system and — per the table above — is **not exported to Access**, for the committee this is not a change to the shared schema but a **change to the code-table lifecycle policy** ("delete" becomes "deprecate / merge," plus the inclusion rules for released versions). For the discussion, prepare a one-page brief: the semantics of `c_deprecated`, the export rules above, and confirmation that released Access versions keep an unchanged schema. This discussion is a prerequisite for Step 2 milestone 2.
+
+---
+
+## Appendix A: Re-runnable Verification Commands
+
+```bash
+# ON DELETE behavior statistics (against the migration)
+grep -o "ON DELETE [A-Z ]*" database/migrations/2025_01_01_000000_import_cbdb_schema.php | sort | uniq -c
+
+# Ranking of incoming CASCADE edges per table
+grep -o "CONSTRAINT \`[A-Za-z_0-9]*\` FOREIGN KEY (\`[a-z_]*\`) REFERENCES \`[A-Z_]*\`" \
+  database/migrations/2025_01_01_000000_import_cbdb_schema.php \
+  | sed 's/.*REFERENCES `\([A-Z_]*\)`/\1/' | sort | uniq -c | sort -rn | head -20
+
+# BIOG_MAIN's own foreign keys (13, all CASCADE)
+grep -o "CONSTRAINT \`BIOG_MAIN_ibfk_[0-9]*\`[^,]*" database/migrations/2025_01_01_000000_import_cbdb_schema.php
+
+# All foreign keys referencing TEXT_CODES (22 CASCADE + 1 SET NULL)
+grep -o "CONSTRAINT \`[A-Za-z_0-9]*\` FOREIGN KEY (\`[a-z_]*\`) REFERENCES \`TEXT_CODES\`[^,]*" \
+  database/migrations/2025_01_01_000000_import_cbdb_schema.php
+```
+
+## Appendix B: Production Verification Query (MariaDB)
+
+```sql
+SELECT rc.CONSTRAINT_NAME, rc.TABLE_NAME, kcu.COLUMN_NAME,
+       rc.REFERENCED_TABLE_NAME, rc.DELETE_RULE, rc.UPDATE_RULE
+FROM information_schema.REFERENTIAL_CONSTRAINTS rc
+JOIN information_schema.KEY_COLUMN_USAGE kcu
+  ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+ AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+ORDER BY rc.DELETE_RULE, rc.REFERENCED_TABLE_NAME, rc.TABLE_NAME;
+
+-- CASCADE only
+-- ... AND rc.DELETE_RULE = 'CASCADE'
+```
+
+## Appendix C: Minimal Reproduction of the Disaster Scenario (Verified on MariaDB 10.11)
+
+Constraint clauses taken verbatim from `import_cbdb_schema.php` (`BIOG_MAIN_ibfk_2`, `ALTNAME_DATA_ibfk_2`, `KIN_DATA_ibfk_1`):
+
+```bash
+docker run -d --name cascade-test -e MARIADB_ROOT_PASSWORD=test \
+  -e MARIADB_DATABASE=cbdbtest mariadb:10.11
+```
+
+```sql
+CREATE TABLE NIAN_HAO (c_nianhao_id INT PRIMARY KEY, c_nianhao_chn VARCHAR(50)) ENGINE=InnoDB;
+CREATE TABLE BIOG_MAIN (
+  c_personid INT PRIMARY KEY, c_name_chn VARCHAR(255), c_by_nh_code INT DEFAULT NULL,
+  CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
+    REFERENCES NIAN_HAO (c_nianhao_id) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+CREATE TABLE ALTNAME_DATA (
+  c_personid INT NOT NULL, c_alt_name_chn VARCHAR(255),
+  CONSTRAINT ALTNAME_DATA_ibfk_2 FOREIGN KEY (c_personid)
+    REFERENCES BIOG_MAIN (c_personid) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+CREATE TABLE KIN_DATA (
+  c_personid INT NOT NULL, c_kin_id INT NOT NULL,
+  CONSTRAINT KIN_DATA_ibfk_1 FOREIGN KEY (c_personid)
+    REFERENCES BIOG_MAIN (c_personid) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+
+INSERT INTO NIAN_HAO VALUES (630, '至元');
+INSERT INTO BIOG_MAIN VALUES (1,'張三',630),(2,'李四',630),(3,'王五',NULL);
+INSERT INTO ALTNAME_DATA VALUES (1,'張三別名A'),(1,'張三別名B'),(2,'李四別名'),(3,'王五別名');
+INSERT INTO KIN_DATA VALUES (1,3),(2,3),(3,1);
+
+DELETE FROM NIAN_HAO WHERE c_nianhao_id = 630;
+SELECT ROW_COUNT();          -- → 1 (the only number the application layer sees)
+SELECT COUNT(*) FROM BIOG_MAIN;    -- 3 → 1 (Zhang San and Li Si vanish whole)
+SELECT COUNT(*) FROM ALTNAME_DATA; -- 4 → 1
+SELECT COUNT(*) FROM KIN_DATA;     -- 3 → 1
+```
+
+Measured result: one DELETE, reporting 1 row, actually deleting 8, with the cascade propagating two levels (reign period → persons → the persons' alt-names/kinship records).
+The second-level deletions correspond to **no DELETE statement at all**; the application layer (audit, operations, Eloquent observers) has nothing to hook.
+Note: in the real schema, `KIN_DATA.c_kin_id` also has a CASCADE foreign key to `BIOG_MAIN`, so rows in **other persons'** records where "the kin is the deleted person" vanish as well (this experiment built only the one-sided foreign key, which is why Wang Wu's kinship row pointing at Zhang San survived) — the real spread is wider than the experiment shows.

--- a/docs/ON_DELETE_CASCADE_RISK.md
+++ b/docs/ON_DELETE_CASCADE_RISK.md
@@ -1,0 +1,328 @@
+# 「物理刪除 × ON DELETE CASCADE」是唯一不可接受的組合
+
+> 撰寫日期：2026-07-07 ｜ 依據：`database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
+>
+> **本文目的**：說明本專案 schema 目前處於「物理刪除 × 級聯刪除」這個對資料資產最危險的組合中，
+> 解釋其原理性風險（這在資料庫應用領域本應是共識）；並給出破局矩陣——**去級聯（RESTRICT）與
+> 軟刪除（deprecate）各自解決什麼、為何兩者互補而非二選一**——以及可執行的改造路線圖。
+>
+> 文中所有數字皆可用附錄 A 的指令重跑驗證。
+
+---
+
+## TL;DR
+
+1. 本專案 schema 有 **186 個 `ON DELETE CASCADE` 外鍵**（另有 187 個 `ON UPDATE CASCADE`），遍布所有核心表，其中絕大多數掛在「傳記資料 → 詞表（code 表）」的**引用關係**上；而應用層對詞表執行的是**物理刪除**（且多數路徑無引用檢查）。
+2. 這個組合的後果：**刪除一筆詞表記錄（一個年號、一個朝代、一筆書名），資料庫會靜默連帶刪除所有引用它的傳記資料**——包括 `BIOG_MAIN` 的人物本身，並繼續向下刪光這些人物的全部記錄。應用層的審計（audit_log）、操作紀錄（operations）、提案審核、回退機制**全部無感知**。
+3. 破局矩陣（本文核心論點）：
+
+   | | `ON DELETE CASCADE` | `RESTRICT` |
+   |---|---|---|
+   | **物理刪除** | **現狀：災難**（一條 DELETE 靜默毀庫） | 可接受（配合引用檢查與遷移工具） |
+   | **軟刪除 / deprecate** | 帶電的陷阱（僅靠約定護體，違約即災難） | **目標形態** |
+
+   必須至少打破一個因子；兩個都打破才是完整方案。**去級聯是保險絲（出錯時的後果封頂），軟刪除是產品語義（正常路徑不再發生刪除）——層次不同，互補而非替代。**
+4. 改造路徑：先翻約束（一個 migration，成本最低的止血步），再上詞表生命週期（deprecate 為主、重複合併為輔、零引用才允許真刪）。兩步互相成就：全面軟刪除後沒有合法硬刪流程，翻 RESTRICT 阻力為零；翻了 RESTRICT 後，軟刪除約定被違反時有兜底。詳見 §5。
+
+---
+
+## 1. 現狀（證據）
+
+`import_cbdb_schema.php` 中的外鍵行為統計：
+
+| ON DELETE 行為 | 數量 |
+|---|---|
+| `CASCADE` | **186** |
+| `SET NULL` | 1（`fk_merged_person_source`，較新的表，做法正確） |
+| `RESTRICT` / `NO ACTION` | 0 |
+
+被引用最多的目標表（入邊數）：
+
+| 被引用表 | 引用它的 CASCADE 外鍵數 | 性質 |
+|---|---|---|
+| `BIOG_MAIN` | 25 | 人物主表 |
+| `NIAN_HAO` | 24 | 詞表（年號） |
+| `YEAR_RANGE_CODES` | 23 | 詞表 |
+| `TEXT_CODES` | 22 | 詞表（書目） |
+| `ADDR_CODES` | 11 | 詞表（地名） |
+| `GANZHI_CODES` / `DYNASTIES` | 各 9 | 詞表 |
+
+特別注意：**`BIOG_MAIN` 自身有 13 個指向詞表的 CASCADE 外鍵**（`BIOG_MAIN_ibfk_1`–`13`，指向 `NIAN_HAO`×4、`YEAR_RANGE_CODES`×3、`GANZHI_CODES`×2、`DYNASTIES`、`CHORONYM_CODES`、`ETHNICITY_TRIBE_CODES`、`HOUSEHOLD_STATUS_CODES`）。
+
+同時，應用層對詞表的「刪除」目前是**物理 DELETE**：`/codes` 編輯器與 `AdminBatchLoadBookTitlesController::deleteBatch` 硬刪 `TEXT_CODES`，刪除前不做引用檢查——矩陣左上角的兩個條件同時成立。
+
+## 2. 一個具體的災難場景
+
+以 `NIAN_HAO`（年號詞表）為例，執行一條看似無害的語句：
+
+```sql
+DELETE FROM NIAN_HAO WHERE c_nianhao_id = 630;   -- 刪除一筆「重複的」年號
+```
+
+InnoDB 實際執行的是：
+
+1. 刪除該年號；
+2. **級聯刪除所有 `c_by_nh_code` / `c_dy_nh_code` / `c_fl_ey_nh_code` / `c_fl_ly_nh_code` 引用它的 `BIOG_MAIN` 列**——即所有用這個年號記錄生卒年或活動年的**人物本身**；
+3. 每一個被刪的人物，再級聯刪除 25 張表中屬於他的全部記錄：別名、親屬、社會關係、任職（連同任職地址）、著述、入仕、事件、財產……；
+4. 其中親屬/社會關係的鏡像列牽涉**其他人物**的資料頁；
+5. 全程：應用層收到的 affected rows 只有第 1 步的 `1`；`operations` 與 `audit_log` **一列都不會多**；提案審核流程完全未被觸發；沒有任何可回退的快照。
+
+換句話說：**一條 DELETE 可以無聲地抹掉數百人的完整傳記，且事後無從得知發生過**。
+
+> 此場景聽起來難以置信，因此已在真實 MariaDB 10.11 上以逐字取自本 schema 的約束做了最小重現實驗（附錄 C）：
+> 刪 1 筆年號，`ROW_COUNT()` 回報 **1**，實際 8 列消失（2 個人物整列＋其別名/親屬記錄），級聯傳遞兩層，
+> 第二層的刪除不存在任何對應的 DELETE 語句可供應用層攔截。
+
+這不是純理論。現有代碼中已經存在完整的事故鏈路：
+
+- `/codes` 編輯器與 `AdminBatchLoadBookTitlesController::deleteBatch` 會硬刪 `TEXT_CODES`，**刪除前不做任何引用檢查**；
+- `TEXT_CODES` 有 22 條 CASCADE 入邊（`ALTNAME_DATA.c_source`、`BIOG_SOURCE_DATA.c_textid`、`TEXT_DATA`、`KIN_DATA.c_source`……甚至 `TEXT_CODES` 自引用），刪一筆書名會靜默刪除引用它的別名、出處、著述記錄；
+- `deleteBatch` 還會主動刪除對應的 `operations` 紀錄——僅存的痕跡也被抹掉。
+
+另外，**測試完全無法捕捉這類問題**：本地與 CI 測試環境是 SQLite，建表語句不含這些外鍵（`PRAGMA foreign_keys` 亦為 0），級聯行為只在生產 MariaDB 上存在。測試全綠證明不了任何事。
+
+## 3. 為什麼「物理刪除 × CASCADE」危險——原理
+
+### 3.1 它把「引用」誤當成「從屬」
+
+級聯刪除的正當語義只有一種：**組合關係（composition）**——子記錄離開父記錄毫無意義，如訂單之於訂單明細。刪訂單連帶刪明細，天經地義。
+
+但 CBDB 的外鍵幾乎全是**引用關係（reference）**：一筆別名記錄「引用」某書作為出處，不代表這筆別名「從屬」於那本書。書名詞條寫錯了要處理，是詞表維護；因此連帶銷毀幾百條傳記事實，是資料災難。詞表是**詞彙**，傳記資料是**資產**；詞彙的增刪改永遠不應該有權力銷毀資產。
+
+用一個判別法：問「刪掉被引用方時，引用方記錄承載的歷史事實還成立嗎？」——「張三的別名見於某書」這個事實，不因某書的詞條被刪而消失。事實還在，記錄就不該被刪。CBDB 的 186 個 CASCADE 裡，能通過組合關係檢驗的屈指可數（如 `POSTED_TO_ADDR_DATA` 之於 `POSTED_TO_OFFICE_DATA`）。
+
+### 3.2 它是一台無界的放大器
+
+CASCADE 是**傳遞閉包**：詞表 → `BIOG_MAIN` → 25 張子表 → 鏡像列。一條 DELETE 的實際破壞範圍取決於整張外鍵圖和當下的資料分佈，寫這條 DELETE 的人（或代碼）**無法從語句本身看出**會刪掉多少東西。破壞量與操作意圖完全脫鉤——這違反了資料操作最基本的可預期性原則。
+
+### 3.3 它對應用層完全不可見
+
+這一點對本專案是致命的。我們投入了大量工程建立資料保護機制——`operations` 操作紀錄、`audit_log` 前後鏡像、提案審核（proposal/approve）、回退（restore）——它們全部工作在**應用層**。而 DB 級聯發生在**存儲引擎層**：
+
+- 被級聯刪除的列，`audit_log` 沒有鏡像，`operations` 沒有紀錄；
+- 提案審核形同虛設：單筆編輯要走審核，而一條詞表 DELETE 可以繞過一切；
+- 「所有操作皆可回退」的目標在數學上不可能達成——你無法回放你從未看見的刪除。
+
+**只要 CASCADE 存在，任何應用層的審計與撤銷機制都有一個結構性天窗。**
+
+### 3.4 失效模式不對稱
+
+工程上選擇機制，要比較的不是「正常時誰更方便」，而是「出錯時代價是什麼」：
+
+| | 出錯情境 | 後果 | 可見性 | 可恢復性 |
+|---|---|---|---|---|
+| `RESTRICT` | 應用層忘了處理引用就刪 | **報錯，操作被拒** | 立即、明確 | 完全（什麼都沒發生） |
+| `CASCADE` | 應用層發出一條錯誤的 DELETE | **資料被靜默銷毀** | 可能數月後才發現 | 備份輪換後即永久丟失 |
+
+RESTRICT 的失敗模式是「煩人但無害」（fail-closed），CASCADE 的失敗模式是「安靜但毀滅」。CASCADE 唯一安全的前提是「應用層永遠不會發出錯誤的 DELETE」——這個前提在任何真實系統中都不成立，本專案的 `deleteBatch` 就是現成的反例。**注意這個論證不依賴「應用層打算怎麼刪」：無論應用層採用物理刪除還是軟刪除約定，只要 CASCADE 還在，違約/出錯的代價就是毀庫。這是 §4 矩陣「左下格仍然不可接受」的原因。**
+
+### 3.5 為什麼說這是行業共識
+
+- 幾乎所有以資料為資產的領域（金融、醫療、檔案）的資料庫規範都禁止或嚴格限制級聯刪除，正是出於 3.3/3.4 的理由：審計完整性要求一切變更經過應用層。
+- 主流 ORM（Laravel/Eloquent、Rails、Django、Hibernate）都提供**應用層級聯**作為推薦路徑，因為只有應用層級聯才會觸發 hooks、observers、審計與業務校驗；Eloquent 的 model event 在 DB 級聯下完全不觸發，這正是本專案 audit 失明的機制。
+- `ON DELETE CASCADE` 的合理使用場景被普遍限定為：純從屬的組合關係＋無應用層審計需求＋刪除範圍可預期。CBDB 的 186 個裡幾乎沒有同時滿足三條的。
+
+順帶一提，schema 裡唯一的例外 `fk_merged_person_source`（`ON DELETE SET NULL`）出自較新的工作——說明專案內部已經有人在新表上做出了正確判斷，現在需要的是把這個判斷推廣回存量。
+
+## 4. 破局矩陣：去級聯與軟刪除各解決什麼
+
+### 4.1 物理刪除下的三種衝突解法
+
+外鍵約束保證的不變量是**引用完整性**：不存在懸掛引用。當你**物理刪除**一個仍被引用的目標時，這個不變量受到威脅，解法在數學上只有三種：
+
+1. **拒絕**（RESTRICT）：不許刪，先去處理引用；
+2. **置空**（SET NULL）：引用欄設為 NULL（僅適用於「引用可缺失」的欄）；
+3. **傳播**（CASCADE）：把引用方一起刪掉。
+
+**三種解法維持的不變量一模一樣。** cascade 沒有提供任何額外的一致性——它只是選了「自動銷毀最多資料」的那一種，且不徵求任何人的同意。所以「不 cascade 一致性怎麼辦」是個偽問題：改用 RESTRICT 之後，資料庫依然**強制**保證無懸掛引用，變化只是把衝突拋給應用層和人來決策。
+
+### 4.2 第四個選項：不做物理刪除（軟刪除 / deprecate）
+
+上面三選一的前提是「刪除必鬚髮生」。現代資料資產系統的標準做法是消解這個前提：**詞表項根本不物理刪除，而是退役（deprecate）**。這正是權威檔案系統（圖書館規範檔、SNOMED、MeSH）的通行實踐——詞條從不消失，只標記「不再允許新引用」。CBDB 的詞表本質上就是規範檔。
+
+對詞表加狀態欄（建議語義化為 `c_deprecated` 而非 `deleted_at`——詞條沒有被刪，只是退役）之後：
+
+- 選擇器/搜尋端點過濾掉已退役詞條，達成「刪除」的業務目的；
+- 既有傳記資料的外鍵照常成立，**不會產生懸掛引用**；
+- 「某人的別名見於某書」的歷史事實得以保留。
+
+兩個必要的細節：
+
+- **可見性是按上下文的，不能全局一刀切**：選擇器裡要隱藏，但傳記資料頁 JOIN 詞表取顯示標籤時**必須照常顯示**（否則老記錄的年號/書名全部變空白）。實作上只改「選用」端點，工作量有界。
+- **deprecate 解決「退役」，解決不了「錯誤與重複」**：實踐中觸發「刪詞條」需求最多的是錯字詞條、重複詞條（如重複的「至元」）。這時舊引用指向的是**錯誤記錄**，保留它不是保存歷史而是保存錯誤——引用被分裂在正確與錯誤詞條之間，按正確詞條檢索永遠漏掉那批記錄。這類場景的正解是**合併＋重定向**（把引用批次改指到正確詞條，錯誤詞條退役並留重定向），所以「引用遷移工具」不是去級聯方案強加的複雜度，是資料品質治理本身的需求，軟刪除方案同樣需要它。
+
+### 4.3 為什麼軟刪除不能替代去級聯——矩陣
+
+把兩個維度交叉，得到本文的核心結論：
+
+| | `ON DELETE CASCADE` | `RESTRICT` |
+|---|---|---|
+| **物理刪除** | **① 現狀：災難。** 一條 DELETE 靜默毀庫，審計失明，不可恢復 | **② 可接受。** 需配套引用檢查與遷移工具；忘了配套時得到報錯而非資料丟失 |
+| **軟刪除 / deprecate** | **③ 帶電的陷阱。** 正常路徑安全，但保護只來自「約定」；任何違約的 DELETE（腳本、遷移、bug）觸發與 ① 相同的毀滅 | **④ 目標形態。** 正常路徑無刪除，違約時 fail-closed |
+
+關鍵在 ③：**軟刪除是應用層約定，約束是資料庫層保險絲，層次不同**。約定管「正常時怎麼做」，保險絲管「出錯時會怎樣」。選了軟刪除而保留 CASCADE，等於拆掉煙霧報警器並承諾「我不會失火」——`deleteBatch` 已經示範過約定會被違反。§3.4 的失效模式論證對軟刪除方案原封不動地適用。
+
+反過來，兩者互相成就：
+
+- **全面軟刪除之後，翻 RESTRICT 的成本歸零**——不再存在任何合法的硬刪流程，約束不會擋住任何正常功能，純粹變成防呆；
+- **翻了 RESTRICT 之後，軟刪除約定有了兜底**——新人不知道約定、舊腳本沒改到，得到的是報錯，不是無聲的災難。
+
+因此本文的主張不是「去級聯 vs 軟刪除」二選一，而是：**至少打破矩陣的一個因子（其中翻約束是一個 migration 就能完成的止血步），並以 ④ 為目標形態。**
+
+### 4.4 每一類關係的完整策略
+
+| 關係類型 | 例子 | DB 約束 | 應用層職責 |
+|---|---|---|---|
+| **詞表引用**（絕大多數） | `ALTNAME_DATA.c_source → TEXT_CODES`、`BIOG_MAIN.c_dy → DYNASTIES` | `RESTRICT` | 詞條生命週期：**deprecate 為主**（退役，選擇器隱藏、顯示照常）；**合併＋重定向**處理錯誤/重複；**真刪僅限零引用**的詞條 |
+| **組合從屬**（少數） | `POSTED_TO_ADDR_DATA → POSTED_TO_OFFICE_DATA` | `RESTRICT`（兜底） | 應用層**顯式級聯**：同一交易內先展開子記錄集合、逐列快照寫 audit_log（同一 operation_id）、再刪除；UI 事前告知「將連帶刪除 N 列」 |
+| **對等鏡像** | `KIN_DATA` / `ASSOC_DATA` 反向列 | `RESTRICT` | 應用層同組處理＋既有的鏡像衝突偵測 |
+| **可缺失引用** | `fk_merged_person_source` | `SET NULL` 可接受 | 已是現行正確樣板 |
+
+「應用層顯式級聯」不是新發明——`OfficePostingRepository` 刪任職時在交易內顯式刪除 `POSTED_TO_ADDR_DATA`，就是現成的正確寫法。最後一道防線是**週期性孤兒掃描**（縱深防禦，不是主要機制）。
+
+### 4.5 「這樣『刪除』會變麻煩」——對，這正是目的
+
+改造後，「刪」一筆還被引用的年號不再是隨手一按：退役它、或先把引用遷走。**銷毀（或藏起）一個仍被幾百筆傳記引用的詞條，本來就不該是一個能隨手完成的操作。** 麻煩沒有消失，只是從「事後追查資料去哪了」變成「事前多點兩下」——這是所有資料資產系統都做出的取捨。
+
+## 5. 改造路線圖
+
+### 5.0 目標形態（矩陣 ④）
+
+- **詞表項的生命週期**取代「刪除」：正常退役走 **deprecate**（選擇器隱藏、顯示照常、既有引用不動）；錯誤/重複走**合併＋重定向**（受審計的批次 re-point，錯誤詞條退役）；**物理刪除僅限引用數為零**的詞條，且經引用檢查確認。
+- **刪從屬記錄**（任職→任職地址等真組合關係）：統一刪除服務——同一交易內展開子記錄、逐列快照寫 `audit_log`（同一 operation_id）、刪除、可整組回退。
+- **DB 約束全面 `RESTRICT`**：以上任何一層被繞過時，得到報錯而不是資料丟失。所有寫入皆有 operations/audit 紀錄、皆可回放。
+
+### 5.1 改造步驟
+
+> 順序刻意安排為「應用層先行、DB 約束殿後」：若先把約束翻成 RESTRICT，現存**隱式依賴級聯**的刪除路徑會立刻開始報 500。先補齊應用層，再翻約束，全程無行為斷崖。
+
+**Step 0：核實生產庫（半天）**
+在生產 MariaDB 跑附錄 B 查詢，導出實際生效的約束清單。本文以 migration 為據，**線上以此為準**。
+產出：`cascade_inventory.csv`（約束名、表、欄、目標表、DELETE_RULE、UPDATE_RULE）。
+
+**Step 1：分類與影響面盤點（1–2 天）**
+對每個 CASCADE 外鍵標注關係類型（§4.4 四類）；同時 grep 全部刪除代碼路徑（controllers/repositories/commands），標記哪些**隱式依賴 DB 級聯**清理引用（已知：`/codes` 刪除、`AdminBatchLoadBookTitlesController::deleteBatch`；需全面排查）。
+產出：決策表（每個約束一行：現狀 → 目標規則 → 依賴它的代碼路徑 → 需要的應用層改動）。
+
+**Step 2：應用層補課（每項獨立 PR）**
+1. **引用檢查服務**：輸入（詞表, 主鍵值），輸出各引用表的計數與樣例——資料來源就是 Step 0 的外鍵清單，可直接由 `information_schema` 驅動，不必手工維護映射。
+2. **詞表生命週期**：詞表加 `c_deprecated` 狀態欄（僅詞表、非資料表；schema 與離線發佈版的對齊需確認）；選擇器/搜尋端點過濾退役詞條，顯示 JOIN 不過濾；`/codes` 的「刪除」改為「退役」，物理刪除僅在引用數為零時開放；廢除 `deleteBatch` 刪 `operations` 紀錄的行為。
+3. **合併＋重定向工具**：把 A 詞條的全部引用批次改指到 B 詞條，受審計、可回退，A 退役留重定向——這也是日後「人物合併」的同構地基。
+4. **顯式級聯刪除服務**：覆蓋 Step 1 標記為「組合」的少數關係（參考 `OfficePostingRepository` 現行寫法，補齊快照與同 operation_id 分組）。
+
+**Step 3：翻轉約束（止血 migration，維護窗口執行）**
+按 Step 1 決策表批量執行：
+
+```sql
+ALTER TABLE ALTNAME_DATA
+  DROP FOREIGN KEY ALTNAME_DATA_ibfk_3,
+  ADD CONSTRAINT ALTNAME_DATA_ibfk_3 FOREIGN KEY (c_source)
+      REFERENCES TEXT_CODES (c_textid)
+      ON DELETE RESTRICT ON UPDATE CASCADE;   -- UPDATE 行為此階段先不動
+```
+
+- 只改約束行為，不動表結構與資料；重建 FK 需要驗證掃描，先在 staging 副本量測大表的執行時間，決定是否用 `SET foreign_key_checks=0` 跳過驗證（資料既有一致性由原約束保證）。
+- 分批執行（每批一組表），批間可回退：回退動作＝把該批約束改回 CASCADE，一條 ALTER 即可，無資料風險。
+- 優先順序按入邊數：`NIAN_HAO`(24)、`YEAR_RANGE_CODES`(23)、`TEXT_CODES`(22)、`ADDR_CODES`(11)、`GANZHI_CODES`/`DYNASTIES`(9)，再及其餘。
+- 同步更新 `import_cbdb_schema.php`（或新增 migration），保持新裝環境一致。
+
+**Step 4：驗證與回歸（與 Step 3 同窗口）**
+- staging 上實測：刪一筆被引用的年號 → 期望應用層擋下（或 DB 報 1451 錯誤），傳記資料一列不少；退役一筆年號 → 選擇器消失、既有記錄顯示照常；
+- 核對 `information_schema`：目標批次內 `DELETE_RULE='CASCADE'` 歸零；
+- 生產執行後同樣核對＋抽測。
+
+**Step 5：收尾與長期項**
+- **孤兒掃描**排程：週期核對引用完整性作為縱深防禦（覆蓋約束缺口與歷史遺留）。
+- **`ON UPDATE CASCADE`（187 個）單獨立項**：改鍵傳播不銷毀資料、危險性低一級，但同樣繞過審計。長期應把「詞表改鍵」收為應用層受審計操作後改為 RESTRICT；在那之前先在文件與 UI 標明現狀。
+- **測試環境缺口單獨立項**：SQLite 無外鍵意味著 CI 永遠測不到本文所有行為，MariaDB 約束相關變更需要專門的整合驗證手段（如 CI 起 MariaDB 容器跑約束測試）。
+
+### 5.2 工作量與依賴總覽
+
+| 步驟 | 工作量 | 依賴 | 風險 |
+|---|---|---|---|
+| 0 核實 | 半天 | 生產庫只讀權限 | 無 |
+| 1 分類盤點 | 1–2 天 | Step 0 | 無（純分析） |
+| 2 應用層補課 | 中（4 個小 PR） | Step 1 | 低；每項獨立可回退 |
+| 3 翻轉約束 | 低（migration）＋維護窗口 | Step 2 完成 | 中；staging 量測＋分批＋單條 ALTER 可回退 |
+| 4 驗證 | 半天 | Step 3 | 無 |
+| 5 長期項 | 各自立項 | — | — |
+
+整條路線沒有一步是「大爆炸」：應用層 PR 各自獨立，約束翻轉分批且逐批可退。完成後系統落在矩陣的 ④（軟刪除 × RESTRICT）：正常路徑上「刪除」不再發生，異常路徑上代價被封頂為一個報錯——「任何操作皆可回退」才第一次在機制上成為可能。在此之前，DB 級聯這個天窗會讓任何審計/撤銷工程的保證落空，這也是為什麼本文的結論是：**打破「物理刪除 × CASCADE」組合應排在所有資料安全工程之前。**
+
+---
+
+## 附錄 A：可重跑的驗證指令
+
+```bash
+# ON DELETE 行為統計（against migration）
+grep -o "ON DELETE [A-Z ]*" database/migrations/2025_01_01_000000_import_cbdb_schema.php | sort | uniq -c
+
+# 各表被 CASCADE 引用的入邊數排名
+grep -o "CONSTRAINT \`[A-Za-z_0-9]*\` FOREIGN KEY (\`[a-z_]*\`) REFERENCES \`[A-Z_]*\`" \
+  database/migrations/2025_01_01_000000_import_cbdb_schema.php \
+  | sed 's/.*REFERENCES `\([A-Z_]*\)`/\1/' | sort | uniq -c | sort -rn | head -20
+
+# BIOG_MAIN 自身的外鍵（13 個，全部 CASCADE）
+grep -o "CONSTRAINT \`BIOG_MAIN_ibfk_[0-9]*\`[^,]*" database/migrations/2025_01_01_000000_import_cbdb_schema.php
+
+# 引用 TEXT_CODES 的全部外鍵（22 個 CASCADE + 1 個 SET NULL）
+grep -o "CONSTRAINT \`[A-Za-z_0-9]*\` FOREIGN KEY (\`[a-z_]*\`) REFERENCES \`TEXT_CODES\`[^,]*" \
+  database/migrations/2025_01_01_000000_import_cbdb_schema.php
+```
+
+## 附錄 B：生產庫核實查詢（MariaDB）
+
+```sql
+SELECT rc.CONSTRAINT_NAME, rc.TABLE_NAME, kcu.COLUMN_NAME,
+       rc.REFERENCED_TABLE_NAME, rc.DELETE_RULE, rc.UPDATE_RULE
+FROM information_schema.REFERENTIAL_CONSTRAINTS rc
+JOIN information_schema.KEY_COLUMN_USAGE kcu
+  ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+ AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+ORDER BY rc.DELETE_RULE, rc.REFERENCED_TABLE_NAME, rc.TABLE_NAME;
+
+-- 只看 CASCADE 的
+-- ... AND rc.DELETE_RULE = 'CASCADE'
+```
+
+## 附錄 C：災難場景的最小重現實驗（已於 MariaDB 10.11 實測）
+
+約束子句逐字取自 `import_cbdb_schema.php`（`BIOG_MAIN_ibfk_2`、`ALTNAME_DATA_ibfk_2`、`KIN_DATA_ibfk_1`）：
+
+```bash
+docker run -d --name cascade-test -e MARIADB_ROOT_PASSWORD=test \
+  -e MARIADB_DATABASE=cbdbtest mariadb:10.11
+```
+
+```sql
+CREATE TABLE NIAN_HAO (c_nianhao_id INT PRIMARY KEY, c_nianhao_chn VARCHAR(50)) ENGINE=InnoDB;
+CREATE TABLE BIOG_MAIN (
+  c_personid INT PRIMARY KEY, c_name_chn VARCHAR(255), c_by_nh_code INT DEFAULT NULL,
+  CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
+    REFERENCES NIAN_HAO (c_nianhao_id) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+CREATE TABLE ALTNAME_DATA (
+  c_personid INT NOT NULL, c_alt_name_chn VARCHAR(255),
+  CONSTRAINT ALTNAME_DATA_ibfk_2 FOREIGN KEY (c_personid)
+    REFERENCES BIOG_MAIN (c_personid) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+CREATE TABLE KIN_DATA (
+  c_personid INT NOT NULL, c_kin_id INT NOT NULL,
+  CONSTRAINT KIN_DATA_ibfk_1 FOREIGN KEY (c_personid)
+    REFERENCES BIOG_MAIN (c_personid) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB;
+
+INSERT INTO NIAN_HAO VALUES (630, '至元');
+INSERT INTO BIOG_MAIN VALUES (1,'張三',630),(2,'李四',630),(3,'王五',NULL);
+INSERT INTO ALTNAME_DATA VALUES (1,'張三別名A'),(1,'張三別名B'),(2,'李四別名'),(3,'王五別名');
+INSERT INTO KIN_DATA VALUES (1,3),(2,3),(3,1);
+
+DELETE FROM NIAN_HAO WHERE c_nianhao_id = 630;
+SELECT ROW_COUNT();          -- → 1（應用層只看得到這個數字）
+SELECT COUNT(*) FROM BIOG_MAIN;    -- 3 → 1（張三、李四整列消失）
+SELECT COUNT(*) FROM ALTNAME_DATA; -- 4 → 1
+SELECT COUNT(*) FROM KIN_DATA;     -- 3 → 1
+```
+
+實測結果：一條 DELETE，回報 1 列，實刪 8 列，級聯傳遞兩層（年號→人物→人物的別名/親屬）。
+第二層的刪除**不存在任何 DELETE 語句**，應用層（audit、operations、Eloquent observer）無從掛鉤。
+註：真實 schema 中 `KIN_DATA.c_kin_id` 亦有 CASCADE 外鍵指向 `BIOG_MAIN`，故**其他人物**記錄中
+「親屬為被刪者」的列也會連帶消失（本實驗僅建單邊外鍵，故王五指向張三的親屬列倖存）——實際擴散比實驗更廣。

--- a/docs/ON_DELETE_CASCADE_RISK.md
+++ b/docs/ON_DELETE_CASCADE_RISK.md
@@ -1,5 +1,7 @@
 # 「物理刪除 × ON DELETE CASCADE」是唯一不可接受的組合
 
+> English version: [ON_DELETE_CASCADE_RISK.en.md](./ON_DELETE_CASCADE_RISK.en.md)
+>
 > 撰寫日期：2026-07-07 ｜ 依據：`database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
 >
 > **本文目的**：說明本專案 schema 目前處於「物理刪除 × 級聯刪除」這個對資料資產最危險的組合中，
@@ -50,6 +52,14 @@
 特別注意：**`BIOG_MAIN` 自身有 13 個指向詞表的 CASCADE 外鍵**（`BIOG_MAIN_ibfk_1`–`13`，指向 `NIAN_HAO`×4、`YEAR_RANGE_CODES`×3、`GANZHI_CODES`×2、`DYNASTIES`、`CHORONYM_CODES`、`ETHNICITY_TRIBE_CODES`、`HOUSEHOLD_STATUS_CODES`）。
 
 同時，應用層對詞表的「刪除」目前是**物理 DELETE**：`/codes` 編輯器與 `AdminBatchLoadBookTitlesController::deleteBatch` 硬刪 `TEXT_CODES`，刪除前不做引用檢查——矩陣左上角的兩個條件同時成立。
+
+### 1.1 歷史背景：這是刻意的設計取捨，而非疏忽
+
+「物理刪除 × CASCADE」在原本的設計中是有意識的省時設置：CBDB 的代碼表並非逐條經過字典式考證，而是在**批量建設、允許一定錯誤率**的前提下累積起來的，「物理刪除 × CASCADE」因此成為清理 codes 連同其引用資料的低成本手段。本文不否定這個取捨在當時的合理性，而是指出取捨賴以成立的成本結構已經改變：
+
+- 在 agent 協助下，把外鍵機制承擔的清理邏輯搬進應用層代碼（引用檢查、合併＋重定向、顯式級聯）的開發時間成本已經可控；
+- 專案的可追溯目標正從**離散可追溯**（發佈離散的版本，版本之間的差異不可考）走向**線性可追溯**（operations / audit_log 記全每個版本差異之間的 logs；Phase B 已為 `/codes` 直寫路徑補上 audit_log）。DB 級聯是這條線上的結構性盲區（§3.3），不移除它，線性可追溯在機制上就無法成立；
+- 線上系統與離線發佈版（Michael 的 Access）在結構上分離，由匯出功能保證發佈版與 Access 架構一致（§5.3），因此線上 schema 的演進（如加 `c_deprecated` 欄）不受發佈格式束縛。
 
 ## 2. 一個具體的災難場景
 
@@ -206,7 +216,7 @@ RESTRICT 的失敗模式是「煩人但無害」（fail-closed），CASCADE 的�
 
 **Step 2：應用層補課（每項獨立 PR）**
 1. **引用檢查服務**：輸入（詞表, 主鍵值），輸出各引用表的計數與樣例——資料來源就是 Step 0 的外鍵清單，可直接由 `information_schema` 驅動，不必手工維護映射。
-2. **詞表生命週期**：詞表加 `c_deprecated` 狀態欄（僅詞表、非資料表；schema 與離線發佈版的對齊需確認）；選擇器/搜尋端點過濾退役詞條，顯示 JOIN 不過濾；`/codes` 的「刪除」改為「退役」，物理刪除僅在引用數為零時開放；廢除 `deleteBatch` 刪 `operations` 紀錄的行為。
+2. **詞表生命週期**：詞表加 `c_deprecated` 狀態欄（僅詞表、非資料表；**新增欄位須先經 executive committee 討論，離線發佈版的對齊規則與匯出更新見 §5.3，匯出更新與本欄位同一里程碑交付**）；選擇器/搜尋端點過濾退役詞條，顯示 JOIN 不過濾；`/codes` 的「刪除」改為「退役」，物理刪除僅在引用數為零時開放；廢除 `deleteBatch` 刪 `operations` 紀錄的行為。
 3. **合併＋重定向工具**：把 A 詞條的全部引用批次改指到 B 詞條，受審計、可回退，A 退役留重定向——這也是日後「人物合併」的同構地基。
 4. **顯式級聯刪除服務**：覆蓋 Step 1 標記為「組合」的少數關係（參考 `OfficePostingRepository` 現行寫法，補齊快照與同 operation_id 分組）。
 
@@ -248,6 +258,27 @@ ALTER TABLE ALTNAME_DATA
 | 5 長期項 | 各自立項 | — | — |
 
 整條路線沒有一步是「大爆炸」：應用層 PR 各自獨立，約束翻轉分批且逐批可退。完成後系統落在矩陣的 ④（軟刪除 × RESTRICT）：正常路徑上「刪除」不再發生，異常路徑上代價被封頂為一個報錯——「任何操作皆可回退」才第一次在機制上成為可能。在此之前，DB 級聯這個天窗會讓任何審計/撤銷工程的保證落空，這也是為什麼本文的結論是：**打破「物理刪除 × CASCADE」組合應排在所有資料安全工程之前。**
+
+### 5.3 離線發佈（SQLite / Access）與治理對齊
+
+線上系統與離線發佈版在結構上分離，由匯出功能保證發佈版與 Access 架構一致。`c_deprecated` 落地時，離線發佈有兩件事必須同步處理：
+
+**(1) 匯出排除規則——deprecated codes 與人物軟刪除結構不同，不能照搬整批排除。**
+
+已有的先例是 BIOG_MAIN 人物軟刪除的匯出排除（commit 8930d73，見 `docs/SQLITE_DATA_RELEASE.md`）：已刪除人物是**整組排除**——人物列、其所有資料列、他人紀錄中提及它的關係列（經 `information_schema` 動態偵測 FK 欄位）一起消失，匯出檔中不留懸掛引用；`information_schema` 查詢失敗時 fail-closed 中止整個匯出，配專屬回歸測試。這個**模式**（過濾集中在 query 建構處、fail-closed、回歸測試）值得沿用。
+
+但 deprecate 的**語義**與人物軟刪除相反：既有引用保留、只禁止新引用。引用某個 deprecated code 的資料列都是正常人物的正常資料，不能連坐排除；若把 deprecated codes 整批從匯出剔除，這些資料列會帶著懸掛外鍵值（指向 Access/SQLite 中不存在的 code），Access 端 JOIN 直接漏資料。因此匯出規則按引用數分兩檔：
+
+| deprecated code 的引用數 | 匯出行為 | 說明 |
+|---|---|---|
+| **零** | 從匯出排除 | 對 Access 而言等同於「已刪除」，與現行認知一致 |
+| **仍有引用** | 照常匯出為普通 code 列（**不帶 `c_deprecated` 欄**） | 對 Access 完全透明、不產生懸掛引用；治理上由合併＋重定向（Step 2-3）逐步把引用遷走，引用歸零後自然從下一個發佈版消失 |
+
+匯出功能的更新與 `c_deprecated` 欄位**放在同一里程碑交付**，不允許出現「欄位上了、匯出還沒跟上」的窗口。
+
+**(2) 治理前提——新增欄位須經 executive committee 討論。**
+
+線上系統新增欄位一律需經 executive committee 討論。由於 `c_deprecated` 只存在於線上系統、依上表規則**不匯出到 Access**，對 committee 而言這不是共享 schema 的變更，而是**詞表生命週期政策的變更**（「刪除」變為「退役／合併」，以及發佈版本的收錄規則）。提交討論時準備一頁說明：`c_deprecated` 的語義、上述匯出規則、以及發佈的 Access 版本 schema 保持不變。此討論是 Step 2 里程碑 2 的前置條件。
 
 ---
 

--- a/docs/ON_DELETE_CASCADE_RISK.md
+++ b/docs/ON_DELETE_CASCADE_RISK.md
@@ -2,11 +2,19 @@
 
 > English version: [ON_DELETE_CASCADE_RISK.en.md](./ON_DELETE_CASCADE_RISK.en.md)
 >
-> 撰寫日期：2026-07-07 ｜ 修訂：2026-07-16（依團隊決議新增 §6 實施方案設計）｜ 依據：`database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
+> 撰寫日期：2026-07-07 ｜ 修訂：2026-07-16（依團隊決議新增 §6 實施方案設計）；2026-07-28（依 Phase 1
+> 分批翻轉的 MariaDB 10.3 實測結果回補 §6.1 執行細節，見下方修正說明）｜ 依據：
+> `database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
 >
 > **本文目的**：說明本專案 schema 目前處於「物理刪除 × 級聯刪除」這個對資料資產最危險的組合中，
 > 解釋其原理性風險（這在資料庫應用領域本應是共識）；並給出破局矩陣——**去級聯（RESTRICT）與
 > 軟刪除（deprecate）各自解決什麼、為何兩者互補而非二選一**——以及可執行的改造路線圖。
+>
+> **現況（2026-07-28）**：本文 §6.1 Phase 1 已分批執行至批次 4（詞表入邊全數翻畢，僅剩
+> `BIOG_MAIN`／`POSTING_DATA`／`POSSESSION_DATA` 共 28 條入邊，應用層前置已完成、進入觀察期），
+> 每批機制細節、10.3 實測結果與逐批 rollout log 見
+> [docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md](./CASCADE_TO_RESTRICT_MIGRATION_NOTES.md)——
+> 該文件是本文 §6.1 的執行紀錄與現行權威來源，兩文所述執行細節如有出入，以該文件為準。
 >
 > 文中所有數字皆可用附錄 A 的指令重跑驗證。
 
@@ -316,19 +324,27 @@ ALTER TABLE ALTNAME_DATA
 **Phase 1 翻轉的執行細節**（細化 §5.1 Step 3）——分批單位＝被引用表，順序按 §1 入邊數：`NIAN_HAO`(24) → `YEAR_RANGE_CODES`(23) → `TEXT_CODES`(22) → `ADDR_CODES`(11) → `GANZHI_CODES`/`DYNASTIES`(各 9) → 其餘詞表 → 最後 `BIOG_MAIN` 的 25 條入邊（配套是顯式級聯刪除服務與既有人物軟刪除，§4.4）。每批流程：
 
 1. **前置**：墊片就緒、staging 演練通過；
-2. **執行**（維護窗口）：MariaDB 不支援原地修改外鍵行為，同一 `ALTER` 內 DROP＋ADD；`foreign_key_checks=0` 時 ADD FK 不掃描既有資料（一致性由原約束保證），`ALTER` 近乎即時，僅短暫 metadata lock，先在 staging 對最大表量測：
+2. **執行**（維護窗口）：MariaDB 不支援原地修改外鍵行為，**兩條獨立 `ALTER`**（先 DROP 再 ADD，
+   **修正**：同名約束若寫在同一條 `ALTER` 內 DROP＋ADD，MariaDB 10.3 實測回
+   `ERROR 1826 (HY000): Duplicate FOREIGN KEY constraint name`，拆成兩條才成功；prod 版本
+   究竟 10.3 或 10.11 待確認，但兩條獨立 `ALTER` 在兩版皆安全，一律採用，細節與實測見
+   `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §2）；`foreign_key_checks=0` 時 ADD FK 不掃描既有資料
+   （一致性由原約束保證），`ALTER` 近乎即時，僅短暫 metadata lock，先在 staging 對最大表量測：
 
    ```sql
    SET SESSION foreign_key_checks = 0;
+   ALTER TABLE BIOG_MAIN DROP FOREIGN KEY BIOG_MAIN_ibfk_2;
    ALTER TABLE BIOG_MAIN
-     DROP FOREIGN KEY BIOG_MAIN_ibfk_2,
      ADD CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
          REFERENCES NIAN_HAO (c_nianhao_id)
          ON DELETE RESTRICT ON UPDATE CASCADE;   -- UPDATE 行為本階段不動
    SET SESSION foreign_key_checks = 1;
    ```
 
-3. **驗證**：附錄 B 查詢確認該批 `DELETE_RULE` 全為 `RESTRICT`；抽測「刪被引用詞條 → 擋下且資料一列不少」；
+3. **驗證**：附錄 B 查詢確認該批 `DELETE_RULE` 全為 `RESTRICT`（**修正**：MariaDB 10.3 上
+   `information_schema.REFERENTIAL_CONSTRAINTS.DELETE_RULE` 會把顯式寫入的 `RESTRICT` 顯示為
+   `NO ACTION`——InnoDB 中兩者等價，故驗證條件應為 `DELETE_RULE IN ('RESTRICT','NO ACTION')`，
+   或直接驗行為）；抽測「刪被引用詞條 → 擋下且資料一列不少」；
 4. **觀察期**（1–2 週再下一批）：監控 1451（`Cannot delete or update a parent row`）——出現＝漏網硬刪路徑，fail-closed 零損失，修應用層即可；
 5. **回滾預案**：反向 `ALTER` 改回 CASCADE，單條語句、無資料風險。
 

--- a/docs/ON_DELETE_CASCADE_RISK.md
+++ b/docs/ON_DELETE_CASCADE_RISK.md
@@ -3,15 +3,21 @@
 > English version: [ON_DELETE_CASCADE_RISK.en.md](./ON_DELETE_CASCADE_RISK.en.md)
 >
 > 撰寫日期：2026-07-07 ｜ 修訂：2026-07-16（依團隊決議新增 §6 實施方案設計）；2026-07-28（依 Phase 1
-> 分批翻轉的 MariaDB 10.3 實測結果回補 §6.1 執行細節，見下方修正說明）｜ 依據：
+> 分批翻轉的 MariaDB 10.3 實測結果回補 §6.1 執行細節，見下方修正說明）；2026-08-03（**Phase 1 全部
+> 完成**，回補現況與數字修正）｜ 依據：
 > `database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
 >
 > **本文目的**：說明本專案 schema 目前處於「物理刪除 × 級聯刪除」這個對資料資產最危險的組合中，
 > 解釋其原理性風險（這在資料庫應用領域本應是共識）；並給出破局矩陣——**去級聯（RESTRICT）與
 > 軟刪除（deprecate）各自解決什麼、為何兩者互補而非二選一**——以及可執行的改造路線圖。
 >
-> **現況（2026-07-28）**：本文 §6.1 Phase 1 已分批執行至批次 4（詞表入邊全數翻畢，僅剩
-> `BIOG_MAIN`／`POSTING_DATA`／`POSSESSION_DATA` 共 28 條入邊，應用層前置已完成、進入觀察期），
+> **現況（2026-08-03）：§6.1 Phase 1 已全部完成。** 五個批次（66＋32＋52＋10＋28＝188 條）依序
+> 翻轉完畢，**全庫 `ON DELETE CASCADE` 歸零**——實測 `CASCADE 0`／`NO ACTION 188`／`RESTRICT 1`／
+> `SET NULL 1`（共 190 條；唯一的 `SET NULL` 是本來就正確的 `fk_merged_person_source`）。本文
+> §2 的災難場景在現行 schema 上**已不可能發生**：刪被引用的父列一律被 DB 以 1451 擋下（fail-closed）。
+> 矩陣位置因此由 ①（物理刪除 × CASCADE）落到 ②（物理刪除 × RESTRICT）；④ 仍待 Phase 2／3。
+> 另：prod 版本已查明為 **MariaDB 10.11.14**（先前記述的 10.3 有誤），全部批次是在較嚴格的 10.3
+> 上驗的，10.3 通過即 10.11 通過，已落地的 migration 不受影響。
 > 每批機制細節、10.3 實測結果與逐批 rollout log 見
 > [docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md](./CASCADE_TO_RESTRICT_MIGRATION_NOTES.md)——
 > 該文件是本文 §6.1 的執行紀錄與現行權威來源，兩文所述執行細節如有出入，以該文件為準。
@@ -22,13 +28,13 @@
 
 ## TL;DR
 
-1. 本專案 schema 有 **186 個 `ON DELETE CASCADE` 外鍵**（另有 187 個 `ON UPDATE CASCADE`），遍布所有核心表，其中絕大多數掛在「傳記資料 → 詞表（code 表）」的**引用關係**上；而應用層對詞表執行的是**物理刪除**（且多數路徑無引用檢查）。
+1. 本專案 schema **原有 186 個 `ON DELETE CASCADE` 外鍵**（baseline；連同後續 migration 新增者共 188 條，另有 190 個 `ON UPDATE CASCADE`）——**截至 2026-08-03 已全數翻為 `RESTRICT`**（見上方現況；以下描述的是翻轉前的狀態與其原理，仍是理解 Phase 2／3 必要性的基礎），遍布所有核心表，其中絕大多數掛在「傳記資料 → 詞表（code 表）」的**引用關係**上；而應用層對詞表執行的是**物理刪除**（且多數路徑無引用檢查）。
 2. 這個組合的後果：**刪除一筆詞表記錄（一個年號、一個朝代、一筆書名），資料庫會靜默連帶刪除所有引用它的傳記資料**——包括 `BIOG_MAIN` 的人物本身，並繼續向下刪光這些人物的全部記錄。應用層的審計（audit_log）、操作紀錄（operations）、提案審核、回退機制**全部無感知**。
 3. 破局矩陣（本文核心論點）：
 
    | | `ON DELETE CASCADE` | `RESTRICT` |
    |---|---|---|
-   | **物理刪除** | **現狀：災難**（一條 DELETE 靜默毀庫） | 可接受（配合引用檢查與遷移工具） |
+   | **物理刪除** | ~~現狀~~**（翻轉前）：災難**（一條 DELETE 靜默毀庫） | **現況（2026-08-03 起）**：可接受（配合引用檢查與遷移工具） |
    | **軟刪除 / deprecate** | 帶電的陷阱（僅靠約定護體，違約即災難） | **目標形態** |
 
    必須至少打破一個因子；兩個都打破才是完整方案。**去級聯是保險絲（出錯時的後果封頂），軟刪除是產品語義（正常路徑不再發生刪除）——層次不同，互補而非替代。**
@@ -228,7 +234,7 @@ RESTRICT 的失敗模式是「煩人但無害」（fail-closed），CASCADE 的�
 3. **合併＋重定向工具**：把 A 詞條的全部引用批次改指到 B 詞條，受審計、可回退，A 退役留重定向——這也是日後「人物合併」的同構地基。
 4. **顯式級聯刪除服務**：覆蓋 Step 1 標記為「組合」的少數關係（參考 `OfficePostingRepository` 現行寫法，補齊快照與同 operation_id 分組）。
 
-**Step 3：翻轉約束（止血 migration，維護窗口執行）**
+**Step 3：翻轉約束（止血 migration，維護窗口執行）** ✅ **已完成（2026-07-20 ～ 2026-08-03，分五批）**
 按 Step 1 決策表批量執行：
 
 ```sql
@@ -244,14 +250,14 @@ ALTER TABLE ALTNAME_DATA
 - 優先順序按入邊數：`NIAN_HAO`(24)、`YEAR_RANGE_CODES`(23)、`TEXT_CODES`(22)、`ADDR_CODES`(11)、`GANZHI_CODES`/`DYNASTIES`(9)，再及其餘。
 - 同步更新 `import_cbdb_schema.php`（或新增 migration），保持新裝環境一致。
 
-**Step 4：驗證與回歸（與 Step 3 同窗口）**
+**Step 4：驗證與回歸（與 Step 3 同窗口）** ✅ **已隨各批完成**（每批在乾淨 MariaDB 10.3 容器上全量 migrate ＋行為抽測 ＋rollback 驗證，逐批結果見 `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §9–§9.4）
 - staging 上實測：刪一筆被引用的年號 → 期望應用層擋下（或 DB 報 1451 錯誤），傳記資料一列不少；退役一筆年號 → 選擇器消失、既有記錄顯示照常；
 - 核對 `information_schema`：目標批次內 `DELETE_RULE='CASCADE'` 歸零；
 - 生產執行後同樣核對＋抽測。
 
 **Step 5：收尾與長期項**
 - **孤兒掃描**排程：週期核對引用完整性作為縱深防禦（覆蓋約束缺口與歷史遺留）。
-- **`ON UPDATE CASCADE`（187 個）單獨立項**：改鍵傳播不銷毀資料、危險性低一級，但同樣繞過審計。長期應把「詞表改鍵」收為應用層受審計操作後改為 RESTRICT；在那之前先在文件與 UI 標明現狀。
+- **`ON UPDATE CASCADE`（實測 190 個）單獨立項**：改鍵傳播不銷毀資料、危險性低一級，但同樣繞過審計。長期應把「詞表改鍵」收為應用層受審計操作後改為 RESTRICT；在那之前先在文件與 UI 標明現狀。
 - **測試環境缺口單獨立項**：SQLite 無外鍵意味著 CI 永遠測不到本文所有行為，MariaDB 約束相關變更需要專門的整合驗證手段（如 CI 起 MariaDB 容器跑約束測試）。
 
 ### 5.2 工作量與依賴總覽
@@ -317,7 +323,7 @@ ALTER TABLE ALTNAME_DATA
 
 | 階段 | 內容 | 交付的價值 |
 |---|---|---|
-| **Phase 1：墊片＋翻約束** | 刪除路徑捕捉 1451 → 友好報錯「仍被 N 處引用」；刪除一律先寫 operations／audit_log ＋必填 reason；廢除 `deleteBatch` 刪 operations 紀錄；隨後分批翻轉（下述） | 災難場景解除；零引用刪除可復原；決議 1／2／3 全數滿足 |
+| **Phase 1：墊片＋翻約束** ✅ **已完成（2026-08-03）** | 刪除路徑捕捉 1451 → 友好報錯「仍被 N 處引用」；刪除一律先寫 operations／audit_log ＋必填 reason；廢除 `deleteBatch` 刪 operations 紀錄；隨後分批翻轉（下述） | 災難場景解除（全庫 CASCADE 歸零）；零引用刪除可復原；決議 1／2 已滿足，決議 3（必填 reason）隨 Phase 2 的刪除流程重建一併補齊 |
 | **Phase 2：合併＋重定向工具** | 受審計批次 re-point ＋清零後物理刪除 | 錯誤／重複詞條（大宗需求）有正規出口；亦是人物合併的同構地基 |
 | **Phase 3：lifecycle registry（按需）** | §6.2–§6.3 | 僅當「退役但保留引用」需求被實務驗證時啟動 |
 
@@ -327,7 +333,8 @@ ALTER TABLE ALTNAME_DATA
 2. **執行**（維護窗口）：MariaDB 不支援原地修改外鍵行為，**兩條獨立 `ALTER`**（先 DROP 再 ADD，
    **修正**：同名約束若寫在同一條 `ALTER` 內 DROP＋ADD，MariaDB 10.3 實測回
    `ERROR 1826 (HY000): Duplicate FOREIGN KEY constraint name`，拆成兩條才成功；prod 版本
-   究竟 10.3 或 10.11 待確認，但兩條獨立 `ALTER` 在兩版皆安全，一律採用，細節與實測見
+   已於 2026-08-03 查明為 **10.11.14**（全部批次仍是在較嚴格的 10.3 上驗的），兩條獨立
+   `ALTER` 在兩版皆安全，一律採用，細節與實測見
    `CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §2）；`foreign_key_checks=0` 時 ADD FK 不掃描既有資料
    （一致性由原約束保證），`ALTER` 近乎即時，僅短暫 metadata lock，先在 staging 對最大表量測：
 
@@ -348,7 +355,7 @@ ALTER TABLE ALTNAME_DATA
 4. **觀察期**（1–2 週再下一批）：監控 1451（`Cannot delete or update a parent row`）——出現＝漏網硬刪路徑，fail-closed 零損失，修應用層即可；
 5. **回滾預案**：反向 `ALTER` 改回 CASCADE，單條語句、無資料風險。
 
-其他要點：RESTRICT 與 NO ACTION 在 InnoDB 等價，統一顯式寫 `RESTRICT`；每批同步提交 migration（新裝環境一致）；SQLite 測試環境無外鍵，驗證必須在 MariaDB 上做（CI 起 MariaDB 容器為長期項，§5 Step 5）；**`operations` 表自身也有一條 CASCADE 指向 `BIOG_MAIN`（人物被級聯刪時操作紀錄一併消失，審計軌跡不設防），納入 `BIOG_MAIN` 批次一併翻轉**；`ON UPDATE CASCADE`（187 條）本階段保留（§5 Step 5 單獨立項）。
+其他要點：RESTRICT 與 NO ACTION 在 InnoDB 等價，統一顯式寫 `RESTRICT`；每批同步提交 migration（新裝環境一致）；SQLite 測試環境無外鍵，驗證必須在 MariaDB 上做（CI 起 MariaDB 容器為長期項，§5 Step 5）；**`operations` 表自身也有一條 CASCADE 指向 `BIOG_MAIN`（人物被級聯刪時操作紀錄一併消失，審計軌跡不設防），納入 `BIOG_MAIN` 批次一併翻轉**；`ON UPDATE CASCADE`（實測 190 條）本階段保留（§5 Step 5 單獨立項）。
 
 ### 6.2 第三階段設計研究：軟刪除狀態怎麼存
 

--- a/docs/ON_DELETE_CASCADE_RISK.md
+++ b/docs/ON_DELETE_CASCADE_RISK.md
@@ -2,7 +2,7 @@
 
 > English version: [ON_DELETE_CASCADE_RISK.en.md](./ON_DELETE_CASCADE_RISK.en.md)
 >
-> 撰寫日期：2026-07-07 ｜ 依據：`database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
+> 撰寫日期：2026-07-07 ｜ 修訂：2026-07-16（依團隊決議新增 §6 實施方案設計）｜ 依據：`database/migrations/2025_01_01_000000_import_cbdb_schema.php`（生產 MariaDB schema 的入庫來源）
 >
 > **本文目的**：說明本專案 schema 目前處於「物理刪除 × 級聯刪除」這個對資料資產最危險的組合中，
 > 解釋其原理性風險（這在資料庫應用領域本應是共識）；並給出破局矩陣——**去級聯（RESTRICT）與
@@ -24,7 +24,7 @@
    | **軟刪除 / deprecate** | 帶電的陷阱（僅靠約定護體，違約即災難） | **目標形態** |
 
    必須至少打破一個因子；兩個都打破才是完整方案。**去級聯是保險絲（出錯時的後果封頂），軟刪除是產品語義（正常路徑不再發生刪除）——層次不同，互補而非替代。**
-4. 改造路徑：先翻約束（一個 migration，成本最低的止血步），再上詞表生命週期（deprecate 為主、重複合併為輔、零引用才允許真刪）。兩步互相成就：全面軟刪除後沒有合法硬刪流程，翻 RESTRICT 阻力為零；翻了 RESTRICT 後，軟刪除約定被違反時有兜底。詳見 §5。
+4. 改造路徑：先翻約束（一個 migration，成本最低的止血步），再上詞表生命週期（deprecate 為主、重複合併為輔、零引用才允許真刪）。兩步互相成就：全面軟刪除後沒有合法硬刪流程，翻 RESTRICT 阻力為零；翻了 RESTRICT 後，軟刪除約定被違反時有兜底。詳見 §5；**2026-07 團隊決議後的實施設計見 §6（三階段：RESTRICT 先行、合併工具次之、生命週期 registry 按需後置）**。
 
 ---
 
@@ -216,7 +216,7 @@ RESTRICT 的失敗模式是「煩人但無害」（fail-closed），CASCADE 的�
 
 **Step 2：應用層補課（每項獨立 PR）**
 1. **引用檢查服務**：輸入（詞表, 主鍵值），輸出各引用表的計數與樣例——資料來源就是 Step 0 的外鍵清單，可直接由 `information_schema` 驅動，不必手工維護映射。
-2. **詞表生命週期**：詞表加 `c_deprecated` 狀態欄（僅詞表、非資料表；**新增欄位須先經 executive committee 討論，離線發佈版的對齊規則與匯出更新見 §5.3，匯出更新與本欄位同一里程碑交付**）；選擇器/搜尋端點過濾退役詞條，顯示 JOIN 不過濾；`/codes` 的「刪除」改為「退役」，物理刪除僅在引用數為零時開放；廢除 `deleteBatch` 刪 `operations` 紀錄的行為。
+2. **詞表生命週期**（**依 2026-07 決議整項降為按需後置，見 §6.1 Phase 3**；若啟動，儲存採 §6.3 的集中式生命週期側表，不在詞表加欄）：選擇器/搜尋端點過濾退役詞條，顯示 JOIN 不過濾；`/codes` 的「刪除」改為「退役」，物理刪除僅在引用數為零時開放。廢除 `deleteBatch` 刪 `operations` 紀錄的行為則**提前至 Phase 1**（§6.1）。離線發佈對齊規則見 §5.3 與 §6.3；executive committee 討論仍為前置條件（議題見 §6.4）。
 3. **合併＋重定向工具**：把 A 詞條的全部引用批次改指到 B 詞條，受審計、可回退，A 退役留重定向——這也是日後「人物合併」的同構地基。
 4. **顯式級聯刪除服務**：覆蓋 Step 1 標記為「組合」的少數關係（參考 `OfficePostingRepository` 現行寫法，補齊快照與同 operation_id 分組）。
 
@@ -261,7 +261,9 @@ ALTER TABLE ALTNAME_DATA
 
 ### 5.3 離線發佈（SQLite / Access）與治理對齊
 
-線上系統與離線發佈版在結構上分離，由匯出功能保證發佈版與 Access 架構一致。`c_deprecated` 落地時，離線發佈有兩件事必須同步處理：
+> **2026-07 更新**：本節撰寫時假設退役狀態以詞表欄位 `c_deprecated` 承載。依團隊決議與 §6 的設計，退役狀態改存於**純內部的生命週期側表**、共享概念表不加任何欄位，因此本節 (1) 的「匯出不帶 `c_deprecated` 欄」自動達成、(2) 的討論主題由 schema 變更轉為政策變更。**按引用數分兩檔的匯出規則仍然有效**（更新版見 §6.3），本節保留作為該規則的完整論證。
+
+線上系統與離線發佈版在結構上分離，由匯出功能保證發佈版與 Access 架構一致。退役狀態落地時，離線發佈有兩件事必須同步處理：
 
 **(1) 匯出排除規則——deprecated codes 與人物軟刪除結構不同，不能照搬整批排除。**
 
@@ -279,6 +281,108 @@ ALTER TABLE ALTNAME_DATA
 **(2) 治理前提——新增欄位須經 executive committee 討論。**
 
 線上系統新增欄位一律需經 executive committee 討論。由於 `c_deprecated` 只存在於線上系統、依上表規則**不匯出到 Access**，對 committee 而言這不是共享 schema 的變更，而是**詞表生命週期政策的變更**（「刪除」變為「退役／合併」，以及發佈版本的收錄規則）。提交討論時準備一頁說明：`c_deprecated` 的語義、上述匯出規則、以及發佈的 Access 版本 schema 保持不變。此討論是 Step 2 里程碑 2 的前置條件。
+
+## 6. 實施方案設計（依 2026-07 團隊決議）
+
+> 撰寫於 2026-07-16。團隊已就方向達成決議（§6.0）。本節給出落地方案：**三階段路線（§6.1）——RESTRICT 先行、合併工具次之、生命週期 registry 按需後置**；以及第三階段的設計研究（§6.2 儲存方案比較、§6.3 registry 草案與匯出規則）。本節與 §5 有出入之處，以本節為準（差異清單見 §6.4）。
+
+### 6.0 團隊決議（本節設計的邊界條件）
+
+1. **逐步移除 `ON DELETE CASCADE`**：在各資料庫系統中以其相應的 schema 語法或管理工具完成去級聯。
+2. **終端使用者拿到的資料庫 schema 與行為保持不變**：不新增欄位，也不出現「本應被刪除」的多餘資料列。
+3. **「刪除原因」必須以可回查的形式保存**，日後能查明一筆記錄為何消失。
+4. **設計原則：內部維護模型（internal maintenance model）與公開資料模型（public data model）分離。**
+5. **線上編輯系統必須包含審計、恢復、歷史重建所需的額外 metadata**；發佈的 Access 與 SQLite 版本繼續向終端使用者呈現並匯出同一個概念模型。
+
+### 6.1 三階段路線：RESTRICT 先行，deprecate 按需後置
+
+單獨檢視 RESTRICT 翻轉，它獨力解除絕大部分顧慮：
+
+- **資料安全**：刪仍被引用的詞條被 DB 以 1451 擋下（fail-closed），矩陣從 ① 直接落到 ②，災難場景不復存在；
+- **可恢復性**：能刪除成功的只剩**零引用列**；刪除路徑刪前寫 audit_log（old_data 全影像）＋ operations，復原即重插一行——被刪列本無人引用，重插無外鍵障礙；
+- **刪除原因（決議 3）**：最小落點是刪除的 operations／audit 紀錄帶必填 reason，不需要新表；
+- **錯誤／重複詞條**（觸發「刪詞條」需求的大宗，§4.2）：走「合併＋重定向 → 引用清零 → 物理刪除（帶 reason）」即有完整解法，全程不需要 deprecate 狀態。
+
+**deprecate 的獨有增量因此收窄到一種場景：「退役但保留既有引用」**——既有引用史實正確、不應改指，但禁止新引用（authority-file 意義的真退役），附帶「選擇器立即乾淨、引用慢慢清」的治理時序優勢。此需求在 CBDB 實務中的頻率是經驗問題，**未經驗證前不建**；registry 是純增量機制（不動共享表、不改前兩階段任何產出），後置零遷移成本。
+
+這也修正 §5.1「應用層先行、約束殿後」的順序論證：避免行為斷崖只需薄墊片，不需先完成整個 Step 2。
+
+| 階段 | 內容 | 交付的價值 |
+|---|---|---|
+| **Phase 1：墊片＋翻約束** | 刪除路徑捕捉 1451 → 友好報錯「仍被 N 處引用」；刪除一律先寫 operations／audit_log ＋必填 reason；廢除 `deleteBatch` 刪 operations 紀錄；隨後分批翻轉（下述） | 災難場景解除；零引用刪除可復原；決議 1／2／3 全數滿足 |
+| **Phase 2：合併＋重定向工具** | 受審計批次 re-point ＋清零後物理刪除 | 錯誤／重複詞條（大宗需求）有正規出口；亦是人物合併的同構地基 |
+| **Phase 3：lifecycle registry（按需）** | §6.2–§6.3 | 僅當「退役但保留引用」需求被實務驗證時啟動 |
+
+**Phase 1 翻轉的執行細節**（細化 §5.1 Step 3）——分批單位＝被引用表，順序按 §1 入邊數：`NIAN_HAO`(24) → `YEAR_RANGE_CODES`(23) → `TEXT_CODES`(22) → `ADDR_CODES`(11) → `GANZHI_CODES`/`DYNASTIES`(各 9) → 其餘詞表 → 最後 `BIOG_MAIN` 的 25 條入邊（配套是顯式級聯刪除服務與既有人物軟刪除，§4.4）。每批流程：
+
+1. **前置**：墊片就緒、staging 演練通過；
+2. **執行**（維護窗口）：MariaDB 不支援原地修改外鍵行為，同一 `ALTER` 內 DROP＋ADD；`foreign_key_checks=0` 時 ADD FK 不掃描既有資料（一致性由原約束保證），`ALTER` 近乎即時，僅短暫 metadata lock，先在 staging 對最大表量測：
+
+   ```sql
+   SET SESSION foreign_key_checks = 0;
+   ALTER TABLE BIOG_MAIN
+     DROP FOREIGN KEY BIOG_MAIN_ibfk_2,
+     ADD CONSTRAINT BIOG_MAIN_ibfk_2 FOREIGN KEY (c_by_nh_code)
+         REFERENCES NIAN_HAO (c_nianhao_id)
+         ON DELETE RESTRICT ON UPDATE CASCADE;   -- UPDATE 行為本階段不動
+   SET SESSION foreign_key_checks = 1;
+   ```
+
+3. **驗證**：附錄 B 查詢確認該批 `DELETE_RULE` 全為 `RESTRICT`；抽測「刪被引用詞條 → 擋下且資料一列不少」；
+4. **觀察期**（1–2 週再下一批）：監控 1451（`Cannot delete or update a parent row`）——出現＝漏網硬刪路徑，fail-closed 零損失，修應用層即可；
+5. **回滾預案**：反向 `ALTER` 改回 CASCADE，單條語句、無資料風險。
+
+其他要點：RESTRICT 與 NO ACTION 在 InnoDB 等價，統一顯式寫 `RESTRICT`；每批同步提交 migration（新裝環境一致）；SQLite 測試環境無外鍵，驗證必須在 MariaDB 上做（CI 起 MariaDB 容器為長期項，§5 Step 5）；**`operations` 表自身也有一條 CASCADE 指向 `BIOG_MAIN`（人物被級聯刪時操作紀錄一併消失，審計軌跡不設防），納入 `BIOG_MAIN` 批次一併翻轉**；`ON UPDATE CASCADE`（187 條）本階段保留（§5 Step 5 單獨立項）。
+
+### 6.2 第三階段設計研究：軟刪除狀態怎麼存
+
+需求（來自決議與 §4）：**R1** 狀態標記供選用端點過濾（顯示 JOIN 不過濾）；**R2** 原因；**R3** when/who、串回 operations/audit_log；**R4** 合併重定向指標；**R5** 公開模型不變；**R6** 相容 Query Builder＋複合主鍵架構（Eloquent SoftDeletes 大多不可用）。
+
+| 方案 | 作法 | 評估 |
+|---|---|---|
+| **A 名稱標記** | 借用資料欄寫魔法字串（現行 `BIOG_MAIN.c_name_chn='<待删除>'`） | 零 schema 變更，但佔用**展示欄位**（引用處顯示垃圾）、R2/R3/R4 全存不下、無法索引。定為歷史遺留，不推廣；長期把 BIOG_MAIN 遷到 E |
+| **B 布林欄** | 各詞表加 `c_deprecated` | 過濾最簡單，但 R2–R4 缺（還得另建機制）；每詞表一個 migration；線上與發佈 schema 出現欄位差異，匯出須逐表剝欄；共享表加欄須逐表過 committee |
+| **C 時間戳欄** | 各詞表加 `c_deprecated_at`，NULL=有效 | 比 B 多存 when，其餘缺點同 B；Laravel SoftDeletes 慣例紅利在本專案落空（R6）；`deleted_at` 命名誤導——詞條是退役非刪除 |
+| **D 完整狀態欄組** | 各詞表加 status/reason/redirect 欄 | R2–R4 可滿足，但 schema 侵入與匯出剝除面最大；when/who 與 audit_log 職能重疊 |
+| **E 集中式側表（推薦）** | 一張純內部表登記任何表任何列的狀態 | **R5 由構造保證**：共享表零變更、匯出零剝除、committee 議題降為純政策；R2–R4 為本表欄位；定位模式 `(table_name, row_pk)` 與 audit_log 同構（R6） |
+
+**E 的三個代價與評估**：
+
+1. **過濾成本**：實際受影響面小——需要過濾的只有**選用面**（選擇器／autocomplete／新引用寫入驗證，個位數端點）；顯示 JOIN、傳記資料查詢、Query Playground 研究型 SQL 按設計**不過濾**（deprecated 而仍被引用的詞條必須可見）。deprecate 鍵集是 10⁰–10³ 量級的低頻治理事件，`LifecycleService` 快取後過濾退化為 `WHERE pk NOT IN (短清單)`，成本與 B/C 的 `WHERE c_deprecated=0` 同量級，不需真 JOIN。
+2. **無真外鍵**：registry 指向已消失列——無害，孤兒掃描清理；目標列**改鍵**（187 條 `ON UPDATE CASCADE`）會讓標記靜默脫鉤（fail-open）——改鍵工具必須同一交易更新 registry，並納入孤兒掃描核對。
+3. **可發現性**：手寫 raw SQL 在詞表裡看不見退役狀態。屬**二階問題**：危險操作（DELETE）由 RESTRICT 在 DB 層兜底，漏看最壞是分析輕微失真或給退役詞條添新引用（可用合併工具修復），不丟資料；且依決議 2/5，發佈版在**任何方案**下都不帶退役狀態，差距僅存於內部使用者。緩解：內部 view（不動基表、不匯出）＋一律經 `LifecycleService`（新端點漏接 service 與 B/C 忘寫 `WHERE` 是同一個工程紀律問題，靠 code review 與回歸測試）。
+
+**為何不借用既有 `audit_log`／`operations`**：兩者是**事件日誌**（回答「發生過什麼」），registry 是**現行狀態**（回答「現在什麼狀態」）。從日誌推導當前 deprecated 鍵集須對每鍵聚合最新事件，恰是最貴的掃描，registry 就是該推導的物化；deprecate 不改動目標列任何欄位，audit_log（契約為記錄列的 old/new 影像）無自然條目可記，reason／redirect 亦無欄位可放；operations 是人物中心的工作流佇列（`c_personid` NOT NULL，且該外鍵本身是 CASCADE）。registry 每列帶 `operation_id` 串回日誌——歷史仍由舊機制承載，並非重複建設。部分例外是墓碑（`deleted`）：物理刪除本就在 audit_log 留有 DELETE 事件與 old_data，缺的只是 reason——這正是 Phase 1 不需要 registry 的原因；registry 的必要性來自 deprecated／merged 的現行狀態。
+
+### 6.3 registry 草案與匯出規則（Phase 3 啟動時適用）
+
+`record_lifecycle`（草案，命名沿用 `audit_log` 慣例）：
+
+| 欄位 | 型別 | 說明 |
+|---|---|---|
+| `id` | bigint PK | — |
+| `table_name` | varchar(64) | 目標表 |
+| `row_pk` / `row_pk_text` | json / varchar(512) | 目標列主鍵（支援複合主鍵，同 `audit_log`）；唯一索引 `(table_name, row_pk_text)`——一列僅一個現行狀態 |
+| `status` | varchar(16) | `deprecated`（退役：列在、選用隱藏、顯示照常）／`merged`（已合併：引用已改指 `redirect_pk`，本列即重定向紀錄）／`deleted`（墓碑：列已物理刪除，本列存原因、影像在 audit_log.old_data） |
+| `reason` | text | 原因，**必填**（決議 3 的落點） |
+| `redirect_pk` | json NULL | `merged` 時：引用被改指到的目標鍵 |
+| `operation_id` / `actor_id` / `created_at` | — | 串回 operations／audit_log |
+
+配套：單一 `LifecycleService` 封裝登記／撤銷／查詢／過濾（含鍵集快取），選用端點一律經由它；registry **純內部、永不匯出**（決議 2 由此滿足）；`BIOG_MAIN` 現行 `<待删除>` 標記暫不動，列為長期遷移項。
+
+匯出規則：§5.3 按引用數分兩檔的規則不變，機制簡化——`deprecated`/`merged` 且**零引用**→ 該詞條列排除；**仍有引用** → 照常匯出（線上詞表本無多餘欄位，無須剝除，對 Access 天然透明）；`deleted` 列本已不存在。沿用 8930d73 模式（過濾集中於 query 建構處、fail-closed、回歸測試）；匯出更新與 registry 同一里程碑交付。
+
+### 6.4 對 §5 路線圖的差異清單
+
+| §5 原文 | 依本節更新為 |
+|---|---|
+| §5.1 順序：「應用層先行、約束殿後」，整個 Step 2 為翻約束前置 | 薄墊片（1451 友好報錯＋刪前落 audit/reason）即可翻轉（§6.1 Phase 1）；Step 2 深層配套後置 |
+| Step 2-2：詞表加 `c_deprecated` 狀態欄 | 整項降為 Phase 3 按需項；若啟動，採 `record_lifecycle` registry（§6.3），共享表零變更 |
+| Step 2-2 前置：committee 討論「新增欄位」 | 議題改為**純政策**（「刪除」改「退役／合併」、發佈收錄規則）；仍為 Phase 3 前置 |
+| §5.3(1)：有引用者匯出「不帶 `c_deprecated` 欄」 | 自動達成——欄位不存在；兩檔規則不變（§6.3） |
+| 決議 3「刪除原因」（§5 未涵蓋） | Phase 1 起刪除紀錄必填 reason；Phase 3 起統一存 registry |
+
+其餘步驟（Step 0／1／4／5）不變。
 
 ---
 


### PR DESCRIPTION
- 盤點 schema 中 186 個 ON DELETE CASCADE 外鍵（另 187 個 ON UPDATE CASCADE），含 BIOG_MAIN 自身 13 個指向詞表的級聯：刪一筆年號會 靜默級聯刪除引用它的人物及其全部傳記資料，且 operations/ audit_log/提案審核/回退機制全程無感知。
- 核心論點為破局矩陣：「物理刪除 × CASCADE」是唯一不可接受的組 合，必須至少打破一個因子。去級聯（RESTRICT）是資料庫層保險絲 （出錯時後果封頂為報錯），軟刪除/deprecate 是應用層產品語義 （正常路徑不再發生刪除）——層次不同、互補而非二選一；軟刪除 約定無法替代約束兜底（deleteBatch 已示範約定會被違反），全面 軟刪除後翻 RESTRICT 成本歸零。
- 詞表生命週期取代「刪除」：deprecate 為主（選擇器隱藏、顯示照 常）、錯誤/重複走合併＋重定向、物理刪除僅限零引用。
- 落點為可執行的改造路線圖：核實生產庫 → 分類盤點 → 應用層補課 （引用檢查/詞表生命週期/合併重定向/顯式級聯）→ 分批翻轉約束 為 RESTRICT → 驗證；應用層先行以避免行為斷崖，每批約束可單條 ALTER 回退。附可重跑驗證指令與生產庫 information_schema 查詢。