### PR TITLE
新增 KINSHIP_CODES 代碼表虛擬欄位 c_up_down_diff_step

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -426,10 +426,14 @@ class CodesController extends Controller {
             ];
         }
 
+        [$thead, $rows, $computedColumns] = $this->injectComputedColumns($table, $payload['thead'], $dataProp['rows']);
+        $dataProp['rows'] = $rows;
+
         return Inertia::render('Codes/Show', [
             'table' => $table,
-            'thead' => $payload['thead'],
+            'thead' => $thead,
             'rows' => $dataProp['rows'],
+            'computed_columns' => $computedColumns,
             'cursor' => $useCursor ? $dataProp : null,
             'meta' => $meta,
             'use_cursor' => $useCursor,
@@ -1491,6 +1495,41 @@ class CodesController extends Controller {
         flash('Delete success @ '.Carbon::now(), 'success');
 
         return redirect()->route($showRoute, ['table_name' => $table]);
+    }
+
+    /**
+     * app/codes/{table_name}（Inertia 版）專用：在 buildShowPayload() 產出的 thead／rows
+     * 之外，疊加純前端展示用的計算欄位（不進資料庫、不可排序／篩選，因為 buildShowPayload()
+     * 內的 sanitizeColumnFilters()/sanitizeSortParameters() 已用原始 $thead 產生白名單，
+     * 這裡才把計算欄位加進去，所以永遠不會被誤判為可查詢欄位）。目前僅 KINSHIP_CODES 的
+     * c_up_down_diff_step（= c_upstep − c_dwnstep）一例；只做在 React 路徑，不動 Blade。
+     *
+     * @param array<int, string> $thead
+     * @param array<int, array<string, mixed>> $rows
+     * @return array{0: array<int, string>, 1: array<int, array<string, mixed>>, 2: array<int, string>}
+     */
+    protected function injectComputedColumns(string $table, array $thead, array $rows): array {
+        if (strtoupper($table) !== 'KINSHIP_CODES') {
+            return [$thead, $rows, []];
+        }
+
+        $virtualColumn = 'c_up_down_diff_step';
+        $anchorIndex = array_search('c_upstep', $thead, true);
+        if ($anchorIndex === false || !in_array('c_dwnstep', $thead, true) || in_array($virtualColumn, $thead, true)) {
+            return [$thead, $rows, []];
+        }
+
+        array_splice($thead, $anchorIndex, 0, [$virtualColumn]);
+
+        $rows = array_map(function (array $row) use ($virtualColumn) {
+            $up = $row['c_upstep'] ?? null;
+            $down = $row['c_dwnstep'] ?? null;
+            $row[$virtualColumn] = (is_numeric($up) && is_numeric($down)) ? ($up - $down) : null;
+
+            return $row;
+        }, $rows);
+
+        return [$thead, $rows, [$virtualColumn]];
     }
 
     protected function buildTableHead(string $table, $sampleRow, ?array $joinConfig = null): array {

--- a/resources/js/inertia/Pages/Codes/Show.tsx
+++ b/resources/js/inertia/Pages/Codes/Show.tsx
@@ -42,6 +42,7 @@ interface CodesShowPageProps extends SharedProps {
     exportable: boolean;
     key_columns: string[];
     joined_columns: string[];
+    computed_columns: string[];
     copyright_note: string | null;
     filters: Record<string, string>;
     sort_by: string;
@@ -69,7 +70,7 @@ export default function CodesShow() {
 
     const {
         table, thead, rows, cursor, meta, use_cursor, dynasty_map, key_columns, joined_columns,
-        copyright_note, sort_by, sort_dir, boolean_enabled, boolean_filter_available,
+        computed_columns, copyright_note, sort_by, sort_dir, boolean_enabled, boolean_filter_available,
         filter_errors, filter_descriptions, can_edit, urls,
     } = props;
 
@@ -297,14 +298,18 @@ export default function CodesShow() {
                         <tr>
                             {thead.map((col) => (
                                 <th key={col} className="whitespace-nowrap px-3 py-2 text-left font-medium">
-                                    <button
-                                        type="button"
-                                        className={cn('hover:underline', !canSortOrFilter && 'cursor-not-allowed opacity-60 hover:no-underline')}
-                                        onClick={() => toggleSort(col)}
-                                        title={canSortOrFilter ? undefined : t('sort_filter_requires_login')}
-                                    >
-                                        {joined_columns.includes(col) ? `(${col})` : col} <span aria-hidden>{sortIcon(col)}</span>
-                                    </button>
+                                    {computed_columns.includes(col) ? (
+                                        <span>{col}</span>
+                                    ) : (
+                                        <button
+                                            type="button"
+                                            className={cn('hover:underline', !canSortOrFilter && 'cursor-not-allowed opacity-60 hover:no-underline')}
+                                            onClick={() => toggleSort(col)}
+                                            title={canSortOrFilter ? undefined : t('sort_filter_requires_login')}
+                                        >
+                                            {joined_columns.includes(col) ? `(${col})` : col} <span aria-hidden>{sortIcon(col)}</span>
+                                        </button>
+                                    )}
                                     {key_columns.includes(col) && (
                                         <span className="ml-1 rounded bg-blue-100 px-1 text-xs text-blue-800">PK</span>
                                     )}
@@ -315,6 +320,9 @@ export default function CodesShow() {
                         {!use_cursor && (
                             <tr>
                                 {thead.map((col) => {
+                                    if (computed_columns.includes(col)) {
+                                        return <th key={col} className="px-2 py-1" />;
+                                    }
                                     const hasErr = boolean_enabled && col in filter_errors;
                                     return (
                                         <th key={col} className="px-2 py-1">

--- a/tests/Feature/CodesShowInertiaTest.php
+++ b/tests/Feature/CodesShowInertiaTest.php
@@ -84,6 +84,70 @@ class CodesShowInertiaTest extends TestCase {
     }
 
     #[Test]
+    public function it_injects_kinship_codes_up_down_diff_step_computed_column(): void {
+        config(['codes.tables' => ['TEST_CODES' => '測試代碼', 'KINSHIP_CODES' => '親屬關係代碼表']]);
+
+        Schema::create('KINSHIP_CODES', function ($table) {
+            $table->smallInteger('c_kincode')->primary();
+            $table->smallInteger('c_pick_sorting')->nullable();
+            $table->smallInteger('c_upstep')->nullable();
+            $table->smallInteger('c_dwnstep')->nullable();
+        });
+        DB::table('KINSHIP_CODES')->insert([
+            ['c_kincode' => 1, 'c_pick_sorting' => 1, 'c_upstep' => 3, 'c_dwnstep' => 1],
+            ['c_kincode' => 2, 'c_pick_sorting' => 2, 'c_upstep' => null, 'c_dwnstep' => 2],
+        ]);
+
+        $this->get(route('app.codes.show', ['table_name' => 'KINSHIP_CODES']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Show')
+                ->where('thead', function ($thead) {
+                    $thead = $thead->all();
+                    $diffIndex = array_search('c_up_down_diff_step', $thead, true);
+                    $upstepIndex = array_search('c_upstep', $thead, true);
+
+                    return $diffIndex !== false && $upstepIndex !== false && $diffIndex === $upstepIndex - 1;
+                })
+                ->where('computed_columns', ['c_up_down_diff_step'])
+                ->where('rows', function ($rows) {
+                    $rows = $rows->all();
+
+                    return $rows[0]['c_up_down_diff_step'] === 2 && $rows[1]['c_up_down_diff_step'] === null;
+                }));
+    }
+
+    #[Test]
+    public function kinship_codes_computed_column_is_not_sortable_or_filterable(): void {
+        config(['codes.tables' => ['KINSHIP_CODES' => '親屬關係代碼表']]);
+        $this->actingAs($this->activeUser());
+
+        Schema::create('KINSHIP_CODES', function ($table) {
+            $table->smallInteger('c_kincode')->primary();
+            $table->smallInteger('c_upstep')->nullable();
+            $table->smallInteger('c_dwnstep')->nullable();
+        });
+        DB::table('KINSHIP_CODES')->insert([
+            ['c_kincode' => 1, 'c_upstep' => 3, 'c_dwnstep' => 1],
+            ['c_kincode' => 2, 'c_upstep' => 1, 'c_dwnstep' => 3],
+        ]);
+
+        // 排序／篩選白名單來自 buildShowPayload() 內原始（未疊加計算欄位）的 $thead，
+        // 帶入計算欄位名應被忽略、不拋 SQL 錯誤，且回傳全部列（篩選未套用）。
+        $this->get(route('app.codes.show', [
+            'table_name' => 'KINSHIP_CODES',
+            'sort_by' => 'c_up_down_diff_step',
+            'filters' => ['c_up_down_diff_step' => '2'],
+        ]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('sort_by', '')
+                ->where('rows', function ($rows) {
+                    return count($rows->all()) === 2;
+                }));
+    }
+
+    #[Test]
     public function unknown_table_404(): void {
         $this->get(route('app.codes.show', ['table_name' => 'NOPE_TABLE']))->assertNotFound();
     }


### PR DESCRIPTION
## Summary
- 在 `/app/codes/KINSHIP_CODES` 頁面於 `c_upstep` 左邊新增純顯示用計算欄位 `c_up_down_diff_step`，值為 `c_upstep - c_dwnstep`
- 該欄位僅存在於前端顯示，不對應真實 DB 欄位，也不可排序／篩選（`injectComputedColumns()` 在 `buildShowPayload()` 算完排序／篩選白名單後才注入，避免虛擬欄位被誤判為可查詢欄位）
- 只修改 Inertia/React 路徑（`appShow()` + `Show.tsx`），未觸碰共用的 Blade `show()` 路徑

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/CodesShowInertiaTest.php`（7 tests, 78 assertions，含 2 個新測試：計算值正確性、排序／篩選安全性）
- [x] `./vendor/bin/phpunit --filter Codes`（既有 9 個失敗為 rate-limit 相關既存 flaky 測試，與本改動無關，改動前後失敗集合一致）
- [x] `./vendor/bin/php-cs-fixer fix`
- [x] `npm run build`
- [x] 已通過內部 review agent 與 `codex exec` review，均無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)