### PR TITLE
fix(ai-fill-logs): 比較表隱藏純表單預設 0 的欄位列

### DIFF
--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -242,20 +242,22 @@ class AiFillLogController extends Controller {
             $aiDisplay = $this->formatValue($aiText);
             $userDisplay = $this->formatValue($userValue);
 
+            // 判斷是否匹配（用原始值比較；normalizeForCompare 會把表單預設 0 視為空）
+            $aiCompare = $this->normalizeForCompare($aiValue);
+            $userCompare = $this->normalizeForCompare($userValue);
+            $matches = ($aiCompare === $userCompare);
+
+            // 若 AI 沒有給值、且用戶值正規化後為空（含表單預設 0／''／null），跳過此欄位。
+            // 這會濾掉像「始年閏月 0」「終年閏月 0」「是否赴任 0」這類純預設值列，
+            // 避免它們污染比較表。（AI 有給顯示值時仍保留，以便呈現 AI 建議 vs 用戶預設的差異。）
+            if ($aiDisplay === '' && $userCompare === '') {
+                continue;
+            }
+
             // 若用戶提交的是代碼，附上中文名稱
             if (isset($codeLabels[$field]) && $userDisplay !== '') {
                 $userDisplay = $userDisplay.' ('.$codeLabels[$field].')';
             }
-
-            // 若兩者都為空，跳過此欄位
-            if ($aiDisplay === '' && $userDisplay === '') {
-                continue;
-            }
-
-            // 判斷是否匹配（用原始值比較）
-            $aiCompare = $this->normalizeForCompare($aiValue);
-            $userCompare = $this->normalizeForCompare($userValue);
-            $matches = ($aiCompare === $userCompare);
 
             $rows[] = [
                 'field' => $label,

--- a/tests/Feature/AiFillLogInertiaTest.php
+++ b/tests/Feature/AiFillLogInertiaTest.php
@@ -124,6 +124,57 @@ class AiFillLogInertiaTest extends TestCase {
     }
 
     #[Test]
+    public function it_omits_default_zero_only_fields_from_comparison(): void {
+        $admin = $this->makeSuperAdmin();
+
+        // AI 只匹配到 c_firstyear；用戶提交除了 c_firstyear 外還帶著表單預設 0
+        // 的欄位（始年閏月／終年閏月／是否赴任）。這些純預設值列不應出現在比較表。
+        $this->seedLog($admin->id, [
+            'ai_matched' => json_encode([
+                'statistics' => ['matched_count' => 1],
+                'matched_fields' => ['c_firstyear' => ['value' => '1050', 'text' => '1050']],
+            ]),
+            'user_submitted' => json_encode([
+                'c_firstyear' => '1050',
+                'c_fy_intercalary' => 0,
+                'c_ly_intercalary' => 0,
+                'c_assume_office_code' => 0,
+            ]),
+        ]);
+
+        $this->actingAs($admin)->get(route('app.admin.ai-fill-logs'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('logs.data.0.comparison_rows', 1)
+                ->where('logs.data.0.comparison_rows.0.field_key', 'c_firstyear'));
+    }
+
+    #[Test]
+    public function it_keeps_field_when_ai_suggests_but_user_left_default_zero(): void {
+        $admin = $this->makeSuperAdmin();
+
+        // AI 對 c_fy_month 有建議值，但用戶留下預設 0：此列仍應保留以呈現差異。
+        $this->seedLog($admin->id, [
+            'ai_matched' => json_encode([
+                'statistics' => ['matched_count' => 1, 'suggested_count' => 1],
+                'matched_fields' => ['c_firstyear' => ['value' => '1050', 'text' => '1050']],
+                'suggested_fields' => ['c_fy_month' => ['value' => '5', 'text' => '5']],
+            ]),
+            'user_submitted' => json_encode([
+                'c_firstyear' => '1050',
+                'c_fy_month' => 0,
+            ]),
+        ]);
+
+        $this->actingAs($admin)->get(route('app.admin.ai-fill-logs'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('logs.data.0.comparison_rows', 2)
+                ->where('logs.data.0.comparison_rows.1.field_key', 'c_fy_month')
+                ->where('logs.data.0.comparison_rows.1.ai_value', '5')
+                // 用戶留預設 0 vs AI 建議 5：正規化後視為不相符，仍應呈現差異。
+                ->where('logs.data.0.comparison_rows.1.matches', false));
+    }
+
+    #[Test]
     public function non_super_admin_gets_403(): void {
         $expert = User::create([
             'name' => 'Exp', 'email' => 'e@example.com', 'password' => bcrypt('x'),


### PR DESCRIPTION
## 問題

`/app/admin/ai-fill-logs` 的「AI Match Result vs User Submitted Comparison」，在 AI 未從原文提取、而用戶表單留下預設值 `0` 的欄位（如 **始年閏月 / 終年閏月 / 是否赴任**）仍會顯示一列「欄位 vs 0」，形成雜訊。

## 根因

`buildComparisonRows` 的 skip 條件用 `formatValue` 的顯示字串判斷空值，`formatValue(0)` 回 `'0'`（非空）→ 該列未被略過。但 `normalizeForCompare` 早已把 `'0'` 視為「未設定」（表單預設值），造成「比對高亮視為相符、卻仍顯示 0」的不一致。

## 修法

skip 條件改為：**AI 無顯示值 且 用戶值正規化後為空（含 `0` / `''` / `null`）** 才略過。

- 略過語意與既有比對高亮語意一致（重用 `normalizeForCompare`，未新增任何「0=未設定」假設）。
- AI 有建議值時仍保留該列，以呈現「AI 建議 vs 用戶預設」的差異。
- `index()`（Blade 舊版）與 `appIndex()`（React/Inertia）共用同一個 `buildComparisonRows`，兩條路徑一併修正。

## 測試

新增兩則回歸測試：
- 純預設 0 欄位（AI 無值）→ 從比較表移除。
- AI 有建議、用戶留預設 0 → 該列保留並標記為不相符。

`./vendor/bin/phpunit --filter AiFillLog` → 17 tests, 106 assertions, 綠。

## 審查

已通過兩組 review agent 與 codex 覆核，無 CRITICAL/HIGH/MEDIUM 問題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)