### PR TITLE
feat(mutation): 新增批次變更端點 POST /api/v2/batch_mutate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 2026-07
 
+### 新增批次變更端點 `POST /api/v2/batch_mutate`
+- 一個請求帶多筆 `items`，逐筆分發到既有 `MutationHandlerRegistry` handler，**完全沿用單筆端點的校驗／改鍵碰撞偵測／授權／`operations`＋AuditLog**，不另起平行寫入邏輯；用於消除逐筆 HTTP 往返與限流（429）成本。
+- `atomic=false`（預設）：逐筆獨立結算，單筆失敗不影響其餘，回 200 + `results[]` + `summary{total,ok,failed}`（`body.ok`＝是否全數成功）。
+- `atomic=true`：整批單一交易，任一筆失敗整批回滾（handler 內層交易降為 savepoint），回 409 + `failed_index`。
+- 支援頂層 `resource/mode/operation/meta` 預設（逐項可覆寫）；單次上限 `BATCH_MAX_ITEMS=500`（超過回 422）；單筆未預期例外隔離為該筆 500，不拖垮整批。
+- 端點列入 CSRF 豁免、`auth.optional`；`direct` 寫入仍需 `canWriteDirectly()`。
+- 測試 `tests/Feature/ApiV2MutateBatchTest.php`：missing-items/over-limit 422、非原子部分成功、原子全成、原子失敗回滾、頂層預設合併、群眾外包 direct 403。
+
 ### `/codes` 排序／篩選功能加登入門檻（僅 React/Inertia 版）
 - 背景：一次生產環境癱瘓事後分析發現，`/codes/{TABLE}?sort_by=...` 這類深分頁＋任意欄位排序／前導通配符 filter 查詢先於請求量異常變慢，推擠掉 php-fpm worker 拖垮全站。
 - `app/codes/{table_name}`（`CodesController@appShow`）新增 `guardSortFilterRequiresAuth()`：請求帶 `sort_by` 或非空 `filters[...]` 時，未登入導向 `login`（記錄 intended URL）；已登入但未激活（`Auth::user()->isActive()` 為 false）改用 flash 訊息 + `redirect()->back()`（避免被 `login` 路由的 `guest` middleware 攔截）；已登入且已激活不受影響。無 sort/filter 的基礎瀏覽維持公開，不需登入。

--- a/app/Http/Controllers/Api/MutationController.php
+++ b/app/Http/Controllers/Api/MutationController.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class MutationController extends Controller {
+    /** batch_mutate 單次請求最多筆數（避免超大請求撐爆記憶體/逾時）。 */
+    public const BATCH_MAX_ITEMS = 500;
+
     protected MutationHandlerRegistry $handlerRegistry;
     protected MutationReadService $readService;
     protected RelationshipMirrorService $mirrorService;
@@ -265,6 +268,167 @@ class MutationController extends Controller {
         }
 
         return $handler->handle($resource, $mode, 'delete', (int) $personId, $targetPk, [], is_array($meta) ? $meta : []);
+    }
+
+    /**
+     * 批次變更：一個請求帶多筆 item，逐筆分發到既有 handler（沿用同一套校驗／改鍵碰撞／授權／
+     * operations／AuditLog，避免另起平行寫入邏輯造成語義漂移）。用於降低逐筆 HTTP 往返成本。
+     *
+     * 請求：{ items: [ {resource, mode, operation, person_id, target:{pk}, changes, meta}, ... ],
+     *        atomic?: bool, resource?/mode?/operation?/meta?: 頂層預設（逐項可覆寫） }
+     *
+     * atomic=false（預設）：逐筆獨立結算，單筆失敗不影響其餘；回 200，body.results 為逐筆結果、
+     *   body.summary 為彙總；body.ok = 是否全數成功。
+     * atomic=true：整批單一交易，任一筆失敗整批回滾，回 409 並帶 failed_index。
+     */
+    public function batchStore(Request $request): JsonResponse {
+        $payload = $request->json()->all();
+        if (!is_array($payload) || empty($payload)) {
+            $payload = $request->all();
+        }
+
+        $items = $payload['items'] ?? null;
+        if (!is_array($items) || $items === []) {
+            return $this->errorResponse('缺少 items', 422, ['items' => ['required']]);
+        }
+
+        if (count($items) > self::BATCH_MAX_ITEMS) {
+            return $this->errorResponse('單次批次筆數超過上限', 422, [
+                'items' => ['too_many', 'max:'.self::BATCH_MAX_ITEMS, 'count:'.count($items)],
+            ]);
+        }
+
+        $atomic = filter_var($payload['atomic'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $defaults = [
+            'resource' => $payload['resource'] ?? null,
+            'mode' => $payload['mode'] ?? null,
+            'operation' => $payload['operation'] ?? null,
+            'meta' => $payload['meta'] ?? null,
+        ];
+
+        if (!$atomic) {
+            $results = [];
+            foreach ($items as $index => $item) {
+                $results[] = $this->runBatchItem($item, $defaults, (int) $index);
+            }
+
+            return $this->batchSummaryResponse($results, false);
+        }
+
+        // atomic：手動交易，任一筆非成功即整批回滾（handler 內層交易為 savepoint，外層 rollBack 一併撤銷）。
+        DB::beginTransaction();
+
+        try {
+            $results = [];
+            foreach ($items as $index => $item) {
+                $res = $this->runBatchItem($item, $defaults, (int) $index);
+                $results[] = $res;
+                if (!$res['ok']) {
+                    DB::rollBack();
+
+                    return response()->json([
+                        'ok' => false,
+                        'atomic' => true,
+                        'message' => '批次原子模式：某筆失敗，整批已回滾',
+                        'failed_index' => $res['index'],
+                        'failed' => $res,
+                        'results' => $results,
+                    ], 409);
+                }
+            }
+            DB::commit();
+        } catch (\Throwable $e) {
+            if (DB::transactionLevel() > 0) {
+                DB::rollBack();
+            }
+
+            throw $e;
+        }
+
+        return $this->batchSummaryResponse($results, true);
+    }
+
+    /**
+     * 執行單筆批次 item：解析頂層預設、做與單筆端點一致的必要欄位檢查、解析 handler、呼叫 handle()，
+     * 並把回傳的 JsonResponse 正規化為含 index/http_status/ok 的陣列。
+     */
+    protected function runBatchItem($item, array $defaults, int $index): array {
+        if (!is_array($item)) {
+            return ['index' => $index, 'http_status' => 422, 'ok' => false,
+                'message' => 'item 必須為物件', 'errors' => ['item' => ['invalid']]];
+        }
+
+        $resource = strtolower((string) ($item['resource'] ?? $defaults['resource'] ?? ''));
+        $mode = strtolower((string) ($item['mode'] ?? $defaults['mode'] ?? 'direct'));
+        $operation = strtolower((string) ($item['operation'] ?? $defaults['operation'] ?? 'update'));
+        $personId = $item['person_id'] ?? null;
+        $targetPk = $item['target']['pk'] ?? null;
+        $changes = $item['changes'] ?? null;
+        $meta = $item['meta'] ?? $defaults['meta'] ?? [];
+
+        $fail = fn (string $msg, array $errors): array => [
+            'index' => $index, 'http_status' => 422, 'ok' => false, 'message' => $msg, 'errors' => $errors,
+        ];
+
+        if (!is_array($targetPk)) {
+            return $fail('缺少 target.pk', ['target.pk' => ['required']]);
+        }
+        if ($operation !== 'delete' && !is_array($changes)) {
+            return $fail('缺少 changes', ['changes' => ['required']]);
+        }
+        if ($personId === null || $personId === '') {
+            return $fail('缺少 person_id', ['person_id' => ['required']]);
+        }
+
+        $handler = $this->handlerRegistry->resolve($resource, $mode, $operation);
+        if (!$handler) {
+            return ['index' => $index, 'http_status' => 501, 'ok' => false,
+                'message' => '目前尚未支援此變更模式',
+                'errors' => ['resource' => $resource, 'mode' => $mode, 'operation' => $operation]];
+        }
+
+        try {
+            $response = $handler->handle(
+                $resource,
+                $mode,
+                $operation,
+                (int) $personId,
+                $targetPk,
+                is_array($changes) ? $changes : [],
+                is_array($meta) ? $meta : []
+            );
+        } catch (\Throwable $e) {
+            // 單筆未預期例外不拖垮整個請求：轉為該筆 500 錯誤（atomic 模式下會經 !ok 路徑觸發整批回滾）。
+            return ['index' => $index, 'http_status' => 500, 'ok' => false,
+                'message' => '處理時發生例外', 'errors' => ['exception' => [$e->getMessage()]]];
+        }
+
+        $status = $response->getStatusCode();
+        $body = json_decode($response->getContent(), true);
+        if (!is_array($body)) {
+            $body = [];
+        }
+
+        $out = ['index' => $index, 'http_status' => $status] + $body;
+        $out['ok'] = ($body['ok'] ?? false) === true;
+
+        return $out;
+    }
+
+    protected function batchSummaryResponse(array $results, bool $atomic): JsonResponse {
+        $failed = 0;
+        foreach ($results as $r) {
+            if (!$r['ok']) {
+                $failed++;
+            }
+        }
+
+        return response()->json([
+            'ok' => $failed === 0,
+            'atomic' => $atomic,
+            'summary' => ['total' => count($results), 'ok' => count($results) - $failed, 'failed' => $failed],
+            'results' => $results,
+        ]);
     }
 
     protected function errorResponse(string $message, int $status, array $errors = []): JsonResponse {

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -16,6 +16,7 @@ class VerifyCsrfToken extends BaseVerifier {
         'api/v2/delete',
         'api/v2/get',
         'api/v2/mutate',
+        'api/v2/batch_mutate',
     ];
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::get('openapi.yaml', function () {
     ]);
 })->name('openapi.yaml');
 Route::middleware(['auth.optional'])->post('api/v2/mutate', 'Api\\MutationController@store')->name('api.v2.mutate.web');
+Route::middleware(['auth.optional'])->post('api/v2/batch_mutate', 'Api\\MutationController@batchStore')->name('api.v2.batch-mutate.web');
 Route::middleware(['auth.optional'])->post('api/v2/create', 'Api\\MutationController@create')->name('api.v2.create.web');
 Route::middleware(['auth.optional'])->post('api/v2/delete', 'Api\\MutationController@delete')->name('api.v2.delete.web');
 Route::middleware(['auth.optional'])->match(['get', 'post'], 'api/v2/get', 'Api\\MutationController@get')->name('api.v2.get.web');

--- a/tests/Feature/ApiV2MutateBatchTest.php
+++ b/tests/Feature/ApiV2MutateBatchTest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\Api\MutationController;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * batch_mutate（POST /api/v2/batch_mutate）回歸測試。
+ *
+ * 以 sources（BIOG_SOURCE_DATA）為載具，驗證批次端點：
+ * - 沿用既有 handler（校驗/改鍵/授權/operations 一致），逐筆結果 + 彙總。
+ * - atomic=false：逐筆獨立結算，單筆失敗不影響其餘。
+ * - atomic=true：任一筆失敗整批回滾。
+ * - 頂層預設（resource/mode）逐項可覆寫；超過上限 422；缺 items 422。
+ */
+class ApiV2MutateBatchTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('app.env', 'testing');
+        $this->app['env'] = 'testing';
+        config()->set('prometheus.enabled', false);
+        config()->set('prometheus.storage_adapter', 'memory');
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createUsersTable();
+        $this->createSanctumTables();
+        $this->createOperationsTable();
+        $this->createAuditLogTable();
+        $this->createTextCodesTable();
+        $this->createSourceTable();
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('BIOG_SOURCE_DATA');
+        Schema::dropIfExists('TEXT_CODES');
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    protected function createUsersTable(): void {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function createSanctumTables(): void {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function createOperationsTable(): void {
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    protected function createAuditLogTable(): void {
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+    }
+
+    protected function createTextCodesTable(): void {
+        Schema::create('TEXT_CODES', function (Blueprint $table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title')->nullable();
+            $table->string('c_title_chn')->nullable();
+        });
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 0, 'c_title' => 'n/a', 'c_title_chn' => '未詳'],
+            ['c_textid' => 500, 'c_title' => 'Book A', 'c_title_chn' => '甲書'],
+            ['c_textid' => 700, 'c_title' => 'Book B', 'c_title_chn' => '乙書'],
+        ]);
+    }
+
+    protected function createSourceTable(): void {
+        Schema::create('BIOG_SOURCE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_textid')->default(0);
+            $table->string('c_pages', 255)->default('');
+            $table->longText('c_notes')->nullable();
+            $table->smallInteger('c_main_source')->nullable();
+            $table->smallInteger('c_self_bio')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->primary(['c_personid', 'c_textid', 'c_pages']);
+        });
+    }
+
+    protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'batch@example.com'): User {
+        return User::create([
+            'name' => 'batch-tester',
+            'email' => $email,
+            'confirmation_token' => 'token-b',
+            'is_active' => $status,
+            'is_admin' => $role,
+        ]);
+    }
+
+    /** 一筆 create item（sources）。 */
+    protected function createItem(int $personid, int $textid, string $pages, array $changes = []): array {
+        return [
+            'resource' => 'sources',
+            'operation' => 'create',
+            'person_id' => $personid,
+            'target' => ['pk' => ['c_personid' => $personid, 'c_textid' => $textid, 'c_pages' => $pages]],
+            'changes' => array_merge(['c_textid' => $textid, 'c_pages' => $pages, 'c_notes' => 'b'], $changes),
+        ];
+    }
+
+    #[Test]
+    public function testMissingItemsReturns422(): void {
+        $this->actingAs($this->makeUser(email: 'b-empty@example.com'));
+
+        $this->postJson('/api/v2/batch_mutate', ['items' => []])
+            ->assertStatus(422)
+            ->assertJson(['ok' => false, 'errors' => ['items' => ['required']]]);
+    }
+
+    #[Test]
+    public function testOverLimitReturns422(): void {
+        $this->actingAs($this->makeUser(email: 'b-over@example.com'));
+
+        $items = [];
+        for ($i = 0; $i <= MutationController::BATCH_MAX_ITEMS; $i++) {
+            $items[] = $this->createItem(1000, 500, (string) $i);
+        }
+
+        $this->postJson('/api/v2/batch_mutate', ['items' => $items])
+            ->assertStatus(422)
+            ->assertJsonPath('errors.items.0', 'too_many');
+    }
+
+    #[Test]
+    public function testNonAtomicPartialSuccessKeepsGoing(): void {
+        // item0 create OK；item1 = 與 item0 相同主鍵 → 409 已存在；item2 create OK。
+        // 非原子：全部照跑，成功者落庫，失敗者不影響其餘。
+        $this->actingAs($this->makeUser(email: 'b-partial@example.com'));
+
+        $res = $this->postJson('/api/v2/batch_mutate', [
+            'items' => [
+                $this->createItem(1000, 500, '10'),
+                $this->createItem(1000, 500, '10'), // duplicate → 409
+                $this->createItem(1000, 500, '20'),
+            ],
+        ]);
+
+        $res->assertOk()
+            ->assertJson(['ok' => false, 'atomic' => false, 'summary' => ['total' => 3, 'ok' => 2, 'failed' => 1]]);
+        $res->assertJsonPath('results.0.ok', true);
+        $res->assertJsonPath('results.1.ok', false);
+        $res->assertJsonPath('results.1.http_status', 409);
+        $res->assertJsonPath('results.2.ok', true);
+
+        $this->assertDatabaseHas('BIOG_SOURCE_DATA', ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '10']);
+        $this->assertDatabaseHas('BIOG_SOURCE_DATA', ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '20']);
+        $this->assertSame(2, DB::table('BIOG_SOURCE_DATA')->count());
+    }
+
+    #[Test]
+    public function testAtomicAllSuccessCommits(): void {
+        $this->actingAs($this->makeUser(email: 'b-atomic-ok@example.com'));
+
+        $this->postJson('/api/v2/batch_mutate', [
+            'atomic' => true,
+            'items' => [
+                $this->createItem(1000, 500, '1'),
+                $this->createItem(1000, 500, '2'),
+                $this->createItem(1000, 700, '3'),
+            ],
+        ])->assertOk()->assertJson(['ok' => true, 'atomic' => true, 'summary' => ['total' => 3, 'ok' => 3, 'failed' => 0]]);
+
+        $this->assertSame(3, DB::table('BIOG_SOURCE_DATA')->count());
+    }
+
+    #[Test]
+    public function testAtomicFailureRollsBackWholeBatch(): void {
+        // item0/1 create OK，item2 = 與 item1 撞主鍵 → 409；原子模式整批回滾，DB 一列都不留。
+        $this->actingAs($this->makeUser(email: 'b-atomic-fail@example.com'));
+
+        $res = $this->postJson('/api/v2/batch_mutate', [
+            'atomic' => true,
+            'items' => [
+                $this->createItem(1000, 500, '1'),
+                $this->createItem(1000, 500, '2'),
+                $this->createItem(1000, 500, '2'), // duplicate of item1 → 409
+            ],
+        ]);
+
+        $res->assertStatus(409)
+            ->assertJson(['ok' => false, 'atomic' => true, 'failed_index' => 2]);
+        $res->assertJsonPath('failed.http_status', 409);
+
+        // 整批回滾：item0/1 雖曾成功，也一併撤銷。
+        $this->assertSame(0, DB::table('BIOG_SOURCE_DATA')->count());
+    }
+
+    #[Test]
+    public function testTopLevelDefaultsMergeIntoItems(): void {
+        // 頂層帶 resource/mode/operation，item 只給 person_id/target/changes。
+        $this->actingAs($this->makeUser(email: 'b-defaults@example.com'));
+
+        $this->postJson('/api/v2/batch_mutate', [
+            'resource' => 'sources',
+            'mode' => 'direct',
+            'operation' => 'create',
+            'items' => [
+                [
+                    'person_id' => 1000,
+                    'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => 'd1']],
+                    'changes' => ['c_textid' => 500, 'c_pages' => 'd1', 'c_notes' => 'x'],
+                ],
+            ],
+        ])->assertOk()->assertJson(['ok' => true, 'summary' => ['ok' => 1]]);
+
+        $this->assertDatabaseHas('BIOG_SOURCE_DATA', ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => 'd1']);
+    }
+
+    #[Test]
+    public function testDirectRejectsCrowdsourcingUserPerItem(): void {
+        // 直接寫入需 canWriteDirectly()；群眾外包帳號逐筆 403（沿用 handler 授權）。
+        $this->actingAs($this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'b-crowd@example.com'));
+
+        $res = $this->postJson('/api/v2/batch_mutate', [
+            'items' => [$this->createItem(1000, 500, '1')],
+        ]);
+
+        $res->assertOk()->assertJson(['ok' => false, 'summary' => ['failed' => 1]]);
+        $res->assertJsonPath('results.0.http_status', 403);
+        $this->assertSame(0, DB::table('BIOG_SOURCE_DATA')->count());
+    }
+}


### PR DESCRIPTION
一個請求帶多筆 items，逐筆分發到既有 MutationHandlerRegistry handler， 完全沿用單筆端點的校驗／改鍵碰撞偵測／授權／operations＋AuditLog，不另起平行寫入邏輯；用於消除逐筆 HTTP 往返與限流（429）成本。

- atomic=false（預設）：逐筆獨立結算，回 200 + results[] + summary
- atomic=true：整批單一交易，任一筆失敗整批回滾，回 409 + failed_index
- 支援頂層 resource/mode/operation/meta 預設（逐項可覆寫）
- 上限 BATCH_MAX_ITEMS=500；單筆例外隔離為該筆 500
- 端點 CSRF 豁免、auth.optional；direct 仍需 canWriteDirectly()
- 測試 tests/Feature/ApiV2MutateBatchTest.php