### PR TITLE
fix(person-browser): 拼音搜尋不再誤走中文 FTS 索引（修 lv/lü 查不到姓呂）

### DIFF
--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -6,6 +6,19 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class PersonBrowserService {
+    /**
+     * 該查詢是否應走 CBDB__NAME_FTS 倒排索引。
+     *
+     * FTS 只索引「中文姓名」（c_name_chn／c_alt_name_chn 的中文字後綴）。拼音／拉丁字母
+     * 查詢不應查 FTS：索引中偶有夾帶拉丁子字串的外文名（例如某人 c_name_chn 含 "Lves…"），
+     * 拼音輸入（如 "lv"）會誤命中這類雜訊記錄、拿到極少數 id 後短路，跳過底下能命中全部
+     * 呂（Lü）姓的拼音 LIKE 回退，造成「搜 lv／lü 查不到大量姓呂的人，但搜 zhang 卻正常」。
+     * 拉丁查詢一律改走多欄位 LIKE 回退（含 c_name_chn，故外文名仍可被回退命中）。
+     */
+    private function queryUsesFtsIndex(string $q): bool {
+        return preg_match('/\p{Han}/u', $q) === 1;
+    }
+
     private function formatAdminCatLabel(?string $hz, ?string $trans): ?string {
         $parts = array_values(array_filter([
             $hz ? trim($hz) : null,
@@ -50,25 +63,28 @@ class PersonBrowserService {
                 $idQuery->where('BIOG_MAIN.c_personid', '=', (int) $q)
                     ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
             } else {
-                // 先嘗試倒排索引
-                $ftsIds = DB::table('CBDB__NAME_FTS')
-                    ->where('search_term', 'LIKE', $q . '%')
-                    ->orderByRaw('LENGTH(search_term) ASC')
-                    ->limit(500)
-                    ->pluck('c_personid')
-                    ->unique()
-                    ->values()
-                    ->toArray();
-
-                if ($dynasty !== '' && !empty($ftsIds)) {
-                    // 倒排索引結果需要過濾朝代
-                    $ftsIds = DB::table('BIOG_MAIN')
-                        ->whereIn('c_personid', $ftsIds)
-                        ->where('c_dy', '=', (int) $dynasty)
+                // 先嘗試倒排索引（僅中文查詢；拼音／拉丁查詢直接走下方 LIKE 回退）
+                $ftsIds = [];
+                if ($this->queryUsesFtsIndex($q)) {
+                    $ftsIds = DB::table('CBDB__NAME_FTS')
+                        ->where('search_term', 'LIKE', $q . '%')
+                        ->orderByRaw('LENGTH(search_term) ASC')
+                        ->limit(500)
                         ->pluck('c_personid')
-                        ->map(fn ($id) => (int) $id)
+                        ->unique()
                         ->values()
                         ->toArray();
+
+                    if ($dynasty !== '' && !empty($ftsIds)) {
+                        // 倒排索引結果需要過濾朝代
+                        $ftsIds = DB::table('BIOG_MAIN')
+                            ->whereIn('c_personid', $ftsIds)
+                            ->where('c_dy', '=', (int) $dynasty)
+                            ->pluck('c_personid')
+                            ->map(fn ($id) => (int) $id)
+                            ->values()
+                            ->toArray();
+                    }
                 }
 
                 if (!empty($ftsIds)) {
@@ -182,14 +198,19 @@ class PersonBrowserService {
             if (ctype_digit($q)) {
                 $query->where('BIOG_MAIN.c_personid', '=', (int) $q);
             } else {
-                $ftsIds = DB::table('CBDB__NAME_FTS')
-                    ->where('search_term', 'LIKE', $q . '%')
-                    ->orderByRaw('LENGTH(search_term) ASC')
-                    ->limit(500)
-                    ->pluck('c_personid')
-                    ->unique()
-                    ->values()
-                    ->toArray();
+                // 與 search() 同口徑：拼音／拉丁查詢不走中文 FTS，直接以 LIKE 展開集分面，
+                // 否則朝代側欄會沿用 FTS 雜訊命中而與人物列表（已回退）不一致。
+                $ftsIds = [];
+                if ($this->queryUsesFtsIndex($q)) {
+                    $ftsIds = DB::table('CBDB__NAME_FTS')
+                        ->where('search_term', 'LIKE', $q . '%')
+                        ->orderByRaw('LENGTH(search_term) ASC')
+                        ->limit(500)
+                        ->pluck('c_personid')
+                        ->unique()
+                        ->values()
+                        ->toArray();
+                }
 
                 if (!empty($ftsIds)) {
                     $query->whereIn('BIOG_MAIN.c_personid', $ftsIds);

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -951,6 +951,40 @@ class PersonBrowserTest extends TestCase {
     }
 
     #[Test]
+    public function test_pinyin_search_not_hijacked_by_stray_latin_fts_row(): void {
+        // 迴歸：CBDB__NAME_FTS 只索引中文，但索引中偶有夾帶拉丁子字串的外文名（如 "Lves…"）。
+        // 拼音查詢 "lv" 曾以 LIKE 'lv%' 誤命中該筆雜訊、短路 FTS 分支（whereIn 只含那 1 筆），
+        // 跳過能命中全部呂(Lü)姓的拼音 LIKE 回退，造成「搜 lv／lü 查不到大量姓呂的人，
+        // 但搜 zhang 卻正常」。修法：拉丁查詢不走中文 FTS，一律改走多欄位 LIKE 回退。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 800,
+            'c_name_chn' => '呂大防',
+            'c_name' => 'Lü Dafang',
+            'c_surname' => 'Lü',
+            'c_mingzi' => 'Dafang',
+            'c_dy' => 2,
+        ]);
+        // 夾帶拉丁子字串的外文名（模擬 c_name_chn 內含 "Lves"）＋對應的雜訊 FTS 列。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 801,
+            'c_name_chn' => 'Lves',
+            'c_name' => 'Lves',
+            'c_surname' => 'Lves',
+            'c_dy' => 2,
+        ]);
+        DB::table('CBDB__NAME_FTS')->insert([
+            ['search_term' => 'lves', 'c_personid' => 801],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson(route('app.person-browser.search') . '?' . http_build_query(['q' => 'lv']));
+
+        $response->assertOk();
+        $ids = collect($response->json('data'))->pluck('c_personid')->map(fn ($id) => (int) $id)->all();
+        $this->assertContains(800, $ids, '拼音 "lv" 應命中以 ü 儲存的呂大防(800)，不應被雜訊 FTS 列 "lves" 短路排除');
+    }
+
+    #[Test]
     public function test_search_by_alt_name_via_fts(): void {
         $response = $this->actingAs($this->user)
             ->getJson(route('app.person-browser.search') . '?q=太白');


### PR DESCRIPTION
## 問題

Person Browser 搜 `lv`／`lü` 只回 **1 筆**、查不到大量姓呂（Lü）的人；但搜 `zhang` 卻能正常查到很多張姓。

## 根因（已對真實庫 `cbdb_data`／659,812 列實測確認）

`CBDB__NAME_FTS` 是「中文姓名」倒排索引（只索引 `c_name_chn`／`c_alt_name_chn` 的中文字後綴）。但索引中偶有**夾帶拉丁子字串的外文名**——例如某人 `c_name_chn` 含拉丁字母，被索引成 `search_term = "lves"`（`c_personid = 571895`）。

`search()` 的 FTS 分支以單一折疊形 `$q` 做 `search_term LIKE '$q%'`：
- `zhang` → FTS 命中 **0** → 正確落到 LIKE 回退 → **46,845 筆** ✓
- `lv` → FTS 命中 **1**（雜訊列 `lves`）→ `$ftsIds` 非空 → 走 `whereIn` 短路 → 只回 1 筆，**跳過能命中全部姓呂的拼音 LIKE 回退** ✗
- `lü` → `umlautToV` 折成 `lv` → 同上

差別純粹是「輸入是否剛好為某個混進索引的拉丁子字串的前綴」，與資料正確性無關。

## 修法

新增 `queryUsesFtsIndex()`（查詢含 Han 字才走 FTS）。`search()` 與 `buildDynastyCounts()` 一致改為：**僅中文查詢查 FTS；拼音／拉丁查詢一律走多欄位 LIKE 回退**（含 `c_name_chn`，故外文名仍可被回退命中；並以展開集 OR 同查 v／ü 形）。人物列表與朝代側欄口徑一致。

修正後 `lv`／`lü` 回 **32,576 筆**（含全部 3,221 位姓呂者）。

## 負載

- 中文查詢：仍走 FTS，不變且最快（實測 64–109ms）。
- 拼音查詢：本就多數走全表掃描回退（`zhang`／`wang` 早已如此，~0.9s）；本次只把少數「誤短路」的拼音查詢導回同路徑（`lv` ~1.2s），增量負載小，且原本結果是錯的。
- 既有特性提醒：拼音搜尋為 leading-wildcard 全表掃描，量大時的正解是另建羅馬字/拼音索引（獨立優化任務，與本修正無關）。

## 測試

新增回歸測試 `test_pinyin_search_not_hijacked_by_stray_latin_fts_row`：夾帶 `lves` 雜訊 FTS 列時，搜 `lv` 仍須命中以 ü 儲存的呂姓人（無修正時失敗、有修正時通過，已驗證）。

`./vendor/bin/phpunit --filter "PersonBrowser|NameSearch"` → 107 tests, 786 assertions，綠。

## 審查

已通過兩組 review agent 與 codex 覆核，無 CRITICAL/HIGH/MEDIUM 問題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)