### PR TITLE
SQLite 匯出自動排除已被軟刪除的人物

### DIFF
--- a/app/Console/Commands/ExportMysqlToSqlite.php
+++ b/app/Console/Commands/ExportMysqlToSqlite.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use PDO;
 
 class ExportMysqlToSqlite extends Command {
@@ -65,6 +66,32 @@ class ExportMysqlToSqlite extends Command {
      * @var array
      */
     protected $tableMetadata = [];
+
+    /**
+     * 軟刪除標記（見 App\Services\Mutations\BiogMainDeleteHandler::DELETE_MARKER）。
+     * 匯出時：
+     *   1. BIOG_MAIN 本身排除 c_name_chn 為此標記的列；
+     *   2. 其餘表中，所有指向 BIOG_MAIN.c_personid 的欄位（包含 c_personid 本身，
+     *      以及 ASSOC_DATA.c_kin_id、KIN_DATA.c_kin_id 等透過 FK 宣告的關係欄位）
+     *      排除該欄位屬於上述已刪除人物的列，
+     * 避免已刪除人物的資料或其與他人的關係外流到公開釋出檔。
+     *
+     * @var string
+     */
+    protected const DELETED_NAME_MARKER = '<待删除>';
+
+    /**
+     * 額外的人物 ID 欄位對照表：用於資料庫中「語意上」指向 BIOG_MAIN.c_personid，
+     * 但因故未宣告正式 FK、無法透過 information_schema 自動偵測的欄位。
+     * 例如 MERGED_PERSON_DATA.c_merged_from_personid（重複人物合併來源，見遷移
+     * database/migrations/2025_11_12_140940_rename_merged_to_personid_column_in_merged_person_data_table.php）。
+     * 新增此類欄位前應優先確認資料庫端是否能補上正式 FK，讓自動偵測涵蓋。
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected const EXTRA_PERSON_ID_COLUMNS = [
+        'MERGED_PERSON_DATA' => ['c_merged_from_personid'],
+    ];
 
     /**
      * Execute the console command.
@@ -140,7 +167,7 @@ class ExportMysqlToSqlite extends Command {
      */
     protected function validateSourceConnection() {
         try {
-            $driver = DB::connection($this->sourceConnection)->getDriverName();
+            $driver = $this->getSourceDriver();
 
             if ($driver !== 'mysql') {
                 $this->error(sprintf('源数据库必须是 MySQL，当前是: %s', $driver));
@@ -923,6 +950,7 @@ class ExportMysqlToSqlite extends Command {
         try {
             $query = DB::connection($this->sourceConnection)
                 ->table($tableName);
+            $this->excludeSoftDeletedPersons($tableName, $query);
 
             $chunkCallback = function ($rows) use (
                 $tableName,
@@ -1182,18 +1210,137 @@ class ExportMysqlToSqlite extends Command {
     }
 
     /**
-     * 计算数据表的总行数
+     * 计算数据表的总行数。
+     *
+     * 建立過濾條件（excludeSoftDeletedPersons，含 MySQL information_schema 查詢）刻意放在
+     * try/catch 之外：該查詢若失敗必須直接中斷匯出，不可被下方「統計失敗就降級為 0」的
+     * 容錯邏輯吞掉，否則已刪除人物的關係欄位可能在未被察覺的情況下外流。
+     * try/catch 僅保護 COUNT(*) 本身的執行（逾時、鎖等統計性失敗），這類失敗只影響
+     * 進度條與 --limit-records 估算，不影響實際匯出資料是否已正確過濾。
      */
     protected function getTableRowCount($tableName) {
+        $query = DB::connection($this->sourceConnection)->table($tableName);
+        $this->excludeSoftDeletedPersons($tableName, $query);
+
         try {
-            return (int) DB::connection($this->sourceConnection)
-                ->table($tableName)
-                ->count();
+            return (int) $query->count();
         } catch (\Exception $e) {
             $this->warn(sprintf('⚠ 无法统计表 %s 行数: %s', $tableName, $e->getMessage()));
 
             return 0;
         }
+    }
+
+    /**
+     * 排除已被軟刪除人物的資料列，避免其外流到公開釋出檔：
+     *   - BIOG_MAIN 本身：排除 c_name_chn = DELETED_NAME_MARKER 的列。
+     *   - 其餘表：排除所有指向 BIOG_MAIN.c_personid 的欄位（見 getPersonIdColumnsForTable()）
+     *     屬於上述已刪除人物的列，涵蓋該人物自己的資料列，以及他人紀錄中提及該人物的
+     *     關係欄位（如 KIN_DATA.c_kin_id、ASSOC_DATA.c_assoc_id 等）。
+     *   - 沒有任何人物 ID 欄位的表（代碼表等）不受影響。
+     * 相關欄位為 NULL 時不視為已刪除，予以保留；一列只要有任一欄位命中已刪除人物即排除。
+     *
+     * @param string $tableName
+     * @param \Illuminate\Database\Query\Builder $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function excludeSoftDeletedPersons($tableName, $query) {
+        if ($tableName === 'BIOG_MAIN') {
+            return $query->where(function ($q) {
+                $q->where('c_name_chn', '!=', self::DELETED_NAME_MARKER)
+                    ->orWhereNull('c_name_chn');
+            });
+        }
+
+        $personIdColumns = $this->getPersonIdColumnsForTable($tableName);
+
+        if (empty($personIdColumns)) {
+            return $query;
+        }
+
+        return $query->where(function ($q) use ($personIdColumns) {
+            foreach ($personIdColumns as $column) {
+                $q->where(function ($columnQuery) use ($column) {
+                    $columnQuery->whereNull($column)
+                        ->orWhereNotIn($column, function ($sub) {
+                            $sub->select('c_personid')
+                                ->from('BIOG_MAIN')
+                                ->where('c_name_chn', self::DELETED_NAME_MARKER);
+                        });
+                });
+            }
+        });
+    }
+
+    /**
+     * 取得指定表中所有指向 BIOG_MAIN.c_personid 的欄位名稱：
+     *   1. 欄位名稱本身即為 c_personid（最常見的「擁有者」欄位）。
+     *   2. 透過 information_schema 偵測到的、正式宣告 FK 指向 BIOG_MAIN.c_personid 的欄位
+     *      （如 ASSOC_DATA.c_kin_id、ENTRY_DATA.c_assoc_id 等關係欄位）。
+     *   3. EXTRA_PERSON_ID_COLUMNS 中列出的例外欄位（未宣告 FK 但語意上仍指向人物）。
+     * 正式匯出時若 MySQL information_schema 查詢失敗，必須直接拋錯中止；僅當來源本來就不是
+     * MySQL（例如測試用 SQLite 連線）時，才略過第 2 點並回退為第 1、3 點。
+     *
+     * @param string $tableName
+     * @return array<int, string>
+     */
+    protected function getPersonIdColumnsForTable($tableName) {
+        $columns = [];
+
+        if (Schema::connection($this->sourceConnection)->hasColumn($tableName, 'c_personid')) {
+            $columns[] = 'c_personid';
+        }
+
+        // information_schema 僅 MySQL 來源可查詢；正式匯出的 sourceConnection 一律是 MySQL
+        // （見 validateSourceConnection()），此處若查詢失敗必須真的中斷匯出，不可悄悄降級，
+        // 否則可能讓已刪除人物的關係欄位在未被察覺的情況下外流。僅當來源本來就不是 MySQL
+        // （例如測試使用 SQLite 連線）才略過此步驟。
+        if ($this->sourceUsesInformationSchemaPersonReferences()) {
+            $columns = array_merge($columns, $this->getMysqlPersonIdColumnsFromInformationSchema($tableName));
+        }
+
+        foreach (self::EXTRA_PERSON_ID_COLUMNS[$tableName] ?? [] as $extraColumn) {
+            $columns[] = $extraColumn;
+        }
+
+        return array_values(array_unique($columns));
+    }
+
+    /**
+     * 取得來源資料庫 driver 名稱。
+     */
+    protected function getSourceDriver(): string {
+        return DB::connection($this->sourceConnection)->getDriverName();
+    }
+
+    /**
+     * 正式匯出時是否應依賴 MySQL information_schema 偵測人物 FK 欄位。
+     */
+    protected function sourceUsesInformationSchemaPersonReferences(): bool {
+        return $this->getSourceDriver() === 'mysql';
+    }
+
+    /**
+     * 透過 MySQL information_schema 取得所有 FK 指向 BIOG_MAIN.c_personid 的欄位。
+     *
+     * @param string $tableName
+     * @return array<int, string>
+     */
+    protected function getMysqlPersonIdColumnsFromInformationSchema($tableName): array {
+        $databaseName = DB::connection($this->sourceConnection)->getDatabaseName();
+        $rows = DB::connection($this->sourceConnection)->select(
+            'SELECT DISTINCT COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE '
+            . 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? '
+            . 'AND REFERENCED_TABLE_NAME = ? AND REFERENCED_COLUMN_NAME = ?',
+            [$databaseName, $tableName, 'BIOG_MAIN', 'c_personid']
+        );
+
+        $columns = [];
+        foreach ($rows as $row) {
+            $columns[] = $row->COLUMN_NAME;
+        }
+
+        return $columns;
     }
 
     /**

--- a/docs/SQLITE_DATA_RELEASE.md
+++ b/docs/SQLITE_DATA_RELEASE.md
@@ -58,6 +58,16 @@ Metadata 內容包含：
 - 在 HuggingFace 根目錄更新 `latest.zip` 與 `latest.json`。
 - 將當日 zip 複製為 `public/latest.zip`。
 
+## 已刪除人物過濾
+
+匯出（`db:export-to-sqlite`，實作於 [app/Console/Commands/ExportMysqlToSqlite.php](../app/Console/Commands/ExportMysqlToSqlite.php)）會自動排除已被軟刪除的人物，避免其外流到公開釋出檔：
+
+- 人物「刪除」是軟刪除：只把 `BIOG_MAIN.c_name_chn` 設為標記字串 `<待删除>`，列本身與 `c_personid` 不會被移除（見 [app/Services/Mutations/BiogMainDeleteHandler.php](../app/Services/Mutations/BiogMainDeleteHandler.php)）。
+- 匯出 `BIOG_MAIN` 時排除 `c_name_chn = '<待删除>'` 的列（`c_name_chn` 為 `NULL` 視為正常，保留）。
+- 匯出其餘表時，排除所有指向 `BIOG_MAIN.c_personid` 的欄位（含 `c_personid` 本身，以及透過正式 FK 宣告、由 `information_schema.KEY_COLUMN_USAGE` 動態偵測到的關係欄位，如 `KIN_DATA.c_kin_id`、`ASSOC_DATA.c_assoc_id` 等）屬於已刪除人物的列；一列只要有任一人物 ID 欄位命中已刪除人物即整列排除。
+- 少數未宣告正式 FK、但語意上仍指向人物的欄位（目前僅 `MERGED_PERSON_DATA.c_merged_from_personid`）列在程式碼常數 `EXTRA_PERSON_ID_COLUMNS` 中，需手動維護。
+- 正式匯出（來源為 MySQL）時，若 `information_schema` 查詢失敗，該表會被標記為匯出失敗（不會悄悄降級為「只過濾 `c_personid`」）；`export-daily-sqlite.sh` 仍會繼續處理其餘表，但只要有任何表失敗就以非零結束碼收尾，`weekly-sqlite-sync.sh`（`set -e`）因此不會繼續執行後面的壓縮與 `hf upload`，避免關係欄位過濾被無聲跳過又外流到公開釋出檔。
+
 ## 注意事項
 
 - 若 `db-data/cbdb_YYYYMMDD.json` 不存在，zip 內只會包含 SQLite 檔案。

--- a/tests/Feature/ExportMysqlToSqliteExcludesDeletedBiogMainTest.php
+++ b/tests/Feature/ExportMysqlToSqliteExcludesDeletedBiogMainTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\ExportMysqlToSqlite;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Tests\TestCase;
+
+/**
+ * 驗證 db:export-to-sqlite 匯出時，會排除已被軟刪除
+ * （BIOG_MAIN.c_name_chn = '<待删除>'，見 App\Services\Mutations\BiogMainDeleteHandler::DELETE_MARKER）
+ * 人物的資料列，避免這些人物外流到公開釋出的 SQLite 檔案：
+ *   - BIOG_MAIN 本身排除該列。
+ *   - 其餘表中，所有指向 BIOG_MAIN.c_personid 的欄位（含 c_personid 本身與關係欄位，
+ *     如 KIN_DATA.c_kin_id）只要命中已刪除人物即排除該列。
+ *   - 沒有任何人物 ID 欄位的表（代碼表等）不受影響。
+ */
+class ExportMysqlToSqliteExcludesDeletedBiogMainTest extends TestCase {
+    private function invokeExcludeSoftDeletedPersons(string $tableName, $query, array $personIdColumnsOverride = null) {
+        $command = new class ($personIdColumnsOverride) extends ExportMysqlToSqlite {
+            private $personIdColumnsOverride;
+
+            public function __construct($personIdColumnsOverride) {
+                parent::__construct();
+                $this->personIdColumnsOverride = $personIdColumnsOverride;
+            }
+
+            public function option($key = null) {
+                return false;
+            }
+
+            protected function getPersonIdColumnsForTable($tableName) {
+                if ($this->personIdColumnsOverride !== null) {
+                    return $this->personIdColumnsOverride;
+                }
+
+                return parent::getPersonIdColumnsForTable($tableName);
+            }
+        };
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('excludeSoftDeletedPersons');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $tableName, $query);
+    }
+
+    private function invokeGetPersonIdColumnsForTable(ExportMysqlToSqlite $command, string $tableName): array {
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('getPersonIdColumnsForTable');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $tableName);
+    }
+
+    private function invokeGetTableRowCount(ExportMysqlToSqlite $command, string $tableName): int {
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('getTableRowCount');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $tableName);
+    }
+
+    public function test_biog_main_query_excludes_deleted_marker_rows(): void {
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '王安石'],
+            ['c_personid' => 2, 'c_name_chn' => '<待删除>'],
+            ['c_personid' => 3, 'c_name_chn' => null],
+        ]);
+
+        $query = DB::table('BIOG_MAIN');
+        $this->invokeExcludeSoftDeletedPersons('BIOG_MAIN', $query);
+
+        $remainingIds = $query->pluck('c_personid')->sort()->values()->all();
+
+        // 已標記待刪除的 person 2 應被排除；正常資料與 NULL 姓名的資料須保留。
+        $this->assertSame([1, 3], $remainingIds);
+
+        DB::statement('DROP TABLE BIOG_MAIN');
+    }
+
+    public function test_related_table_with_c_personid_excludes_rows_of_deleted_person(): void {
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+        DB::statement('CREATE TABLE ALTNAME_DATA (c_seq INTEGER PRIMARY KEY, c_personid INTEGER NULL, c_alt_name_chn TEXT NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '王安石'],
+            ['c_personid' => 2, 'c_name_chn' => '<待删除>'],
+        ]);
+
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_seq' => 1, 'c_personid' => 1, 'c_alt_name_chn' => '介甫'],
+            ['c_seq' => 2, 'c_personid' => 2, 'c_alt_name_chn' => '應被排除的別名'],
+            ['c_seq' => 3, 'c_personid' => null, 'c_alt_name_chn' => 'c_personid 為 NULL 應保留'],
+        ]);
+
+        $query = DB::table('ALTNAME_DATA');
+        $this->invokeExcludeSoftDeletedPersons('ALTNAME_DATA', $query);
+
+        $remainingSeqs = $query->pluck('c_seq')->sort()->values()->all();
+
+        $this->assertSame([1, 3], $remainingSeqs);
+
+        DB::statement('DROP TABLE ALTNAME_DATA');
+        DB::statement('DROP TABLE BIOG_MAIN');
+    }
+
+    public function test_tables_without_c_personid_column_are_not_filtered(): void {
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+        DB::statement('CREATE TABLE COUNTRY_CODES (c_country_code INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '<待删除>'],
+        ]);
+
+        DB::table('COUNTRY_CODES')->insert([
+            ['c_country_code' => 1, 'c_name_chn' => '<待删除>'],
+        ]);
+
+        $query = DB::table('COUNTRY_CODES');
+        $this->invokeExcludeSoftDeletedPersons('COUNTRY_CODES', $query);
+
+        // COUNTRY_CODES 沒有 c_personid 欄位，即使 c_name_chn 剛好等於標記字串也不受影響。
+        $this->assertSame(1, $query->count());
+
+        DB::statement('DROP TABLE COUNTRY_CODES');
+        DB::statement('DROP TABLE BIOG_MAIN');
+    }
+
+    public function test_relationship_column_referencing_deleted_person_is_excluded(): void {
+        // 模擬 KIN_DATA：c_personid 是資料擁有者，c_kin_id 是關係中的另一方，
+        // 兩者都可能指向已刪除人物，任一命中即應排除該列。
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+        DB::statement('CREATE TABLE KIN_DATA (c_seq INTEGER PRIMARY KEY, c_personid INTEGER NULL, c_kin_id INTEGER NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '王安石'],
+            ['c_personid' => 2, 'c_name_chn' => '<待删除>'],
+            ['c_personid' => 3, 'c_name_chn' => '蘇軾'],
+        ]);
+
+        DB::table('KIN_DATA')->insert([
+            ['c_seq' => 1, 'c_personid' => 1, 'c_kin_id' => 3], // 兩邊都正常，應保留
+            ['c_seq' => 2, 'c_personid' => 2, 'c_kin_id' => 3], // 擁有者已刪除，應排除
+            ['c_seq' => 3, 'c_personid' => 1, 'c_kin_id' => 2], // 關係對象已刪除，應排除
+            ['c_seq' => 4, 'c_personid' => 1, 'c_kin_id' => null], // 關係對象為 NULL，應保留
+        ]);
+
+        $query = DB::table('KIN_DATA');
+        $this->invokeExcludeSoftDeletedPersons('KIN_DATA', $query, ['c_personid', 'c_kin_id']);
+
+        $remainingSeqs = $query->pluck('c_seq')->sort()->values()->all();
+
+        $this->assertSame([1, 4], $remainingSeqs);
+
+        DB::statement('DROP TABLE KIN_DATA');
+        DB::statement('DROP TABLE BIOG_MAIN');
+    }
+
+    public function test_get_person_id_columns_falls_back_to_c_personid_and_extra_map_without_information_schema(): void {
+        // 測試環境的來源連線是 SQLite，沒有 information_schema，getPersonIdColumnsForTable()
+        // 應優雅回退為「c_personid（若存在）＋ EXTRA_PERSON_ID_COLUMNS」，不可拋例外。
+        DB::statement('CREATE TABLE MERGED_PERSON_DATA (c_personid INTEGER NOT NULL, c_merged_from_personid INTEGER NOT NULL)');
+
+        $command = new class () extends ExportMysqlToSqlite {
+            public function option($key = null) {
+                return false;
+            }
+        };
+        $columns = $this->invokeGetPersonIdColumnsForTable($command, 'MERGED_PERSON_DATA');
+        sort($columns);
+
+        $this->assertSame(['c_merged_from_personid', 'c_personid'], $columns);
+
+        DB::statement('DROP TABLE MERGED_PERSON_DATA');
+    }
+
+    public function test_get_table_row_count_rethrows_mysql_metadata_failures_instead_of_returning_zero(): void {
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+        DB::statement('CREATE TABLE KIN_DATA (c_seq INTEGER PRIMARY KEY, c_personid INTEGER NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '王安石'],
+            ['c_personid' => 2, 'c_name_chn' => '<待删除>'],
+        ]);
+        DB::table('KIN_DATA')->insert([
+            ['c_seq' => 1, 'c_personid' => 1],
+            ['c_seq' => 2, 'c_personid' => 2],
+        ]);
+
+        $command = new class () extends ExportMysqlToSqlite {
+            public function option($key = null) {
+                return false;
+            }
+
+            protected function sourceUsesInformationSchemaPersonReferences(): bool {
+                return true;
+            }
+
+            protected function getMysqlPersonIdColumnsFromInformationSchema($tableName): array {
+                throw new \RuntimeException('mock information_schema failure');
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('mock information_schema failure');
+
+        try {
+            $this->invokeGetTableRowCount($command, 'KIN_DATA');
+        } finally {
+            DB::statement('DROP TABLE KIN_DATA');
+            DB::statement('DROP TABLE BIOG_MAIN');
+        }
+    }
+
+    public function test_get_table_row_count_still_degrades_gracefully_on_unrelated_count_failure(): void {
+        // 排除已刪除人物的過濾條件建立成功後，COUNT(*) 本身失敗（逾時、鎖等）
+        // 屬於統計性失敗，只影響進度條，不應該讓整張表的匯出被視為錯誤中斷。
+        DB::statement('CREATE TABLE BIOG_MAIN (c_personid INTEGER PRIMARY KEY, c_name_chn TEXT NULL)');
+        DB::statement('CREATE TABLE KIN_DATA (c_seq INTEGER PRIMARY KEY, c_personid INTEGER NULL)');
+
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 1, 'c_name_chn' => '王安石'],
+        ]);
+        DB::table('KIN_DATA')->insert([
+            ['c_seq' => 1, 'c_personid' => 1],
+        ]);
+
+        // KIN_DATA 建完過濾條件後才 DROP，讓 count() 本身失敗，但 excludeSoftDeletedPersons()
+        // 已成功執行（不涉及 information_schema 失敗）。
+        $command = new class () extends ExportMysqlToSqlite {
+            public function option($key = null) {
+                return false;
+            }
+        };
+        // getTableRowCount() 在 count() 失敗時會呼叫 warn()；測試直接 new command 時需補上 output，
+        // 否則 Console\Command 的輸出物件為 null，會讓這個「應降級為 0」的案例變成輸出層例外。
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new NullOutput()));
+
+        DB::statement('DROP TABLE KIN_DATA');
+
+        $count = $this->invokeGetTableRowCount($command, 'KIN_DATA');
+
+        $this->assertSame(0, $count);
+
+        DB::statement('DROP TABLE BIOG_MAIN');
+    }
+}


### PR DESCRIPTION
## Summary
- BIOG_MAIN 匯出時排除 c_name_chn 為軟刪除標記 `<待删除>` 的列
- 其餘表匯出時排除所有指向 BIOG_MAIN.c_personid 的欄位（含 c_personid 本身，以及透過 information_schema 動態偵測到的關係欄位，如 KIN_DATA.c_kin_id、ASSOC_DATA.c_assoc_id）屬於已刪除人物的列，避免其資料或人際關係外流到公開釋出的 SQLite 檔
- 少數無正式 FK 的例外欄位（MERGED_PERSON_DATA.c_merged_from_personid）以 EXTRA_PERSON_ID_COLUMNS 常數手動維護
- 正式匯出來源為 MySQL 時，若 information_schema 查詢失敗會讓該表匯出失敗，並讓整個每週釋出流程（export-daily-sqlite.sh / weekly-sqlite-sync.sh）中止，不會悄悄少過濾而外洩
- 同步更新 docs/SQLITE_DATA_RELEASE.md

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/ExportMysqlToSqliteExcludesDeletedBiogMainTest.php tests/Feature/SqliteExportPreservesCommentsTest.php tests/Unit/ExportMysqlToSqliteCommentEscapeTest.php`
- [x] `./vendor/bin/php-cs-fixer fix`（無需修正）
- [x] 多輪 code review agent + codex 審查，已修正發現的問題（NULL 處理、關聯表覆蓋範圍、information_schema 失敗時的容錯範圍）

🤖 Generated with [Claude Code](https://claude.com/claude-code)