### PR TITLE
feat(codes): 新增/編輯表單標記必填欄位並預填資料庫預設值

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -248,7 +248,7 @@ class CodesController extends Controller {
     /**
      * Per-request column NOT NULL / default metadata cache (keyed by table name).
      *
-     * @var array<string, array<string, array{not_null: bool, has_default: bool}>>
+     * @var array<string, array<string, array{not_null: bool, has_default: bool, default: string|null}>>
      */
     protected $columnConstraintsCache = [];
 
@@ -872,6 +872,7 @@ class CodesController extends Controller {
             'columns' => array_keys($rowArray),
             'values' => $rowArray,
             'key_columns' => array_values($keyColumns),
+            'required_columns' => $this->codeColumnFormMeta($table)['required'],
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
             'urls' => [
@@ -1030,10 +1031,20 @@ class CodesController extends Controller {
             }
         }
 
+        // 以資料庫的字面量預設值預填（如 c_lastname → 0），讓「留白 → null」的問題在來源就避免；
+        // 主鍵預填（guessNextKeyValue）優先，不被覆蓋。
+        $formMeta = $this->codeColumnFormMeta($table);
+        foreach ($formMeta['defaults'] as $column => $value) {
+            if (!array_key_exists($column, $defaults)) {
+                $defaults[$column] = $value;
+            }
+        }
+
         return Inertia::render('Codes/Create', [
             'table' => $table,
             'columns' => array_values($columns),
             'defaults' => (object) $defaults,
+            'required_columns' => $formMeta['required'],
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
             'urls' => [
@@ -1554,10 +1565,11 @@ class CodesController extends Controller {
     }
 
     /**
-     * 取得各欄位的 NOT NULL / 是否有預設值資訊（相容 MySQL 與 SQLite），供
-     * applyColumnDefaultsForBlanks 判斷「留白 NOT NULL 欄」是否可退回資料庫預設值。
+     * 取得各欄位的 NOT NULL / 是否有預設值 / 原始預設值（相容 MySQL 與 SQLite）。
+     * 供 applyColumnDefaultsForBlanks 判斷留白欄可否退回預設，以及 codeColumnFormMeta
+     * 計算前端必填標記與預填值。
      *
-     * @return array<string, array{not_null: bool, has_default: bool}>
+     * @return array<string, array{not_null: bool, has_default: bool, default: string|null}>
      */
     protected function getColumnConstraints(string $table): array {
         if (array_key_exists($table, $this->columnConstraintsCache)) {
@@ -1570,15 +1582,35 @@ class CodesController extends Controller {
             $connection = DB::connection();
 
             if ($connection->getDriverName() === 'sqlite') {
+                $pkColumns = [];
                 foreach ($connection->select('PRAGMA table_info("' . $table . '")') as $row) {
                     $col = (array) $row;
                     if (empty($col['name'])) {
                         continue;
                     }
+                    $default = $col['dflt_value'] ?? null;
                     $meta[$col['name']] = [
                         'not_null' => (int) ($col['notnull'] ?? 0) === 1,
-                        'has_default' => ($col['dflt_value'] ?? null) !== null,
+                        'has_default' => $default !== null,
+                        'default' => $default !== null ? (string) $default : null,
                     ];
+                    if (!empty($col['pk']) && stripos((string) ($col['type'] ?? ''), 'INT') !== false) {
+                        $pkColumns[] = $col['name'];
+                    }
+                }
+                // AUTOINCREMENT 的單一 INTEGER 主鍵由資料庫自動指派，等同「有預設值」
+                // （MySQL 端由 EXTRA=auto_increment 判定，此處補齊 SQLite）。以 AUTOINCREMENT
+                // 關鍵字判定，才能與 `integer()->primary()` 這類手填整數主鍵區分。
+                if (count($pkColumns) === 1) {
+                    $createRow = $connection->selectOne(
+                        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+                        [$table]
+                    );
+                    // 比對 'primary key autoincrement'（SQLite/Laravel 產生 rowid 別名的固定寫法），
+                    // 較單純比對 'autoincrement' 字串更不易誤命中欄名/預設值等其他位置。
+                    if (stripos($createRow->sql ?? '', 'primary key autoincrement') !== false) {
+                        $meta[$pkColumns[0]]['has_default'] = true;
+                    }
                 }
             } else {
                 $databaseName = $connection->getDatabaseName();
@@ -1593,11 +1625,13 @@ class CodesController extends Controller {
                         if ($name === null || $name === '') {
                             continue;
                         }
-                        $hasDefault = ($col['COLUMN_DEFAULT'] ?? null) !== null
+                        $rawDefault = $col['COLUMN_DEFAULT'] ?? null;
+                        $hasDefault = $rawDefault !== null
                             || stripos((string) ($col['EXTRA'] ?? ''), 'auto_increment') !== false;
                         $meta[$name] = [
                             'not_null' => strtoupper((string) ($col['IS_NULLABLE'] ?? 'YES')) === 'NO',
                             'has_default' => $hasDefault,
+                            'default' => $rawDefault !== null ? (string) $rawDefault : null,
                         ];
                     }
                 }
@@ -1607,6 +1641,59 @@ class CodesController extends Controller {
         }
 
         return $this->columnConstraintsCache[$table] = $meta;
+    }
+
+    /**
+     * 供新增/編輯表單使用的欄位中繼資料：
+     * - required：使用者必填欄（NOT NULL 且無預設值；auto_increment 因帶預設而排除）。
+     * - defaults：NOT NULL 且有「字面量」預設值的欄與其值（如 c_lastname → 0），
+     *   供新增表單預填，讓留白造成 null 的問題在來源就避免。
+     *
+     * @return array{required: array<int, string>, defaults: array<string, string>}
+     */
+    protected function codeColumnFormMeta(string $table): array {
+        $meta = $this->getColumnConstraints($table);
+        $required = [];
+        $defaults = [];
+
+        foreach ($meta as $column => $info) {
+            if ($info['not_null'] && !$info['has_default']) {
+                $required[] = $column;
+
+                continue;
+            }
+            if ($info['not_null'] && $info['has_default']) {
+                $value = $this->normalizeColumnDefault($info['default'] ?? null);
+                if ($value !== null) {
+                    $defaults[$column] = $value;
+                }
+            }
+        }
+
+        return ['required' => $required, 'defaults' => $defaults];
+    }
+
+    /**
+     * 把資料庫回報的原始預設值正規化為可預填的字面量；非字面量（SQL 函式、
+     * MariaDB 對「無預設」欄回報的字串 'NULL'、auto_increment 的 null）回傳 null。
+     */
+    protected function normalizeColumnDefault(?string $raw): ?string {
+        if ($raw === null) {
+            return null;
+        }
+
+        $value = $raw;
+        // SQLite 對字串/數值預設會帶外層單引號（如 '0'），去除以取得純值。
+        if (strlen($value) >= 2 && $value[0] === "'" && substr($value, -1) === "'") {
+            $value = substr($value, 1, -1);
+        }
+
+        $upper = strtoupper(trim($value));
+        if ($upper === 'NULL' || str_contains($upper, 'CURRENT_TIMESTAMP') || str_ends_with($upper, '()')) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**

--- a/resources/js/inertia/Pages/Codes/Create.tsx
+++ b/resources/js/inertia/Pages/Codes/Create.tsx
@@ -13,6 +13,7 @@ interface CodesCreatePageProps extends SharedProps {
     table: string;
     columns: string[];
     defaults: Record<string, string | number>;
+    required_columns?: string[];
     can_propose: boolean;
     tier2_fields?: string[];
     urls: { store: string; propose: string; show: string };
@@ -31,7 +32,8 @@ const COLUMN_HINTS: Record<string, Record<string, { text: string; link?: { href:
 
 export default function CodesCreate() {
     const props = usePage<CodesCreatePageProps>().props;
-    const { table, columns, defaults, can_propose, tier2_fields, urls } = props;
+    const { table, columns, defaults, required_columns, can_propose, tier2_fields, urls } = props;
+    const requiredSet = new Set(required_columns ?? []);
     const t = useTranslation('codes');
     const tc = useTranslation('common');
     const tb = useTranslation('biogmains'); // 復用 AltnameEditor 的彈窗字串
@@ -79,7 +81,7 @@ export default function CodesCreate() {
                 {columns.map((col) => {
                     const hint = tableHints[col];
                     return (
-                        <FormField key={col} label={col} htmlFor={col} error={form.errors[col]}>
+                        <FormField key={col} label={col} htmlFor={col} required={requiredSet.has(col)} error={form.errors[col]}>
                             <Input
                                 id={col}
                                 value={form.data[col] ?? ''}

--- a/resources/js/inertia/Pages/Codes/Edit.tsx
+++ b/resources/js/inertia/Pages/Codes/Edit.tsx
@@ -16,6 +16,7 @@ interface CodesEditPageProps extends SharedProps {
     columns: string[];
     values: Record<string, string | number | null>;
     key_columns: string[];
+    required_columns?: string[];
     can_propose: boolean;
     tier2_fields?: string[];
     urls: { update: string; propose: string; destroy: string; show: string };
@@ -23,7 +24,8 @@ interface CodesEditPageProps extends SharedProps {
 
 export default function CodesEdit() {
     const props = usePage<CodesEditPageProps>().props;
-    const { table, columns, values, key_columns, can_propose, tier2_fields, urls } = props;
+    const { table, columns, values, key_columns, required_columns, can_propose, tier2_fields, urls } = props;
+    const requiredSet = new Set(required_columns ?? []);
     const t = useTranslation('codes');
     const tc = useTranslation('common');
     const tb = useTranslation('biogmains'); // 復用 AltnameEditor 的彈窗字串
@@ -73,6 +75,7 @@ export default function CodesEdit() {
                         key={col}
                         label={col}
                         htmlFor={col}
+                        required={requiredSet.has(col)}
                         error={form.errors[col]}
                     >
                         <Input

--- a/tests/Feature/CodesCreateInertiaTest.php
+++ b/tests/Feature/CodesCreateInertiaTest.php
@@ -133,6 +133,19 @@ class CodesCreateInertiaTest extends TestCase {
     }
 
     #[Test]
+    public function create_form_marks_required_columns_and_prefills_db_defaults(): void {
+        // c_chn（NOT NULL 無預設）標必填；auto id 與 c_lastname（NOT NULL 有預設）不算必填；
+        // c_lastname 以資料庫預設值 0 預填（避免留白→null 的假性重複）。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'TEST_AUTOINC_CODES']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Create')
+                ->where('required_columns', ['c_chn'])
+                ->where('defaults.c_lastname', '0'));
+    }
+
+    #[Test]
     public function store_blank_not_null_with_default_uses_db_default_not_false_duplicate(): void {
         // 復現回報情境：使用者留白 c_lastname（NOT NULL，預設 0）。空字串經
         // ConvertEmptyStringsToNull 會變 null，若直接寫入會觸發 NOT NULL 違規（SQLSTATE 23000），

--- a/tests/Feature/CodesEditInertiaTest.php
+++ b/tests/Feature/CodesEditInertiaTest.php
@@ -104,6 +104,17 @@ class CodesEditInertiaTest extends TestCase {
     }
 
     #[Test]
+    public function edit_form_marks_required_columns(): void {
+        // code_id（NOT NULL 手填主鍵、無預設）標必填；description 可空不標。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEST_EDIT_CODES', 'id' => 5]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Edit')
+                ->where('required_columns', ['code_id']));
+    }
+
+    #[Test]
     public function update_modifies_row_and_redirects(): void {
         $this->actingAs($this->activeUser())
             ->patch(route('app.codes.update', ['table_name' => 'TEST_EDIT_CODES', 'id' => 5]), [


### PR DESCRIPTION
## 目的

延續 #1161（修正代碼表留白欄位的假性「主鍵或唯一值已存在」），在**來源端**進一步降低「留白 → null」風險並改善表單可用性：

1. 新增/編輯表單為真正必填的欄位加上紅色 `*`。
2. 新增表單以資料庫的字面量預設值預填（例如 pinyin `c_lastname` 顯示 `0` 而非留白）。

## 變更

**後端 `CodesController`**
- `getColumnConstraints` 補回原始預設值（`default`）。
- 新增 `codeColumnFormMeta`：
  - `required` = NOT NULL 且無預設值的欄（auto_increment 因帶預設而排除；手填整數主鍵仍必填）。
  - `defaults` = NOT NULL 且有「字面量」預設值的欄與其值。
- 新增 `normalizeColumnDefault`：處理 SQLite 引號、排除 SQL 函式與 MariaDB 對無預設欄回報的 `'NULL'` 字串。
- `appCreate` 把 DB 預設值併入 `defaults`（主鍵 `guessNextKeyValue` 優先，不被覆蓋），並與 `appEdit` 一併傳出 `required_columns`。
- SQLite 端以 `primary key autoincrement` 判定 auto 主鍵，正確區分 `integer()->primary()` 手填整數主鍵。

**前端 `Create.tsx` / `Edit.tsx`**
- 接收 `required_columns`，為 `FormField` 加上必填 `*`（僅視覺標記，不改變原生驗證）。

## 驗證

- 真實 MySQL 抽驗：`pinyin`→required `[c_chn]`、defaults `{c_lastname:0}`；`TEXT_CODES`→`[c_textid]`；`ADDR_CODES`→`[c_addr_id]`、defaults `{c_admin_cat_code:0}`。
- 測試：`CodesCreateInertiaTest`（10）、`CodesEditInertiaTest`（7）、`CodesControllerTest`（61）、其餘 codes 套件全過。
- `npm run build` 成功；`php-cs-fixer`（dist config、清 cache）clean。

純加值變更：預填的值正是 DB 對留白 NOT-NULL-有預設欄本就會套用的值，不引入新的假性重複。

🤖 Generated with [Claude Code](https://claude.com/claude-code)