### PR TITLE
修正提案／直接保存「修改說明」靜默遺失

### DIFF
--- a/resources/js/inertia/components/AddressEditor.tsx
+++ b/resources/js/inertia/components/AddressEditor.tsx
@@ -142,7 +142,7 @@ export default function AddressEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'addresses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'addresses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -138,7 +138,7 @@ export default function AltnameEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'altnames', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'altnames', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -374,7 +374,7 @@ export default function AssocEditor({
         try {
             // #66：meta 可帶 comment（proposal）與 force（衝突警告中選「強制覆寫」時）。
             const meta: Record<string, unknown> = {};
-            if (sm === 'proposal' && comment) meta.comment = comment;
+            if (comment) meta.comment = comment;
             if (force) meta.force = true;
             const res = await fetch(endpoint, {
                 method: 'POST',

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -254,7 +254,7 @@ export default function BasicInfoEditor({
                 body: JSON.stringify({
                     resource: 'basicinformation', person_id: personId, mode, operation: 'update',
                     target: { pk: { c_personid: personId } }, changes,
-                    ...(mode === 'proposal' ? { comment } : {}),
+                    ...(comment ? { meta: { comment } } : {}),
                 }),
             });
             const json = await res.json().catch(() => ({}));

--- a/resources/js/inertia/components/EntryEditor.tsx
+++ b/resources/js/inertia/components/EntryEditor.tsx
@@ -175,7 +175,7 @@ export default function EntryEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'entries', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'entries', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/EventEditor.tsx
+++ b/resources/js/inertia/components/EventEditor.tsx
@@ -168,7 +168,7 @@ export default function EventEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'events', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'events', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/KinEditor.tsx
+++ b/resources/js/inertia/components/KinEditor.tsx
@@ -214,7 +214,7 @@ export default function KinEditor({
         try {
             // #66：meta 可帶 comment（proposal）與 force（衝突警告中選「強制覆寫」時）。
             const meta: Record<string, unknown> = {};
-            if (sm === 'proposal' && comment) meta.comment = comment;
+            if (comment) meta.comment = comment;
             if (force) meta.force = true;
             const res = await fetch(endpoint, {
                 method: 'POST',

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -255,7 +255,7 @@ export default function OfficeEditor({
         // meta：proposal 附帶審核備註；create 且曾用 AI 自動填時附帶 ai_fill_log_id，供後端回寫
         // ai_fill_logs 的 user_submitted + submitted_at（不論是否人工修改過 AI 建議皆以 log id 連結）。
         const meta: Record<string, unknown> = {};
-        if (sm === 'proposal' && comment) meta.comment = comment;
+        if (comment) meta.comment = comment;
         if (creating && aiFillLogId.current) meta.ai_fill_log_id = aiFillLogId.current;
 
         try {

--- a/resources/js/inertia/components/PossessionEditor.tsx
+++ b/resources/js/inertia/components/PossessionEditor.tsx
@@ -148,7 +148,7 @@ export default function PossessionEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'possessions', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'possessions', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/SocialInstEditor.tsx
+++ b/resources/js/inertia/components/SocialInstEditor.tsx
@@ -156,7 +156,7 @@ export default function SocialInstEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'social_institutions', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'social_institutions', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/SourceEditor.tsx
+++ b/resources/js/inertia/components/SourceEditor.tsx
@@ -140,7 +140,7 @@ export default function SourceEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'sources', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'sources', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/StatusEditor.tsx
+++ b/resources/js/inertia/components/StatusEditor.tsx
@@ -175,7 +175,7 @@ export default function StatusEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'statuses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'statuses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);

--- a/resources/js/inertia/components/TextEditor.tsx
+++ b/resources/js/inertia/components/TextEditor.tsx
@@ -113,7 +113,7 @@ export default function TextEditor({
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'texts', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(sm === 'proposal' && comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'texts', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);


### PR DESCRIPTION
新版 React 編輯器的「修改說明」在部分路徑未能送達後端，導致使用者填寫的說明被靜默丟棄：

- BasicInfoEditor 將說明送成頂層 `comment`，但後端（MutationController）只讀 `meta.comment`， 基本資料提案的說明完全遺失，管理端顯示為空。
- 全部 13 個編輯器僅在 proposal 模式送出說明（`sm === 'proposal'` gate）， 直接保存時說明被前端丟棄，即使後端 direct 路徑已支援寫入 `__note`。

改為只要 `comment` 非空即以 `meta.comment` 送出（不再受模式限制），
一次修正兩條路徑。後端持久化位置不變：提案存 `__proposal_meta.comment`、
直接保存存 `__note`，管理端與 operations 詳情皆能正常顯示。

涉及：BasicInfo、Address、Altname、Assoc、Entry、Event、Kin、Office、 Possession、SocialInst、Source、Status、Text 共 13 個編輯器。

Claude-Session: https://claude.ai/code/session_019r1424dvYH8K95utZKp3ih