### PR TITLE
新增書稿批次匯入的罕見字檢測

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -81,6 +81,7 @@ class AdminBatchLoadBookTitlesController extends Controller {
                 'undo' => route('app.admin.batch-load-book-titles.undo', [], false),
                 'reset' => route('app.admin.batch-load-book-titles', [], false),
                 'update_pinyin' => route('app.admin.batch-load-book-titles.update-pinyin', [], false),
+                'check_rare_chars' => route('app.admin.batch-load-book-titles.check-rare-chars', [], false),
             ],
             'page_translations' => [
                 'admin' => is_array($t = trans('admin')) ? $t : [],
@@ -309,6 +310,85 @@ class AdminBatchLoadBookTitlesController extends Controller {
             'modified_by' => $stored->c_modified_by,
             'modified_date' => (string) $stored->c_modified_date,
         ]);
+    }
+
+    /**
+     * 罕見字檢測：逐行檢查書名中的漢字是否「直接存在於人工策展的 pinyin 表」，
+     * 把查不到的字連同行號列出，供管理員在正式匯入前先補齊表資料或人工確認。
+     *
+     * 與 store() 的匯入前檢查（collectUnpinyinableHan）刻意不同：
+     *   - 匯入檢查用 PinyinDictionary::getPinyin()，會退回 opencc-pinyin 靜態字典，
+     *     只有連 opencc 都查不到（極生僻字/非漢字）才擋。
+     *   - 本檢測用 PinyinDictionary::isInTable()，「只看 pinyin 表」，不吃 opencc 退回，
+     *     因此只要不在權威表內（即使 opencc 補得出讀音）都會被列為罕見字。
+     *
+     * 檢測範圍與匯入實際寫入 c_title 的拼音對齊：先 stripVolumeInfo() 去掉冒號後的
+     * 卷冊註記（那段不會進拼音），但不套 VariantCharNormalizer——異體字歸一化屬於
+     * 另一層退回機制，這裡同樣要如實回報「表未收此字形」。書名本身的字形標準化
+     * （峯→峰，TITLE_VARIANT_MAP）已在 parseEntries 完成，故檢測看到的是標準化後的書名。
+     */
+    public function checkRareChars(Request $request): JsonResponse {
+        $this->ensureAdmin();
+
+        $data = $request->validate([
+            'entries' => 'required|string',
+        ]);
+
+        [$rows, $parseErrors] = $this->parseEntries($data['entries']);
+
+        $missing = [];
+        $uniqueChars = [];
+
+        foreach ($rows as $row) {
+            $rareChars = $this->collectCharsMissingFromPinyinTable((string) $row['title']);
+            if (empty($rareChars)) {
+                continue;
+            }
+
+            $chars = [];
+            foreach ($rareChars as $ch) {
+                $chars[] = ['char' => $ch, 'codepoint' => sprintf('U+%04X', mb_ord($ch, 'UTF-8'))];
+                $uniqueChars[$ch] = true;
+            }
+
+            $missing[] = [
+                'line' => $row['line'],
+                'title' => $row['title'],
+                'chars' => $chars,
+            ];
+        }
+
+        return response()->json([
+            'ok' => true,
+            'checked' => count($rows),
+            'parse_errors' => array_values($parseErrors),
+            'missing' => $missing,
+            'unique_char_count' => count($uniqueChars),
+        ]);
+    }
+
+    /**
+     * 回傳書名中「不在 pinyin 表」的漢字（去重，保留出現順序）。
+     * 檢測步驟與 buildPinyin 對齊（去卷冊註記後逐字檢查），但改用 isInTable()
+     * 只查權威表、不吃 opencc 退回，也不套 VariantCharNormalizer 異體字歸一化。
+     *
+     * @return array<int,string>
+     */
+    protected function collectCharsMissingFromPinyinTable(string $title): array {
+        $titleWithoutVolume = $this->stripVolumeInfo($title);
+        $chars = preg_split('//u', $titleWithoutVolume, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $missing = [];
+        foreach ($chars as $ch) {
+            if (!preg_match('/^\p{Han}$/u', $ch)) {
+                continue;
+            }
+            if (!PinyinDictionary::isInTable($ch)) {
+                $missing[$ch] = true;
+            }
+        }
+
+        return array_keys($missing);
     }
 
     /**

--- a/app/Services/PinyinDictionary.php
+++ b/app/Services/PinyinDictionary.php
@@ -88,6 +88,20 @@ class PinyinDictionary {
     }
 
     /**
+     * 判斷某個字元是否直接存在於人工策展的 `pinyin` 表（不含 opencc-pinyin
+     * 靜態字典的退回層）。供「罕見字檢測」使用：一個字若僅能靠 opencc 退回層
+     * 或完全查無讀音，isInTable() 會回傳 false，代表它不在權威表內。
+     *
+     * 注意：這裡刻意「只看表」，與 getPinyin()/getSyllables() 會退回 opencc
+     * 字典的行為不同——罕見字檢測的目的正是找出表未覆蓋的字。
+     */
+    public static function isInTable(string $char): bool {
+        self::ensureLoaded();
+
+        return array_key_exists($char, self::$cache);
+    }
+
+    /**
      * 載入整表快取（同一個 PHP request 生命週期內只查一次 DB）。
      *
      * 建構順序：先塞入 c_lastname=1（姓氏讀音）的資料當作退回值，

--- a/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
@@ -82,7 +82,20 @@ interface BatchBooksPageProps extends SharedProps {
     batch_errors: string[];
     batch_id: string | null;
     toast: Toast | null;
-    urls: { store: string; undo: string; reset: string; update_pinyin: string };
+    urls: { store: string; undo: string; reset: string; update_pinyin: string; check_rare_chars: string };
+}
+
+interface RareCharMissingRow {
+    line: number;
+    title: string;
+    chars: { char: string; codepoint: string }[];
+}
+
+interface RareCharResult {
+    checked: number;
+    parse_errors: string[];
+    missing: RareCharMissingRow[];
+    unique_char_count: number;
 }
 
 export default function BatchLoadBookTitles() {
@@ -103,6 +116,11 @@ export default function BatchLoadBookTitles() {
     const [busyId, setBusyId] = useState<number | null>(null);
     const [rowStatus, setRowStatus] = useState<{ id: number; msg: string; kind: 'success' | 'error' } | null>(null);
 
+    // 罕見字檢測（只查 pinyin 表）狀態。發現的罕見字/解析錯誤顯示於既有的訊息窗口
+    // （與匯入錯誤共用同一個 box）；「未發現/空輸入/網路錯誤」等單行狀態走頁面既有的 toast。
+    const [rareChecking, setRareChecking] = useState(false);
+    const [rareResult, setRareResult] = useState<RareCharResult | null>(null);
+
     useEffect(() => {
         setToastShown(toast);
         if (toast) {
@@ -117,6 +135,7 @@ export default function BatchLoadBookTitles() {
         setEditId(null);
         setDraft('');
         setRowStatus(null);
+        setRareResult(null);
     }, [results]);
 
     const flashToast = (tt: Toast) => {
@@ -184,7 +203,58 @@ export default function BatchLoadBookTitles() {
         }
     };
 
+    const checkRareChars = async () => {
+        if (rareChecking) {
+            return;
+        }
+        if (form.data.entries.trim() === '') {
+            setRareResult(null);
+            flashToast({ msg: t('batch_check_rare_chars_empty_input'), type: 'warning' });
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            return;
+        }
+        setRareChecking(true);
+        try {
+            const res = await fetch(urls.check_rare_chars, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': getCsrfToken(),
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify({ entries: form.data.entries }),
+            });
+            const json = await res.json().catch(() => null);
+            if (!res.ok || !json || json.ok === false) {
+                setRareResult(null);
+                flashToast({ msg: (json && json.message) || t('batch_network_error'), type: 'error' });
+                return;
+            }
+            const result: RareCharResult = {
+                checked: json.checked ?? 0,
+                parse_errors: Array.isArray(json.parse_errors) ? json.parse_errors : [],
+                missing: Array.isArray(json.missing) ? json.missing : [],
+                unique_char_count: json.unique_char_count ?? 0,
+            };
+            setRareResult(result);
+            // 有罕見字或解析錯誤 → 顯示於訊息窗口（下方 box）；否則全部通過 → 綠色 toast。
+            if (result.missing.length === 0 && result.parse_errors.length === 0) {
+                flashToast({ msg: t('batch_check_rare_chars_none', { count: String(result.checked) }), type: 'success' });
+            }
+        } catch {
+            setRareResult(null);
+            flashToast({ msg: t('batch_network_error'), type: 'error' });
+        } finally {
+            setRareChecking(false);
+            // 訊息窗口／toast 都在頁面頂端，檢測後捲回頂端讓結果立即可見。
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    };
+
     const submit = (force: boolean) => {
+        setRareResult(null);
         form.transform((d) => (force ? { entries: d.entries, force: '1' } : { entries: d.entries }));
         form.post(urls.store, { preserveScroll: true });
     };
@@ -224,12 +294,54 @@ export default function BatchLoadBookTitles() {
                     </div>
                 )}
 
-                {batch_errors.length > 0 && (
+                {(batch_errors.length > 0 || (rareResult && (rareResult.missing.length > 0 || rareResult.parse_errors.length > 0))) && (
                     <div className="mb-3 rounded border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-800">
-                        <p className="font-semibold">{t('batch_import_failed')}</p>
-                        <ul className="mt-1">
-                            {batch_errors.map((m, i) => <li key={i}>・{m}</li>)}
-                        </ul>
+                        {batch_errors.length > 0 && (
+                            <>
+                                <p className="font-semibold">{t('batch_import_failed')}</p>
+                                <ul className="mt-1">
+                                    {batch_errors.map((m, i) => <li key={i}>・{m}</li>)}
+                                </ul>
+                            </>
+                        )}
+                        {rareResult && (rareResult.missing.length > 0 || rareResult.parse_errors.length > 0) && (
+                            <div className={batch_errors.length > 0 ? 'mt-3 border-t border-red-200 pt-2' : ''}>
+                                <p className="font-semibold">{t('batch_check_rare_chars_title')}</p>
+                                {rareResult.missing.length > 0 && (
+                                    <>
+                                        <p className="mt-1">
+                                            {t('batch_check_rare_chars_summary', {
+                                                count: String(rareResult.checked),
+                                                chars: String(rareResult.unique_char_count),
+                                                lines: String(rareResult.missing.length),
+                                            })}
+                                        </p>
+                                        <ul className="mt-1 space-y-0.5">
+                                            {rareResult.missing.map((row) => (
+                                                <li key={row.line}>
+                                                    <span className="font-medium">{t('batch_check_rare_chars_line', { line: String(row.line) })}</span>
+                                                    {'：'}
+                                                    {row.chars.map((c, i) => (
+                                                        <span key={c.codepoint} className="font-mono">
+                                                            {i > 0 ? ' ' : ''}
+                                                            「{c.char}」({c.codepoint})
+                                                        </span>
+                                                    ))}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </>
+                                )}
+                                {rareResult.parse_errors.length > 0 && (
+                                    <div className={rareResult.missing.length > 0 ? 'mt-2 border-t border-red-200 pt-2' : 'mt-1'}>
+                                        <p>{t('batch_check_rare_chars_parse_note', { count: String(rareResult.parse_errors.length) })}</p>
+                                        <ul className="mt-1">
+                                            {rareResult.parse_errors.map((m, i) => <li key={i}>・{m}</li>)}
+                                        </ul>
+                                    </div>
+                                )}
+                            </div>
+                        )}
                     </div>
                 )}
 
@@ -245,6 +357,9 @@ export default function BatchLoadBookTitles() {
                         <Button type="submit" disabled={form.processing}>{t('batch_submit')}</Button>
                         <Button type="button" variant="secondary" disabled={form.processing} onClick={() => setConfirmForce(true)}>
                             {t('batch_force_submit')}
+                        </Button>
+                        <Button type="button" variant="outline" disabled={rareChecking} onClick={checkRareChars}>
+                            {rareChecking ? t('batch_check_rare_chars_checking') : t('batch_check_rare_chars')}
                         </Button>
                         <a href={urls.reset} className="inline-flex items-center rounded-md border border-input px-4 py-2 text-sm hover:bg-muted">
                             {t('batch_clear_reset')}

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -163,6 +163,14 @@ return [
     'batch_network_error' => 'Network error, please try again',
     'batch_copied_n' => 'Copied :count record(s)',
     'batch_copy_failed' => 'Auto-copy failed. The text area below has been expanded — please copy manually with Ctrl+C',
+    'batch_check_rare_chars' => 'Detect Rare Characters',
+    'batch_check_rare_chars_checking' => 'Checking…',
+    'batch_check_rare_chars_title' => 'Rare-character check (pinyin table only, opencc fallback excluded)',
+    'batch_check_rare_chars_none' => 'No rare characters found: checked :count title line(s); every Han character is in the pinyin table.',
+    'batch_check_rare_chars_summary' => 'Checked :count title line(s); found :chars Han character(s) not in the pinyin table (across :lines line(s)):',
+    'batch_check_rare_chars_line' => 'Line :line',
+    'batch_check_rare_chars_parse_note' => ':count line(s) had a malformed format and were skipped:',
+    'batch_check_rare_chars_empty_input' => 'Please enter batch data before running the check.',
 
     // batch_load_offices
     'batch_offices_page_title' => 'Batch Load Offices',

--- a/resources/lang/zh-TW/admin.php
+++ b/resources/lang/zh-TW/admin.php
@@ -163,6 +163,14 @@ return [
     'batch_network_error' => '網路錯誤，請重試',
     'batch_copied_n' => '已複製 :count 筆',
     'batch_copy_failed' => '自動複製失敗，已展開下方文字框，請 Ctrl+C 手動複製',
+    'batch_check_rare_chars' => '罕見字檢測',
+    'batch_check_rare_chars_checking' => '檢測中…',
+    'batch_check_rare_chars_title' => '罕見字檢測結果（僅比對 pinyin 表，不含 opencc 退回）',
+    'batch_check_rare_chars_none' => '未發現罕見字：已檢測 :count 行書名，所有漢字皆在 pinyin 表內。',
+    'batch_check_rare_chars_summary' => '已檢測 :count 行書名，發現 :chars 個不在 pinyin 表的漢字（分佈於 :lines 行）：',
+    'batch_check_rare_chars_line' => '第 :line 行',
+    'batch_check_rare_chars_parse_note' => '另有 :count 行格式不符、未納入檢測：',
+    'batch_check_rare_chars_empty_input' => '請先輸入批次資料再進行檢測。',
 
     // batch_load_offices
     'batch_offices_page_title' => '批次匯入官職',

--- a/routes/web.php
+++ b/routes/web.php
@@ -463,6 +463,9 @@ Route::middleware('auth')->group(function () {
     // 逐列直接編輯拼音（回傳 JSON，React 以 fetch 呼叫並就地更新該列；重用既有 updatePinyin）
     Route::post('app/admin/batch-load-book-titles/update-pinyin', 'AdminBatchLoadBookTitlesController@updatePinyin')
         ->name('app.admin.batch-load-book-titles.update-pinyin');
+    // 罕見字檢測（回傳 JSON）：只查 pinyin 表，列出表未收的漢字與行號，匯入前先行檢查。
+    Route::post('app/admin/batch-load-book-titles/check-rare-chars', 'AdminBatchLoadBookTitlesController@checkRareChars')
+        ->name('app.admin.batch-load-book-titles.check-rare-chars');
     Route::get('admin/batch-load-social-institutes', 'AdminBatchLoadSocialInstitutesController@showForm')->name('admin.batch-load-social-institutes');
     Route::post('admin/batch-load-social-institutes', 'AdminBatchLoadSocialInstitutesController@store')->name('admin.batch-load-social-institutes.store');
     // Inertia + React 版（store 重用，依請求路徑重導）

--- a/tests/Feature/AdminBatchLoadBookTitlesPinyinRouteTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesPinyinRouteTest.php
@@ -27,4 +27,20 @@ class AdminBatchLoadBookTitlesPinyinRouteTest extends TestCase {
             $route->getActionName()
         );
     }
+
+    #[Test]
+    public function app_check_rare_chars_route_is_registered_and_maps_to_controller() {
+        $this->assertTrue(
+            Route::has('app.admin.batch-load-book-titles.check-rare-chars'),
+            'app 版 check-rare-chars 路由必須存在，前端罕見字檢測按鈕才呼叫得到'
+        );
+
+        $route = Route::getRoutes()->getByName('app.admin.batch-load-book-titles.check-rare-chars');
+        $this->assertSame('app/admin/batch-load-book-titles/check-rare-chars', $route->uri());
+        $this->assertContains('POST', $route->methods());
+        $this->assertSame(
+            'App\Http\Controllers\AdminBatchLoadBookTitlesController@checkRareChars',
+            $route->getActionName()
+        );
+    }
 }

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\PinyinDictionary;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -1007,6 +1008,171 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
         $followUp->assertSee('class="pinyin-cell"', false);
         $followUp->assertSee('pinyin-edit-btn', false);
         $followUp->assertSee('pinyin-save-btn', false);
+    }
+
+    #[Test]
+    public function test_check_rare_chars_flags_table_missing_char_even_when_opencc_covers_it(): void {
+        // 罕見字檢測「只查 pinyin 表」：麤（U+9EA4）不在權威表，但 opencc-pinyin 靜態
+        // 字典查得到讀音（cu）。匯入檢查（getPinyin）會放行，但本檢測仍要把它列為罕見字。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t安石集\t2\n3\t麤俗編\t4",
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertTrue($json['ok']);
+        $this->assertSame(2, $json['checked']);
+        $this->assertSame([], $json['parse_errors']);
+        // 只有含麤的第 2 行被列出，安石集整行皆在表內不列。
+        $this->assertCount(1, $json['missing']);
+        // 麤 位在輸入的第 2 行（第一欄的 3 是作者 ID，不是行號）。
+        $this->assertSame(2, $json['missing'][0]['line']);
+        $this->assertSame('麤俗編', $json['missing'][0]['title']);
+        $this->assertSame('麤', $json['missing'][0]['chars'][0]['char']);
+        $this->assertSame('U+9EA4', $json['missing'][0]['chars'][0]['codepoint']);
+        $this->assertSame(1, $json['unique_char_count']);
+
+        // 佐證差異點：麤在匯入路徑（含 opencc 退回）查得到拼音，不會被 store() 擋。
+        $this->assertSame('cu', PinyinDictionary::getPinyin('麤'));
+        $this->assertFalse(PinyinDictionary::isInTable('麤'));
+    }
+
+    #[Test]
+    public function test_check_rare_chars_returns_empty_missing_for_common_title(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t安石集\t2",
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertSame(1, $json['checked']);
+        $this->assertSame([], $json['missing']);
+        $this->assertSame(0, $json['unique_char_count']);
+    }
+
+    #[Test]
+    public function test_check_rare_chars_does_not_apply_variant_normalization(): void {
+        // 罕見字檢測刻意「不套 VariantCharNormalizer 異體字歸一化」：菴（U+83F4）不在
+        // pinyin 表，但 VariantCharNormalizer 會把它歸一為在表內的 庵。匯入路徑
+        // （collectUnpinyinableHan）會先歸一化故放行；本檢測不歸一化，仍須把 菴 列為罕見字。
+        // 這個 test 鎖住該設計差異——若有人把 normalize() 加進檢測，菴 會漏報而此測試失敗。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t菴集\t2",
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertCount(1, $json['missing']);
+        $this->assertSame('菴', $json['missing'][0]['chars'][0]['char']);
+        $this->assertSame('U+83F4', $json['missing'][0]['chars'][0]['codepoint']);
+
+        // 佐證：菴 經 VariantCharNormalizer 歸一為在表內的 庵，故匯入路徑不會被擋。
+        $this->assertSame('庵', \App\Services\VariantCharNormalizer::normalize('菴'));
+        $this->assertTrue(PinyinDictionary::isInTable('庵'));
+        $this->assertFalse(PinyinDictionary::isInTable('菴'));
+    }
+
+    #[Test]
+    public function test_check_rare_chars_checks_stored_glyph_after_title_variant_standardization(): void {
+        // 設計決策（已與需求方確認）：罕見字檢測看的是「實際入庫的字形」，而非原始貼上字形。
+        // 峯（U+5CEF）不在 pinyin 表，但 TITLE_VARIANT_MAP 會在 parseEntries 就把書名本身
+        // 改寫成標準字形 峰（入庫的 c_title_chn 即為 峰），而 峰 在表內，故不列為罕見字。
+        // 此測試鎖住此決策：若有人改成檢測原始字形，峯 會被列出而此測試失敗。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t峯集\t2",
+        ]);
+
+        $response->assertOk();
+        $this->assertSame([], $response->json('missing'));
+    }
+
+    #[Test]
+    public function test_check_rare_chars_dedups_repeated_chars_but_counts_lines(): void {
+        // 同一罕見字重複出現：每行內去重（chars 不重複），unique_char_count 全域去重，
+        // 但每一含該字的行都各列一筆 missing。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t麤麤編\t2\n3\t麤俗集\t4",
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        // 兩行都含麤 → 兩筆 missing；但麤只算一個相異字。
+        $this->assertCount(2, $json['missing']);
+        $this->assertCount(1, $json['missing'][0]['chars']);
+        $this->assertSame('麤', $json['missing'][0]['chars'][0]['char']);
+        $this->assertSame(1, $json['unique_char_count']);
+    }
+
+    #[Test]
+    public function test_check_rare_chars_ignores_non_han_characters(): void {
+        // 非漢字（拉丁字母、數字、標點）不納入檢測。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\tABC 123 安石集\t2",
+        ]);
+
+        $response->assertOk();
+        $this->assertSame([], $response->json('missing'));
+    }
+
+    #[Test]
+    public function test_check_rare_chars_ignores_chars_after_volume_separator(): void {
+        // 與 buildPinyin/匯入檢查一致：冒號後的卷冊註記不進拼音，也不納入罕見字檢測。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t安石集: 麤卷\t2",
+        ]);
+
+        $response->assertOk();
+        $this->assertSame([], $response->json('missing'));
+    }
+
+    #[Test]
+    public function test_check_rare_chars_reports_parse_errors_for_malformed_lines(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "只有一欄\n1\t麤俗編\t2",
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        // 格式不符的行進 parse_errors；合法行仍照常檢測。
+        $this->assertNotEmpty($json['parse_errors']);
+        $this->assertStringContainsString('未找到三欄資料', implode("\n", $json['parse_errors']));
+        $this->assertSame(1, $json['checked']);
+        $this->assertCount(1, $json['missing']);
+    }
+
+    #[Test]
+    public function test_non_admin_cannot_check_rare_chars(): void {
+        $user = $this->makeUser(['is_admin' => 0]);
+        $this->actingAs($user);
+
+        $response = $this->postJson(route('app.admin.batch-load-book-titles.check-rare-chars'), [
+            'entries' => "1\t麤俗編\t2",
+        ]);
+        $response->assertStatus(403);
     }
 
     #[Test]

--- a/tests/Unit/PinyinDictionaryTest.php
+++ b/tests/Unit/PinyinDictionaryTest.php
@@ -142,6 +142,23 @@ class PinyinDictionaryTest extends TestCase {
     }
 
     #[Test]
+    public function is_in_table_only_checks_the_curated_table_not_the_opencc_fallback(): void {
+        // 先塞好所有資料再查詢：首次 isInTable() 會載入整表快取，之後的 insert 不會反映。
+        DB::table('pinyin')->insert(['c_chn' => '安', 'c_pinyin' => 'an', 'c_lastname' => 0]);
+        // 姓氏讀音（c_lastname=1）也算在表內。
+        DB::table('pinyin')->insert(['c_chn' => '單', 'c_pinyin' => 'Shan', 'c_lastname' => 1]);
+
+        // 安 在表內 → true。
+        $this->assertTrue(PinyinDictionary::isInTable('安'));
+        $this->assertTrue(PinyinDictionary::isInTable('單'));
+
+        // 峯 不在表內、但 opencc-pinyin 靜態字典查得到讀音（getPinyin 會回 feng）；
+        // isInTable() 刻意「只看表」，故仍回 false——這正是罕見字檢測要抓的對象。
+        $this->assertSame('feng', PinyinDictionary::getPinyin('峯'));
+        $this->assertFalse(PinyinDictionary::isInTable('峯'));
+    }
+
+    #[Test]
     public function reset_forces_cache_to_reload_from_database(): void {
         DB::table('pinyin')->insert(['c_chn' => '安', 'c_pinyin' => 'an', 'c_lastname' => 0]);
         $this->assertSame('an', PinyinDictionary::getPinyin('安'));


### PR DESCRIPTION
## 目的

在 `/app/admin/batch-load-book-titles`（React/Inertia）新增「罕見字檢測」按鈕，讓管理員在正式匯入前先檢查書名中是否含有 **不在人工策展 `pinyin` 表** 的漢字，並列出對應行號。

## 前提

現行 `PinyinDictionary` 先查策展 `pinyin` 表，查無時退回 `frankslin/opencc-pinyin`（zdic 全量字典）。本功能刻意只檢查「表」，不吃退回層。

## 主要變更

- **後端**
  - `PinyinDictionary::isInTable()`：只查 `pinyin` 表快取、不吃 opencc 退回層。
  - `AdminBatchLoadBookTitlesController::checkRareChars()` + `collectCharsMissingFromPinyinTable()`：逐行回傳表未收的漢字（含行號、U+ 碼位、去重與 `unique_char_count`）。
  - 新路由 `app.admin.batch-load-book-titles.check-rare-chars`（POST，`ensureAdmin` 授權，與既有批次端點同群組）。
- **前端**
  - 新增按鈕；發現的罕見字／解析錯誤顯示於 **頁面既有訊息窗口**（與匯入錯誤共用同一 box），未發現／空輸入／網路錯誤走既有 toast；檢測後捲回頁首。
- **i18n**：zh-TW／en 同步新增 `batch_check_rare_chars*` 鍵。

## 設計決策

- **只查表、不吃退回層**：僅靠 opencc（如 `麤`→cu）或 `VariantCharNormalizer`（如 `菴`→庵）才有讀音的字，仍列為罕見字。
- **看「入庫後字形」**：書名先經 `TITLE_VARIANT_MAP` 標準化（`峯`→`峰`）再檢查，與實際存入 `c_title_chn` 的字形一致（已與需求方確認）。

## 測試

`./vendor/bin/phpunit --filter 'AdminBatchLoadBookTitlesTest|AdminBatchLoadBookTitlesPinyinRouteTest|PinyinDictionaryTest'` → 65 tests 通過。涵蓋：opencc-可轉但表未收仍列出、不套異體字歸一化、看入庫後字形、去重＋行數、非漢字略過、卷冊註記略過、解析錯誤、非管理員 403、路由註冊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)