### PR TITLE
fix(operations): 補 (resource, resource_id, op_type) 索引，消除每筆 create 全表掃描

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 2026-07
 
+### 修復 operations 表缺索引導致每筆 create 全表掃描（生產穩定性）
+- **問題**：所有子資源 create 都會對 operations 做「pending 提案」預檢（`WHERE resource=? AND resource_id IN(?) AND op_type=?`，見 `AbstractPersonSubresourceCreateHandler` / `SourceMutationHandler` / `PostingCreateHandler`），但 operations 僅有 `PRIMARY(id)` 與 `KEY(c_personid)`，`resource`/`resource_id` 無索引 → 每寫一筆就**全表掃描一次** operations（該表隨每次 mutation 持續增長）。批次/並發寫入時大量並發全表掃描飽和 DB、堆積慢查詢、推爆 php-fpm（與 /codes 深分頁那次生產癱瘓同一模式）。
+- **修復**：新增 migration 為 operations 補 `(resource, resource_id, op_type)` 複合索引（`2026_07_12_000000_add_resource_index_to_operations_table`），把預檢由全表掃描收斂為索引 seek。
+- ⚠ **部署**：operations 表大，`ADD INDEX` 於 MariaDB 10.3 為 ONLINE（不長鎖表）但需建置時間，建議低峰執行。
+- 後續可再收斂 `hasPendingCreateProposal` 系列由 `get()->contains()` 改為 `exists()` 語義（另議）。
+
 ### `/codes` 排序／篩選功能加登入門檻（僅 React/Inertia 版）
 - 背景：一次生產環境癱瘓事後分析發現，`/codes/{TABLE}?sort_by=...` 這類深分頁＋任意欄位排序／前導通配符 filter 查詢先於請求量異常變慢，推擠掉 php-fpm worker 拖垮全站。
 - `app/codes/{table_name}`（`CodesController@appShow`）新增 `guardSortFilterRequiresAuth()`：請求帶 `sort_by` 或非空 `filters[...]` 時，未登入導向 `login`（記錄 intended URL）；已登入但未激活（`Auth::user()->isActive()` 為 false）改用 flash 訊息 + `redirect()->back()`（避免被 `login` 路由的 `guest` middleware 攔截）；已登入且已激活不受影響。無 sort/filter 的基礎瀏覽維持公開，不需登入。

--- a/database/migrations/2026_07_12_000000_add_resource_index_to_operations_table.php
+++ b/database/migrations/2026_07_12_000000_add_resource_index_to_operations_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 為 operations 補上 (resource, resource_id, op_type) 複合索引。
+ *
+ * 背景：每一筆子資源 create 都會做「pending 提案」預檢（避免同主鍵重複提案），查詢形如
+ *   SELECT * FROM operations
+ *   WHERE resource = ? AND resource_id IN (?) AND op_type = ?
+ * 呼叫點遍及所有 create 路徑：
+ *   - AbstractPersonSubresourceCreateHandler（address/altname/entry/status/event/assoc/kinship/
+ *     possession/text/social-institution 共用）
+ *   - SourceMutationHandler（BIOG_SOURCE_DATA）、PostingCreateHandler（POSTED_TO_OFFICE_DATA）
+ *
+ * 但 operations 原本只有 PRIMARY(id) 與 KEY(c_personid)，resource / resource_id 上無索引，
+ * 上述查詢在 MariaDB/MySQL 退化成**整張 operations 全表掃描**。operations 是操作日誌表，隨每一次
+ * mutation（含歷史所有提案與 direct 寫入）持續增長，於是每寫一筆就掃全表一次；批次/並發寫入時
+ * 大量並發全表掃描會飽和 DB CPU/IO、堆積慢查詢、推爆 php-fpm worker（與 /codes 深分頁那次生產
+ * 癱瘓同一模式）。
+ *
+ * 索引把該預檢由全表掃描收斂為索引 seek。欄序：resource（等值）→ resource_id（等值/IN，最具選擇性，
+ * 幾近唯一定位到該主鍵的提案列）→ op_type（尾欄過濾），同時服務 hasPending{Create,Update,Delete}Proposal
+ * 三種變體與任何 (resource, resource_id) 查詢。
+ *
+ * 部署：operations 表大，ADD INDEX 於 MariaDB 10.3 預設為 ONLINE（INPLACE/LOCK=NONE）、不長時間鎖表，
+ * 但仍需一段建置時間，建議於低峰執行。SQLite（測試）建索引為即時。
+ */
+return new class () extends Migration {
+    private const INDEX_NAME = 'operations_resource_resource_id_op_type_index';
+
+    public function up(): void {
+        // operations 由 2025_01_01 schema import 必然先建立；若不存在屬異常狀態，fail-fast 而非靜默跳過。
+        if ($this->indexExists()) {
+            return;
+        }
+
+        Schema::table('operations', function (Blueprint $table) {
+            $table->index(['resource', 'resource_id', 'op_type'], self::INDEX_NAME);
+        });
+    }
+
+    public function down(): void {
+        if (!$this->indexExists()) {
+            return;
+        }
+
+        Schema::table('operations', function (Blueprint $table) {
+            $table->dropIndex(self::INDEX_NAME);
+        });
+    }
+
+    /**
+     * 幂等守衛：索引已存在則跳過（重跑 migrate、或環境已手動補過索引時皆安全）。
+     */
+    private function indexExists(): bool {
+        try {
+            return Schema::hasIndex('operations', self::INDEX_NAME);
+        } catch (\Throwable $e) {
+            // 舊版 Schema 無 hasIndex 時退回「不確定 → 讓 up/down 照跑」；重複建索引會由 DB 報錯，屬可見失敗。
+            return false;
+        }
+    }
+};


### PR DESCRIPTION
所有子資源 create 都對 operations 做 pending 提案預檢
（WHERE resource=? AND resource_id IN(?) AND op_type=?），但 operations 只有 PRIMARY(id) 與 KEY(c_personid)，resource/resource_id 無索引，導致每寫一筆就 全表掃描一次持續增長的 operations 表；批次/並發寫入時大量並發全表掃描飽和
DB、堆積慢查詢、推爆 php-fpm（與 /codes 深分頁生產癱瘓同一模式）。

新增 migration 補複合索引，把預檢由全表掃描收斂為索引 seek。
索引欄序 resource（等值）→ resource_id（最具選擇性）→ op_type（尾欄過濾）， 兼服務 hasPending{Create,Update,Delete}Proposal 三種變體。

部署注意：operations 表若較大，ADD INDEX 於 MariaDB 10.3 為 ONLINE 但需建置時間， 建議低峰執行。