### PR TITLE
fix(offices): 修復 React 遷移後官職錄入朝代不自動同步＋ai-fill-logs 全誤判「未提交」

### DIFF
--- a/app/Services/Mutations/PostingCreateHandler.php
+++ b/app/Services/Mutations/PostingCreateHandler.php
@@ -12,6 +12,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * POSTED_TO_OFFICE_DATA（任官）create handler（API v2）
@@ -137,6 +139,9 @@ class PostingCreateHandler extends AbstractMutationHandler {
             ->where('c_posting_id', $pk['c_posting_id'])
             ->first();
 
+        // AI 自動填：使用者實際提交後回寫 ai_fill_logs（見 recordAiFillSubmission）。
+        $this->recordAiFillSubmission($meta, $personId, $writable, $addr);
+
         return response()->json([
             'ok' => true,
             'resource' => 'postings',
@@ -208,5 +213,53 @@ class PostingCreateHandler extends AbstractMutationHandler {
                 'operation_id' => $operation?->id,
             ],
         ]);
+    }
+
+    /**
+     * AI 自動填任官：使用者實際提交（direct create）後，把提交的表單資料回寫 ai_fill_logs
+     * （user_submitted + submitted_at），使 /admin/ai-fill-logs 正確顯示「已提交」。
+     *
+     * 背景：舊 Blade offices/store 以 ai_fill_log_id 回寫；React 遷移（2026-06-26 上線）改走
+     * v2 mutation 後遺漏此步，導致上線後所有經 AI 自動填的任官日誌一律誤顯示「Not Submitted」，
+     * 與使用者是否人工修改過 AI 建議無關（以 log id 連結、不比對欄位值）。
+     *
+     * 守衛：
+     * - log id 由前端經 meta.ai_fill_log_id 傳入；非正整數則略過。
+     * - WHERE 以 id + user_id(Auth) + category='posting' + c_personid 四重限定：user_id 防止覆寫
+     *   他人日誌，category 防止誤寫非任官日誌，c_personid 確保只回寫「同一人物」的日誌（此處
+     *   $personId 為 handler 已知的權威值，非舊路徑那種脆弱的 request 推導，故可安全保留此守衛，
+     *   避免把 A 人物的 AI 日誌誤標為在 B 人物存檔時已提交）。
+     * - Schema::hasTable 守衛，使無 ai_fill_logs 的既有測試不受影響。
+     * - 任何例外只記 warning、不影響主流程（任官已成功寫入）。
+     *
+     * 註：proposal 模式於核准時才落庫，不在此回寫（另計）。
+     */
+    protected function recordAiFillSubmission(array $meta, int $personId, array $writable, array $addr): void {
+        $logId = $meta['ai_fill_log_id'] ?? null;
+        if (!is_numeric($logId) || (int) $logId <= 0) {
+            return;
+        }
+
+        if (!Schema::hasTable('ai_fill_logs')) {
+            return;
+        }
+
+        try {
+            $submitted = $writable;
+            $submitted['c_addr'] = array_values($addr);
+
+            DB::table('ai_fill_logs')
+                ->where('id', (int) $logId)
+                ->where('user_id', Auth::id())
+                ->where('category', 'posting')
+                ->where('c_personid', $personId)
+                ->update([
+                    'user_submitted' => json_encode($submitted, JSON_UNESCAPED_UNICODE),
+                    'submitted_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
+        } catch (\Throwable $e) {
+            Log::warning('[AI Fill Log] v2 任官提交回寫失敗: '.$e->getMessage());
+        }
     }
 }

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -77,6 +77,10 @@ export default function OfficeEditor({
         c_office_id: '', c_source: '0',
         c_inst_code: '0', c_inst_name_code: '0',
         c_fy_intercalary: '0', c_ly_intercalary: '0',
+        // 朝代預設為人物朝代（對齊 legacy：舊 offices/_form 於頁面載入時即從 person dynasty_code
+        // 預填 c_dy，AI 僅在依任官時間判定不同朝代時覆寫）。list 模式 CodeAutocomplete 會依此值
+        // 自載朝代名稱標籤，故不需另傳 label。編輯模式由 initialFields 的 c_dy 覆寫。
+        ...(isCreate && dynastyCode != null ? { c_dy: String(dynastyCode) } : {}),
         ...initialFields,
     };
     const [fields, setFields] = useState<Fields>(base);
@@ -149,7 +153,11 @@ export default function OfficeEditor({
 
     // AI 自動填套用前的快照（供「清除 AI 填入」還原）。
     const preAi = useRef<{ f: Fields; l: Fields; a: AddrItem[] } | null>(null);
-    const applyAiData = (data: AiAutofillData) => {
+    // AI extract 回傳的 ai_fill_logs log id：儲存（create）時經 meta 回傳後端，回寫 user_submitted +
+    // submitted_at，使 /admin/ai-fill-logs 正確顯示「已提交」。清除 AI 填入時一併還原。
+    const aiFillLogId = useRef<number | null>(null);
+    const applyAiData = (data: AiAutofillData, logId?: number | null) => {
+        aiFillLogId.current = logId ?? null;
         if (!preAi.current) preAi.current = { f: { ...fields }, l: { ...labels }, a: [...addr] };
         const entries: Record<string, AiFieldEntry> = { ...(data.matched_fields ?? {}), ...(data.suggested_fields ?? {}) };
         setFields((prev) => {
@@ -193,6 +201,7 @@ export default function OfficeEditor({
         setLabels(preAi.current.l);
         setAddr(preAi.current.a);
         preAi.current = null;
+        aiFillLogId.current = null;
     };
 
     const onPickTextperson = (p: { source: string; pages: string; sourceLabel: string }) => {
@@ -243,12 +252,18 @@ export default function OfficeEditor({
             if (Object.keys(changes).length === 0) { setSaving(false); setError(tr('no_change', '沒有變更')); return; }
         }
 
+        // meta：proposal 附帶審核備註；create 且曾用 AI 自動填時附帶 ai_fill_log_id，供後端回寫
+        // ai_fill_logs 的 user_submitted + submitted_at（不論是否人工修改過 AI 建議皆以 log id 連結）。
+        const meta: Record<string, unknown> = {};
+        if (sm === 'proposal' && comment) meta.comment = comment;
+        if (creating && aiFillLogId.current) meta.ai_fill_log_id = aiFillLogId.current;
+
         try {
             const res = await fetch(endpoint, {
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'postings', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'postings', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(Object.keys(meta).length ? { meta } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/PersonEditorShared/PostingAiAutofill.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/PostingAiAutofill.tsx
@@ -21,7 +21,8 @@ interface Props {
     aiModel?: string;
     disabled?: boolean;
     t?: (k: string) => string;
-    onApply: (data: AiAutofillData) => void;
+    // 第二參數為 ai_fill_logs 的 log id（extract 回應於頂層回傳），供儲存時回寫「已提交」。
+    onApply: (data: AiAutofillData, aiFillLogId?: number | null) => void;
     onClear: () => void;
 }
 
@@ -49,7 +50,8 @@ export default function PostingAiAutofill({ personId, extractEndpoint, aiModel, 
                 throw new Error(json?.error?.message || json?.error || `HTTP ${res.status}`);
             }
             const data: AiAutofillData = json.data ?? {};
-            onApply(data);
+            const logId = typeof json.ai_fill_log_id === 'number' ? json.ai_fill_log_id : null;
+            onApply(data, logId);
             setStats(data.statistics ?? null);
             setApplied(true);
             setStatus({ kind: 'ok', msg: tr('ai_fill_done_status', 'AI 填充完成，請核對') });

--- a/tests/Feature/ApiV2CreatePostingTest.php
+++ b/tests/Feature/ApiV2CreatePostingTest.php
@@ -29,9 +29,11 @@ class ApiV2CreatePostingTest extends TestCase {
         $this->createOperationsTable();
         $this->createAuditLogTable();
         $this->createPostingTables();
+        $this->createAiFillLogsTable();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ai_fill_logs');
         Schema::dropIfExists('POSTED_TO_ADDR_DATA');
         Schema::dropIfExists('POSTED_TO_OFFICE_DATA');
         Schema::dropIfExists('POSTING_DATA');
@@ -155,6 +157,40 @@ class ApiV2CreatePostingTest extends TestCase {
             $table->string('c_created_by', 255)->nullable();
             $table->string('c_created_date', 255)->nullable();
         });
+    }
+
+    protected function createAiFillLogsTable(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('c_personid');
+            $table->string('category', 20)->default('posting');
+            $table->string('route_name', 255)->nullable();
+            $table->string('route_url', 500)->nullable();
+            $table->text('source_text')->nullable();
+            $table->longText('ai_raw')->nullable();
+            $table->longText('ai_matched')->nullable();
+            $table->longText('user_submitted')->nullable();
+            $table->boolean('success')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /** 建立一筆待提交的 AI 填充日誌，回傳 log id。 */
+    protected function insertAiFillLog(int $userId, int $personId = 1000, string $category = 'posting'): int {
+        return DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $userId,
+            'c_personid' => $personId,
+            'category' => $category,
+            'route_name' => 'app.basicinformation.office.edit',
+            'route_url' => '/app/basicinformation/'.$personId.'/office',
+            'source_text' => '至和年間知某縣',
+            'ai_matched' => json_encode(['matched_fields' => []]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-post-tester@example.com'): User {
@@ -325,6 +361,93 @@ class ApiV2CreatePostingTest extends TestCase {
         $audit = DB::table('audit_log')->where('table_name', 'POSTED_TO_OFFICE_DATA')->first();
         $this->assertNotNull($audit);
         $this->assertSame('INSERT', $audit->operation);
+    }
+
+    #[Test]
+    public function testDirectPostingCreateWithAiFillLogIdMarksLogSubmitted(): void {
+        // 回歸：React 遷移後，v2 direct create 未回寫 ai_fill_logs → /admin/ai-fill-logs 全部誤顯示
+        // 「Not Submitted」。修法：meta.ai_fill_log_id 傳入時回寫 user_submitted + submitted_at。
+        $user = $this->makeUser(email: 'create-post-ailog@example.com');
+        $this->actingAs($user);
+
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted, 'user_submitted 應回寫（已提交）');
+        $this->assertNotNull($log->submitted_at, 'submitted_at 應回寫');
+
+        $submitted = json_decode($log->user_submitted, true);
+        // 使用者實際提交的欄位值（不論是否人工修改過 AI 建議，皆以 log id 連結、原樣記錄）。
+        $this->assertSame(87473, (int) $submitted['c_office_id']);
+        $this->assertSame([130], $submitted['c_addr']);
+    }
+
+    #[Test]
+    public function testDirectPostingCreateWithoutAiFillLogIdLeavesLogUntouched(): void {
+        // 未使用 AI 自動填（無 meta.ai_fill_log_id）時，不得誤動任何既有日誌。
+        $user = $this->makeUser(email: 'create-post-noailog@example.com');
+        $this->actingAs($user);
+
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload())->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '無 log id 不應回寫');
+        $this->assertNull($log->submitted_at);
+    }
+
+    #[Test]
+    public function testAiFillLogNotOverwrittenForOtherUsersLog(): void {
+        // 安全：只能回寫自己的日誌。傳入他人的 log id 不得覆寫（WHERE user_id 守衛）。
+        $owner = $this->makeUser(email: 'create-post-ailog-owner@example.com');
+        $actor = $this->makeUser(email: 'create-post-ailog-actor@example.com');
+        $logId = $this->insertAiFillLog($owner->id);
+
+        $this->actingAs($actor);
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '他人日誌不得被覆寫');
+    }
+
+    #[Test]
+    public function testAiFillLogNotOverwrittenForDifferentPerson(): void {
+        // 連結完整性：只回寫「同一人物」的日誌。log 屬於人物 999，卻在人物 1000 存檔時帶入其 log id，
+        // c_personid 守衛應擋下（$personId 為 handler 權威值，非脆弱推導）。
+        $user = $this->makeUser(email: 'create-post-ailog-person@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id, 999);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'person_id' => 1000,
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同人物的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testProposalPostingCreateDoesNotRecordAiFillSubmission(): void {
+        // 提案模式於核准時才落庫，提交當下不回寫 user_submitted（另計）。
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'create-post-ailog-proposal@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'mode' => 'proposal',
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, 'proposal 提交當下不回寫');
     }
 
     #[Test]


### PR DESCRIPTION
## 背景
React/Inertia 遷移正式上線（commit `3f131d61`，2026-06-26 21:15）後，官職 AI 自動錄入出現兩個回歸，經 SSH 唯讀調查生產庫確認。

## 問題一：新增任官時朝代不自動同步
- 舊 Blade `offices/_form` 於頁面載入即從 person `dynasty_code` 預填 `c_dy`，AI 僅在依任官年判定不同朝代時覆寫（見 `PostingAutofillService.php:286` 註解）。
- 新 `OfficeEditor.tsx` 收到 `dynastyCode` prop 卻從未使用 → 新增任官時朝代欄空白。
- **修法**：create 時 `base` 預設 `c_dy = String(dynastyCode)`；list 模式 `CodeAutocomplete` 自載朝代名稱標籤；`applyAiData` 仍可覆寫；編輯模式由 `initialFields` 覆寫、不受影響。

## 問題二：/admin/ai-fill-logs 全部誤顯示「Not Submitted」
- 「已提交」判定 = `user_submitted` 非空（`AiFillLogController:161`）。舊 Blade `store` 以 `ai_fill_log_id` 回寫 `user_submitted`+`submitted_at`；React 改走 v2 mutation（`PostingCreateHandler`）後整條回寫鏈遺漏——`PostingAiAutofill` 未接住 extract 回應頂層的 `ai_fill_log_id`，存檔亦未回傳後端。
- **生產庫證實**：2026-06-27 起 **100% 使用者**日誌全為 null（分界正是遷移上線日）。與使用者是否人工修改過 AI 建議無關（以 log id 連結、不比對欄位值）。使用者反映的「有提交卻顯示未提交」實為此系統性回歸。
- **修法**：
  - `PostingAiAutofill` 接住 `json.ai_fill_log_id` → `onApply(data, logId)`。
  - `OfficeEditor` 以 ref 保存 log id、`clearAi` 清除、create 存檔帶 `meta.ai_fill_log_id`。
  - `PostingCreateHandler::recordAiFillSubmission()`：direct create 成功後回寫 `user_submitted`（白名單 changes + `c_addr`）+ `submitted_at`；WHERE 以 `id + user_id(Auth) + category='posting' + c_personid`（`$personId` 權威值）四重守衛，防止覆寫他人或跨人物日誌；`Schema::hasTable` 守衛＋`try/catch`，永不影響主流程。proposal 模式於核准時才落庫、不在此回寫（另計）。

## 測試與驗證
- `ApiV2CreatePostingTest` 新增 6 案（帶/不帶 log id、他人日誌、跨人物、proposal 不回寫、`user_submitted` 內容）。
- 相關 AI 任官/日誌測試共 **55 tests 全過**；`npm run build` 成功；`php-cs-fixer` 無需修正。
- Review：review agent 無 CRITICAL/MAJOR；codex 首輪報一個 MAJOR（漏 `c_personid` 守衛），已補上並加測試，二輪 codex 判定 clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)