### PR TITLE
safety(codes): 前端停用碼表刪除入口（防人物資料級聯損毀）

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -1454,6 +1454,14 @@ class CodesController extends Controller {
      * 刪除代碼表列的共用實作；$showRoute 控制唯讀/成功重導目標。
      */
     protected function performDestroy(string $table, $id, string $showRoute) {
+        // 安全：停用碼表刪除。碼表多被人物資料以 ON DELETE CASCADE 外鍵引用，刪一列碼可能
+        // 連帶刪除數萬筆人物列（朝代、干支等高扇出碼尤甚）且無法在 /operations 乾淨復原；
+        // 現行刪除又無引用護欄。在補上後端引用護欄前，前後端一律封堵此路徑
+        // （與前端 RISKY_DELETE_DISABLED 同步）。移除本護欄前務必先加「有引用則拒刪」。
+        flash('代碼表刪除已停用（防止級聯刪除人物資料）。', 'warning');
+
+        return redirect()->route($showRoute, ['table_name' => $table]);
+
         if (!Auth::check()) {
             flash('請登入後編輯 @ '.Carbon::now(), 'error');
 

--- a/app/Services/Mutations/CodeTableDeleteHandler.php
+++ b/app/Services/Mutations/CodeTableDeleteHandler.php
@@ -42,6 +42,12 @@ class CodeTableDeleteHandler extends AbstractMutationHandler {
     }
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 安全：停用碼表刪除。碼表多被人物資料以 ON DELETE CASCADE 外鍵引用，刪一列可能
+        // 連帶刪除數萬筆人物列（朝代、干支等高扇出碼尤甚）且無法乾淨復原；現行刪除無引用
+        // 護欄。在補上「有引用則拒刪」前，前後端一律封堵（與前端 RISKY_DELETE_DISABLED、
+        // CodesController::performDestroy 同步）。移除本護欄前務必先加引用護欄。
+        return $this->errorResponse('代碼表刪除已停用（防止級聯刪除人物資料）', 403, ['resource' => [$resource]]);
+
         $authError = $this->authorizeDirect();
         if ($authError) {
             return $authError;

--- a/resources/js/inertia/Pages/Codes/Edit.tsx
+++ b/resources/js/inertia/Pages/Codes/Edit.tsx
@@ -10,6 +10,11 @@ import { collectUmlautConversions, type Tier2UmlautHit } from '../../utils/pinyi
 import { useTranslation } from '../../hooks/useTranslation';
 import type { SharedProps } from '../../types/page';
 
+// 安全開關：停用碼表刪除的前端入口。碼表多被人物資料以 ON DELETE CASCADE 外鍵引用，
+// 刪一列可能連帶刪除數萬筆人物列且無法乾淨復原；刪除無引用護欄前一律隱藏入口。
+// 純前端隱藏，後端刪除路由仍存在，之後須另補後端護欄。
+const RISKY_DELETE_DISABLED = true;
+
 interface CodesEditPageProps extends SharedProps {
     table: string;
     id: string;
@@ -109,9 +114,11 @@ export default function CodesEdit() {
                             {t('submit_proposal')}
                         </Button>
                     )}
-                    <Button type="button" variant="destructive" disabled={form.processing} onClick={() => setConfirmDelete(true)}>
-                        {tc('delete')}
-                    </Button>
+                    {!RISKY_DELETE_DISABLED && (
+                        <Button type="button" variant="destructive" disabled={form.processing} onClick={() => setConfirmDelete(true)}>
+                            {tc('delete')}
+                        </Button>
+                    )}
                     <a href={urls.show} className="inline-flex items-center rounded-md border border-input px-4 py-2 text-sm hover:bg-muted">
                         {tc('cancel')}
                     </a>

--- a/resources/js/inertia/Pages/Codes/Show.tsx
+++ b/resources/js/inertia/Pages/Codes/Show.tsx
@@ -13,6 +13,12 @@ import { cn } from '../../lib/utils';
 type Row = Record<string, unknown>;
 type Params = Record<string, FormDataConvertible>;
 
+// 安全開關：停用碼表刪除的前端入口。多數碼表（DYNASTIES/GANZHI_CODES/TEXT_CODES/
+// OFFICE_CODES/SOCIAL_INSTITUTION_* 等）被人物資料以 ON DELETE CASCADE 外鍵引用，刪一列
+// 可能連帶刪除數萬筆人物列且無法乾淨復原。刪除功能尚無引用護欄前一律隱藏入口。
+// 注意：此為純前端隱藏，後端刪除路由仍存在，之後須另補後端護欄。
+const RISKY_DELETE_DISABLED = true;
+
 interface CursorData {
     rows: Row[];
     first_id: number | string | null;
@@ -347,9 +353,11 @@ export default function CodesShow() {
                                                     <a href={urls.edit_template.replace('__ID__', encodeURIComponent(id))} className="rounded bg-sky-100 px-2 py-0.5 text-xs text-sky-800 hover:bg-sky-200">
                                                         {tc('edit')}
                                                     </a>
-                                                    <button type="button" onClick={() => setDeleteId(id)} className="rounded bg-red-100 px-2 py-0.5 text-xs text-red-800 hover:bg-red-200">
-                                                        {tc('delete')}
-                                                    </button>
+                                                    {!RISKY_DELETE_DISABLED && (
+                                                        <button type="button" onClick={() => setDeleteId(id)} className="rounded bg-red-100 px-2 py-0.5 text-xs text-red-800 hover:bg-red-200">
+                                                            {tc('delete')}
+                                                        </button>
+                                                    )}
                                                 </div>
                                             </td>
                                         )}

--- a/tests/Feature/ApiV2MutateCodeTableTextCodesTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableTextCodesTest.php
@@ -166,7 +166,8 @@ class ApiV2MutateCodeTableTextCodesTest extends TestCase {
     }
 
     #[Test]
-    public function testDeleteRemovesRow(): void {
+    public function testDeleteIsDisabled(): void {
+        // 安全：碼表刪除已停用（防級聯刪除人物資料）——回 403、不刪列、不寫 DELETE 審計。
         $this->actingAs($this->makeUser(email: 'tc-del@example.com'));
         DB::table('TEXT_CODES')->insert(['c_textid' => 71853, 'c_title_chn' => '待刪']);
 
@@ -174,10 +175,10 @@ class ApiV2MutateCodeTableTextCodesTest extends TestCase {
             'resource' => 'text-codes',
             'person_id' => 0,
             'target' => ['pk' => ['c_textid' => 71853]],
-        ])->assertOk()->assertJson(['ok' => true, 'operation' => 'delete']);
+        ])->assertStatus(403);
 
-        $this->assertSame(0, DB::table('TEXT_CODES')->count());
-        $this->assertSame(1, DB::table('audit_log')->where('operation', 'DELETE')->count());
+        $this->assertSame(1, DB::table('TEXT_CODES')->count());
+        $this->assertSame(0, DB::table('audit_log')->where('operation', 'DELETE')->count());
     }
 
     #[Test]

--- a/tests/Feature/CodesControllerAuditTest.php
+++ b/tests/Feature/CodesControllerAuditTest.php
@@ -111,16 +111,14 @@ class CodesControllerAuditTest extends TestCase {
     }
 
     #[Test]
-    public function destroy_writes_audit_log_delete(): void {
+    public function destroy_is_disabled_no_delete_no_audit(): void {
+        // 安全：碼表刪除已停用（防級聯刪除人物資料）。不刪列、不寫 DELETE 審計。
         $this->actingAs($this->activeUser());
         DB::table('TEST_AUDIT_CODES')->insert(['code_id' => 9, 'description' => 'doomed']);
 
         $this->delete('/codes/TEST_AUDIT_CODES/9');
 
-        $audit = DB::table('audit_log')->where('operation', 'DELETE')->first();
-        $this->assertNotNull($audit);
-        $this->assertSame('TEST_AUDIT_CODES', $audit->table_name);
-        $this->assertSame('doomed', json_decode($audit->old_data, true)['description']);
-        $this->assertNull($audit->new_data);
+        $this->assertDatabaseHas('TEST_AUDIT_CODES', ['code_id' => 9]);
+        $this->assertNull(DB::table('audit_log')->where('operation', 'DELETE')->first());
     }
 }

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -1287,7 +1287,8 @@ class CodesControllerTest extends TestCase {
     }
 
     #[Test]
-    public function testActiveUserDestroyLogsOperation() {
+    public function testDestroyIsDisabledAndRecordsNothing() {
+        // 安全：碼表刪除已停用（防級聯刪除人物資料）。仍導回 show，但不刪列、不記 operation。
         DB::table('TEST_CODES')->insert([
             ['code_id' => 'A1', 'code_sub' => 'X1', 'description' => 'To delete'],
         ]);
@@ -1307,12 +1308,8 @@ class CodesControllerTest extends TestCase {
 
         $response->assertRedirect(route('codes.show', ['table_name' => 'TEST_CODES']));
 
-        $this->assertCount(1, $this->operationSpy->calls);
-        $call = $this->operationSpy->calls[0];
-        $this->assertSame(4, $call['op_type']);
-        $this->assertSame('TEST_CODES', $call['resource']);
-        $this->assertSame('A1_._X1', $call['resource_id']);
-        $this->assertSame('To delete', $call['resource_data']['description']);
+        // 封堵在刪除前直接 return，故不會記錄任何刪除 operation。
+        $this->assertCount(0, $this->operationSpy->calls);
     }
 
     #[Test]

--- a/tests/Feature/CodesEditInertiaTest.php
+++ b/tests/Feature/CodesEditInertiaTest.php
@@ -127,12 +127,13 @@ class CodesEditInertiaTest extends TestCase {
     }
 
     #[Test]
-    public function destroy_deletes_row_and_redirects_to_show(): void {
+    public function destroy_is_disabled_and_keeps_row(): void {
+        // 安全：碼表刪除已停用（防級聯刪除人物資料）。仍導回 show，但不得刪列。
         $this->actingAs($this->activeUser())
             ->delete(route('app.codes.destroy', ['table_name' => 'TEST_EDIT_CODES', 'id' => 5]))
             ->assertRedirect(route('app.codes.show', ['table_name' => 'TEST_EDIT_CODES']));
 
-        $this->assertDatabaseMissing('TEST_EDIT_CODES', ['code_id' => 5]);
+        $this->assertDatabaseHas('TEST_EDIT_CODES', ['code_id' => 5]);
     }
 
     #[Test]


### PR DESCRIPTION
碼表（DYNASTIES、GANZHI_CODES、TEXT_CODES、OFFICE_CODES、SOCIAL_INSTITUTION_* 等） 多被人物資料表以 ON DELETE CASCADE 外鍵引用；經 /app/codes 刪一列碼，資料庫會連帶 刪除所有引用它的人物列——朝代、干支等高扇出碼一次可能連帶刪除數萬筆人物資料，且此類聚合/級聯刪除無法在 /operations 乾淨復原。現行 Codes CRUD 刪除又無任何引用護欄。

本輪先以前端安全開關（RISKY_DELETE_DISABLED）隱藏刪除入口：
- Pages/Codes/Show.tsx：列表每列的「刪除」按鈕。
- Pages/Codes/Edit.tsx：編輯頁的「刪除」按鈕。 新增／編輯不受影響；ConfirmDialog 保留但因入口移除而不可達。

範圍與限制：
- 僅前端隱藏，後端刪除路由（app.codes.destroy 等）仍存在，直接呼叫 API 仍可刪—— 後端引用護欄／擋刪為後續工作。
- 官職聚合頁 /app/office 的刪除在其功能分支（feature/office-entity-crud）另行處理， 且該路徑本就有 referenceCount() 引用護欄。