### PR TITLE
feat(office): 官職實體推進 step 4——/app/office 補齊 parity、側欄改指、OFFICE_CODES 封寫

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 2026-07
 
+### 官職實體聚合推進至 step 4：/app/office 成為唯一寫入入口、OFFICE_CODES 裸表封寫（#1159）
+- `/app/office` 列表補齊與 `app/codes/OFFICE_CODES` 的 feature parity 並成為超集：全部 OFFICE_CODES 欄位、任意欄排序＋主鍵 tie-breaker、逐欄篩選（含 AND/OR/NOT 布林模式，复用 `ColumnFilterExpression` 與 codes 同組 i18n）、關鍵字全欄搜尋、朝代標籤、全表匯出連結，另加聚合特有的 `type_count` 計算欄（OFFICE_CODE_TYPE_REL 關聯數，exact 比對）。
+- 訪問模型對齊 codes 頁：列表公開可讀；排序／篩選需登入且已激活（鏡像 `guardSortFilterRequiresAuth`）；新增／編輯／刪除仍需 `canWriteDirectly`。
+- 側欄「任官編碼表」改指 `/app/office`（`Navigation::officeEntityItem()`），active 保留 `OFFICE_CODES` page-title 相容直訪裸表頁。
+- `OFFICE_CODES` 加入 `CodesController::$readOnlyTables`：裸表 create／edit／update／destroy／proposal 全部封閉（讀取與匯出開放）。裸表 proposal 一併封閉是實體級提案（§4.5）就緒前的有意取捨；回退＝自 `$readOnlyTables` 移除一行。
+- 測試 `tests/Feature/OfficeEntityIndexTest.php`；設計文件 §5 差距表同步更新。
+
 ### mutation API 支援 code 表寫入（先接 TEXT_CODES，resource=text-codes）
 - 讓單主鍵 code 表可經 `/api/v2/{create,delete}` 與 `batch_mutate` 機器化寫入（token、`operations` + AuditLog、可回滾），補上目前 codes 網頁表單/書目導入工具缺的統一審計。
 - config 驅動（`config/code_table_writes.php`）：每張表定 `resource/aliases/table/key_column/auto_assign_id/allowed_fields`。新增 `CodeTableCreateHandler` / `CodeTableDeleteHandler`（獨立於 person-subresource 基底，因 code 表無 c_personid）。

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -42,6 +42,12 @@ class CodesController extends Controller {
         'CBDB__TRAD_SIMP_MAP',
         'DYNASTIES',
         'GANZHI_CODES',
+        // 官職為複合實體（OFFICE_CODES + OFFICE_CODE_TYPE_REL），裸表直寫會產出殘缺聚合
+        // （docs/ENTITY_AGGREGATE_ARCHITECTURE.md §3.1）。實體級入口（/app/office，含
+        // create/update/delete 與側欄連結）就緒後在此封寫；讀取與匯出維持開放。
+        // 注意：這同時擋掉裸表 proposal——實體級提案就緒前為有意取捨（§4.5）。
+        // 回退：自本清單移除即可恢復裸表寫入。
+        'OFFICE_CODES',
     ];
     /**
      * Copyright notices for specific tables.

--- a/app/Http/Controllers/OfficeEntityController.php
+++ b/app/Http/Controllers/OfficeEntityController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Services\Import\OfficeImportService;
+use App\Support\ColumnFilterExpression;
+use App\Support\ColumnFilterParseException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -19,7 +22,37 @@ use Inertia\Inertia;
  * 有別於 /app/codes/OFFICE_CODES 的裸單表 CRUD（後者為待收斂的下層洩漏路徑）。
  */
 class OfficeEntityController extends Controller {
-    public function __construct(protected OfficeImportService $service) {
+    /**
+     * OFFICE_CODES 實體欄位（物理欄序，與 codes 裸表頁一致）。
+     * 列表 thead ＝ 此清單 ＋ 計算欄位 type_count（見 COMPUTED_COLUMNS）。
+     *
+     * @var array<int, string>
+     */
+    protected const OFFICE_COLUMNS = [
+        'c_office_id', 'c_dy', 'c_office_pinyin', 'c_office_chn',
+        'c_office_pinyin_alt', 'c_office_chn_alt', 'c_office_trans', 'c_office_trans_alt',
+        'c_source', 'c_pages', 'c_notes',
+        'c_category_1', 'c_category_2', 'c_category_3', 'c_category_4', 'c_office_id_old',
+    ];
+
+    /**
+     * 聚合計算欄位（對齊 CodesController::$tableComputedColumns 的結構）：
+     * type_count ＝ 該官職在 OFFICE_CODE_TYPE_REL 的類型關聯數，是聚合視角特有、
+     * 裸單表頁沒有的欄位；exact 比對避免數值欄位 LIKE 子字串誤命中。
+     *
+     * @var array<string, array{expression: string, match_mode: string}>
+     */
+    protected const COMPUTED_COLUMNS = [
+        'type_count' => [
+            'expression' => '(SELECT COUNT(*) FROM OFFICE_CODE_TYPE_REL WHERE OFFICE_CODE_TYPE_REL.c_office_id = OFFICE_CODES.c_office_id)',
+            'match_mode' => 'exact',
+        ],
+    ];
+
+    public function __construct(
+        protected OfficeImportService $service,
+        protected ColumnFilterExpression $columnFilterExpression,
+    ) {
     }
 
     /** 瀏覽需登入且帳號有效。 */
@@ -48,67 +81,229 @@ class OfficeEntityController extends Controller {
             'api_delete' => '/api/v2/delete',
             'search_type' => '/api/select/search/officetype',
             'search_source' => '/api/select/search/text',
+            // 全表匯出沿用既有公開 codes 匯出路由（throttle:6,1、CC BY-NC-SA），不另開端點。
+            'export' => '/codes/OFFICE_CODES/export',
         ];
     }
 
     protected function translations(): array {
         return [
             'office' => is_array($t = trans('office')) ? $t : [],
+            // 列表的排序／篩選 UI（布林語法、錯誤訊息、套用說明）與 codes 頁共用同一組字串。
+            'codes' => is_array($t = trans('codes')) ? $t : [],
         ];
     }
 
-    /** 官職列表（分頁 + 關鍵字），含朝代標籤與類型數。 */
+    /**
+     * 官職列表：與 app/codes/OFFICE_CODES 裸表頁 feature parity（全欄位、任意欄排序＋主鍵
+     * tie-breaker、逐欄篩選含布林模式、關鍵字搜尋、朝代標籤、公開可讀），另加聚合特有的
+     * type_count 計算欄位。此頁是側欄「任官編碼表」的新入口，裸表頁封寫後為唯一編輯入口。
+     */
     public function appIndex(Request $request) {
-        $this->ensureActive();
+        // 對齊 codes 頁的訪問模型：讀取公開；排序／篩選需登入且已激活
+        // （見 docs/CODES_SORT_FILTER_AUTH_GATE.md 的成本理由）。
+        $guardRedirect = $this->guardSortFilterRequiresAuth($request);
+        if ($guardRedirect !== null) {
+            return $guardRedirect;
+        }
 
+        $thead = array_merge(self::OFFICE_COLUMNS, array_keys(self::COMPUTED_COLUMNS));
+
+        $query = DB::table('OFFICE_CODES')->select('OFFICE_CODES.*');
+        foreach (self::COMPUTED_COLUMNS as $name => $definition) {
+            $query->selectRaw($definition['expression'].' as '.$name);
+        }
+
+        // 關鍵字搜尋：所有實體欄位 %term%（與 codes 頁 determineSearchableColumns 一致）。
         $q = trim((string) $request->query('q', ''));
-        $query = DB::table('OFFICE_CODES');
         if ($q !== '') {
-            $query->where(function ($w) use ($q) {
-                $w->where('c_office_chn', 'like', '%'.$q.'%')
-                    ->orWhere('c_office_pinyin', 'like', '%'.$q.'%');
-                if (ctype_digit($q)) {
-                    $w->orWhere('c_office_id', (int) $q);
+            $query->where(function ($sub) use ($q) {
+                foreach (self::OFFICE_COLUMNS as $column) {
+                    $sub->orWhere($column, 'like', '%'.$q.'%');
                 }
             });
         }
-        $paginator = $query->orderByDesc('c_office_id')->paginate(20)->appends(['q' => $q]);
 
-        $rows = collect($paginator->items());
-        $officeIds = $rows->pluck('c_office_id')->all();
-        $dynastyCodes = $rows->pluck('c_dy')->filter(fn ($v) => $v !== null)->unique()->all();
+        // 逐欄篩選（欄位間 AND；布林模式逐欄解析，失敗記錯誤並略過，不轉字面）。
+        $filters = $this->sanitizeColumnFilters($request->query('filters', []), $thead);
+        $booleanAvailable = (bool) config('codes.boolean_filter_enabled', true);
+        $booleanEnabled = $booleanAvailable && $request->boolean('filter_bool');
+        $appliedFilters = [];
+        $filterErrors = [];
+        $filterDescriptions = [];
+        $descLabels = $booleanEnabled ? [
+            'contains' => (string) __('codes.filter_desc_contains'),
+            'not' => (string) __('codes.filter_desc_not'),
+            'and' => (string) __('codes.filter_desc_and'),
+            'or' => (string) __('codes.filter_desc_or'),
+        ] : [];
+        foreach ($filters as $column => $value) {
+            if ($value === '') {
+                continue;
+            }
+            $filterColumn = $this->resolveColumnForQuery($column);
+            $matchMode = self::COMPUTED_COLUMNS[$column]['match_mode'] ?? 'contains';
+            if ($matchMode === 'exact' && !$booleanEnabled && !is_numeric($value)) {
+                // 非數字輸入略過：避免 MySQL 將字串隱式轉 0，誤命中 count=0 的列。
+                continue;
+            }
 
-        $dynastyLabels = empty($dynastyCodes) ? collect() : DB::table('DYNASTIES')
-            ->whereIn('c_dy', $dynastyCodes)->pluck('c_dynasty_chn', 'c_dy');
-        $typeCounts = empty($officeIds) ? collect() : DB::table('OFFICE_CODE_TYPE_REL')
-            ->whereIn('c_office_id', $officeIds)
-            ->select('c_office_id', DB::raw('COUNT(*) AS n'))
-            ->groupBy('c_office_id')->pluck('n', 'c_office_id');
+            if ($booleanEnabled) {
+                try {
+                    $ast = $this->columnFilterExpression->parse($value);
+                } catch (ColumnFilterParseException $e) {
+                    $filterErrors[$column] = $e->errorCode;
 
-        $data = $rows->map(fn ($r) => [
-            'office_id' => (int) $r->c_office_id,
-            'name' => (string) ($r->c_office_chn ?? ''),
-            'pinyin' => (string) ($r->c_office_pinyin ?? ''),
-            'translation' => $r->c_office_trans,
-            'dynasty_code' => $r->c_dy !== null ? (int) $r->c_dy : null,
-            'dynasty_label' => $r->c_dy !== null ? ($dynastyLabels[$r->c_dy] ?? null) : null,
-            'type_count' => (int) ($typeCounts[$r->c_office_id] ?? 0),
-            'source_id' => $r->c_source !== null ? (int) $r->c_source : null,
-        ])->values();
+                    continue;
+                }
+                $this->columnFilterExpression->applyToBuilder($query, $filterColumn, $ast, $matchMode);
+                $termLabels = $descLabels;
+                if ($matchMode === 'exact') {
+                    $termLabels['contains'] = (string) __('codes.filter_desc_exact');
+                }
+                $filterDescriptions[$column] = $this->columnFilterExpression->describe($ast, $termLabels);
+            } elseif ($matchMode === 'exact') {
+                // SQLite 對運算式比對字串繫結值不做數字轉換，先轉數字再綁定（MySQL 亦相容）。
+                $query->where($filterColumn, '=', $value + 0);
+            } else {
+                $query->where($filterColumn, 'like', '%'.$value.'%');
+            }
+
+            $appliedFilters[$column] = $value;
+        }
+
+        // 排序 + 主鍵 tie-breaker（未指定排序時維持原本的 ID 倒序瀏覽體驗）。
+        [$sortBy, $sortDir] = $this->sanitizeSortParameters(
+            (string) $request->query('sort_by', ''),
+            (string) $request->query('sort_dir', 'asc'),
+            $thead
+        );
+        if ($sortBy !== '') {
+            $query->orderBy($this->resolveColumnForQuery($sortBy), $sortDir);
+            $query->orderBy('c_office_id', 'asc');
+        } else {
+            $query->orderByDesc('c_office_id');
+        }
+
+        // 分頁連結只攜帶實際套用的 filters（排除語法錯誤欄位），其餘 query 參數原樣保留。
+        $appendQuery = $request->except(['page', 'filters']);
+        if (!empty($appliedFilters)) {
+            $appendQuery['filters'] = $appliedFilters;
+        }
+        $paginator = $query->paginate((int) config('codes.per_page', 20))->appends($appendQuery);
+
+        $dynastyMap = DB::table('DYNASTIES')->pluck('c_dynasty_chn', 'c_dy')->all();
 
         return Inertia::render('Office/Index', [
-            'rows' => $data,
-            'q' => $q,
-            'pagination' => [
+            'thead' => $thead,
+            'rows' => array_map(fn ($r) => (array) $r, $paginator->items()),
+            'meta' => [
                 'current_page' => $paginator->currentPage(),
                 'last_page' => $paginator->lastPage(),
-                'total' => $paginator->total(),
                 'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'from' => $paginator->firstItem(),
+                'to' => $paginator->lastItem(),
             ],
+            'q' => $q,
+            'dynasty_map' => (object) $dynastyMap,
+            'key_columns' => ['c_office_id'],
+            'computed_columns' => array_keys(self::COMPUTED_COLUMNS),
+            'filters' => (object) $filters,
+            'sort_by' => $sortBy,
+            'sort_dir' => $sortDir,
+            'boolean_enabled' => $booleanEnabled,
+            'boolean_filter_available' => $booleanAvailable,
+            'filter_errors' => (object) $filterErrors,
+            'filter_descriptions' => (object) $filterDescriptions,
             'can_write' => Auth::check() && Auth::user()->canWriteDirectly(),
             'urls' => $this->urls(),
             'page_translations' => $this->translations(),
         ]);
+    }
+
+    /**
+     * 排序／篩選需登入且已激活（鏡像 CodesController::guardSortFilterRequiresAuth；
+     * 理由與行為一致：未登入導回登入頁記 intended、未激活 flash 後導回）。
+     */
+    protected function guardSortFilterRequiresAuth(Request $request): ?RedirectResponse {
+        $hasSortBy = trim((string) $request->query('sort_by', '')) !== '';
+
+        $hasFilter = false;
+        $filters = $request->query('filters', []);
+        if (is_array($filters)) {
+            foreach ($filters as $value) {
+                if (is_scalar($value) && trim((string) $value) !== '') {
+                    $hasFilter = true;
+
+                    break;
+                }
+            }
+        }
+
+        if (!$hasSortBy && !$hasFilter) {
+            return null;
+        }
+
+        if (!Auth::check()) {
+            return redirect()->guest(route('login'));
+        }
+
+        if (!Auth::user()->isActive()) {
+            flash('該用戶沒有權限使用排序／篩選功能，請聯絡管理員', 'error');
+
+            return redirect()->route('app.office.index');
+        }
+
+        return null;
+    }
+
+    /** 欄位名 → 查詢用欄位（計算欄位還原為原始運算式，供 WHERE／ORDER BY 使用）。 */
+    protected function resolveColumnForQuery(string $column): \Illuminate\Contracts\Database\Query\Expression|string {
+        if (isset(self::COMPUTED_COLUMNS[$column])) {
+            return DB::raw(self::COMPUTED_COLUMNS[$column]['expression']);
+        }
+
+        return $column;
+    }
+
+    /**
+     * 只保留 thead 白名單內、scalar、trim 後的 filters（鏡像 CodesController::sanitizeColumnFilters）。
+     *
+     * @param mixed $rawFilters
+     * @return array<string, string>
+     */
+    protected function sanitizeColumnFilters($rawFilters, array $thead): array {
+        if (!is_array($rawFilters)) {
+            return [];
+        }
+
+        $filters = [];
+        foreach ($rawFilters as $column => $value) {
+            if (!in_array($column, $thead, true) || !is_scalar($value)) {
+                continue;
+            }
+            $trimmed = trim((string) $value);
+            if ($trimmed !== '') {
+                $filters[$column] = $trimmed;
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * 排序參數白名單化（鏡像 CodesController::sanitizeSortParameters）。
+     *
+     * @return array{0: string, 1: string}
+     */
+    protected function sanitizeSortParameters(string $sortBy, string $sortDir, array $thead): array {
+        $sortBy = trim($sortBy);
+        if ($sortBy === '' || !in_array($sortBy, $thead, true)) {
+            return ['', 'asc'];
+        }
+
+        return [$sortBy, strtolower($sortDir) === 'desc' ? 'desc' : 'asc'];
     }
 
     /** 新增官職表單頁。 */

--- a/app/Support/Navigation.php
+++ b/app/Support/Navigation.php
@@ -251,7 +251,9 @@ class Navigation {
             self::codeItem('addresses', 'codes.addresses', 'fas fa-map', 'ADDRESSES'),
             self::codeItem('altname-codes', 'codes.altname_codes', 'fas fa-user-tag', 'ALTNAME_CODES'),
             self::codeItem('appointment-codes', 'codes.appointment_codes', 'fas fa-briefcase', 'APPOINTMENT_CODES'),
-            self::codeItem('office-codes', 'codes.office_codes', 'fas fa-id-badge', 'OFFICE_CODES'),
+            // 官職改指實體聚合頁（/app/office，feature parity 的超集）；裸表 /app/codes/OFFICE_CODES
+            // 已封寫、僅供讀取回退。active.pages 保留 'OFFICE_CODES' 讓直訪裸表頁時仍高亮此節點。
+            self::officeEntityItem(),
             self::codeItem('social-institution-codes', 'codes.social_institution_codes', 'fas fa-university', 'SOCIAL_INSTITUTION_CODES'),
             self::codeItem('text-codes', 'codes.text_codes', 'fas fa-book', 'TEXT_CODES'),
             self::codeItem('text-instance-data', 'codes.text_instance_data', 'fas fa-book-open', 'TEXT_INSTANCE_DATA'),
@@ -347,6 +349,26 @@ class Navigation {
             'children' => $children,
             'gate' => $gate,
         ];
+    }
+
+    /**
+     * 任官編碼表節點：href 指向官職實體聚合頁（app.office.index）。與 codeItem 不同，
+     * 這是「上層實體」入口而非裸表；路由不存在時回退裸表頁（防呆，正常部署不會發生）。
+     *
+     * @return array<string, mixed>
+     */
+    protected static function officeEntityItem(): array {
+        $href = self::routeUrl('app.office.index') ?? '/codes/OFFICE_CODES';
+        $node = self::item(
+            'office-codes',
+            'codes.office_codes',
+            'fas fa-id-badge',
+            $href,
+            ['pages' => ['OFFICE_CODES'], 'patterns' => ['app.office.*']]
+        );
+        $node['suffix'] = '(OFFICE_CODES)';
+
+        return $node;
     }
 
     /**

--- a/docs/ENTITY_AGGREGATE_ARCHITECTURE.md
+++ b/docs/ENTITY_AGGREGATE_ARCHITECTURE.md
@@ -118,7 +118,7 @@ CBDB 目前**只有「人物」做到了這一點**，其餘實體都停在「�
 | 人物 | BIOG_MAIN ＋ 12 子資源 | ✅ | ✅ CRUD | ✅（13 編輯器）| N/A（子資源即實體單位）| ✅ |
 | 書籍／文本 | TEXT_CODES ＋ INSTANCE ＋ BIBLCAT… | ❌ | 僅裸 TEXT_CODES CRUD | ❌ | ❌ | ❌（退化下層）|
 | 地點 | ADDRESSES ＋ ADDR_CODES ＋ … | ❌ | ❌ | ❌ | ❌ | ❌ |
-| 官職 | OFFICE_CODES ＋ TYPE_REL | 🟡 雛形（僅 create）| 🟡 create | ❌ | ❌ | ❌ |
+| 官職 | OFFICE_CODES ＋ TYPE_REL | ✅ | ✅ CRUD | ✅（/app/office，與裸表頁 feature parity 的超集；側欄「任官編碼表」已改指此頁）| ✅（codes 寫入封閉，讀取／匯出開放）| ❌（裸表提案一併封閉、標示未支援，待實體級提案）|
 | 社交機構 | NAME_CODES ＋ CODES ＋ ADDR | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 （🟡＝進行中／部分；本表隨實作推進更新。）

--- a/resources/js/inertia/Pages/Office/Index.tsx
+++ b/resources/js/inertia/Pages/Office/Index.tsx
@@ -1,51 +1,154 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { usePage, router } from '@inertiajs/react';
+import type { FormDataConvertible } from '@inertiajs/core';
 import DashboardLayout from '../../Layouts/DashboardLayout';
 import { getCsrfToken } from '../../components/PersonBrowser/shared/csrf';
 import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+import { Pagination, type PaginationMeta } from '../../components/ui/Pagination';
 import { useTranslation } from '../../hooks/useTranslation';
+import type { SharedProps } from '../../types/page';
+import { cn } from '../../lib/utils';
 import { OfficeUrls } from './OfficeForm';
 
-interface Row {
-    office_id: number;
-    name: string;
-    pinyin: string;
-    translation: string | null;
-    dynasty_code: number | null;
-    dynasty_label: string | null;
-    type_count: number;
-    source_id: number | null;
-}
+type Row = Record<string, unknown>;
+type Params = Record<string, FormDataConvertible>;
 
-interface Pagination {
-    current_page: number;
-    last_page: number;
-    total: number;
-    per_page: number;
-}
-
-interface Props {
+/**
+ * 官職實體列表：與 app/codes/OFFICE_CODES 裸表頁 feature parity（全欄位、排序、逐欄／
+ * 布林篩選、關鍵字搜尋、朝代標籤、全表匯出），另加聚合特有的 type_count 欄與
+ * 走 mutation API 的編輯／刪除入口。排序／篩選 UI 字串沿用 codes 翻譯群組。
+ */
+interface Props extends SharedProps {
+    thead: string[];
     rows: Row[];
+    meta: PaginationMeta;
     q: string;
-    pagination: Pagination;
+    dynasty_map: Record<string, string>;
+    key_columns: string[];
+    computed_columns: string[];
+    filters: Record<string, string>;
+    sort_by: string;
+    sort_dir: 'asc' | 'desc';
+    boolean_enabled: boolean;
+    boolean_filter_available: boolean;
+    filter_errors: Record<string, string>;
+    filter_descriptions: Record<string, string>;
     can_write: boolean;
     urls: OfficeUrls;
-    [key: string]: unknown;
 }
 
 export default function OfficeIndex() {
-    const { rows, q, pagination, can_write, urls } = usePage<Props>().props;
+    const props = usePage<Props>().props;
+    const {
+        thead, rows, meta, dynasty_map, key_columns, computed_columns,
+        sort_by, sort_dir, boolean_enabled, boolean_filter_available,
+        filter_errors, filter_descriptions, can_write, urls,
+    } = props;
     const t = useTranslation('office');
-    const [search, setSearch] = useState(q);
+    const tCodes = useTranslation('codes');
+    const tc = useTranslation('common');
+
+    const [search, setSearch] = useState(props.q ?? '');
+    const [filters, setFilters] = useState<Record<string, string>>(props.filters ?? {});
     const [busyId, setBusyId] = useState<number | null>(null);
+
+    // 排序／篩選需已登入且已啟用的帳號（純 UX 提示；後端 guard 才是防線）。
+    const canSortOrFilter = Boolean(props.auth?.user?.roles?.is_active);
 
     const editUrl = (id: number) => urls.edit_template.replace('__ID__', String(id));
 
+    const reload = (params: Params) =>
+        router.get(urls.index, params, { preserveState: true, preserveScroll: true, replace: true });
+
+    /** 組合並導覽：保留 q/filters/sort/bool，merge 額外參數（page）。 */
+    const visit = (extra: Params = {}, useFilters = filters) => {
+        const params: Params = {};
+        if (search) params.q = search;
+        const applied = Object.fromEntries(Object.entries(useFilters).filter(([, v]) => v !== ''));
+        if (Object.keys(applied).length) params.filters = applied;
+        if (sort_by) {
+            params.sort_by = sort_by;
+            params.sort_dir = sort_dir;
+        }
+        if (boolean_enabled) params.filter_bool = 1;
+        Object.assign(params, extra);
+        reload(params);
+    };
+
     const doSearch = (e: React.FormEvent) => {
         e.preventDefault();
-        router.get(urls.index, { q: search }, { preserveState: true, preserveScroll: true });
+        visit({ page: undefined });
     };
-    const gotoPage = (p: number) => router.get(urls.index, { q, page: p }, { preserveState: true, preserveScroll: true });
+    const resetSearch = () => {
+        setSearch('');
+        const params: Params = {};
+        if (boolean_enabled) params.filter_bool = 1;
+        reload(params);
+    };
+    const applyFilters = () => {
+        if (!canSortOrFilter) return;
+        visit({ page: 1 });
+    };
+    const clearFilters = () => {
+        setFilters({});
+        const params: Params = {};
+        if (search) params.q = search;
+        if (boolean_enabled) params.filter_bool = 1;
+        reload(params);
+    };
+
+    const toggleSort = (col: string) => {
+        if (!canSortOrFilter) return;
+        let nextBy = col;
+        let nextDir: 'asc' | 'desc' | '' = 'asc';
+        if (sort_by === col) {
+            if (sort_dir === 'asc') {
+                nextDir = 'desc';
+            } else {
+                nextBy = '';
+                nextDir = '';
+            }
+        }
+        visit({ sort_by: nextBy || undefined, sort_dir: nextDir || undefined, page: 1 });
+    };
+
+    const sortIcon = (col: string) => (sort_by !== col ? '⇅' : sort_dir === 'asc' ? '▲' : '▼');
+
+    const toggleBoolean = () => {
+        const params: Params = {};
+        if (search) params.q = search;
+        const applied = Object.fromEntries(Object.entries(filters).filter(([, v]) => v !== ''));
+        if (Object.keys(applied).length) params.filters = applied;
+        if (sort_by) {
+            params.sort_by = sort_by;
+            params.sort_dir = sort_dir;
+        }
+        if (!boolean_enabled) params.filter_bool = 1;
+        reload(params);
+    };
+
+    const cellValue = (row: Row, col: string): string => {
+        let v = row[col];
+        if (col === 'c_dy' && v !== '' && v != null) {
+            const key = String(v);
+            if (dynasty_map[key]) v = `${v} - ${dynasty_map[key]}`;
+        }
+        return v == null ? '' : String(v);
+    };
+
+    const colSpan = thead.length + 1;
+
+    const filterErrMsg = (code: string) => {
+        const key = `filter_err_${code}`;
+        const msg = tCodes(key);
+        return msg === key ? tCodes('filter_err_unknown') : msg;
+    };
+
+    const booleanExamples = useMemo(() => {
+        const ex = (props.page_translations?.codes as Record<string, unknown> | undefined)?.filter_chip_examples;
+        return Array.isArray(ex) ? (ex as string[]) : [];
+    }, [props.page_translations]);
 
     const del = async (id: number) => {
         if (!window.confirm(t('delete_confirm'))) return;
@@ -68,7 +171,7 @@ export default function OfficeIndex() {
                 setBusyId(null);
                 return;
             }
-            router.reload({ only: ['rows', 'pagination'] });
+            router.reload({ only: ['rows', 'meta'] });
         } catch (e) {
             alert(String(e));
         }
@@ -77,109 +180,176 @@ export default function OfficeIndex() {
 
     return (
         <DashboardLayout title={t('page_title_index')}>
-            <div className="rounded-lg border border-border bg-card p-4">
-                <p className="mb-3 text-sm text-muted-foreground">{t('intro')}</p>
+            <p className="mb-3 text-sm text-muted-foreground">{t('intro')}</p>
 
-                <div className="mb-3 flex flex-wrap items-center gap-2">
-                    <form onSubmit={doSearch} className="flex flex-1 gap-2">
-                        <input
-                            className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            placeholder={t('search_placeholder')}
-                            value={search}
-                            onChange={(e) => setSearch(e.target.value)}
-                        />
-                        <Button type="submit" variant="outline">
-                            {t('search')}
-                        </Button>
-                    </form>
-                    {can_write && (
-                        <a
-                            href={urls.create}
-                            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-                        >
-                            {t('btn_create')}
-                        </a>
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+                <form onSubmit={doSearch} className="flex items-center gap-1">
+                    <Input
+                        value={search}
+                        placeholder={t('search_placeholder')}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="w-72"
+                    />
+                    <Button type="submit" variant="secondary" size="sm">{tc('search')}</Button>
+                    {props.q && (
+                        <Button type="button" variant="secondary" size="sm" onClick={resetSearch}>{tc('reset')}</Button>
                     )}
-                </div>
+                </form>
+                <Button
+                    type="button"
+                    size="sm"
+                    onClick={applyFilters}
+                    disabled={!canSortOrFilter}
+                    title={canSortOrFilter ? undefined : tCodes('sort_filter_requires_login')}
+                >
+                    {tCodes('apply_filters')}
+                </Button>
+                {(Object.keys(props.filters).length > 0 || sort_by) && (
+                    <Button type="button" size="sm" variant="secondary" onClick={clearFilters}>{tCodes('clear_filters')}</Button>
+                )}
+                {!canSortOrFilter && (
+                    <span className="text-xs text-muted-foreground">{tCodes('sort_filter_requires_login')}</span>
+                )}
+                {can_write && (
+                    <a href={urls.create} className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90">
+                        {t('btn_create')}
+                    </a>
+                )}
+                <a href={urls.export} download className="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-sm hover:bg-muted">
+                    <i className="fas fa-download" aria-hidden /> {tCodes('download_full_table')}
+                </a>
+                {boolean_filter_available && (
+                    <div className="ml-auto flex items-center gap-2">
+                        {boolean_enabled ? (
+                            <>
+                                <span className="rounded bg-primary px-2 py-0.5 text-xs font-semibold text-primary-foreground">{tCodes('advanced_filter_on')}</span>
+                                <Button type="button" size="sm" variant="outline" onClick={toggleBoolean}>{tCodes('advanced_filter_disable')}</Button>
+                            </>
+                        ) : (
+                            <Button type="button" size="sm" variant="outline" onClick={toggleBoolean}>{tCodes('advanced_filter')}</Button>
+                        )}
+                    </div>
+                )}
+            </div>
 
-                <p className="mb-2 text-xs text-muted-foreground">{t('total_count', { n: String(pagination.total) })}</p>
+            {boolean_enabled && (
+                <>
+                    <div className="mb-2 text-xs text-muted-foreground">{tCodes('advanced_filter_hint')}</div>
+                    {booleanExamples.length > 0 && (
+                        <div className="mb-2 hidden text-xs text-muted-foreground md:block">
+                            {tCodes('filter_chip_label')}{' '}
+                            {booleanExamples.map((chip, i) => (
+                                <code key={i} className="mr-1 rounded border px-1">{chip}</code>
+                            ))}
+                        </div>
+                    )}
+                    {Object.keys(filter_errors).length > 0 && (
+                        <div className="mb-2 rounded border border-yellow-300 bg-yellow-50 px-3 py-2 text-sm text-yellow-800" role="alert">
+                            {tCodes('filter_errors_heading', { count: String(Object.keys(filter_errors).length) })}
+                            <ul className="mt-1 list-disc pl-5">
+                                {Object.entries(filter_errors).map(([col, code]) => (
+                                    <li key={col}><code>{col}</code>：{filterErrMsg(code)}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    {Object.keys(filter_descriptions).length > 0 && (
+                        <div className="mb-2 text-xs text-muted-foreground">
+                            {tCodes('filter_applied_label')}：
+                            {Object.entries(filter_descriptions).map(([col, desc]) => (
+                                <span key={col} className="ml-1 rounded border px-1"><code>{col}</code>：{desc}</span>
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
 
-                <div className="overflow-x-auto rounded-md border border-border">
-                    <table className="w-full text-sm">
-                        <thead className="bg-muted/50">
+            <div className="overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                    <thead className="bg-muted/50">
+                        <tr>
+                            {thead.map((col) => (
+                                <th key={col} className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                                    <button
+                                        type="button"
+                                        className={cn('hover:underline', !canSortOrFilter && 'cursor-not-allowed opacity-60 hover:no-underline')}
+                                        onClick={() => toggleSort(col)}
+                                        title={canSortOrFilter ? undefined : tCodes('sort_filter_requires_login')}
+                                    >
+                                        {computed_columns.includes(col) ? `(${col})` : col} <span aria-hidden>{sortIcon(col)}</span>
+                                    </button>
+                                    {key_columns.includes(col) && (
+                                        <span className="ml-1 rounded bg-blue-100 px-1 text-xs text-blue-800">PK</span>
+                                    )}
+                                </th>
+                            ))}
+                            <th className="px-3 py-2 text-left font-medium">{t('col_actions')}</th>
+                        </tr>
+                        <tr>
+                            {thead.map((col) => {
+                                const hasErr = boolean_enabled && col in filter_errors;
+                                return (
+                                    <th key={col} className="px-2 py-1">
+                                        <Input
+                                            value={filters[col] ?? ''}
+                                            placeholder={col}
+                                            aria-label={col}
+                                            aria-invalid={hasErr || undefined}
+                                            onChange={(e) => setFilters((f) => ({ ...f, [col]: e.target.value }))}
+                                            onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
+                                            className={cn('h-7 text-xs', hasErr && 'border-destructive')}
+                                        />
+                                    </th>
+                                );
+                            })}
+                            <th />
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.length === 0 ? (
                             <tr>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_id')}</th>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_name')}</th>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_pinyin')}</th>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_dynasty')}</th>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_types')}</th>
-                                <th className="px-3 py-2 text-left font-medium">{t('col_actions')}</th>
+                                <td colSpan={colSpan} className="px-3 py-6 text-center text-muted-foreground">{t('empty_list')}</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {rows.length === 0 ? (
-                                <tr>
-                                    <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
-                                        {t('empty_list')}
-                                    </td>
-                                </tr>
-                            ) : (
-                                rows.map((r) => (
-                                    <tr key={r.office_id} className="border-t border-border">
-                                        <td className="px-3 py-1.5">{r.office_id}</td>
-                                        <td className="px-3 py-1.5">{r.name}</td>
-                                        <td className="px-3 py-1.5">{r.pinyin}</td>
-                                        <td className="px-3 py-1.5">{r.dynasty_label ?? r.dynasty_code ?? ''}</td>
-                                        <td className="px-3 py-1.5">{r.type_count}</td>
+                        ) : (
+                            rows.map((row) => {
+                                const id = Number(row.c_office_id);
+                                return (
+                                    <tr key={id} className="border-t border-border hover:bg-muted/30">
+                                        {thead.map((col) => (
+                                            <td key={col} className="px-3 py-1.5">{cellValue(row, col)}</td>
+                                        ))}
                                         <td className="px-3 py-1.5">
-                                            <div className="flex gap-2">
-                                                <a href={editUrl(r.office_id)} className="text-primary hover:underline">
-                                                    {t('btn_edit')}
-                                                </a>
-                                                {can_write && (
+                                            {can_write && (
+                                                <div className="flex gap-2 whitespace-nowrap">
+                                                    <a href={editUrl(id)} className="text-primary hover:underline">
+                                                        {t('btn_edit')}
+                                                    </a>
                                                     <button
                                                         type="button"
                                                         className="text-red-600 hover:underline disabled:opacity-50"
-                                                        disabled={busyId === r.office_id}
-                                                        onClick={() => del(r.office_id)}
+                                                        disabled={busyId === id}
+                                                        onClick={() => del(id)}
                                                     >
                                                         {t('btn_delete')}
                                                     </button>
-                                                )}
-                                            </div>
+                                                </div>
+                                            )}
                                         </td>
                                     </tr>
-                                ))
-                            )}
-                        </tbody>
-                    </table>
-                </div>
+                                );
+                            })
+                        )}
+                    </tbody>
+                </table>
+            </div>
 
-                {pagination.last_page > 1 && (
-                    <div className="mt-3 flex items-center justify-center gap-2 text-sm">
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            disabled={pagination.current_page <= 1}
-                            onClick={() => gotoPage(pagination.current_page - 1)}
-                        >
-                            ‹
-                        </Button>
-                        <span className="text-muted-foreground">
-                            {pagination.current_page} / {pagination.last_page}
-                        </span>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            disabled={pagination.current_page >= pagination.last_page}
-                            onClick={() => gotoPage(pagination.current_page + 1)}
-                        >
-                            ›
-                        </Button>
-                    </div>
-                )}
+            <div className="mt-3">
+                <Pagination
+                    meta={meta}
+                    onPageChange={(page) => visit({ page })}
+                    summaryTemplate="{from}–{to} / {total}"
+                    labels={{ previous: tc('previous'), next: tc('next') }}
+                />
             </div>
         </DashboardLayout>
     );

--- a/resources/js/inertia/Pages/Office/OfficeForm.tsx
+++ b/resources/js/inertia/Pages/Office/OfficeForm.tsx
@@ -8,7 +8,9 @@ import { useTranslation } from '../../hooks/useTranslation';
 
 export interface OfficeUrls {
     index: string;
+    create: string;
     edit_template: string;
+    export: string;
     api_create: string;
     api_mutate: string;
     api_delete: string;

--- a/tests/Feature/OfficeEntityIndexTest.php
+++ b/tests/Feature/OfficeEntityIndexTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * /app/office 官職實體列表：與 app/codes/OFFICE_CODES 裸表頁 feature parity
+ * （全欄位、排序、逐欄／布林篩選、公開讀、排序篩選登入門檻），
+ * 以及 step 4 封寫（OFFICE_CODES 進 CodesController::$readOnlyTables）。
+ */
+class OfficeEntityIndexTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-office-entity-index';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+        config(['codes.per_page' => 20]);
+        config(['codes.tables' => ['OFFICE_CODES' => '官職代碼']]);
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+        // 生產 OFFICE_CODES 全欄位（appIndex 關鍵字搜尋會掃全部實體欄位，schema 須齊全）。
+        Schema::create('OFFICE_CODES', function (Blueprint $table) {
+            $table->integer('c_office_id')->primary();
+            $table->integer('c_dy')->nullable();
+            $table->string('c_office_pinyin')->nullable();
+            $table->string('c_office_chn')->nullable();
+            $table->string('c_office_pinyin_alt')->nullable();
+            $table->string('c_office_chn_alt')->nullable();
+            $table->string('c_office_trans')->nullable();
+            $table->string('c_office_trans_alt')->nullable();
+            $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_category_1')->nullable();
+            $table->string('c_category_2')->nullable();
+            $table->string('c_category_3')->nullable();
+            $table->string('c_category_4')->nullable();
+            $table->integer('c_office_id_old')->nullable();
+        });
+        Schema::create('OFFICE_CODE_TYPE_REL', function (Blueprint $table) {
+            $table->integer('c_office_id');
+            $table->string('c_office_tree_id');
+            $table->primary(['c_office_id', 'c_office_tree_id']);
+        });
+        Schema::create('DYNASTIES', function (Blueprint $table) {
+            $table->integer('c_dy')->primary();
+            $table->string('c_dynasty_chn')->nullable();
+        });
+
+        DB::table('DYNASTIES')->insert(['c_dy' => 15, 'c_dynasty_chn' => '宋']);
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 1, 'c_office_chn' => '知府', 'c_office_pinyin' => 'zhifu', 'c_dy' => 15],
+            ['c_office_id' => 2, 'c_office_chn' => '尚書', 'c_office_pinyin' => 'shangshu', 'c_dy' => 15],
+            ['c_office_id' => 3, 'c_office_chn' => '縣令', 'c_office_pinyin' => 'xianling', 'c_dy' => null],
+        ]);
+        DB::table('OFFICE_CODE_TYPE_REL')->insert([
+            ['c_office_id' => 1, 'c_office_tree_id' => 'x01'],
+            ['c_office_id' => 1, 'c_office_tree_id' => 'x02'],
+            ['c_office_id' => 2, 'c_office_tree_id' => 'x01'],
+        ]);
+    }
+
+    protected function tearDown(): void {
+        foreach (['DYNASTIES', 'OFFICE_CODE_TYPE_REL', 'OFFICE_CODES', 'users'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    private function activeUser(int $id = 31): User {
+        $user = new User(['name' => 'active', 'email' => "active$id@example.com", 'confirmation_token' => Str::random(32)]);
+        $user->id = $id;
+        $user->is_active = 1;
+
+        return $user;
+    }
+
+    private function inactiveUser(int $id = 32): User {
+        $user = new User(['name' => 'inactive', 'email' => "inactive$id@example.com", 'confirmation_token' => Str::random(32)]);
+        $user->id = $id;
+        $user->is_active = 0;
+
+        return $user;
+    }
+
+    // ── 讀取公開 + 排序／篩選門檻 ──────────────────────────────
+
+    #[Test]
+    public function testGuestCanViewIndexWithFullTheadAndTypeCount() {
+        $this->get(route('app.office.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Office/Index')
+                ->where('can_write', false)
+                ->where('key_columns', ['c_office_id'])
+                ->where('computed_columns', ['type_count'])
+                ->has('thead', 17)
+                ->where('thead.0', 'c_office_id')
+                ->where('thead.16', 'type_count')
+                ->has('rows', 3)
+                // 預設 ID 倒序；type_count 為 OFFICE_CODE_TYPE_REL 關聯數
+                ->where('rows.0.c_office_id', 3)
+                ->where('rows.0.type_count', 0)
+                ->where('rows.2.c_office_id', 1)
+                ->where('rows.2.type_count', 2)
+                ->where('dynasty_map.15', '宋'));
+    }
+
+    #[Test]
+    public function testGuestWithSortByIsRedirectedToLoginWithIntendedUrl() {
+        $url = route('app.office.index', ['sort_by' => 'c_office_chn']);
+
+        $this->get($url)->assertRedirect(route('login'));
+        $this->assertSame($url, session('url.intended'));
+    }
+
+    #[Test]
+    public function testGuestWithNonEmptyFilterIsRedirectedToLogin() {
+        $this->get(route('app.office.index', ['filters' => ['c_office_chn' => '知']]))
+            ->assertRedirect(route('login'));
+    }
+
+    #[Test]
+    public function testInactiveUserWithSortIsRedirectedBackToIndex() {
+        $this->actingAs($this->inactiveUser());
+
+        $this->get(route('app.office.index', ['sort_by' => 'c_office_chn']))
+            ->assertRedirect(route('app.office.index'));
+    }
+
+    // ── 排序／篩選 parity ──────────────────────────────
+
+    #[Test]
+    public function testActiveUserCanSortByColumnWithPkTieBreaker() {
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.office.index', ['sort_by' => 'c_office_pinyin', 'sort_dir' => 'asc']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('sort_by', 'c_office_pinyin')
+                ->where('sort_dir', 'asc')
+                ->where('rows.0.c_office_pinyin', 'shangshu')
+                ->where('rows.1.c_office_pinyin', 'xianling')
+                ->where('rows.2.c_office_pinyin', 'zhifu'));
+    }
+
+    #[Test]
+    public function testActiveUserCanFilterByColumnContains() {
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.office.index', ['filters' => ['c_office_chn' => '知']]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('rows', 1)
+                ->where('rows.0.c_office_chn', '知府'));
+    }
+
+    #[Test]
+    public function testActiveUserCanSortAndFilterByComputedTypeCount() {
+        $this->actingAs($this->activeUser());
+
+        // exact 比對：type_count=1 只命中尚書
+        $this->get(route('app.office.index', ['filters' => ['type_count' => '1']]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('rows', 1)
+                ->where('rows.0.c_office_id', 2));
+
+        $this->get(route('app.office.index', ['sort_by' => 'type_count', 'sort_dir' => 'desc']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('rows.0.c_office_id', 1));
+    }
+
+    #[Test]
+    public function testBooleanFilterOrAndParseError() {
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.office.index', ['filter_bool' => 1, 'filters' => ['c_office_chn' => '知府|尚書']]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('boolean_enabled', true)
+                ->has('rows', 2)
+                ->has('filter_descriptions.c_office_chn'));
+
+        // 語法錯誤：記錄錯誤碼並略過該欄（不轉字面），列表不縮減
+        $this->get(route('app.office.index', ['filter_bool' => 1, 'filters' => ['c_office_chn' => '知府|']]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('filter_errors.c_office_chn', 'dangling_operator')
+                ->has('rows', 3));
+    }
+
+    #[Test]
+    public function testKeywordSearchScansEntityColumns() {
+        $this->get(route('app.office.index', ['q' => 'shang']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('rows', 1)
+                ->where('rows.0.c_office_id', 2));
+    }
+
+    #[Test]
+    public function testUnknownSortAndFilterColumnsAreIgnored() {
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.office.index', ['sort_by' => 'no_such_col', 'filters' => ['no_such_col' => 'x']]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('sort_by', '')
+                ->has('rows', 3));
+    }
+
+    // ── step 4：OFFICE_CODES 裸表封寫 ──────────────────────────────
+
+    #[Test]
+    public function testCodesShowMarksOfficeCodesReadOnly() {
+        $this->actingAs($this->activeUser());
+
+        $this->get(route('app.codes.show', ['table_name' => 'OFFICE_CODES']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('is_read_only', true)
+                ->where('can_edit', false));
+    }
+
+    #[Test]
+    public function testCodesCreatePageIsBlockedForOfficeCodes() {
+        $this->actingAs($this->activeUser());
+
+        $this->get('/codes/OFFICE_CODES/create')->assertRedirect();
+        $this->get(route('app.codes.create', ['table_name' => 'OFFICE_CODES']))->assertRedirect();
+    }
+
+    // ── 側欄 ──────────────────────────────
+
+    #[Test]
+    public function testSidebarOfficeCodesNodePointsToEntityPage() {
+        $tree = \App\Support\Navigation::tree(null);
+        $codes = collect($tree)->firstWhere('key', 'codes');
+        $node = collect($codes['children'])->firstWhere('key', 'office-codes');
+
+        $this->assertSame(route('app.office.index'), $node['href']);
+        $this->assertContains('OFFICE_CODES', $node['active']['pages']);
+        $this->assertContains('app.office.*', $node['active']['patterns']);
+    }
+}


### PR DESCRIPTION
- /app/office 列表補齊與 app/codes/OFFICE_CODES 的 feature parity 並成為超集： 全部 OFFICE_CODES 欄位、任意欄排序＋主鍵 tie-breaker、逐欄篩選（含 AND/OR/NOT 布林模式，复用 ColumnFilterExpression 與 codes 同組 i18n）、關鍵字全欄搜尋、 朝代標籤、全表匯出連結，另加聚合特有 type_count 計算欄（exact 比對）
- 訪問模型對齊 codes 頁：列表公開可讀；排序／篩選需登入且已激活 （鏡像 guardSortFilterRequiresAuth）；寫入仍需 canWriteDirectly
- 側欄「任官編碼表」改指 /app/office（Navigation::officeEntityItem()）， active 保留 OFFICE_CODES page-title 相容直訪裸表頁
- OFFICE_CODES 加入 CodesController::$readOnlyTables：裸表 create／edit／ update／destroy／proposal 全封（讀取與匯出開放）。裸表提案一併封閉為實體級 提案（§4.5）就緒前的有意取捨；回退＝自清單移除一行
- 設計文件 §5 差距表與 CHANGELOG 同步更新
- 已執行 ./vendor/bin/phpunit（2230 tests OK）與 npm run build； 新增 tests/Feature/OfficeEntityIndexTest.php（13 案例）

參見 docs/ENTITY_AGGREGATE_ARCHITECTURE.md（#1159）