### PR TITLE
KINSHIP_CODES 計算欄位 c_up_down_diff_step 篩選改為 exact match

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -234,13 +234,19 @@ class CodesController extends Controller {
      * 與其他欄位一致，不做特例放寬。目前僅 KINSHIP_CODES 一例：
      * c_up_down_diff_step = c_upstep − c_dwnstep，顯示於 c_upstep 左邊。
      *
-     * @var array<string, array<string, array{expression: string, insert_before: string}>>
+     * `match_mode`（預設 'contains'）：'exact' 表示該欄位篩選走完全比對（=）而非 LIKE
+     * 子字串比對——數值型計算欄位用 LIKE 會有誤導性命中（例如篩 "2" 會連 "-2"、"12" 都
+     * 命中），改用 exact 更符合直覺。僅影響逐欄篩選框；上方全域搜尋框（多欄 OR LIKE）
+     * 不受影響，維持原本子字串搜尋語意。
+     *
+     * @var array<string, array<string, array{expression: string, insert_before: string, match_mode?: string}>>
      */
     protected $tableComputedColumns = [
         'KINSHIP_CODES' => [
             'c_up_down_diff_step' => [
                 'expression' => '(c_upstep - c_dwnstep)',
                 'insert_before' => 'c_upstep',
+                'match_mode' => 'exact',
             ],
         ],
     ];
@@ -662,6 +668,14 @@ class CodesController extends Controller {
                 continue;
             }
 
+            // 計算欄位可個別指定 match_mode（見 $tableComputedColumns 註解）：'exact' 用
+            // `=` 完全比對，避免數值欄位用 LIKE 子字串造成誤判命中（如篩 "2" 連 "-2" 都中）。
+            $matchMode = $computedColumns[$column]['match_mode'] ?? 'contains';
+            if ($matchMode === 'exact' && !$booleanEnabled && !is_numeric($value)) {
+                // 非數字輸入略過套用：避免 MySQL 將非數字字串隱式轉型為 0，誤配對到 diff=0 的列。
+                continue;
+            }
+
             if ($booleanEnabled) {
                 try {
                     $ast = $this->columnFilterExpression->parse($value);
@@ -670,8 +684,16 @@ class CodesController extends Controller {
 
                     continue;
                 }
-                $this->columnFilterExpression->applyToBuilder($query, $filterColumn, $ast);
-                $filterDescriptions[$column] = $this->columnFilterExpression->describe($ast, $descLabels);
+                $this->columnFilterExpression->applyToBuilder($query, $filterColumn, $ast, $matchMode);
+                $termLabels = $descLabels;
+                if ($matchMode === 'exact') {
+                    $termLabels['contains'] = (string) __('codes.filter_desc_exact');
+                }
+                $filterDescriptions[$column] = $this->columnFilterExpression->describe($ast, $termLabels);
+            } elseif ($matchMode === 'exact') {
+                // SQLite 對算術運算式（無欄位型別可依附）比對字串繫結值時不會做數字轉換，
+                // 因此需先轉成數字型別再綁定，MySQL 亦相容。
+                $query->where($filterColumn, '=', $value + 0);
             } else {
                 $query->where($filterColumn, 'like', '%' . $value . '%');
             }

--- a/app/Support/ColumnFilterExpression.php
+++ b/app/Support/ColumnFilterExpression.php
@@ -88,9 +88,11 @@ class ColumnFilterExpression {
      *
      * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $query
      * @param array<string,mixed> $ast
+     * @param string $matchMode 'contains'（預設，LIKE 子字串）或 'exact'（=，完全比對；
+     *     供數值型計算欄位使用，避免 LIKE 對負數/子字串的誤導性命中）。
      */
-    public function applyToBuilder($query, Expression|string $column, array $ast): void {
-        $this->applyNode($query, $column, $ast, false);
+    public function applyToBuilder($query, Expression|string $column, array $ast, string $matchMode = 'contains'): void {
+        $this->applyNode($query, $column, $ast, false, $matchMode);
     }
 
     /**
@@ -393,9 +395,32 @@ class ColumnFilterExpression {
      * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $query
      * @param array<string,mixed> $node
      */
-    private function applyNode($query, Expression|string $col, array $node, bool $negate): void {
+    private function applyNode($query, Expression|string $col, array $node, bool $negate, string $matchMode = 'contains'): void {
         switch ($node['type']) {
             case 'term':
+                if ($matchMode === 'exact') {
+                    // 非數字詞項對數值運算式而言恆不相等；直接下「恆假／恆真」條件，避免
+                    // 字串繫結值被資料庫隱式轉型（如轉 0）造成誤配對。數字詞項需顯式轉數字
+                    // 型別再繫結——SQLite 對算術運算式比對字串繫結值不會做數字轉換。
+                    $isNumeric = is_numeric($node['value']);
+                    if (!$negate) {
+                        if ($isNumeric) {
+                            $query->where($col, '=', $node['value'] + 0);
+                        } else {
+                            $query->whereRaw('1 = 0');
+                        }
+                    } elseif ($isNumeric) {
+                        // NULL-safe NOT: a NULL column must NOT be excluded.
+                        $query->where(function ($q) use ($col, $node): void {
+                            $q->whereNull($col)->orWhere($col, '!=', $node['value'] + 0);
+                        });
+                    } else {
+                        $query->whereRaw('1 = 1');
+                    }
+
+                    return;
+                }
+
                 $pattern = '%' . $node['value'] . '%';
                 if (!$negate) {
                     $query->where($col, 'like', $pattern);
@@ -410,7 +435,7 @@ class ColumnFilterExpression {
 
             case 'not':
                 // Push negation down toward the leaves (De Morgan): no bare NOT(...) group.
-                $this->applyNode($query, $col, $node['child'], !$negate);
+                $this->applyNode($query, $col, $node['child'], !$negate, $matchMode);
 
                 return;
 
@@ -421,11 +446,11 @@ class ColumnFilterExpression {
                 $effectiveAnd = $negate ? !$isAnd : $isAnd;
                 $children = $node['children'];
 
-                $query->where(function ($q) use ($col, $children, $negate, $effectiveAnd): void {
+                $query->where(function ($q) use ($col, $children, $negate, $effectiveAnd, $matchMode): void {
                     $first = true;
                     foreach ($children as $child) {
-                        $apply = function ($qq) use ($col, $child, $negate): void {
-                            $this->applyNode($qq, $col, $child, $negate);
+                        $apply = function ($qq) use ($col, $child, $negate, $matchMode): void {
+                            $this->applyNode($qq, $col, $child, $negate, $matchMode);
                         };
                         if ($first) {
                             $q->where($apply);

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -165,6 +165,7 @@ return [
     'filter_err_unknown' => 'Syntax error',
     // AST -> human phrases (assembled by ColumnFilterExpression::describe())
     'filter_desc_contains' => 'contains ":term"',
+    'filter_desc_exact' => 'equals ":term"',
     'filter_desc_not' => 'not ',
     'filter_desc_and' => ' and ',
     'filter_desc_or' => ' or ',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -163,6 +163,7 @@ return [
     'filter_err_unknown' => '語法錯誤',
     // AST→人話片語（由 ColumnFilterExpression::describe() 組裝）
     'filter_desc_contains' => '含「:term」',
+    'filter_desc_exact' => '等於「:term」',
     'filter_desc_not' => '非',
     'filter_desc_and' => ' 且 ',
     'filter_desc_or' => ' 或 ',

--- a/tests/Feature/CodesShowInertiaTest.php
+++ b/tests/Feature/CodesShowInertiaTest.php
@@ -157,8 +157,8 @@ class CodesShowInertiaTest extends TestCase {
         $this->seedKinshipCodesForSortFilter();
         $this->actingAs($this->activeUser());
 
-        // 與其他數值欄位一致：篩選用 LIKE '%2%' 字面比對，diff=-2 的列也會命中（因為 "-2"
-        // 內含子字串 "2"），非本功能特有行為。
+        // 此計算欄位是數值型，match_mode 設為 exact（完全比對）而非 LIKE 子字串，所以篩
+        // "2" 只命中 diff=2 的列（kincode 1），diff=-2 的列（kincode 2）不會被誤配對。
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
             'filters' => ['c_up_down_diff_step' => '2'],
@@ -167,9 +167,65 @@ class CodesShowInertiaTest extends TestCase {
             ->assertInertia(fn (Assert $page) => $page
                 ->where('rows', function ($rows) {
                     $ids = collect($rows->all())->pluck('c_kincode')->all();
+
+                    return $ids === [1];
+                }));
+    }
+
+    #[Test]
+    public function kinship_codes_computed_column_exact_filter_can_match_negative_values(): void {
+        $this->seedKinshipCodesForSortFilter();
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.codes.show', [
+            'table_name' => 'KINSHIP_CODES',
+            'filters' => ['c_up_down_diff_step' => '-2'],
+        ]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('rows', function ($rows) {
+                    $ids = collect($rows->all())->pluck('c_kincode')->all();
+
+                    return $ids === [2];
+                }));
+    }
+
+    #[Test]
+    public function kinship_codes_computed_column_exact_filter_ignores_non_numeric_input(): void {
+        $this->seedKinshipCodesForSortFilter();
+        $this->actingAs($this->activeUser());
+
+        // 非數字輸入不套用篩選（避免 MySQL 隱式轉型為 0 誤配對 diff=0 的列），回傳全部列。
+        $this->get(route('app.codes.show', [
+            'table_name' => 'KINSHIP_CODES',
+            'filters' => ['c_up_down_diff_step' => 'abc'],
+        ]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('rows', function ($rows) {
+                    return count($rows->all()) === 3;
+                }));
+    }
+
+    #[Test]
+    public function kinship_codes_computed_column_exact_filter_works_in_boolean_mode(): void {
+        $this->seedKinshipCodesForSortFilter();
+        $this->actingAs($this->activeUser());
+
+        // 進階布林篩選模式（filter_bool=1）下，exact match_mode 仍應走 `=` 完全比對，
+        // NOT 詞項對數字仍走 NULL-safe 排除；非數字詞項恆不相等（見 ColumnFilterExpression）。
+        $this->get(route('app.codes.show', [
+            'table_name' => 'KINSHIP_CODES',
+            'filter_bool' => 1,
+            'filters' => ['c_up_down_diff_step' => '!2'],
+        ]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('rows', function ($rows) {
+                    $ids = collect($rows->all())->pluck('c_kincode')->all();
                     sort($ids);
 
-                    return $ids === [1, 2];
+                    return $ids === [2, 3];
                 }));
     }
 


### PR DESCRIPTION
## Summary
- `/app/codes/KINSHIP_CODES` 的計算欄位 `c_up_down_diff_step`（= `c_upstep - c_dwnstep`）篩選從 LIKE 子字串比對改為 exact match（=），因為這是數值欄位，LIKE '%2%' 會誤中 '-2'
- 新增 `$tableComputedColumns` 的 `match_mode` 設定（僅此欄位設為 `'exact'`，其他欄位維持預設 `'contains'`，行為不變）
- 修正過程中發現 SQLite 對「算術運算式 = 字串繫結值」不會做數字轉換，需先將輸入轉成數字型別再綁定（`$value + 0`），MySQL 亦相容
- 非數字輸入直接略過套用，避免資料庫把非數字字串隱式轉型為 0 誤配對 diff=0 的列
- 進階布林篩選模式（`filter_bool=1`）下同樣支援 exact match，含 NOT 語意

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/CodesShowInertiaTest.php`（12 tests，含 4 個新測試：exact 只中 diff=2、可篩負數、非數字輸入被忽略、進階布林模式 NOT 語意）
- [x] `./vendor/bin/phpunit tests/Feature/ColumnFilterExpressionTest.php`（24 tests，確認其他欄位的 LIKE 行為不受影響）
- [x] `./vendor/bin/phpunit --filter Codes`（既有 9 個失敗為 rate-limit 相關既存 flaky 測試，與本改動無關）
- [x] `./vendor/bin/php-cs-fixer fix`
- [x] 已通過內部 review agent 與 `codex exec` review，均無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)