### PR TITLE
更新 Docker base image PHP 至 8.4.23 修補安全漏洞

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1-php8.4.15 AS build
+FROM dunglas/frankenphp:1-php8.4.23 AS build
 
 WORKDIR /build
 
@@ -24,7 +24,7 @@ RUN cd /tmp \
     && ldconfig \
     && rm -rf /tmp/sqlite-autoconf-${SQLITE_VERSION}*
 
-FROM dunglas/frankenphp:1-php8.4.15
+FROM dunglas/frankenphp:1-php8.4.23
 
 WORKDIR /app
 


### PR DESCRIPTION
- docker/Dockerfile build 與 runtime 兩處 base image 由 dunglas/frankenphp:1-php8.4.15 更新至 1-php8.4.23
- 涵蓋 8.4.16~8.4.23 之間多個 PHP 安全 CVE (CVE-2026-14355 openssl heap 損毀、CVE-2026-6735 FPM status XSS、 SOAP use-after-free、mbstring 等)