### PR TITLE
KINSHIP_CODES 計算欄位改名為 c_down_up_diff_step，公式反向

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -232,7 +232,9 @@ class CodesController extends Controller {
      * resolveColumnForQuery() 會把欄位名解回 `expression`（DB::raw）而非誤判為真實
      * 資料表欄位。排序／篩選仍受 guardSortFilterRequiresAuth() 登入且已激活門檻保護，
      * 與其他欄位一致，不做特例放寬。目前僅 KINSHIP_CODES 一例：
-     * c_up_down_diff_step = c_upstep − c_dwnstep，顯示於 c_upstep 左邊。
+     * c_down_up_diff_step = c_dwnstep − c_upstep，顯示於 c_upstep 左邊。用 dwnstep - upstep
+     * （而非 upstep - dwnstep）是因為輩份上，負值代表往上（長輩）較符合直覺——例如
+     * dwnstep=1、upstep=2 時 diff = -1，代表往上一輩。
      *
      * `match_mode`（預設 'contains'）：'exact' 表示該欄位篩選走完全比對（=）而非 LIKE
      * 子字串比對——數值型計算欄位用 LIKE 會有誤導性命中（例如篩 "2" 會連 "-2"、"12" 都
@@ -243,8 +245,8 @@ class CodesController extends Controller {
      */
     protected $tableComputedColumns = [
         'KINSHIP_CODES' => [
-            'c_up_down_diff_step' => [
-                'expression' => '(c_upstep - c_dwnstep)',
+            'c_down_up_diff_step' => [
+                'expression' => '(c_dwnstep - c_upstep)',
                 'insert_before' => 'c_upstep',
                 'match_mode' => 'exact',
             ],

--- a/tests/Feature/CodesShowInertiaTest.php
+++ b/tests/Feature/CodesShowInertiaTest.php
@@ -84,7 +84,7 @@ class CodesShowInertiaTest extends TestCase {
     }
 
     #[Test]
-    public function it_injects_kinship_codes_up_down_diff_step_computed_column(): void {
+    public function it_injects_kinship_codes_down_up_diff_step_computed_column(): void {
         config(['codes.tables' => ['TEST_CODES' => '測試代碼', 'KINSHIP_CODES' => '親屬關係代碼表']]);
 
         Schema::create('KINSHIP_CODES', function ($table) {
@@ -104,16 +104,17 @@ class CodesShowInertiaTest extends TestCase {
                 ->component('Codes/Show')
                 ->where('thead', function ($thead) {
                     $thead = $thead->all();
-                    $diffIndex = array_search('c_up_down_diff_step', $thead, true);
+                    $diffIndex = array_search('c_down_up_diff_step', $thead, true);
                     $upstepIndex = array_search('c_upstep', $thead, true);
 
                     return $diffIndex !== false && $upstepIndex !== false && $diffIndex === $upstepIndex - 1;
                 })
-                ->where('computed_columns', ['c_up_down_diff_step'])
+                ->where('computed_columns', ['c_down_up_diff_step'])
                 ->where('rows', function ($rows) {
                     $rows = $rows->all();
 
-                    return $rows[0]['c_up_down_diff_step'] === 2 && $rows[1]['c_up_down_diff_step'] === null;
+                    // diff = c_dwnstep - c_upstep = 1 - 3 = -2；第二列 c_upstep 為 null → diff 為 null。
+                    return $rows[0]['c_down_up_diff_step'] === -2 && $rows[1]['c_down_up_diff_step'] === null;
                 }));
     }
 
@@ -126,8 +127,8 @@ class CodesShowInertiaTest extends TestCase {
             $table->smallInteger('c_dwnstep')->nullable();
         });
         DB::table('KINSHIP_CODES')->insert([
-            ['c_kincode' => 1, 'c_upstep' => 3, 'c_dwnstep' => 1],  // diff = 2
-            ['c_kincode' => 2, 'c_upstep' => 1, 'c_dwnstep' => 3],  // diff = -2
+            ['c_kincode' => 1, 'c_upstep' => 3, 'c_dwnstep' => 1],  // diff = c_dwnstep - c_upstep = -2
+            ['c_kincode' => 2, 'c_upstep' => 1, 'c_dwnstep' => 3],  // diff = 2
             ['c_kincode' => 3, 'c_upstep' => 5, 'c_dwnstep' => 5],  // diff = 0
         ]);
     }
@@ -139,16 +140,17 @@ class CodesShowInertiaTest extends TestCase {
 
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
-            'sort_by' => 'c_up_down_diff_step',
+            'sort_by' => 'c_down_up_diff_step',
             'sort_dir' => 'asc',
         ]))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
-                ->where('sort_by', 'c_up_down_diff_step')
+                ->where('sort_by', 'c_down_up_diff_step')
                 ->where('rows', function ($rows) {
                     $rows = $rows->all();
 
-                    return $rows[0]['c_kincode'] === 2 && $rows[1]['c_kincode'] === 3 && $rows[2]['c_kincode'] === 1;
+                    // 升冪：kincode1(-2) < kincode3(0) < kincode2(2)。
+                    return $rows[0]['c_kincode'] === 1 && $rows[1]['c_kincode'] === 3 && $rows[2]['c_kincode'] === 2;
                 }));
     }
 
@@ -158,28 +160,10 @@ class CodesShowInertiaTest extends TestCase {
         $this->actingAs($this->activeUser());
 
         // 此計算欄位是數值型，match_mode 設為 exact（完全比對）而非 LIKE 子字串，所以篩
-        // "2" 只命中 diff=2 的列（kincode 1），diff=-2 的列（kincode 2）不會被誤配對。
+        // "2" 只命中 diff=2 的列（kincode 2），diff=-2 的列（kincode 1）不會被誤配對。
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
-            'filters' => ['c_up_down_diff_step' => '2'],
-        ]))
-            ->assertOk()
-            ->assertInertia(fn (Assert $page) => $page
-                ->where('rows', function ($rows) {
-                    $ids = collect($rows->all())->pluck('c_kincode')->all();
-
-                    return $ids === [1];
-                }));
-    }
-
-    #[Test]
-    public function kinship_codes_computed_column_exact_filter_can_match_negative_values(): void {
-        $this->seedKinshipCodesForSortFilter();
-        $this->actingAs($this->activeUser());
-
-        $this->get(route('app.codes.show', [
-            'table_name' => 'KINSHIP_CODES',
-            'filters' => ['c_up_down_diff_step' => '-2'],
+            'filters' => ['c_down_up_diff_step' => '2'],
         ]))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
@@ -191,6 +175,24 @@ class CodesShowInertiaTest extends TestCase {
     }
 
     #[Test]
+    public function kinship_codes_computed_column_exact_filter_can_match_negative_values(): void {
+        $this->seedKinshipCodesForSortFilter();
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.codes.show', [
+            'table_name' => 'KINSHIP_CODES',
+            'filters' => ['c_down_up_diff_step' => '-2'],
+        ]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('rows', function ($rows) {
+                    $ids = collect($rows->all())->pluck('c_kincode')->all();
+
+                    return $ids === [1];
+                }));
+    }
+
+    #[Test]
     public function kinship_codes_computed_column_exact_filter_ignores_non_numeric_input(): void {
         $this->seedKinshipCodesForSortFilter();
         $this->actingAs($this->activeUser());
@@ -198,7 +200,7 @@ class CodesShowInertiaTest extends TestCase {
         // 非數字輸入不套用篩選（避免 MySQL 隱式轉型為 0 誤配對 diff=0 的列），回傳全部列。
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
-            'filters' => ['c_up_down_diff_step' => 'abc'],
+            'filters' => ['c_down_up_diff_step' => 'abc'],
         ]))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
@@ -217,7 +219,7 @@ class CodesShowInertiaTest extends TestCase {
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
             'filter_bool' => 1,
-            'filters' => ['c_up_down_diff_step' => '!2'],
+            'filters' => ['c_down_up_diff_step' => '!2'],
         ]))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
@@ -225,7 +227,7 @@ class CodesShowInertiaTest extends TestCase {
                     $ids = collect($rows->all())->pluck('c_kincode')->all();
                     sort($ids);
 
-                    return $ids === [2, 3];
+                    return $ids === [1, 3];
                 }));
     }
 
@@ -237,12 +239,12 @@ class CodesShowInertiaTest extends TestCase {
 
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
-            'sort_by' => 'c_up_down_diff_step',
+            'sort_by' => 'c_down_up_diff_step',
         ]))->assertRedirect(route('login'));
 
         $this->get(route('app.codes.show', [
             'table_name' => 'KINSHIP_CODES',
-            'filters' => ['c_up_down_diff_step' => '2'],
+            'filters' => ['c_down_up_diff_step' => '2'],
         ]))->assertRedirect(route('login'));
     }
 


### PR DESCRIPTION
## Summary
- `/app/codes/KINSHIP_CODES` 的計算欄位 `c_up_down_diff_step`（= `c_upstep - c_dwnstep`）改名為 `c_down_up_diff_step`，公式改為 `c_dwnstep - c_upstep`（運算元順序對調，不只是改名）
- 原因：輩份上負值代表往上一輩比較符合直覺，例如 `dwnstep=1, upstep=2` 時新公式 = 1-2 = -1，代表往上一輩
- `insert_before`（`c_upstep`）與 `match_mode`（`exact`）維持不變，欄位仍顯示在 `c_upstep` 左邊、篩選仍走完全比對
- 舊書籤網址若帶 `sort_by=c_up_down_diff_step` 或 `filters[c_up_down_diff_step]=...` 會被當未知欄位優雅忽略（不會報錯），與其他欄位一致的既有行為

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/CodesShowInertiaTest.php`（12 tests，全部改名並依新公式重新計算預期值）
- [x] `./vendor/bin/phpunit --filter Codes`（既有 9 個失敗為 rate-limit 相關既存 flaky 測試，與本改動無關）
- [x] `./vendor/bin/php-cs-fixer fix`
- [x] 已通過內部 review agent 與 `codex exec` review，均無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)