### PR TITLE
docs(wiki-sync): skill 改推薦 batch API；zh-wiki 與 Wikidata 同步最終狀態

### DIFF
--- a/.claude/skills/mutation-api-record-editing.md
+++ b/.claude/skills/mutation-api-record-editing.md
@@ -23,8 +23,17 @@ description: 使用 /api/v2 mutation 端點對 CBDB 人物子資源與 code 表�
 | 新增 | `POST /api/v2/create` | `operation` 固定 `create` |
 | 修改 | `POST /api/v2/mutate` | `operation` 預設 `update`（也可傳 `create`） |
 | 刪除 | `POST /api/v2/delete` | `operation` 固定 `delete` |
+| **批次** | **`POST /api/v2/batch_mutate`** | **一個請求多筆——大批量首選**（見下節） |
 
-> 目前每個端點**一次一筆**；大批量（如上千筆）建議分批 + 退避（見下文安全流程）。**批次接口 `POST /api/v2/batch_mutate`（一次多筆）規劃中、另行 PR**，落地後大批量改走它。
+> **大批量（幾十筆以上）一律優先用 `/api/v2/batch_mutate`**：一次請求多筆，大幅減少 HTTP 往返與限流（429）壓力，且每筆仍走同一套 handler／校驗／`operations`＋AuditLog。單筆端點僅用於零星改動或需逐筆即時回應的場景。
+
+### 批次端點 `/api/v2/batch_mutate`（大批量首選，已上線 #1156）
+
+- Payload：`{ items: [ {resource, mode, operation, person_id, target:{pk}, changes, meta}, … ], atomic?, 頂層 resource/mode/operation/meta 預設（逐項可覆寫） }`；上限 `BATCH_MAX_ITEMS=500`（超過回 422，缺 items 回 422）。
+- **逐筆分發到既有 `*MutationHandler`**：校驗／改鍵碰撞偵測／授權／`operations`＋AuditLog 與單筆端點**完全一致**，無平行寫入路徑。
+- `atomic=false`（**預設**）：逐筆獨立結算，回 200 + `results[]`（各含 `index/http_status/ok/result.operation_id`）+ `summary{total,ok,failed}`；`body.ok`＝是否全數成功。單筆失敗不影響其餘（例：create 撞 409 只該筆 failed）。
+- `atomic=true`：整批單一交易，任一筆失敗整批回滾，回 409 + `failed_index`（handler 內層交易降為 savepoint）。
+- 授權同單筆（Bearer PAT；direct 需 `canWriteDirectly()`）；已列入 CSRF 豁免。單筆未預期例外隔離為該筆 500，不拖垮整批。
 
 ## 授權與模式（mode）
 
@@ -105,8 +114,9 @@ CBDB prod 的維基／維基數據關聯存在 **`BIOG_SOURCE_DATA`**（不是 `
 3. **小批寫入**：先寫 5~10 筆（`direct`），到 prod 覆核（用 `/api/v2/get` 或 MCP 讀回），確認連結正確、`c_notes` batch id 有寫、`operation_id` 有記錄。
 4. **逐步擴大**：確認無誤後逐步加大批次，直到清單全數處理。
 5. **限流與網路**：`/api/v2/*` 會回 `429`（限流）；批次腳本要對 429／暫時性錯誤做**指數退避重試**，並在每筆間 `sleep`（0.2s 起）。
-6. **可回滾／可追溯**：每筆都有 `operation_id` + `c_notes` batch id；出錯用 Operations／Restore（`OperationRepository`）回退。
-7. 授權用 **Bearer PAT**（可直接用 MCP token；寫入靠 `canWriteDirectly()` 而非 token ability），**不寫成跑在 prod 的 artisan**（操作員未必有後台），全程**不改 Cloudflare（D1）**。
+6. **生產負載**：每筆 `create` 會對 `operations` 表做 pending 提案預檢。此查詢**曾因缺索引拖垮過 prod**（大批寫入全表掃描 → 飽和 DB／php-fpm）；已補 `(resource, resource_id, op_type)` 索引修復（migration `2026_07_12_000000_add_resource_index_to_operations_table`，已入 develop）。**歷史教訓**：任何走 mutation 的大批寫入，先確認該類慢查詢已有索引，否則放慢節奏。優先用 **batch 端點**（一次請求、不製造並發掃描風暴）進一步降載。註：`409 already` 於 create 在 `findByPk` 命中即短路、不觸發該掃描，故廉價。
+7. **可回滾／可追溯**：每筆都有 `operation_id` + `c_notes` batch id；出錯用 Operations／Restore（`OperationRepository`）回退。
+8. 授權用 **Bearer PAT**（可直接用 MCP token；寫入靠 `canWriteDirectly()` 而非 token ability），**不寫成跑在 prod 的 artisan**（操作員未必有後台），全程**不改 Cloudflare（D1）**。
 
 參考實作：`cbdb-dbs/d1_build_*/round3/sync_zhwiki_sources.py`（dry-run 預設、`--only`/`--limit`/`--offset` 分批、`--operator`、`--renote`、429 退避、結果 CSV 存 operation_id）。流程總覽見 `docs/ZHWIKI_SOURCE_SYNC.md`。
 

--- a/docs/ZHWIKI_SOURCE_SYNC.md
+++ b/docs/ZHWIKI_SOURCE_SYNC.md
@@ -62,6 +62,8 @@ direct 模式 `meta.comment` **不落庫**，故批次識別碼寫進 `c_notes`�
 
 ## 執行腳本
 
+> **新批次首選 `POST /api/v2/batch_mutate`**（一次多筆、少往返/限流；見 skill）。下面的 `sync_zhwiki_sources.py` 走**單筆**端點、寫於 batch 上線前，仍可用（dry-run/分批/幂等/429 退避俱全）；新腳本建議直接組 batch 請求。
+
 `cbdb-dbs/d1_build_<date>/round3/sync_zhwiki_sources.py`
 
 ```bash
@@ -77,22 +79,67 @@ CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --only new     
 
 # 只回填 c_notes（不改 c_pages）
 CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --renote --only changed --operator "Frank Lin"
+
+# 大批量放慢（operations 索引未部署前的止血）：每筆間隔 10 秒
+CBDB_MUTATE_TOKEN=<PAT> python3 sync_zhwiki_sources.py --execute --only new --offset 5 --sleep 10 --operator "Frank Lin"
 ```
 
 結果寫入 `sync_zhwiki_result_*.csv`（含 http_status / result / operation_id / batch_id）。
 
+腳本行為：
+- **429／暫時性錯誤**：指數退避重試（`post()` 內）。
+- **`--sleep` 只在真正 `done`（有寫入）後生效**：409 already 於 create 在 `findByPk` 命中即短路返回（**早於**那條 operations 全表掃描），僅一次主鍵 SELECT、無掃描無寫入，故廉價、免限速；因此幂等續跑會**秒過**已建部分，只在新寫入時按 `--sleep` 節流。
+- 冪等：`create` 撞已存在 → 409 略過；`update` 找不到舊列 → 404（多半 prod 早已是新標題）。
+
 ## 驗證（只讀 MCP）
 
 ```sql
--- 整批筆數
+-- 本批寫入/訂正的筆數（帶 batch note 者）
 SELECT COUNT(*) FROM BIOG_SOURCE_DATA WHERE c_textid=60795 AND c_notes='<batch note>';
 -- 抽驗某人現況
 SELECT c_personid, c_pages, c_notes FROM BIOG_SOURCE_DATA WHERE c_textid=60795 AND c_personid IN (...);
 ```
 
+**完成度權威核對**（不依賴 batch note，因已存在的列不帶本批 note）：把報表全部 person_id 切成 ~400 一塊的 `IN` 清單，逐塊 `SELECT COUNT(DISTINCT c_personid) ... WHERE c_textid=60795 AND c_personid IN (...)`，各塊相加應等於報表總數（本次 new：5 塊 400/400/400/400/370 = **1970/1970**）。
+
 ## 進度紀錄
 
-- **2026-07-12 / batch `zhwiki-r3-67368e91`**：
-  - report_zhwiki_changed 99 筆全部完成（95 筆更新到新標題並打 batch note；4 筆 CBDB 本就正確、保留原 note；2 筆遇 429 已重試）。
-  - report_zhwiki_new：測試 5 筆已 create（+renote）；**剩 1965 筆待跑**（`--only new --offset 5`）。
+- **2026-07-12 / batch `zhwiki-r3-67368e91`（全部完成）**：
+  - report_zhwiki_changed **99/99**：95 筆更新到新標題並打 batch note；4 筆（83671/123971/202517/365932）CBDB 本就是新標題（外部報表快照落後於 CBDB）跳過、保留原 note；2 筆遇 429 已重試補上。
+  - report_zhwiki_new **1970/1970**：分批寫入；最終以 MCP 分塊 `COUNT(DISTINCT c_personid)`（把 1970 個 id 切成 5 塊 IN 查詢，合計 1970）逐一核實，全部人物皆有 c_textid=60795 行。
   - report_zhwiki_removed 3 筆已手動處理。
+
+### 事故與教訓：operations 全表掃描（重要）
+
+寫入 new 途中 prod 一度整站不可達（先 429、後連根路徑都逾時）。事後定位：**每筆 create 都對 `operations` 表做一次全表掃描**——所有子資源 create 都會查 pending 提案（`WHERE resource=? AND resource_id IN(?) AND op_type=?`），但 `operations` 在 `resource`/`resource_id` 上無索引；該表隨每次 mutation 持續增長，於是連續/並發寫入時大量全表掃描飽和 DB、推爆 php-fpm（與 /codes 深分頁那次同一模式）。
+
+- **根因修復（已合併）**：為 operations 補 `(resource, resource_id, op_type)` 索引（migration `2026_07_12_000000_add_resource_index_to_operations_table`，已入 develop）。修復後該預檢由全表掃描收斂為索引 seek，大批寫入不再製造掃描風暴。
+- **本次緩解（索引前）**：中斷後改為 `--sleep 10`（10 秒/筆）續跑，避開並發掃描壓力，順利補齊。索引部署後不再需要如此保守。
+- **恢復方式**：腳本幂等，`--offset` 從中斷點續跑；已建的回 409 略過。中斷時若客戶端收到 network error，記得**用 MCP 覆核該筆是否其實已落庫**（伺服器可能已寫入僅回應遺失）。
+
+## Wikidata ID 同步（`c_textid=68942`，機制相同）
+
+Wikidata 關聯（`c_textid=68942`、`c_pages`=QID）用同一套 `sources` mutation 通道維護。與 Wikidata 現況對帳用 QLever 抓 truthy P497（CBDB ID）：
+```
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?item ?cbdb WHERE { ?item wdt:P497 ?cbdb . }
+```
+（?cbdb 為零填充字串，需轉 int；QLever 端點 `https://qlever.cs.uni-freiburg.de/api/wikidata`，比 WDQS 快、能吐全量。）
+
+**⚠ 不可全盤接收 Wikidata 當前版**：Wikidata 人人可編輯，當前狀態含 vandalism（**刪除 P497 是最常見的破壞**）。策略：
+- **移除/降級類差異絕不自動套用**（不因 Wikidata 少了就刪 CBDB）；逐條查修訂史防破壞。
+- **新增類風險低**（純追加、可回滾、一人多 QID 合法）——即便 QID 後來被歸併或與現有並存也不算錯數據；只保留輕量身份核對（姓名/年代明顯不符者單看）。
+- 詳見記憶 `wikidata-sync-not-wholesale`。
+
+**結構備忘**：一人可有多條 wikidata（PK 含 `c_pages`）；prod 現況約 134 人有 2~3 個 QID。故 create 不會因「已有一條」而 409（QID 不同即新行）。
+
+### 進度紀錄（2026-07-13，本輪完成）
+
+對帳基準：datadump `harvard_cbdb_20260711.db` 68942 vs 當前 Wikidata truthy P497（QLever）。初始差異：完全一致 ~417,457；待補（Wikidata有CBDB無）519；待清（CBDB有Wikidata無）662。
+
+- **差異主因＝Wikidata 實體合併**：偵測法——查 CBDB 側 QID 的 redirect 狀態（`wbgetentities` 回 `redirects:{from,to}` 即已被合併）。**待補 519 中 514（99%）是合併；待清 662 中 526（79%）是被合併掉的舊 QID**。
+- **已完成**（皆走 `POST /api/v2/batch_mutate`、direct、每筆 operation_id 可回滾）：
+  - **19 條純新增**（note `wikidata-r3-add19`）：CBDB 完全缺 wikidata 的人物補上；MCP 核實 19/19。含 189181 查證為嘉王李運本人（「李嘉」＝姓+封號訛稱，與 Wikidata 同一實體，鏈接正確）。
+  - **514 條合併遷移**（note `wikidata-r3-merge`）：把 CBDB 的舊 QID 就地改鍵為合併後的新 QID（一次 update 同消該人待補＋待清）。分批 100×5，MCP 核實 514/514。
+- **Wikidata 側**：本輪對帳查出的「移除 P497」全屬 vandalism，已在 Wikidata 全部恢復（含德壽 Q45671126）；QLever 重索引後對帳的移除類差異隨之消失。
+- **剩餘小尾巴（暫緩）**：~5 條非合併變更（P497 被改掛他 item，需人工核）；~137 條「一人多 QID」多餘項（去重擇優，需先定規則）；少數 deprecated。移除/vandalism 類一律不自動刪 CBDB。


### PR DESCRIPTION
skill（.claude/skills/mutation-api-record-editing.md）：
- 端點總覽加 batch_mutate；新增「批次端點」小節，明確「大批量一律優先用 POST /api/v2/batch_mutate」（#1156 已上線，payload/atomic/上限/授權寫清）
- 安全流程：operations 掃描步驟改為「索引已修復（migration 已入 develop）」； 補 c_notes 批號慣例、409 短路廉價免限速

docs/ZHWIKI_SOURCE_SYNC.md：
- 中文維基（c_textid=60795）：round3 全部完成——changed 99/99、new 1970/1970 （MCP 分塊 COUNT 核實）、removed 3；補 operations 全表掃描事故與根因修復、 腳本行為與完成度核對法
- Wikidata（c_textid=68942）：新增整節——同一套 sources 通道、QLever truthy P497 對帳法、不可全盤接收(vandalism) 策略、一人多 QID 結構、合併偵測（redirect）。 本輪已完成：19 條純新增 + 514 條合併遷移（皆走 batch_mutate、direct、可回滾）， Wikidata 側 vandalism 已全部恢復；剩 ~5 非合併變更 + ~137 一人多 QID 待人工