### PR TITLE
批次匯入書名頁補回行號側欄

### DIFF
--- a/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { router, useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../../Layouts/DashboardLayout';
 import { Button } from '../../../components/ui/Button';
@@ -25,6 +25,55 @@ interface ResultRow {
 interface Toast {
     msg: string;
     type?: 'success' | 'error' | 'warning';
+}
+
+interface EntriesEditorProps {
+    id?: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+}
+
+// FormField 會把 id / aria-invalid / aria-describedby clone 到單一子元素上；
+// 這裡把這些屬性轉發到真正的 <textarea>，讓行號側欄僅作為視覺裝飾疊加。
+function EntriesEditor({ id, value, onChange, placeholder, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy }: EntriesEditorProps) {
+    const gutterRef = useRef<HTMLPreElement>(null);
+    const lineCount = Math.max(1, value.split('\n').length);
+
+    return (
+        <div
+            className={cn(
+                'flex items-stretch overflow-hidden rounded-md border border-input bg-background shadow-sm focus-within:ring-2 focus-within:ring-ring',
+                ariaInvalid && 'border-destructive'
+            )}
+        >
+            <pre
+                ref={gutterRef}
+                aria-hidden="true"
+                className="m-0 select-none overflow-hidden whitespace-pre border-r border-border bg-muted/50 px-2 py-2 text-right font-mono text-sm leading-normal text-muted-foreground"
+            >
+                {Array.from({ length: lineCount }, (_, i) => i + 1).join('\n')}
+            </pre>
+            <textarea
+                id={id}
+                rows={10}
+                spellCheck={false}
+                aria-invalid={ariaInvalid}
+                aria-describedby={ariaDescribedBy}
+                className="w-full flex-1 resize-y border-0 bg-transparent px-3 py-2 font-mono text-sm leading-normal shadow-none focus-visible:outline-none"
+                placeholder={placeholder}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onScroll={(e) => {
+                    if (gutterRef.current) {
+                        gutterRef.current.scrollTop = e.currentTarget.scrollTop;
+                    }
+                }}
+            />
+        </div>
+    );
 }
 
 interface BatchBooksPageProps extends SharedProps {
@@ -186,14 +235,10 @@ export default function BatchLoadBookTitles() {
 
                 <form onSubmit={(e) => { e.preventDefault(); submit(false); }}>
                     <FormField label={t('batch_data_tab_sep')} htmlFor="entries" error={form.errors.entries}>
-                        <textarea
-                            id="entries"
-                            rows={10}
-                            spellCheck={false}
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            placeholder={t('batch_book_placeholder')}
+                        <EntriesEditor
                             value={form.data.entries}
-                            onChange={(e) => form.setData('entries', e.target.value)}
+                            onChange={(v) => form.setData('entries', v)}
+                            placeholder={t('batch_book_placeholder')}
                         />
                     </FormField>
                     <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- React/Inertia 遷移版的批次匯入書名頁（`/app/admin/batch-load-book-titles`）遺失了舊 Blade 版 textarea 旁的行號側欄，導致匯入失敗訊息（如「第 118 行作者 ID 必須為整數」）無法對照文字區塊行號
- 新增 `EntriesEditor` 元件重建行號側欄，與 textarea 同步捲動、行數即時更新
- 正確轉發 `FormField` 的 `id` / `aria-invalid` / `aria-describedby` clone-child 到內層 `<textarea>`，避免 a11y/id 重複回歸
- 保留 `resize-y`，對齊舊版 `resize: vertical` 行為

## Test plan
- [x] `npm run build`
- [x] `./vendor/bin/phpunit --filter BatchLoadBookTitles`（44 tests, 214 assertions）
- [x] 兩輪獨立 review agent + codex review，均無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)