### PR TITLE
fix(codes): 修正代碼表新增/編輯留白欄位誤報「主鍵或唯一值已存在」

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -245,6 +245,13 @@ class CodesController extends Controller {
      */
     protected $tableColumnsCache = [];
 
+    /**
+     * Per-request column NOT NULL / default metadata cache (keyed by table name).
+     *
+     * @var array<string, array<string, array{not_null: bool, has_default: bool}>>
+     */
+    protected $columnConstraintsCache = [];
+
     protected ColumnFilterExpression $columnFilterExpression;
 
     protected AuditLogService $auditLogService;
@@ -923,6 +930,9 @@ class CodesController extends Controller {
         $data = Arr::except($request->all(), ['_method', '_token', '__proposal_comment']);
         $data = $this->enforceAuditFieldsForUpdate($data, $originalRow ?: []);
         $data = $this->normalizeCodeTablePinyin($table, $data);
+        // 與 performStore 一致：留白的 NOT NULL（有預設值）欄不寫入 null（更新時等於保留原值），
+        // 避免觸發完整性違規；留白但無預設值的 NOT NULL 欄仍交由資料庫拋出誠實錯誤。
+        $data = $this->applyColumnDefaultsForBlanks($table, $data);
 
         try {
             $query->update($data);
@@ -933,6 +943,16 @@ class CodesController extends Controller {
                 return redirect()->back()
                     ->withInput()
                     ->withErrors(['duplicate' => '更新失敗：主鍵或唯一值已存在。']);
+            }
+
+            // 其餘完整性違規（NOT NULL、外鍵…）給誠實訊息，不再誤標為重複，也不要直接 500。
+            if ($this->isIntegrityConstraintException($e)) {
+                \Illuminate\Support\Facades\Log::warning('Codes 更新完整性違規', ['table' => $table, 'error' => $e->getMessage()]);
+                flash('更新失敗：必填欄位未填寫或關聯值不存在。', 'error');
+
+                return redirect()->back()
+                    ->withInput()
+                    ->withErrors(['integrity' => '更新失敗：必填欄位未填寫或關聯值不存在。']);
             }
 
             throw $e;
@@ -1302,17 +1322,10 @@ class CodesController extends Controller {
         }
         $data = $this->enforceAuditFieldsForCreate($table, $data);
         $data = $this->normalizeCodeTablePinyin($table, $data);
+        // 留白的 NOT NULL 欄（空字串經 ConvertEmptyStringsToNull 已成 null）改套用資料庫預設值，
+        // 避免把 null 寫入 NOT NULL 欄觸發完整性違規（例如 pinyin.c_lastname 留白應視為預設 0）。
+        $data = $this->applyColumnDefaultsForBlanks($table, $data);
 
-        //20210323遮除「第一欄預設隱藏」
-        //$id_ = $this->getIdName($table_name);
-        //if($table_name != 'SOCIAL_INSTITUTION_CODES') {
-        //$id = DB::table($table_name)->max($id_) + 1;
-        //$data[$id_] = $id;
-        //}
-        //else {
-        //當資料表等於SOCIAL_INSTITUTION_CODES，$id從表單取值。
-        //$id = $data[$id_];
-        //}
         try {
             DB::table($table)->insert($data);
         } catch (\Illuminate\Database\QueryException $e) {
@@ -1322,6 +1335,17 @@ class CodesController extends Controller {
                 return redirect()->back()
                     ->withInput()
                     ->withErrors(['duplicate' => '新增失敗：主鍵或唯一值已存在。']);
+            }
+
+            // 其餘完整性違規（NOT NULL、外鍵…）給出誠實訊息，不可再誤標為「主鍵或唯一值已存在」。
+            if ($this->isIntegrityConstraintException($e)) {
+                // 友善訊息會吞掉例外，仍記一筆 warning 以保留可觀測性（非預期 FK/NOT NULL bug 才好追）。
+                \Illuminate\Support\Facades\Log::warning('Codes 新增完整性違規', ['table' => $table, 'error' => $e->getMessage()]);
+                flash('新增失敗：必填欄位未填寫或關聯值不存在。', 'error');
+
+                return redirect()->back()
+                    ->withInput()
+                    ->withErrors(['integrity' => '新增失敗：必填欄位未填寫或關聯值不存在。']);
             }
 
             throw $e;
@@ -1527,6 +1551,89 @@ class CodesController extends Controller {
         }
 
         return $cache[$table] = array_values(array_unique(array_filter($keys)));
+    }
+
+    /**
+     * 取得各欄位的 NOT NULL / 是否有預設值資訊（相容 MySQL 與 SQLite），供
+     * applyColumnDefaultsForBlanks 判斷「留白 NOT NULL 欄」是否可退回資料庫預設值。
+     *
+     * @return array<string, array{not_null: bool, has_default: bool}>
+     */
+    protected function getColumnConstraints(string $table): array {
+        if (array_key_exists($table, $this->columnConstraintsCache)) {
+            return $this->columnConstraintsCache[$table];
+        }
+
+        $meta = [];
+
+        try {
+            $connection = DB::connection();
+
+            if ($connection->getDriverName() === 'sqlite') {
+                foreach ($connection->select('PRAGMA table_info("' . $table . '")') as $row) {
+                    $col = (array) $row;
+                    if (empty($col['name'])) {
+                        continue;
+                    }
+                    $meta[$col['name']] = [
+                        'not_null' => (int) ($col['notnull'] ?? 0) === 1,
+                        'has_default' => ($col['dflt_value'] ?? null) !== null,
+                    ];
+                }
+            } else {
+                $databaseName = $connection->getDatabaseName();
+                if ($databaseName !== null && $databaseName !== '') {
+                    $rows = $connection->select(
+                        'SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+                        [$databaseName, $table]
+                    );
+                    foreach ($rows as $row) {
+                        $col = (array) $row;
+                        $name = $col['COLUMN_NAME'] ?? null;
+                        if ($name === null || $name === '') {
+                            continue;
+                        }
+                        $hasDefault = ($col['COLUMN_DEFAULT'] ?? null) !== null
+                            || stripos((string) ($col['EXTRA'] ?? ''), 'auto_increment') !== false;
+                        $meta[$name] = [
+                            'not_null' => strtoupper((string) ($col['IS_NULLABLE'] ?? 'YES')) === 'NO',
+                            'has_default' => $hasDefault,
+                        ];
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            $meta = [];
+        }
+
+        return $this->columnConstraintsCache[$table] = $meta;
+    }
+
+    /**
+     * 對「NOT NULL 且有預設值」的欄位，若送來的值為 null（空字串經
+     * ConvertEmptyStringsToNull 中介層會轉成 null），改為移除該欄，讓資料庫套用預設值。
+     *
+     * 若不處理，直接把 null 寫入 NOT NULL 欄會拋 SQLSTATE 23000（NOT NULL 違規），
+     * 造成使用者留白某欄（如 pinyin.c_lastname，預設 0）時新增失敗。留白但「無預設值」
+     * 的 NOT NULL 欄不動，交由資料庫拋出誠實的完整性錯誤。
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    protected function applyColumnDefaultsForBlanks(string $table, array $data): array {
+        $meta = $this->getColumnConstraints($table);
+
+        foreach ($data as $column => $value) {
+            if ($value !== null) {
+                continue;
+            }
+            $info = $meta[$column] ?? null;
+            if ($info !== null && $info['not_null'] && $info['has_default']) {
+                unset($data[$column]);
+            }
+        }
+
+        return $data;
     }
 
     /**
@@ -2159,13 +2266,38 @@ class CodesController extends Controller {
     }
 
     protected function isDuplicateKeyException(\Illuminate\Database\QueryException $exception): bool {
-        if ($exception->getCode() === '23000') {
+        // 只認「唯一鍵／主鍵重複」。SQLSTATE 23000 是「完整性違規」大類，同時涵蓋
+        // NOT NULL（MySQL 1048）、外鍵（1452）等，不能整個類別都當成重複，否則使用者
+        // 留白某 NOT NULL 欄時會看到假的「主鍵或唯一值已存在」（實際上並無重複資料）。
+        if ($exception instanceof \Illuminate\Database\UniqueConstraintViolationException) {
             return true;
         }
 
         $message = $exception->getMessage();
 
-        return strpos($message, 'Duplicate entry') !== false;
+        // MySQL/MariaDB：1062 Duplicate entry；SQLite：UNIQUE constraint failed。
+        return strpos($message, 'Duplicate entry') !== false
+            || stripos($message, 'UNIQUE constraint failed') !== false;
+    }
+
+    /**
+     * 是否為「非重複」的完整性約束違規（NOT NULL、外鍵…），即 SQLSTATE 23000
+     * 但不屬於唯一鍵重複者。用於給出誠實錯誤訊息，而非誤標為重複或直接 500。
+     */
+    protected function isIntegrityConstraintException(\Illuminate\Database\QueryException $exception): bool {
+        if ($this->isDuplicateKeyException($exception)) {
+            return false;
+        }
+
+        if ((string) $exception->getCode() === '23000') {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+
+        return strpos($message, 'SQLSTATE[23000]') !== false
+            || stripos($message, 'NOT NULL constraint failed') !== false
+            || stripos($message, 'FOREIGN KEY constraint failed') !== false;
     }
 
     /**

--- a/tests/Feature/CodesCreateInertiaTest.php
+++ b/tests/Feature/CodesCreateInertiaTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Testing\AssertableInertia as Assert;
 use PHPUnit\Framework\Attributes\Test;
@@ -29,7 +30,7 @@ class CodesCreateInertiaTest extends TestCase {
             'database' => ':memory:',
             'prefix' => '',
         ]);
-        config(['codes.tables' => ['TEST_CREATE_CODES' => '測試代碼', 'ADDR_CODES' => '地址代碼']]);
+        config(['codes.tables' => ['TEST_CREATE_CODES' => '測試代碼', 'ADDR_CODES' => '地址代碼', 'TEST_AUTOINC_CODES' => '自增測試']]);
 
         Schema::create('users', function ($table) {
             $table->increments('id');
@@ -51,6 +52,16 @@ class CodesCreateInertiaTest extends TestCase {
             $table->integer('c_addr_id')->primary();
             $table->string('c_name')->nullable();
             $table->string('c_name_chn')->nullable();
+        });
+
+        // auto_increment 主鍵 + (c_chn, c_lastname) 複合唯一鍵，模擬 pinyin 表結構，
+        // 用於驗證「新增頁不帶明確 auto_increment id」的假性主鍵衝突修復。
+        Schema::create('TEST_AUTOINC_CODES', function ($table) {
+            $table->increments('id');
+            $table->string('c_chn', 10);
+            $table->string('c_pinyin', 30)->nullable();
+            $table->tinyInteger('c_lastname')->default(0);
+            $table->unique(['c_chn', 'c_lastname'], 'test_autoinc_chn_lastname_unique');
         });
 
         Schema::create('operations', function ($table) {
@@ -119,6 +130,89 @@ class CodesCreateInertiaTest extends TestCase {
             ->post(route('app.codes.store', ['table_name' => 'TEST_CREATE_CODES']), ['description' => 'no key'])
             ->assertRedirect()
             ->assertSessionHasErrors();
+    }
+
+    #[Test]
+    public function store_blank_not_null_with_default_uses_db_default_not_false_duplicate(): void {
+        // 復現回報情境：使用者留白 c_lastname（NOT NULL，預設 0）。空字串經
+        // ConvertEmptyStringsToNull 會變 null，若直接寫入會觸發 NOT NULL 違規（SQLSTATE 23000），
+        // 舊 isDuplicateKeyException 又把整個 23000 誤判為重複 → 顯示假的「主鍵或唯一值已存在」。
+        // 修復後：留白欄退回資料庫預設值 0，順利新增，且無任何錯誤。
+        // 新增表單會預填主鍵 id（max+1），故 request 帶明確 id，比照真實表單送出。
+        $this->actingAs($this->activeUser())
+            ->from(route('app.codes.create', ['table_name' => 'TEST_AUTOINC_CODES']))
+            ->post(route('app.codes.store', ['table_name' => 'TEST_AUTOINC_CODES']), [
+                'id' => 100,
+                'c_chn' => '菴',
+                'c_pinyin' => 'an',
+                'c_lastname' => '', // 留白 → null → 套用預設 0
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+
+        $row = DB::table('TEST_AUTOINC_CODES')->where('c_chn', '菴')->first();
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int) $row->c_lastname);
+    }
+
+    #[Test]
+    public function store_still_rejects_genuine_unique_duplicate(): void {
+        // 真正已存在的 (c_chn, c_lastname) 唯一鍵衝突仍須被擋下（不可誤放）。
+        DB::table('TEST_AUTOINC_CODES')->insert(['id' => 1, 'c_chn' => '菴', 'c_pinyin' => 'an', 'c_lastname' => 0]);
+
+        // PK id=2 為未使用，衝突純粹來自 (c_chn, c_lastname) 唯一鍵。
+        $this->actingAs($this->activeUser())
+            ->from(route('app.codes.create', ['table_name' => 'TEST_AUTOINC_CODES']))
+            ->post(route('app.codes.store', ['table_name' => 'TEST_AUTOINC_CODES']), [
+                'id' => 2,
+                'c_chn' => '菴',
+                'c_pinyin' => 'an',
+                'c_lastname' => '', // 空 → 0，與既有列同鍵
+            ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('duplicate');
+
+        $this->assertSame(1, DB::table('TEST_AUTOINC_CODES')->where('c_chn', '菴')->count());
+    }
+
+    #[Test]
+    public function update_blank_not_null_with_default_keeps_value_without_500(): void {
+        // 編輯時留白 c_lastname（NOT NULL，有預設值）。修復前：null 寫入觸發 23000 →
+        // 收窄 isDuplicateKeyException 後會直接 500。修復後：留白等於保留原值，順利更新其他欄位。
+        DB::table('TEST_AUTOINC_CODES')->insert(['id' => 5, 'c_chn' => '菴', 'c_pinyin' => 'an', 'c_lastname' => 1]);
+
+        $this->actingAs($this->activeUser())
+            ->from(route('app.codes.edit', ['table_name' => 'TEST_AUTOINC_CODES', 'id' => 5]))
+            ->patch(route('app.codes.update', ['table_name' => 'TEST_AUTOINC_CODES', 'id' => 5]), [
+                'c_chn' => '菴',
+                'c_pinyin' => 'AN',
+                'c_lastname' => '', // 留白 → null → 保留原值 1
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+
+        $row = DB::table('TEST_AUTOINC_CODES')->where('id', 5)->first();
+        $this->assertSame(1, (int) $row->c_lastname); // 原值保留
+        $this->assertSame('AN', $row->c_pinyin);      // 其他欄位照常更新
+    }
+
+    #[Test]
+    public function update_blank_not_null_without_default_reports_integrity_not_false_duplicate(): void {
+        // 編輯時清空 c_chn（NOT NULL 且無預設值）：應得到誠實的完整性錯誤（非假「主鍵或唯一值已存在」、非 500）。
+        DB::table('TEST_AUTOINC_CODES')->insert(['id' => 6, 'c_chn' => '菴', 'c_pinyin' => 'an', 'c_lastname' => 1]);
+
+        $this->actingAs($this->activeUser())
+            ->from(route('app.codes.edit', ['table_name' => 'TEST_AUTOINC_CODES', 'id' => 6]))
+            ->patch(route('app.codes.update', ['table_name' => 'TEST_AUTOINC_CODES', 'id' => 6]), [
+                'c_chn' => '', // NOT NULL 無預設 → null → 完整性錯誤
+                'c_pinyin' => 'an',
+                'c_lastname' => 1,
+            ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('integrity');
+
+        // 原列未被破壞。
+        $this->assertSame('菴', DB::table('TEST_AUTOINC_CODES')->where('id', 6)->value('c_chn'));
     }
 
     #[Test]


### PR DESCRIPTION
## 問題

在 `/app/codes/pinyin/create`（及所有代碼表的新增/編輯）填入資料、但把某個 **NOT NULL 且有預設值**的欄位留白（例如 `pinyin.c_lastname`，預設 0）時，會出現假性錯誤：

> 新增失敗：主鍵或唯一值已存在。

但資料庫裡根本沒有這條記錄。

## 根因（已於本地真實 MySQL 復現確認）

1. 留白欄位經全域中介層 `ConvertEmptyStringsToNull` 由 `''` 轉成 `null`。
2. 把 `null` 寫入 NOT NULL 欄 → MySQL 1048「Column cannot be null」，SQLSTATE **23000**。
3. `CodesController::isDuplicateKeyException` 舊寫法把**整個 SQLSTATE 23000 類別**都視為「重複」——但 23000 同時涵蓋 NOT NULL（1048）、外鍵（1452）等——於是 NOT NULL 違規被誤標成「主鍵或唯一值已存在」。

> 復現陷阱：直接 `Request::create` 呼叫 controller 不會經過中介層，`''` 不會變 `null`，會誤以為「乾淨庫也能成功」。必須走真正 HTTP（或手動傳 `null`）才能復現。

## 修正（僅動 `CodesController` + 測試）

- **`isDuplicateKeyException`** 收窄為只認真正的唯一鍵重複（`UniqueConstraintViolationException`／`Duplicate entry`／`UNIQUE constraint failed`）。
- 新增 **`isIntegrityConstraintException`**：非重複的 23000（NOT NULL、外鍵）給誠實訊息並記 `warning`，不再誤標重複、也不直接 500（`performStore` 與 `performUpdate` 都處理）。
- 新增 **`applyColumnDefaultsForBlanks`＋`getColumnConstraints`**：留白且「NOT NULL 有預設值」的欄退回資料庫預設值（`c_lastname` 空→0）；相容 MySQL `information_schema` 與 SQLite `PRAGMA`。可空欄位永不被丟棄。

## 測試

`tests/Feature/CodesCreateInertiaTest.php` 新增迴歸測試（用 `TEST_AUTOINC_CODES`：auto id + 複合唯一鍵 + NOT NULL 有預設）：
- 留白 NOT NULL 有預設欄 → 套用預設值、無假性重複
- 真正的 `(c_chn, c_lastname)` 唯一鍵重複仍被擋下
- 更新時留白有預設欄 → 保留原值、不 500
- 更新時清空無預設的 NOT NULL 欄 → 誠實的 integrity 訊息（非假重複、非 500）

已跑：`CodesCreateInertiaTest`、`CodesControllerTest`、`CodesControllerAuditTest`、`CodesEditInertiaTest`、`CodesProposalEditInertiaTest`、`MigrateCodeTablePinyinVTest`、`ApiV2MutateCodeTablesTest` 全數通過；`php-cs-fixer`（dist config、清 cache）clean。

## 備註

一度嘗試把 auto_increment 主鍵從新增表單/insert 剝除改由 DB 指派，但 code review 指出會破壞 pinyin 提案→核准流程（核准端仍要求 payload 帶 `id`），且非本 bug 真因，已整段還原；新增頁仍照舊預填 `id=max+1`。前端必填 `*` 與預填 `c_lastname=0` 將於後續 PR 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)