### PR TITLE
refactor(office, social-institution): 批量匯入 web 寫入路徑改走共用 ImportService (step 2/4)

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadOfficesController.php
+++ b/app/Http/Controllers/AdminBatchLoadOfficesController.php
@@ -2,10 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Repositories\OperationRepository;
-use App\Services\PinyinDictionary;
-use App\Support\CompositePrimaryKey;
-use App\Support\PinyinUmlaut;
+use App\Services\Import\OfficeImportService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -13,12 +10,12 @@ use Inertia\Inertia;
 
 class AdminBatchLoadOfficesController extends Controller {
     /**
-     * @var OperationRepository
+     * @var OfficeImportService
      */
-    protected $operationRepository;
+    protected $officeImportService;
 
-    public function __construct(OperationRepository $operationRepository) {
-        $this->operationRepository = $operationRepository;
+    public function __construct(OfficeImportService $officeImportService) {
+        $this->officeImportService = $officeImportService;
     }
 
     public function showForm() {
@@ -86,49 +83,26 @@ class AdminBatchLoadOfficesController extends Controller {
 
         $results = [];
 
+        // 寫入委派給 OfficeImportService（與 mutation API 共用同一存儲過程），
+        // controller 只保留解析／校驗／組裝畫面結果。逐列於同一交易內呼叫 create()，
+        // 派生（拼音）、自動 c_office_id、配套 REL 行、operations + audit_log 皆由 service 負責。
         DB::transaction(function () use (&$results, $rows, $dynastyMap) {
-            $nextOfficeId = (int) DB::table('OFFICE_CODES')->max('c_office_id');
-
             foreach ($rows as $row) {
-                $nextOfficeId++;
-                $pinyin = $this->buildPinyin($row['name']);
                 $dynastyCode = $dynastyMap[$row['dynasty_label']];
 
-                $officePayload = [
-                    'c_office_id' => $nextOfficeId,
-                    'c_dy' => $dynastyCode,
-                    'c_office_pinyin' => $pinyin,
-                    'c_office_trans' => $row['translation'],
-                    'c_office_chn' => $row['name'],
-                    'c_source' => $row['source_id'],
-                ];
-
-                DB::table('OFFICE_CODES')->insert($officePayload);
-                $this->operationRepository->store(Auth::id(), '', 1, 'OFFICE_CODES', $nextOfficeId, $officePayload);
-
-                $relationPayload = [
-                    'c_office_id' => $nextOfficeId,
-                    'c_office_tree_id' => $row['type_id'],
-                ];
-
-                DB::table('OFFICE_CODE_TYPE_REL')->insert($relationPayload);
-                $this->operationRepository->store(
-                    Auth::id(),
-                    '',
-                    1,
-                    'OFFICE_CODE_TYPE_REL',
-                    CompositePrimaryKey::buildStoredResourceId([
-                        'c_office_id' => $nextOfficeId,
-                        'c_office_tree_id' => $row['type_id'],
-                    ]),
-                    $relationPayload
-                );
+                $created = $this->officeImportService->create([
+                    'name' => $row['name'],
+                    'translation' => $row['translation'],
+                    'dynasty_code' => $dynastyCode,
+                    'type_id' => $row['type_id'],
+                    'source_id' => $row['source_id'],
+                ]);
 
                 $results[] = [
                     'line' => $row['line'],
-                    'office_id' => $nextOfficeId,
+                    'office_id' => $created['office_id'],
                     'name' => $row['name'],
-                    'pinyin' => $pinyin,
+                    'pinyin' => $created['pinyin'],
                     'translation' => $row['translation'],
                     'dynasty_label' => $row['dynasty_label'],
                     'dynasty_code' => $dynastyCode,
@@ -315,33 +289,6 @@ class AdminBatchLoadOfficesController extends Controller {
         return array_map(function ($id) {
             return "找不到來源 TEXT_ID {$id}，請確認 TEXT_CODES 是否已有資料";
         }, $missing);
-    }
-
-    /**
-     * Convert Chinese string to space-separated pinyin.
-     */
-    protected function buildPinyin(string $value): string {
-        $chars = preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
-        $syllables = [];
-
-        foreach ($chars as $char) {
-            if (preg_match('/\p{Han}/u', $char)) {
-                $syllables[] = strtolower(PinyinDictionary::getPinyin($char));
-            } elseif (preg_match('/[A-Za-z0-9]/u', $char)) {
-                $syllables[] = strtolower($char);
-            }
-        }
-
-        $syllables = array_filter($syllables, static function ($syllable) {
-            return $syllable !== '';
-        });
-
-        if (empty($syllables)) {
-            return strtolower(trim(preg_replace('/\s+/u', ' ', $value)));
-        }
-
-        // 止血：把生成拼音中殘留的 v 代寫正規化為 ü。
-        return PinyinUmlaut::normalize(implode(' ', $syllables));
     }
 
     /**

--- a/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
+++ b/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Repositories\OperationRepository;
-use App\Services\PinyinDictionary;
-use App\Support\PinyinUmlaut;
+use App\Services\Import\SocialInstituteImportService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -12,12 +10,12 @@ use Inertia\Inertia;
 
 class AdminBatchLoadSocialInstitutesController extends Controller {
     /**
-     * @var OperationRepository
+     * @var SocialInstituteImportService
      */
-    protected $operationRepository;
+    protected $socialInstituteImportService;
 
-    public function __construct(OperationRepository $operationRepository) {
-        $this->operationRepository = $operationRepository;
+    public function __construct(SocialInstituteImportService $socialInstituteImportService) {
+        $this->socialInstituteImportService = $socialInstituteImportService;
     }
 
     public function showForm() {
@@ -74,7 +72,6 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
 
         $typeMap = $this->getTypeMap();
         $dynastyMap = $this->getDynastyMap();
-        $existingNames = $this->getExistingNames(array_column($rows, 'name'));
 
         $additionalErrors = $this->validateLookups($rows, $typeMap, $dynastyMap);
         if (!empty($additionalErrors)) {
@@ -91,79 +88,29 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
 
         $results = [];
 
-        DB::transaction(function () use ($rows, $typeMap, $dynastyMap, $existingNames, &$results) {
-            $nextNameCode = (int) DB::table('SOCIAL_INSTITUTION_NAME_CODES')->max('c_inst_name_code');
-            $nextInstCode = (int) DB::table('SOCIAL_INSTITUTION_CODES')->max('c_inst_code');
-
-            $newNameCodes = [];
-            $createdNameCodes = [];
-
+        // 寫入委派給 SocialInstituteImportService（與 mutation API 共用同一存儲過程），
+        // controller 只保留解析／校驗／組裝畫面結果。名稱去重由 service 於同一交易內以
+        // DB 查詢為準：後一列能看見前一列剛插入的 NAME_CODES，故不需在此手動維護跨列狀態。
+        DB::transaction(function () use ($rows, $typeMap, $dynastyMap, &$results) {
             foreach ($rows as $row) {
                 $typeCode = $typeMap[$row['type_label']];
                 $dynastyCode = $dynastyMap[$row['dynasty_label']];
 
-                $nameCode = $this->resolveNameCode($row['name'], $existingNames, $newNameCodes, $nextNameCode);
-                $instCode = ++$nextInstCode;
-
-                $createdName = false;
-                if (!isset($existingNames[$row['name']]) && !isset($createdNameCodes[$nameCode])) {
-                    $namePayload = [
-                        'c_inst_name_code' => $nameCode,
-                        'c_inst_name_hz' => $row['name'],
-                        'c_inst_name_py' => $this->buildPinyin($row['name']),
-                    ];
-
-                    DB::table('SOCIAL_INSTITUTION_NAME_CODES')->insert($namePayload);
-                    $this->operationRepository->store(Auth::id(), '', 1, 'SOCIAL_INSTITUTION_NAME_CODES', $nameCode, $namePayload);
-                    $existingNames[$row['name']] = $namePayload;
-                    $createdNameCodes[$nameCode] = true;
-                    $createdName = true;
-                }
-
-                $codePayload = [
-                    'c_inst_name_code' => $nameCode,
-                    'c_inst_code' => $instCode,
-                    'c_inst_type_code' => $typeCode,
-                    'c_inst_begin_dy' => $dynastyCode,
-                    'c_inst_floruit_dy' => $dynastyCode,
-                    'c_source' => $row['source_id'],
-                ];
-                DB::table('SOCIAL_INSTITUTION_CODES')->insert($codePayload);
-                $this->operationRepository->store(Auth::id(), '', 1, 'SOCIAL_INSTITUTION_CODES', $instCode, $codePayload);
-
-                $addrPayload = [
-                    'c_inst_name_code' => $nameCode,
-                    'c_inst_code' => $instCode,
-                    'c_inst_addr_type_code' => 1,
-                    'c_inst_addr_id' => $row['addr_id'],
-                    'inst_xcoord' => 0,
-                    'inst_ycoord' => 0,
-                    'c_source' => $row['source_id'],
-                ];
-
-                DB::table('SOCIAL_INSTITUTION_ADDR')->insert($addrPayload);
-                $this->operationRepository->store(
-                    Auth::id(),
-                    '',
-                    1,
-                    'SOCIAL_INSTITUTION_ADDR',
-                    $instCode . '_._' . $row['addr_id'],
-                    $addrPayload
-                );
-
-                $nameRecord = $existingNames[$row['name']] ?? [
-                    'c_inst_name_code' => $nameCode,
-                    'c_inst_name_hz' => $row['name'],
-                    'c_inst_name_py' => $this->buildPinyin($row['name']),
-                ];
+                $created = $this->socialInstituteImportService->create([
+                    'name' => $row['name'],
+                    'type_code' => $typeCode,
+                    'dynasty_code' => $dynastyCode,
+                    'addr_id' => $row['addr_id'],
+                    'source_id' => $row['source_id'],
+                ]);
 
                 $results[] = [
                     'line' => $row['line'],
                     'name' => $row['name'],
-                    'name_code' => $nameCode,
-                    'name_pinyin' => $nameRecord['c_inst_name_py'],
-                    'name_created' => $createdName,
-                    'inst_code' => $instCode,
+                    'name_code' => $created['name_code'],
+                    'name_pinyin' => $created['name_pinyin'],
+                    'name_created' => $created['name_created'],
+                    'inst_code' => $created['inst_code'],
                     'type_label' => $row['type_label'],
                     'type_code' => $typeCode,
                     'dynasty_label' => $row['dynasty_label'],
@@ -311,40 +258,6 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
     }
 
     /**
-     * Fetch existing names keyed by label.
-     *
-     * @param array<int,string> $names
-     * @return array<string,array<string,mixed>>
-     */
-    protected function getExistingNames(array $names): array {
-        if (empty($names)) {
-            return [];
-        }
-
-        $records = DB::table('SOCIAL_INSTITUTION_NAME_CODES')
-            ->whereIn('c_inst_name_hz', $names)
-            ->orderBy('c_inst_name_code')
-            ->get();
-
-        $map = [];
-        foreach ($records as $record) {
-            $hz = trim((string) $record->c_inst_name_hz);
-            if ($hz === '') {
-                continue;
-            }
-            if (!isset($map[$hz])) {
-                $map[$hz] = [
-                    'c_inst_name_code' => (int) $record->c_inst_name_code,
-                    'c_inst_name_hz' => $hz,
-                    'c_inst_name_py' => (string) ($record->c_inst_name_py ?? ''),
-                ];
-            }
-        }
-
-        return $map;
-    }
-
-    /**
      * Validate type and dynasty labels exist.
      *
      * @param array<int,array<string,mixed>> $rows
@@ -426,57 +339,6 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
         return array_map(function ($id) {
             return "找不到來源 TEXT_ID {$id}，請確認資料是否已存在於 TEXT_CODES";
         }, $missing);
-    }
-
-    /**
-     * Resolve or assign a name code.
-     *
-     * @param string $name
-     * @param array<string,array<string,mixed>> $existingNames
-     * @param array<string,array<int,int>> $newNameCodes
-     * @param int $nextNameCode
-     * @return int
-     */
-    protected function resolveNameCode(string $name, array $existingNames, array &$newNameCodes, int &$nextNameCode): int {
-        if (isset($existingNames[$name])) {
-            return (int) $existingNames[$name]['c_inst_name_code'];
-        }
-
-        if (isset($newNameCodes[$name])) {
-            return $newNameCodes[$name];
-        }
-
-        $newCode = ++$nextNameCode;
-        $newNameCodes[$name] = $newCode;
-
-        return $newCode;
-    }
-
-    /**
-     * Build a space separated lower-case pinyin string.
-     */
-    protected function buildPinyin(string $value): string {
-        $chars = preg_split('//u', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
-        $syllables = [];
-
-        foreach ($chars as $char) {
-            if (preg_match('/\p{Han}/u', $char)) {
-                $syllables[] = strtolower(PinyinDictionary::getPinyin($char));
-            } elseif (preg_match('/[A-Za-z0-9]/u', $char)) {
-                $syllables[] = strtolower($char);
-            }
-        }
-
-        $syllables = array_filter($syllables, static function ($syllable) {
-            return $syllable !== '';
-        });
-
-        if (empty($syllables)) {
-            return strtolower(trim(preg_replace('/\s+/u', ' ', $value)));
-        }
-
-        // 止血：把生成拼音中殘留的 v 代寫正規化為 ü。
-        return PinyinUmlaut::normalize(implode(' ', $syllables));
     }
 
     /**

--- a/app/Services/Import/OfficeImportService.php
+++ b/app/Services/Import/OfficeImportService.php
@@ -3,7 +3,6 @@
 namespace App\Services\Import;
 
 use App\Repositories\OperationRepository;
-use App\Repositories\ToolsRepository;
 use App\Services\AuditLogService;
 use App\Services\Import\Concerns\SharesImportHelpers;
 use Illuminate\Support\Facades\DB;
@@ -19,6 +18,10 @@ use Illuminate\Support\Facades\DB;
  *  - OFFICE_CODES：c_office_id(max+1)、c_office_pinyin(派生)、c_dy、c_office_chn/trans、c_source
  *  - OFFICE_CODE_TYPE_REL：(c_office_id, c_office_tree_id=type_id)
  *
+ * OFFICE_CODES 無 c_created_by/date 審計欄（見生產 DB schema），故直接 plain insert、
+ * 不走 ToolsRepository::timestamp（否則會 INSERT 不存在的欄位而 500）；審計改由
+ * operations + audit_log 承載。與 SocialInstituteImportService 一致。
+ *
  * create() 不自開交易，於呼叫端交易內執行（批量：controller 一個交易包全部；單筆 API：handler 包一筆），
  * 以保留「全有或全無」語意。呼叫端須先以 validate*() 過濾非法輸入。
  */
@@ -27,8 +30,7 @@ class OfficeImportService {
 
     public function __construct(
         protected OperationRepository $operationRepository,
-        protected AuditLogService $auditLogService,
-        protected ToolsRepository $toolsRepository
+        protected AuditLogService $auditLogService
     ) {
     }
 
@@ -55,14 +57,14 @@ class OfficeImportService {
         $officeId = max(0, (int) DB::table('OFFICE_CODES')->lockForUpdate()->max('c_office_id')) + 1;
         $pinyin = $this->buildPinyin($input['name']);
 
-        $officePayload = $this->toolsRepository->timestamp([
+        $officePayload = [
             'c_office_id' => $officeId,
             'c_dy' => (int) $input['dynasty_code'],
             'c_office_pinyin' => $pinyin,
             'c_office_trans' => $input['translation'] ?? null,
             'c_office_chn' => $input['name'],
             'c_source' => (int) $input['source_id'],
-        ], true);
+        ];
 
         DB::table('OFFICE_CODES')->insert($officePayload);
         $officeOp = $this->recordOp('OFFICE_CODES', ['c_office_id' => $officeId], $officePayload, $actorPersonId);

--- a/tests/Feature/AdminBatchLoadOfficesTest.php
+++ b/tests/Feature/AdminBatchLoadOfficesTest.php
@@ -85,12 +85,29 @@ class AdminBatchLoadOfficesTest extends TestCase {
             $table->unique(['c_chn', 'c_lastname']);
         });
 
+        // OfficeImportService 經共用 recordOp 寫 operations + audit_log。
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+
         // 職官名逐字轉拼音走一般轉換路徑，需要真實字典資料才能跟現行
         // Pinyin::$dic 行為一致（見 docs/PINYIN_TABLE_CONSOLIDATION_PLAN.md 步驟4）。
         $this->seedPinyinDictionary();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('pinyin');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('TEXT_CODES');

--- a/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
+++ b/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
@@ -101,12 +101,29 @@ class AdminBatchLoadSocialInstitutesTest extends TestCase {
             $table->unique(['c_chn', 'c_lastname']);
         });
 
+        // SocialInstituteImportService 經共用 recordOp 寫 operations + audit_log。
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+
         // 機構名逐字轉拼音走一般轉換路徑，需要真實字典資料才能跟現行
         // Pinyin::$dic 行為一致（見 docs/PINYIN_TABLE_CONSOLIDATION_PLAN.md 步驟4）。
         $this->seedPinyinDictionary();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('audit_log');
         Schema::dropIfExists('pinyin');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('TEXT_CODES');

--- a/tests/Feature/ApiV2MutateOfficeImportTest.php
+++ b/tests/Feature/ApiV2MutateOfficeImportTest.php
@@ -65,6 +65,7 @@ class ApiV2MutateOfficeImportTest extends TestCase {
             $table->longText('old_data')->nullable();
             $table->longText('new_data')->nullable();
         });
+        // 生產 OFFICE_CODES 無 c_created_by/date 審計欄，schema 須如實反映（服務直接 plain insert）。
         Schema::create('OFFICE_CODES', function (Blueprint $table) {
             $table->integer('c_office_id')->primary();
             $table->integer('c_dy')->nullable();
@@ -72,10 +73,6 @@ class ApiV2MutateOfficeImportTest extends TestCase {
             $table->string('c_office_trans')->nullable();
             $table->string('c_office_chn')->nullable();
             $table->integer('c_source')->nullable();
-            $table->string('c_created_by')->nullable();
-            $table->dateTime('c_created_date')->nullable();
-            $table->string('c_modified_by')->nullable();
-            $table->dateTime('c_modified_date')->nullable();
         });
         Schema::create('OFFICE_CODE_TYPE_REL', function (Blueprint $table) {
             $table->integer('c_office_id');
@@ -151,7 +148,6 @@ class ApiV2MutateOfficeImportTest extends TestCase {
         ]);
         $this->assertDatabaseHas('OFFICE_CODES', ['c_office_id' => 101, 'c_office_chn' => '知府', 'c_dy' => 15, 'c_source' => 7596]);
         $this->assertDatabaseHas('OFFICE_CODE_TYPE_REL', ['c_office_id' => 101, 'c_office_tree_id' => 'x01']);
-        $this->assertSame('Office Tester', DB::table('OFFICE_CODES')->where('c_office_id', 101)->value('c_created_by'));
         // operations + audit：OFFICE_CODES 與 OFFICE_CODE_TYPE_REL 各一
         $this->assertSame(1, DB::table('operations')->where('resource', 'OFFICE_CODES')->count());
         $this->assertSame(1, DB::table('operations')->where('resource', 'OFFICE_CODE_TYPE_REL')->count());


### PR DESCRIPTION
把 AdminBatchLoadOfficesController / AdminBatchLoadSocialInstitutesController 的 DB::transaction 內聯 insert 迴圈，改為逐列委派給 OfficeImportService::create() / SocialInstituteImportService::create()——與 mutation API 共用同一存儲過程之單一真源。 controller 只保留解析／校驗／組裝畫面結果，寫入語意（派生拼音、自動 id、配套
REL/ADDR 行、名稱去重、operations + audit_log）不再有第二份實作、消除漂移。

同時修正 OfficeImportService 的潛伏 schema bug：
生產（及 dev cbdb_data_20251223）OFFICE_CODES 並無 c_created_by/c_created_date 審計欄， 但原 service 經 ToolsRepository::timestamp() 在 insert payload 加入該兩欄，對真表會 INSERT 不存在欄位而 500——mutation API 新增官職在真庫其實已壞，僅因 API 測試 schema 虛構了審計欄而未被發現；web 遷入後會一併壞掉。改為 plain insert（與
SocialInstituteImportService 一致），OFFICE_CODES payload 因此與舊 web 路徑逐欄一致， 審計仍由 operations + audit_log 承載。

行為對齊（皆為與 mutation API 一致的提升）：
- 兩者改用共用 recordOp，除 operations 外一併寫 audit_log（原內聯只寫 operations）。
- operations.resource_id 改用 buildStoredResourceId() 的標準 query-string 格式 （c_office_id=N 等），與 CompositePrimaryKey::SCHEMAS 及 OperationsController 復原 分支對齊；歷史舊行仍走 legacy fallback，不受影響。
- 名稱去重改由 service 於同一交易內以 DB 查詢為準（後一列可見前一列剛插入的 NAME_CODES），controller 不再手動維護跨列狀態。

移除 controller 內已死的重複輔助方法：
- offices：buildPinyin
- social-institutes：getExistingNames、resolveNameCode、buildPinyin

測試：
- ApiV2MutateOfficeImportTest：OFFICE_CODES schema 移除虛構的審計欄、刪除 c_created_by 斷言，如實反映生產。
- AdminBatchLoadOffices/SocialInstitutesTest：新增 audit_log 表（recordOp 依賴）。

已於 dev env 實測：官職與社會機構各新增成功、 三表原子寫入、同名去重複用 name_code 不重複建列、無 c_created_by 500。