### PR TITLE
docs(mutation): 新增 mutation API 增量改資料技能與 zhwiki 出處維護文檔

### DIFF
--- a/.claude/skills/mutation-api-record-editing.md
+++ b/.claude/skills/mutation-api-record-editing.md
@@ -1,0 +1,119 @@
+---
+name: 透過 Mutation API 修改記錄
+description: 使用 /api/v2 mutation 端點對 CBDB 人物子資源與 code 表做 create／update／delete／get 的正確流程、payload 格式、授權模式、錯誤碼與批次改資料（dry-run → 小批 → 全量）的安全做法。含 zh-wiki（BIOG_SOURCE_DATA c_textid=60795）實戰範例。
+---
+
+# 透過 Mutation API 修改記錄
+
+## 何時使用此技能
+
+- 要對 CBDB 人物子資源（著述出處、別名、地址、任官、社會關係、親屬、事件、社會身份、著作、機構…）或 code 表做**程式化／批次**的新增、修改、刪除。
+- 要把外部整理好的清單（如 `d1_build_*/round3/report_*.csv`）**增量**寫進 CBDB prod，而不是全量重灌。
+- 需要每筆變更都可審計、可回滾（`operations` 表 + AuditLog）。
+
+**不要**用 `WikiMaintenanceController`（`admin/wiki-maintenance/*`）做增量更新——它是首次全量導入用的，機制是「刪光某 `c_textid` 全部列再從 JSON 批量插」，會抹掉既有資料。維基／維基數據關聯的增量維護一律走本技能描述的 mutation API。
+
+## 端點總覽
+
+全部是 `web` 路由、`auth.optional` middleware，真正授權在 handler 內做。Controller：`app/Http/Controllers/Api/MutationController.php`。
+
+| 操作 | 端點 | 說明 |
+|------|------|------|
+| 讀取 | `GET\|POST /api/v2/get` | 依 PK 取單列；需登入且 `isActive()` |
+| 新增 | `POST /api/v2/create` | `operation` 固定 `create` |
+| 修改 | `POST /api/v2/mutate` | `operation` 預設 `update`（也可傳 `create`） |
+| 刪除 | `POST /api/v2/delete` | `operation` 固定 `delete` |
+
+> 目前每個端點**一次一筆**；大批量（如上千筆）建議分批 + 退避（見下文安全流程）。**批次接口 `POST /api/v2/batch_mutate`（一次多筆）規劃中、另行 PR**，落地後大批量改走它。
+
+## 授權與模式（mode）
+
+handler 內 `authorizeDirect()` / `authorizeProposal()`（見 `AbstractMutationHandler`）：
+
+- `mode=direct`：**立即寫入** prod。需 `Auth::user()->isActive()` **且** `canWriteDirectly()`。
+- `mode=proposal`：寫入**審核佇列**（`operations` 內 pending 提案），需人工核准後才落地。只需 `isActive()`。
+
+批次資料訂正若由操作員親自核對過來源，用 `direct`（立即寫入）；批量走 `proposal` 逐筆審批過於繁瑣，不採用。`direct` 需 `isActive()` 且 `canWriteDirectly()`（= 活躍且非群眾外包帳號）。
+
+**授權方式：Bearer Token（Sanctum PAT），不是 artisan。** `OptionalAuthentication` middleware 同時支援 Session Cookie 與 Bearer Token；`/api/v2/{mutate,create,delete,get}` 皆列於 `VerifyCsrfToken::$except`（CSRF 豁免）。因此正確的批次通道是：
+
+1. 操作員在網頁 **API Token 管理**（`/api-tokens`）建立 Personal Access Token（該帳號需活躍、非群眾外包）。
+2. 腳本以 `Authorization: Bearer <token>` + `Content-Type: application/json` 直接 `POST` 各端點。
+
+**不要寫成跑在 prod 的 artisan 命令**——不是所有操作員都有後台（shell）access；一律走上述 HTTP + Token 通道。腳本端自行實作 dry-run 與分批。
+
+## Payload 格式
+
+```jsonc
+{
+  "resource":  "sources",          // 資源別名，見下表
+  "mode":      "direct",           // direct | proposal
+  "operation": "update",           // create | update | delete（依端點）
+  "person_id": 35370,              // 該記錄所屬人物 c_personid
+  "target": { "pk": { /* 該表完整複合主鍵 */ } },
+  "changes": { /* 欲寫入的欄位；delete 不需要 */ },
+  "meta":    { "comment": "批次訂正 zh-wiki 條目標題" }
+}
+```
+
+- `person_id` 必填，且必須等於 `target.pk` 內的人物欄（`validateMutation` 會擋 mismatch）。
+- `target.pk` 必須是該表**完整**複合主鍵，欄位定義見 `app/Support/CompositePrimaryKey.php` 的 `SCHEMAS`。
+- **改鍵**（更動主鍵欄位）：`target.pk` 放**舊**值、`changes` 放**新**值。handler 會偵測新主鍵碰撞（→ 409）。人物欄 `c_personid` 一律不可改鍵。
+
+## 支援的 resource
+
+由 `MutationHandlerRegistry` 註冊，每個 handler 的 `supports()` 決定 resource／mode／operation 是否成立。人物子資源：`basic-info`(BIOG_MAIN)、`altname`、`address`、`entry`、`status`、`event`、`association`(assoc)、`kinship`(kin)、`possession`、`text`、`posting`、`social-institution`、`sources`。另有 code 表（`ConfigCodeTableMutationHandler`）。resource 名稱有別名正規化（如 `kin`/`kinship`/`kin_data`）。不支援的組合回 501。
+
+## 錯誤碼
+
+- `422` 參數／主鍵格式錯、person_id mismatch、update 無實質變更（`no_effective_changes`）。
+- `404` update／delete 目標列不存在。
+- `409` create 主鍵已存在，或改鍵後新主鍵撞到既有列，或已有相同主鍵的 pending 提案。
+- `403/401` 未登入／非活躍／無 `canWriteDirectly()`。
+
+成功回應含 `result.operation_id`（對應 `operations` 表，可經 Operations／Restore 流程回滾）與 `result.row`（direct 時的落地列）。
+
+## 實戰範例：批次維護中文維基（BIOG_SOURCE_DATA）
+
+CBDB prod 的維基／維基數據關聯存在 **`BIOG_SOURCE_DATA`**（不是 `wikidata_mapping`，後者是 Cloudflare D1、不在本專案範圍）：
+
+- `c_textid = 60795` → 中文維基百科；`c_pages` = 條目**標題**（非 URL）
+- `c_textid = 68942` → Wikidata；`c_pages` = QID
+- `c_textid = 68943` → 英文維基百科；`c_pages` = 英文標題
+- 顯示連結 = `TEXT_CODES.c_url_api` + `c_pages`（含 CJK 則 `rawurlencode`）+ `c_url_api_coda`
+- PK = (`c_personid`, `c_textid`, `c_pages`)；可改欄 = `c_notes`, `c_main_source`, `c_self_bio`
+
+報表（`report_zhwiki_new/changed/removed.csv`）的 URL 需先轉成 `c_pages` 標題：取 `/wiki/` 之後片段並 `urldecode`（例：`https://zh.wikipedia.org/wiki/隋恭帝` → `隋恭帝`）。**寫入前務必先用只讀 MCP 查 prod 現況核對標題格式（底線 vs 空白、CJK 解碼）**，別直接信報表。
+
+**c_pages 慣例（已核實）**：消歧義用**空格**非底線（prod 存「李天錫 (北魏)」），故轉換規則 = 取 `/wiki/` 後片段 → `urldecode` → `_` 換空格。
+
+對應操作：
+
+- **新增條目**（report_zhwiki_new）→ `create`
+  `target.pk = {c_personid, c_textid:60795, c_pages:<新標題>}`，`changes` 至少含 `c_textid`/`c_pages`。已存在回 409（視為已完成、跳過即可）。
+- **標題變更**（report_zhwiki_changed）→ `update`（改鍵）
+  `target.pk = {…, c_pages:<prod 現有舊標題>}`，`changes = {c_pages:<新標題>}`。撞新標題回 409。
+  **404「舊列不存在」多半是 prod 早已是新標題**（外部報表快照落後於 CBDB），內容已對、跳過即可；少數才是真異常，用 MCP 查現況確認。
+- **條目移除**（report_zhwiki_removed）→ `delete`。
+
+**批次標記（c_notes，可追溯）**：direct 模式 `meta.comment` **不落庫**（只有 proposal 用），故批次識別碼要寫進 `c_notes`（屬 `$data`、會持久化）。慣例格式：`日期 | 操作者 | batch_id`（batch_id 建議用來源檔內容 hash，穩定、跨分批共用）。以後查整批：`WHERE c_textid=60795 AND c_notes='<那串>'`。update 覆蓋 c_notes 前的舊值會存進 `operations` before-image + AuditLog，可回溯；若只想補標記不動 `c_pages`，對「現況列」發一筆只帶 `c_notes` 的 update 即可（不改鍵）。
+
+## 批次改資料的安全流程（務必遵守）
+
+1. **只讀盤點**：用 CBDB MCP（`cbdb-http-prod`，唯讀）把每筆的 prod 現況查出來，判定每筆該 create／update／skip，並核對 `c_pages` 格式。
+2. **Dry-run**：腳本先跑 `--dry-run`（預設），只印「將對哪個 PK 做什麼、舊值→新值」與 `c_notes`，不連網、不寫 DB。人工抽查。
+3. **小批寫入**：先寫 5~10 筆（`direct`），到 prod 覆核（用 `/api/v2/get` 或 MCP 讀回），確認連結正確、`c_notes` batch id 有寫、`operation_id` 有記錄。
+4. **逐步擴大**：確認無誤後逐步加大批次，直到清單全數處理。
+5. **限流與網路**：`/api/v2/*` 會回 `429`（限流）；批次腳本要對 429／暫時性錯誤做**指數退避重試**，並在每筆間 `sleep`（0.2s 起）。
+6. **可回滾／可追溯**：每筆都有 `operation_id` + `c_notes` batch id；出錯用 Operations／Restore（`OperationRepository`）回退。
+7. 授權用 **Bearer PAT**（可直接用 MCP token；寫入靠 `canWriteDirectly()` 而非 token ability），**不寫成跑在 prod 的 artisan**（操作員未必有後台），全程**不改 Cloudflare（D1）**。
+
+參考實作：`cbdb-dbs/d1_build_*/round3/sync_zhwiki_sources.py`（dry-run 預設、`--only`/`--limit`/`--offset` 分批、`--operator`、`--renote`、429 退避、結果 CSV 存 operation_id）。流程總覽見 `docs/ZHWIKI_SOURCE_SYNC.md`。
+
+## 相關檔案
+
+- `app/Http/Controllers/Api/MutationController.php`（store／create／delete／get）
+- `app/Services/Mutations/*`（各資源 handler、`MutationHandlerRegistry`、`AbstractMutationHandler`）
+- `app/Repositories/BiogSourceRepository.php`（sources 的 create/update/proposal/direct 實作）
+- `app/Support/CompositePrimaryKey.php`（各表 PK `SCHEMAS`）
+- `tests/Feature/ApiV2Mutate*Test.php`（各資源 mutation 回歸測試，改動後必跑）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,12 +115,14 @@ php artisan cbdb:fetch-chgis-map        # 下載 CHGIS 底圖（缺檔才下載�
 - [CHANGELOG.md](./CHANGELOG.md)
 - [DATABASE.md](./DATABASE.md)
 - [docs/APPROVAL_FLOWS.md](./docs/APPROVAL_FLOWS.md)
+- [docs/ZHWIKI_SOURCE_SYNC.md](./docs/ZHWIKI_SOURCE_SYNC.md)（中文維基連結增量維護：走 mutation API，勿用 WikiMaintenanceController 全量重灌）
 - [docs/VIEWS.md](./docs/VIEWS.md)
 - [docs/POSTING_OFFICE.md](./docs/POSTING_OFFICE.md)
 - [docs/COMPOSITE_PRIMARY_KEY_URL_DESIGN.md](./docs/COMPOSITE_PRIMARY_KEY_URL_DESIGN.md)
 
 ## AI / Claude skills
 - `.claude/skills/database-schema.md`
+- `.claude/skills/mutation-api-record-editing.md`
 - `.claude/skills/migration-guide.md`
 - `.claude/skills/pre-commit-checks.md`
 - `.claude/skills/testing-guide.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 2026-07
 
+### 中文維基連結改走 mutation API 增量維護（BIOG_SOURCE_DATA）
+- 確立中文/英文維基與 Wikidata 連結在 CBDB prod 存於 `BIOG_SOURCE_DATA`（`c_textid` 60795/68943/68942，`c_pages` 存條目標題），維護一律走 `/api/v2/{mutate,create,delete}` 的 `sources` 資源（`direct`、Bearer PAT、CSRF 豁免，寫入靠 `canWriteDirectly()`），每筆有 `operation_id` 可回滾。
+- **`WikiMaintenanceController`（全量刪除重灌）標記為僅限首次導入**，不得用於增量新增／修正；[docs/WIKI_TASK_MANAGEMENT.md](docs/WIKI_TASK_MANAGEMENT.md) 加說明橫幅。
+- 批次追溯：direct 模式 `meta.comment` 不落庫，故批號寫入 `c_notes`（`日期 | 操作者 | batch_id`，batch_id = 來源報表內容 hash）。
+- 新增技能 [.claude/skills/mutation-api-record-editing.md](.claude/skills/mutation-api-record-editing.md) 與流程文檔 [docs/ZHWIKI_SOURCE_SYNC.md](docs/ZHWIKI_SOURCE_SYNC.md)；執行腳本 `cbdb-dbs/d1_build_*/round3/sync_zhwiki_sources.py`（dry-run 預設、分批、429 退避）。
+
 ### `/codes` 排序／篩選功能加登入門檻（僅 React/Inertia 版）
 - 背景：一次生產環境癱瘓事後分析發現，`/codes/{TABLE}?sort_by=...` 這類深分頁＋任意欄位排序／前導通配符 filter 查詢先於請求量異常變慢，推擠掉 php-fpm worker 拖垮全站。
 - `app/codes/{table_name}`（`CodesController@appShow`）新增 `guardSortFilterRequiresAuth()`：請求帶 `sort_by` 或非空 `filters[...]` 時，未登入導向 `login`（記錄 intended URL）；已登入但未激活（`Auth::user()->isActive()` 為 false）改用 flash 訊息 + `redirect()->back()`（避免被 `login` 路由的 `guest` middleware 攔截）；已登入且已激活不受影響。無 sort/filter 的基礎瀏覽維持公開，不需登入。

--- a/docs/WIKI_TASK_MANAGEMENT.md
+++ b/docs/WIKI_TASK_MANAGEMENT.md
@@ -1,5 +1,7 @@
 # Wiki 导入任务管理
 
+> ⚠️ **仅限首次全量导入。** 本文描述的 `WikiMaintenanceController` / `wiki:task` 工具会**删除某 `c_textid` 的全部记录再重灌**，**不得用于增量新增／修正**。日常增量维护中文维基条目（BIOG_SOURCE_DATA）请走 mutation API，见 [ZHWIKI_SOURCE_SYNC.md](./ZHWIKI_SOURCE_SYNC.md) 与技能 [.claude/skills/mutation-api-record-editing.md](../.claude/skills/mutation-api-record-editing.md)。
+
 Wiki 维护工具现在支持任务取消功能，包括前端界面取消和命令行管理。
 
 ## 前端取消功能

--- a/docs/ZHWIKI_SOURCE_SYNC.md
+++ b/docs/ZHWIKI_SOURCE_SYNC.md
@@ -1,0 +1,98 @@
+# 中文維基條目增量維護（BIOG_SOURCE_DATA）
+
+本文記錄「把 Wikidata P497 對照報表增量寫進 CBDB prod 的中文維基連結」的正確流程。
+**此為現行做法；`WikiMaintenanceController`（全量刪除重灌）僅用於首次導入，不得用於增量維護**——見 [WIKI_TASK_MANAGEMENT.md](./WIKI_TASK_MANAGEMENT.md) 的說明橫幅。
+
+操作型技能：[.claude/skills/mutation-api-record-editing.md](../.claude/skills/mutation-api-record-editing.md)。
+
+## 資料位置
+
+CBDB prod 的維基／維基數據關聯存在 **`BIOG_SOURCE_DATA`**（**不是** `wikidata_mapping`；後者是 Cloudflare D1 的下游，**不在本專案範圍、不改**）：
+
+| c_textid | 來源 | c_pages 內容 |
+|----------|------|--------------|
+| 60795 | 中文維基百科 | 條目**標題**（非 URL） |
+| 68942 | Wikidata | QID |
+| 68943 | 英文維基百科 | 英文標題 |
+
+- 顯示連結 = `TEXT_CODES.c_url_api`（zh = `https://zh.wikipedia.org/wiki/`）+ `c_pages`（含 CJK 則 `rawurlencode`）
+- PK = (`c_personid`, `c_textid`, `c_pages`)；可改欄 = `c_notes`, `c_main_source`, `c_self_bio`
+
+## 寫入通道
+
+`POST /api/v2/mutate`（更新）／`/api/v2/create`（新增）／`/api/v2/delete`（刪除），`resource=sources`，`mode=direct`。
+
+- 授權：`Authorization: Bearer <Sanctum PAT>`（可直接用 MCP token）。端點 CSRF 豁免；direct 寫入靠 `canWriteDirectly()`（活躍且非群眾外包），非 token ability。
+- **不寫成跑在 prod 的 artisan**（並非所有操作員都有後台 access）。
+- 每筆寫 `operations`（operation_id，可回滾）+ AuditLog。
+
+## URL → c_pages 轉換（已對 prod 核實）
+
+取 URL 中 `/wiki/` 之後片段 → `urldecode` → **把 `_` 換成空格**（prod 慣例：消歧義用空格，如 `李天錫 (北魏)`）。
+
+```
+https://zh.wikipedia.org/wiki/张茂宗_(唐朝)  ->  '张茂宗 (唐朝)'
+```
+
+## 操作對應
+
+| 報表 | 操作 | target.pk.c_pages | changes |
+|------|------|-------------------|---------|
+| report_zhwiki_new | `create` | 新標題 | `c_textid`,`c_pages`,`c_notes` |
+| report_zhwiki_changed | `update`（改鍵） | prod **舊**標題 | `c_pages`(新),`c_notes` |
+| report_zhwiki_removed | `delete` | 舊標題 | — |
+
+冪等與判讀：
+
+- create 撞已存在 → `409`，視為已完成、跳過。
+- update 找不到舊列 → `404`，**多半是 prod 早已是新標題**（外部報表快照落後於 CBDB），內容已對、跳過；少數才是真異常，用 MCP 查現況確認。
+- `429` 限流 → 指數退避重試。
+
+## 批次標記（c_notes）
+
+direct 模式 `meta.comment` **不落庫**，故批次識別碼寫進 `c_notes`：
+
+```
+日期 | 操作者 | batch_id        例：2026-07-12 | Frank Lin | zhwiki-r3-67368e91
+```
+
+- `batch_id` = 來源報表檔內容 sha1 前 8 碼（穩定、跨分批共用）。
+- 整批檢索：`SELECT ... FROM BIOG_SOURCE_DATA WHERE c_textid=60795 AND c_notes='<那串>'`。
+- update 覆蓋 `c_notes` 前的舊值存於 operations before-image + AuditLog，可回溯。
+
+## 執行腳本
+
+`cbdb-dbs/d1_build_<date>/round3/sync_zhwiki_sources.py`
+
+```bash
+# 1) 只讀盤點 + dry-run（預設不寫）
+python3 sync_zhwiki_sources.py --only changed --operator "Frank Lin" --dry-run
+
+# 2) 小批寫入（direct），到 prod 讀回覆核
+CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --only changed --limit 5 --operator "Frank Lin"
+
+# 3) 逐步擴大（--offset 續跑；幂等可重跑）
+CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --only changed --offset 5 --operator "Frank Lin"
+CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --only new     --offset 5 --operator "Frank Lin"
+
+# 只回填 c_notes（不改 c_pages）
+CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --renote --only changed --operator "Frank Lin"
+```
+
+結果寫入 `sync_zhwiki_result_*.csv`（含 http_status / result / operation_id / batch_id）。
+
+## 驗證（只讀 MCP）
+
+```sql
+-- 整批筆數
+SELECT COUNT(*) FROM BIOG_SOURCE_DATA WHERE c_textid=60795 AND c_notes='<batch note>';
+-- 抽驗某人現況
+SELECT c_personid, c_pages, c_notes FROM BIOG_SOURCE_DATA WHERE c_textid=60795 AND c_personid IN (...);
+```
+
+## 進度紀錄
+
+- **2026-07-12 / batch `zhwiki-r3-67368e91`**：
+  - report_zhwiki_changed 99 筆全部完成（95 筆更新到新標題並打 batch note；4 筆 CBDB 本就正確、保留原 note；2 筆遇 429 已重試）。
+  - report_zhwiki_new：測試 5 筆已 create（+renote）；**剩 1965 筆待跑**（`--only new --offset 5`）。
+  - report_zhwiki_removed 3 筆已手動處理。


### PR DESCRIPTION
- 新增 skill .claude/skills/mutation-api-record-editing.md：/api/v2 mutation 端點的 payload、授權模式、錯誤碼、批次安全流程（dry-run→小批→全量）與 c_notes 批號慣例；並註記批次接口 batch_mutate 規劃中（另行 PR）
- 新增 docs/ZHWIKI_SOURCE_SYNC.md：中文維基連結存 BIOG_SOURCE_DATA(c_textid=60795)， 走 mutation API sources 資源做增量新增/訂正的完整流程、轉換規則與進度紀錄
- docs/WIKI_TASK_MANAGEMENT.md 加橫幅：WikiMaintenanceController 僅限首次全量導入， 增量維護不宜使用
- AGENTS.md 相關文檔清單 / CHANGELOG.md 2026-07 登記