### PR TITLE
fix(name-search): 拼音查詢一律繞過中文 FTS（修 /app/basicinformation 等處 lv/lü 只有一筆）

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -458,13 +458,18 @@ class ApiController extends Controller {
             $data = BiogMain::where('c_personid', '=', $request->q)->paginate($num);
         } else {
             // 優化2：使用 CBDB__NAME_FTS 倒排索引表進行高效前綴匹配
-            $personIds = DB::table('CBDB__NAME_FTS')
-                ->where('search_term', 'LIKE', $request->q . '%')
-                ->orderByRaw('LENGTH(search_term) ASC')  // 優先精確匹配
-                ->limit(500)  // 限制最多 500 個候選人
-                ->pluck('c_personid')
-                ->unique()
-                ->toArray();
+            // 僅中文查詢走 FTS；拼音／拉丁查詢直接落到下方 LIKE 回退（見 isChineseQuery 說明：
+            // 否則 "lv" 會誤命中索引中夾帶的拉丁子字串而短路，查不到姓呂的人）。
+            $personIds = [];
+            if (\App\Support\PinyinSearchNormalizer::isChineseQuery($request->q)) {
+                $personIds = DB::table('CBDB__NAME_FTS')
+                    ->where('search_term', 'LIKE', $request->q . '%')
+                    ->orderByRaw('LENGTH(search_term) ASC')  // 優先精確匹配
+                    ->limit(500)  // 限制最多 500 個候選人
+                    ->pluck('c_personid')
+                    ->unique()
+                    ->toArray();
+            }
 
             if (!empty($personIds)) {
                 // 使用 FIELD() 排序保持匹配質量順序

--- a/app/Http/Controllers/CbdbApiController.php
+++ b/app/Http/Controllers/CbdbApiController.php
@@ -303,7 +303,9 @@ class CbdbApiController extends Controller {
 
         // 20251115新增：使用倒排索引表 CBDB__NAME_FTS 進行高效姓名搜尋
         // 透過前綴匹配，查詢效能從 1500ms 降至 3ms（500倍提升）
-        if (Schema::hasTable('CBDB__NAME_FTS')) {
+        // 僅中文查詢走 FTS；拼音／拉丁查詢直接落到下方 LIKE 回退（見 isChineseQuery 說明：
+        // 否則 "lv" 會誤命中索引中夾帶的拉丁子字串而短路，查不到姓呂的人）。
+        if (Schema::hasTable('CBDB__NAME_FTS') && \App\Support\PinyinSearchNormalizer::isChineseQuery($term)) {
             $personIds = DB::table('CBDB__NAME_FTS')
                 ->where('search_term', 'LIKE', $term . '%')
                 ->orderByRaw('LENGTH(search_term) ASC')  // 優先精確匹配

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -477,13 +477,18 @@ class BiogMainRepository {
 
         // 20251115新增：使用倒排索引表進行高效姓名搜尋
         // 透過 CBDB__NAME_FTS 表實現前綴匹配，查詢效能從 1500ms 降至 3ms（500倍提升）
-        $personIds = DB::table('CBDB__NAME_FTS')
-            ->where('search_term', 'LIKE', $request->q . '%')
-            ->orderByRaw('LENGTH(search_term) ASC')  // 優先精確匹配
-            ->limit(500)  // 限制最多 500 個候選人
-            ->pluck('c_personid')
-            ->unique()
-            ->toArray();
+        // 僅中文查詢走 FTS；拼音／拉丁查詢直接落到下方 LIKE 回退（見 isChineseQuery 說明：
+        // 否則 "lv" 會誤命中索引中夾帶的拉丁子字串而短路，查不到大量姓呂的人）。
+        $personIds = [];
+        if (\App\Support\PinyinSearchNormalizer::isChineseQuery($request->q)) {
+            $personIds = DB::table('CBDB__NAME_FTS')
+                ->where('search_term', 'LIKE', $request->q . '%')
+                ->orderByRaw('LENGTH(search_term) ASC')  // 優先精確匹配
+                ->limit(500)  // 限制最多 500 個候選人
+                ->pluck('c_personid')
+                ->unique()
+                ->toArray();
+        }
 
         // 如果倒排索引查到結果，按找到的 personIds 查詢完整資訊
         if (!empty($personIds)) {
@@ -606,14 +611,18 @@ class BiogMainRepository {
             return collect();
         }
 
-        // 倒排索引路徑
-        $personIds = DB::table('CBDB__NAME_FTS')
-            ->where('search_term', 'LIKE', $q . '%')
-            ->orderByRaw('LENGTH(search_term) ASC')
-            ->limit(500)
-            ->pluck('c_personid')
-            ->unique()
-            ->toArray();
+        // 倒排索引路徑（僅中文查詢；與 namesByQuery 同口徑，拼音／拉丁查詢直接走下方 LIKE 回退，
+        // 否則側欄朝代分面會沿用 FTS 雜訊命中而與人物列表不一致）。
+        $personIds = [];
+        if (\App\Support\PinyinSearchNormalizer::isChineseQuery($q)) {
+            $personIds = DB::table('CBDB__NAME_FTS')
+                ->where('search_term', 'LIKE', $q . '%')
+                ->orderByRaw('LENGTH(search_term) ASC')
+                ->limit(500)
+                ->pluck('c_personid')
+                ->unique()
+                ->toArray();
+        }
 
         if (!empty($personIds)) {
             $validDynasties = DB::table('BIOG_MAIN')

--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -14,9 +14,10 @@ class PersonBrowserService {
      * 拼音輸入（如 "lv"）會誤命中這類雜訊記錄、拿到極少數 id 後短路，跳過底下能命中全部
      * 呂（Lü）姓的拼音 LIKE 回退，造成「搜 lv／lü 查不到大量姓呂的人，但搜 zhang 卻正常」。
      * 拉丁查詢一律改走多欄位 LIKE 回退（含 c_name_chn，故外文名仍可被回退命中）。
+     * 判定邏輯集中於 PinyinSearchNormalizer::isChineseQuery（BiogMainRepository 亦共用）。
      */
     private function queryUsesFtsIndex(string $q): bool {
-        return preg_match('/\p{Han}/u', $q) === 1;
+        return \App\Support\PinyinSearchNormalizer::isChineseQuery($q);
     }
 
     private function formatAdminCatLabel(?string $hz, ?string $trans): ?string {

--- a/app/Support/PinyinSearchNormalizer.php
+++ b/app/Support/PinyinSearchNormalizer.php
@@ -31,6 +31,18 @@ class PinyinSearchNormalizer {
     }
 
     /**
+     * 查詢是否應走「中文姓名」倒排索引（CBDB__NAME_FTS）。
+     *
+     * FTS 只索引中文字後綴。拼音／拉丁字母查詢不應查它：索引中偶有夾帶拉丁子字串的外文名
+     * （例如某人 c_name_chn 含 "Lves…"），拼音輸入（如 "lv"）會以 LIKE 'lv%' 誤命中這類雜訊、
+     * 拿到極少數 id 後短路，跳過能命中全部呂（Lü）姓的拼音 LIKE 回退，導致「搜 lv／lü 查不到
+     * 大量姓呂的人，但搜 zhang 卻正常」。故僅含 Han 字（中文）的查詢才走 FTS，其餘走 LIKE 回退。
+     */
+    public static function isChineseQuery(?string $term): bool {
+        return preg_match('/\p{Han}/u', (string) $term) === 1;
+    }
+
+    /**
      * 查詢展開：回傳應以 OR 同時比對的拼音形式（去重、保序）。
      *
      * 三個來源形式：

--- a/tests/Feature/BiogMainNameSearchTest.php
+++ b/tests/Feature/BiogMainNameSearchTest.php
@@ -355,6 +355,52 @@ class BiogMainNameSearchTest extends TestCase {
     }
 
     #[Test]
+    public function test_pinyin_search_not_hijacked_by_stray_latin_fts_row(): void {
+        // 迴歸（正式環境 /app/basicinformation 實際走的 namesByQuery 路徑）：CBDB__NAME_FTS 只索引
+        // 中文，但索引中偶有夾帶拉丁子字串的外文名（如 "Lves…"）。拼音 "lv" 曾以 LIKE 'lv%' 誤命中
+        // 該雜訊列、短路 FTS 分支（whereIn 只含那 1 筆），跳過能命中姓呂(Lü)的拼音 LIKE 回退，
+        // 造成「搜 lv／lü 只有一筆、查不到大量姓呂的人，但搜 zhang 卻正常」。
+        // 修法：拉丁查詢不走中文 FTS，一律改走多欄位 LIKE 回退。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 5010,
+            'c_name_chn' => '呂大防',
+            'c_name' => 'Lü Dafang',
+            'c_surname' => 'Lü',      // 遷移後以正字 ü 儲存的羅馬字姓
+            'c_mingzi' => 'Dafang',
+            'c_index_year' => 1027,
+            'c_dy' => 15,
+            'c_index_addr_id' => 100,
+        ]);
+        // 夾帶拉丁子字串的外文名（模擬 c_name_chn 內含 "Lves"）＋對應的雜訊 FTS 列。
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 5011,
+            'c_name_chn' => 'Lves',
+            'c_name' => 'Lves',
+            'c_surname' => 'Lves',
+            // 刻意用與呂大防(5010, c_dy=15)不同的朝代，讓朝代分面斷言具鑑別力：
+            // 修正前 facet 只會有雜訊列 5011 的朝代 16、缺 15；修正後才會出現 15。
+            'c_dy' => 16,
+        ]);
+        $now = now();
+        DB::table('CBDB__NAME_FTS')->insert([
+            ['c_personid' => 5011, 'name_type_code' => null, 'name_type_desc' => 'main_name', 'name_type_desc_chn' => '本名', 'search_term' => 'lves', 'full_name' => 'Lves', 'source' => 'biog_main', 'source_key' => 'biog_main:5011', 'is_simplified' => 0, 'created_at' => $now, 'updated_at' => $now],
+        ]);
+
+        $idsFor = fn (string $q): array => collect(
+            BiogMainRepository::namesByQuery(new Request(['q' => $q]), 20)->items()
+        )->pluck('c_personid')->map(fn ($id) => (int) $id)->all();
+
+        $this->assertContains(5010, $idsFor('lv'), '拼音 "lv" 應命中以 ü 儲存的呂大防(5010)，不應被雜訊 FTS 列 "lves" 短路排除');
+        $this->assertContains(5010, $idsFor('lü'), '拼音 "lü" 亦應命中呂大防(5010)');
+
+        // 側欄朝代分面須與人物列表同口徑（同樣繞過雜訊 FTS），否則列表有呂大防、側欄卻漏計。
+        // 修正前 facet 走 FTS→只含雜訊列 5011 的朝代 16、缺 15，故此斷言在修正前會失敗。
+        $facetDynasties = BiogMainRepository::dynastyFacetsByQuery('lv')
+            ->pluck('c_dy')->map(fn ($d) => (int) $d)->all();
+        $this->assertContains(15, $facetDynasties, '拼音 "lv" 的朝代分面應含呂大防(5010)所屬朝代 15，與列表一致');
+    }
+
+    #[Test]
     public function test_pinyin_normalizer_helper(): void {
         // ü／Ü 折成 v／V；中文／無 ü 字串為 no-op；null 安全。
         $this->assertSame('Lv Zhen', \App\Support\PinyinSearchNormalizer::umlautToV('Lü Zhen'));


### PR DESCRIPTION
## 問題

正式站 `/app/basicinformation?q=lü` 仍只回 **1 筆**、查不到大量姓呂（Lü）的人。上一個 PR（#1150）改的 `PersonBrowserService` 其實服務的是**另一個頁面** `/app/person-browser`——`/app/basicinformation` 走的是 `BasicInformationController@appIndex` → **`BiogMainRepository::namesByQuery`／`dynastyFacetsByQuery`**，故未生效。

## 根因（同前，已對真實庫 659,812 列複現）

`CBDB__NAME_FTS` 是「中文姓名」倒排索引，但索引中偶有**夾帶拉丁子字串的外文名**（如 `search_term = "lves"`）。各姓名搜尋入口都以 `search_term LIKE '$q%'` **無條件**查 FTS：
- `zhang` → FTS 命中 0 → 落到 LIKE 回退 → 正常
- `lv` → 誤命中雜訊列 `lves` → `$personIds` 非空 → `whereIn` 短路 → 只回 1 筆、**跳過能命中全部姓呂的回退**

## 修法

抽出共用 `PinyinSearchNormalizer::isChineseQuery()`（含 Han 字才走 FTS），在**所有**姓名搜尋讀取點加同一道閘；拼音／拉丁查詢一律走既有多欄位 LIKE 回退：

- `BiogMainRepository::namesByQuery`（人物列表，`/app/basicinformation` 與 `/api/name`）
- `BiogMainRepository::dynastyFacetsByQuery`（朝代側欄，與列表同口徑）
- `ApiController::searchBiog`（`/api/select/search/biog`，React 編輯器人物選擇器 AssocEditor／EntryEditor／KinEditor）
- `CbdbApiController::searchPersonCandidates`（公開 API 自動完成）
- `PersonBrowserService::queryUsesFtsIndex` 改為委託共用 helper（單一真相來源）

兩位 review agent 皆獨立指出後兩個入口也有同 bug，已一併修正。

## 驗證（真實庫）

| 入口 | 修正前 | 修正後 |
|---|---|---|
| `namesByQuery('lv')` | 1 | **14,559**（含 3,210 位姓呂） |
| `searchBiog('lv')` | 1 | **32,543** |
| `CbdbApi('lv')` | 1 | **20**（上限） |
| 中文「呂」 | FTS | FTS（不變） |

## 測試

新增 `test_pinyin_search_not_hijacked_by_stray_latin_fts_row`（無修正時失敗）：夾帶 `lves` 雜訊 FTS 列時，搜 `lv`/`lü` 仍須命中以 ü 儲存的呂姓人；並含**朝代側欄與列表同口徑**的鑑別性斷言（雜訊列給不同朝代，確保分面在修正前會缺漏）。

全套 **851 tests, 3747 assertions** 綠。

## 註

搜 `lv`/`lü` 的結果同時含 呂／盧／陸（Lu 群），係 DB collation 視 **ü ≈ u** 的既有 §D-8 語意，非本修正引入；要只看姓呂可搜中文「呂」。

## 審查

3 組 review agent + codex 覆核，無 CRITICAL/HIGH/MEDIUM 問題（agent 建議的 2 個額外入口與鑑別性斷言已採納）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)