### PR TITLE
異體字落地替換：串接 char_variant_map 呼叫點

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -6,6 +6,7 @@ use App\Models\Operation;
 use App\Models\TextCode;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
+use App\Services\CharVariantMapService;
 use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\PinyinUmlaut;
@@ -17,19 +18,6 @@ use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class AdminBatchLoadBookTitlesController extends Controller {
-    /**
-     * 書名字形標準化對照表（異體字 → 標準字）。
-     *
-     * 與 VariantCharNormalizer 的差異：此對照表會「改寫存入 TEXT_CODES.c_title_chn
-     * 的書名本身」，而非僅用於拼音轉換。只放確定要把原始書名一併標準化的字形，
-     * 例如「峯」一律正規化為「峰」（兩者皆為繁體，屬同字異形，非繁簡轉換）。
-     */
-    private const TITLE_VARIANT_MAP = [
-        '峯' => '峰',
-        '靑' => '青',
-        '頴' => '穎',
-    ];
-
     /**
      * @var OperationRepository
      */
@@ -172,6 +160,7 @@ class AdminBatchLoadBookTitlesController extends Controller {
                     'created_by' => $payload['c_created_by'] ?? null,
                     'created_date' => $payload['c_created_date'] ?? null,
                     'c_textid' => $nextId,
+                    'variant_replacements' => $row['variant_replacements'] ?? [],
                 ];
             }
         });
@@ -468,14 +457,17 @@ class AdminBatchLoadBookTitlesController extends Controller {
                 continue;
             }
 
+            $standardized = $this->standardizeTitleVariants($title);
+
             $rows[] = [
                 'line' => $lineNumber,
                 'author_id' => (int) $authorId,
                 // 在書名「誕生處」一次性標準化字形（峯→峰），讓後續所有
                 // 消費端（c_title_chn、拼音、無拼音檢查）都只看到標準化後的書名，
                 // 避免任一路徑漏做而三者不一致。
-                'title' => $this->standardizeTitleVariants($title),
+                'title' => $standardized['title'],
                 'source' => $source,
+                'variant_replacements' => $standardized['variant_replacements'],
             ];
         }
 
@@ -592,16 +584,26 @@ class AdminBatchLoadBookTitlesController extends Controller {
     }
 
     /**
-     * Standardize variant glyphs in the title (峯→峰). Unlike VariantCharNormalizer
-     * (which only affects the pinyin lookup and leaves the title untouched), this
-     * rewrites the stored 中文書名 itself. It is applied ONCE in parseEntries() when
-     * the row's title is first built, so every downstream consumer — c_title_chn,
-     * the pinyin (c_title) and the unpinyinable check — receives an already
-     * standardized title and the three can never disagree on which character the
-     * title contains.
+     * Standardize variant glyphs in the title (峯→峰) via char_variant_map, lenient
+     * mode (every row in the table applies, c_strict_excluded is ignored — this is
+     * a book-title context, not a person name). Unlike VariantCharNormalizer (which
+     * only affects the pinyin lookup and leaves the title untouched), this rewrites
+     * the stored 中文書名 itself. It is applied ONCE in parseEntries() when the row's
+     * title is first built, so every downstream consumer — c_title_chn, the pinyin
+     * (c_title) and the unpinyinable check — receives an already standardized title
+     * and the three can never disagree on which character the title contains.
+     *
+     * @return array{title: string, variant_replacements: array<int,array{from:string,to:string}>}
      */
-    protected function standardizeTitleVariants(string $title): string {
-        return strtr($title, self::TITLE_VARIANT_MAP);
+    protected function standardizeTitleVariants(string $title): array {
+        $result = CharVariantMapService::replaceLenient($title);
+
+        $variantReplacements = [];
+        foreach ($result['replaced'] as $from => $to) {
+            $variantReplacements[] = ['from' => $from, 'to' => $to];
+        }
+
+        return ['title' => $result['text'], 'variant_replacements' => $variantReplacements];
     }
 
     /**

--- a/app/Http/Controllers/BasicInformationAltnamesController.php
+++ b/app/Http/Controllers/BasicInformationAltnamesController.php
@@ -7,6 +7,7 @@ use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
@@ -136,6 +137,11 @@ class BasicInformationAltnamesController extends Controller {
                 $data['c_alt_name_type_code'],
                 $data['c_alt_name_chn']
             );
+        }
+
+        // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
+        foreach (CharVariantMapService::buildNotices($data['__variant_replaced'] ?? []) as $notice) {
+            flash($notice.' @ '.Carbon::now(), 'info');
         }
 
         flash('Store success @ '.Carbon::now(), 'success');
@@ -273,11 +279,12 @@ class BasicInformationAltnamesController extends Controller {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
-        // 手動調用索引服務
+        // 手動調用索引服務：用 $newPk（repository 回傳，已含異體字落地替換後的值）而非
+        // 重新讀 $request->all()——後者是替換前的原始輸入，若用它判斷是否改名／建索引，
+        // 會讓 CBDB__NAME_FTS 索引到替換前的舊字形，與實際存入 ALTNAME_DATA 的字不一致。
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
-            $data = $request->all();
-            $nameChanged = $ori->c_alt_name_chn !== ($data['c_alt_name_chn'] ?? $ori->c_alt_name_chn);
-            $typeChanged = $ori->c_alt_name_type_code !== ($data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code);
+            $nameChanged = $ori->c_alt_name_chn !== $newPk['c_alt_name_chn'];
+            $typeChanged = $ori->c_alt_name_type_code !== $newPk['c_alt_name_type_code'];
 
             if ($nameChanged || $typeChanged) {
                 // 刪除舊索引
@@ -290,14 +297,25 @@ class BasicInformationAltnamesController extends Controller {
                 }
 
                 // 創建新索引
-                $newAltNameChn = $data['c_alt_name_chn'] ?? $ori->c_alt_name_chn;
-                if (!empty($newAltNameChn)) {
+                if (!empty($newPk['c_alt_name_chn'])) {
                     $this->nameSearchIndexService->indexAltname(
                         $id,
-                        $data['c_alt_name_type_code'] ?? $ori->c_alt_name_type_code,
-                        $newAltNameChn
+                        $newPk['c_alt_name_type_code'],
+                        $newPk['c_alt_name_chn']
                     );
                 }
+            }
+        }
+
+        // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
+        // 於此重新對提交值做一次替換純粹是為了取得 replaced 組通知文字（同一份
+        // char_variant_map 快取、無額外查表成本），實際落地寫入已在
+        // altnameUpdateById() 內完成，這裡不影響儲存結果。
+        $submittedAltNameChn = $request->input('c_alt_name_chn');
+        if ($submittedAltNameChn !== null) {
+            $noticeReplaced = CharVariantMapService::replaceStrict((string) $submittedAltNameChn)['replaced'];
+            foreach (CharVariantMapService::buildNotices($noticeReplaced) as $notice) {
+                flash($notice.' @ '.Carbon::now(), 'info');
             }
         }
 
@@ -482,8 +500,6 @@ class BasicInformationAltnamesController extends Controller {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
-        // 保留原始請求資料供索引差異判斷
-        $data = $request->all();
         $newPk = $this->biogMainRepository->altnameUpdateById($request, $id, $originalPk);
         if ($newPk === 'bracket_conflict') {
             flash('此別名經括號格式正規化後，會與現有同類型別名重複，請先手動整理後再儲存。 @ '.Carbon::now(), 'error');
@@ -494,10 +510,11 @@ class BasicInformationAltnamesController extends Controller {
             abort(404, 'ALTNAME_DATA 記錄不存在');
         }
 
-        // 更新索引
+        // 更新索引：用 $newPk（repository 回傳，已含異體字落地替換後的值）而非重新讀
+        // $request->all()——後者是替換前的原始輸入，見 update() 同樣的修正說明。
         if ($ori && Schema::hasTable('CBDB__NAME_FTS')) {
-            $nameChanged = ($ori->c_alt_name_chn ?? null) !== ($data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'] ?? null);
-            $typeChanged = ($ori->c_alt_name_type_code ?? null) !== ($data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'] ?? null);
+            $nameChanged = ($ori->c_alt_name_chn ?? null) !== $newPk['c_alt_name_chn'];
+            $typeChanged = ($ori->c_alt_name_type_code ?? null) !== $newPk['c_alt_name_type_code'];
 
             if ($nameChanged || $typeChanged) {
                 if ($ori->c_alt_name_chn) {
@@ -508,14 +525,22 @@ class BasicInformationAltnamesController extends Controller {
                     );
                 }
 
-                $newAltNameChn = $data['c_alt_name_chn'] ?? $originalPk['c_alt_name_chn'] ?? null;
-                if (!empty($newAltNameChn)) {
+                if (!empty($newPk['c_alt_name_chn'])) {
                     $this->nameSearchIndexService->indexAltname(
                         $newPk['c_personid'] ?? $originalPk['c_personid'],
-                        $data['c_alt_name_type_code'] ?? $originalPk['c_alt_name_type_code'] ?? null,
-                        $newAltNameChn
+                        $newPk['c_alt_name_type_code'],
+                        $newPk['c_alt_name_chn']
                     );
                 }
+            }
+        }
+
+        // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
+        $submittedAltNameChn = $request->input('c_alt_name_chn');
+        if ($submittedAltNameChn !== null) {
+            $noticeReplaced = CharVariantMapService::replaceStrict((string) $submittedAltNameChn)['replaced'];
+            foreach (CharVariantMapService::buildNotices($noticeReplaced) as $notice) {
+                flash($notice.' @ '.Carbon::now(), 'info');
             }
         }
 

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -14,6 +14,7 @@ use App\Repositories\ToolsRepository;
 use App\Repositories\YearRangeRepository;
 use App\Services\AuditLogService;
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Services\PersonBrowserService;
 use App\Support\CompositePrimaryKey;
@@ -1602,10 +1603,16 @@ class BasicInformationController extends Controller {
             return redirect()->route('basicinformation.index');
         } else {
             // 使用 Repository 進行儲存（內含事務與審計）
-            $flight = $this->biogMainRepository->store($request);
+            $storeResult = $this->biogMainRepository->store($request);
+            $flight = $storeResult['model'];
 
             if (Schema::hasTable('CBDB__NAME_FTS')) {
                 $this->nameSearchIndexService->reindexPerson($flight);
+            }
+
+            // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
+            foreach (CharVariantMapService::buildNotices($storeResult['replaced']) as $notice) {
+                flash($notice.' @ '.Carbon::now(), 'info');
             }
 
             flash('Create success @ '.Carbon::now(), 'success');
@@ -1778,6 +1785,11 @@ class BasicInformationController extends Controller {
             flash('無實質更新，資料未變更 @ '.Carbon::now(), 'info');
 
             return redirect()->route('basicinformation.edit', $id);
+        }
+
+        // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
+        foreach (CharVariantMapService::buildNotices($result['variant_replaced'] ?? []) as $notice) {
+            flash($notice.' @ '.Carbon::now(), 'info');
         }
 
         //20190531判別是否為眾包用戶

--- a/app/Http/Controllers/BasicInformationProposalController.php
+++ b/app/Http/Controllers/BasicInformationProposalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
+use App\Services\CharVariantMapService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -488,6 +489,29 @@ class BasicInformationProposalController extends Controller {
     }
 
     protected function normalizePayloadForTable(string $table, array $payload): array {
+        // 異體字落地替換（嚴格模式）：legacy Blade 提案路徑不經過
+        // BiogMainMutationHandler::prepareProposalPayload()，需在此另外掛鉤，否則
+        // 同一份輸入走 legacy 提案與走 v2 API 提案，c_name_chn 落地結果會不一致
+        // （見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 3）。先替換分欄、
+        // 再組出 c_name_chn，維持 c_name_chn === c_surname_chn.c_mingzi_chn 的 invariant。
+        if ($table === 'BIOG_MAIN') {
+            $surnameReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_surname_chn'] ?? ''));
+            $mingziReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_mingzi_chn'] ?? ''));
+            $payload['c_surname_chn'] = $surnameReplaced['text'];
+            $payload['c_mingzi_chn'] = $mingziReplaced['text'];
+            $payload['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];
+        }
+
+        // ALTNAME_DATA 同理：legacy Blade 提案路徑（BasicInformationAltnamesController::
+        // store()/update()/updateQuery() 的 action=proposal 分支）也不經過
+        // AltnameCreateHandler/AltnameMutationHandler 的 preprocessCreateData()/
+        // preprocessUpdateData()，需在此另外掛鉤，否則同一份輸入走 legacy 提案與走
+        // legacy direct／v2 API，c_alt_name_chn 落地結果會不一致（見
+        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 5）。
+        if ($table === 'ALTNAME_DATA' && array_key_exists('c_alt_name_chn', $payload)) {
+            $payload['c_alt_name_chn'] = CharVariantMapService::replaceStrict((string) $payload['c_alt_name_chn'])['text'];
+        }
+
         if ($table === 'BIOG_SOURCE_DATA') {
             $payload['c_pages'] = (string) ($payload['c_pages'] ?? '');
 

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -1356,6 +1356,12 @@ class OperationsController extends Controller {
             'SOCIAL_INSTITUTION_ADDR' => ['c_inst_addr_id','c_inst_addr_type_code','c_inst_code','c_inst_name_code','inst_xcoord','inst_ycoord'],
             'ADMIN_CAT_CODES' => ['c_admin_cat_code'],
             'ADDR_CODES' => ['c_addr_id'],
+            // char_variant_map 的實際資料表名是小寫，AbstractCodeTableMutationHandler::handleDirect()/
+            // handleProposal() 傳給 OperationRepository::store() 的 $resource 參數就是 tableName()
+            // 回傳的原始表名字串（此處即小寫 'char_variant_map'），resourceKeyColumns() 這裡是直接依
+            // 字面值查陣列鍵、不像 CompositePrimaryKey::lookup() 會 strtoupper() 正規化，
+            // 因此鍵名必須完全比照實際表名大小寫，不能像其他 Phase B 表一樣使用大寫。
+            'char_variant_map' => ['id'],
         ];
 
         return $map[$resource] ?? [];

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -30,6 +30,7 @@ use App\Services\AuditLogService;
 
 //20210625建安修改
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\CompositePrimaryKey;
@@ -243,7 +244,16 @@ class BiogMainRepository {
     public function updateById($request, $id) {
         $data = $request->all();
 
-        $c_name_chn = $request->c_surname_chn.$request->c_mingzi_chn;
+        // 異體字落地替換（嚴格模式）：先替換姓／名分欄，再組出 c_name_chn，維持
+        // c_name_chn === c_surname_chn.c_mingzi_chn 的既有 invariant（見
+        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
+        $surnameReplaced = CharVariantMapService::replaceStrict((string) $request->c_surname_chn);
+        $mingziReplaced = CharVariantMapService::replaceStrict((string) $request->c_mingzi_chn);
+        $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+        $data['c_surname_chn'] = $surnameReplaced['text'];
+        $data['c_mingzi_chn'] = $mingziReplaced['text'];
+
+        $c_name_chn = $surnameReplaced['text'].$mingziReplaced['text'];
         $c_name = trim($request->c_surname.' '.$request->c_mingzi);
         #20230626修改外文全名呈現順序
         #$c_name_proper = $request->c_surname_proper.' '.$request->c_mingzi_proper;
@@ -324,6 +334,7 @@ class BiogMainRepository {
         return [
             'no_changes' => false,
             'operation_id' => isset($operation) && $operation ? $operation->id : null,
+            'variant_replaced' => $variantReplaced,
         ];
     }
 
@@ -352,6 +363,28 @@ class BiogMainRepository {
 
     public function store(Request $request) {
         $data = $request->all();
+
+        // 異體字落地替換（嚴格模式）。v2 API 的 ALLOWED_FIELDS 允許呼叫端只送
+        // c_name_chn（不拆分姓／名，例如無明確姓氏的歷史人物），也允許送
+        // c_surname_chn/c_mingzi_chn（此時依「待決事項 2」無條件由分欄重組
+        // c_name_chn，不採信客戶端傳來的值，避免分欄與組合欄不同步）。若兩個分欄
+        // 都完全沒出現在請求裡（不是空字串，是 key 都不存在），代表呼叫端這次没有
+        // 送分欄，只能直接替換 c_name_chn 本身，不能無條件拿兩個不存在的分欄相加把
+        // c_name_chn 覆寫成空字串（見 tests/Feature/ApiV2CreateBiogMainTest.php
+        // 只送 c_name_chn 的既有使用情境）。
+        if (array_key_exists('c_surname_chn', $data) || array_key_exists('c_mingzi_chn', $data)) {
+            $surnameReplaced = CharVariantMapService::replaceStrict((string) ($data['c_surname_chn'] ?? ''));
+            $mingziReplaced = CharVariantMapService::replaceStrict((string) ($data['c_mingzi_chn'] ?? ''));
+            $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+            $data['c_surname_chn'] = $surnameReplaced['text'];
+            $data['c_mingzi_chn'] = $mingziReplaced['text'];
+            $data['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];
+        } else {
+            $nameChnReplaced = CharVariantMapService::replaceStrict((string) ($data['c_name_chn'] ?? ''));
+            $data['c_name_chn'] = $nameChnReplaced['text'];
+            $variantReplaced = $nameChnReplaced['replaced'];
+        }
+
         $data = (new ToolsRepository())->timestamp($data, true);
         $data = $this->auto_pinyin($data);
         // 括號正規化：全角轉半角、括號前後補空格
@@ -360,7 +393,7 @@ class BiogMainRepository {
         // 保存時拼音 v→ü 歸一化（Tier 1；冪等防禦：auto_pinyin 已先歸一化 c_surname/c_mingzi）
         $data = PinyinUmlaut::normalizeFields($data, PinyinUmlaut::BIOG_MAIN_PINYIN_V_FIELDS);
 
-        return DB::transaction(function () use ($data) {
+        return DB::transaction(function () use ($data, $variantReplaced) {
             $flight = BiogMain::create($data);
             $operation = (new OperationRepository())->store(Auth::id(), $data['c_personid'], 1, 'BIOG_MAIN', $data['c_personid'], $data);
 
@@ -375,7 +408,7 @@ class BiogMainRepository {
                 $operation ? (string) $operation->id : null
             );
 
-            return $flight;
+            return ['model' => $flight, 'replaced' => $variantReplaced];
         });
     }
 
@@ -3561,6 +3594,17 @@ class BiogMainRepository {
         $data['c_personid'] = $id;
         // 括號正規化：全角→半角（中文）、全角→半角+空格（拼音）
         $data = BracketNormalizer::normalizeAltname($data);
+
+        // 異體字落地替換（嚴格模式）：須在重複檢查之前，讓重複檢查看到的是替換後的
+        // 值（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 3 修正段落，
+        // 這是 legacy Blade 專屬的第二條寫入路徑，與 AltnameCreateHandler 平行、不共用）。
+        $variantReplaced = [];
+        if (array_key_exists('c_alt_name_chn', $data)) {
+            $replaced = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn']);
+            $data['c_alt_name_chn'] = $replaced['text'];
+            $variantReplaced = $replaced['replaced'];
+        }
+
         // 重複檢查使用 3-key，c_sequence 不參與定位
         $duplicate = DB::table('ALTNAME_DATA')->where([
             ['c_personid', '=', $data['c_personid']],
@@ -3572,7 +3616,7 @@ class BiogMainRepository {
         }
         $data = (new ToolsRepository())->timestamp($data, true);
 
-        return DB::transaction(function () use ($id, $data) {
+        return DB::transaction(function () use ($id, $data, $variantReplaced) {
             DB::table('ALTNAME_DATA')->insert($data);
             $pk3 = [
                 'c_personid' => $data['c_personid'],
@@ -3592,7 +3636,9 @@ class BiogMainRepository {
                 $operation ? (string) $operation->id : null
             );
 
-            return $data;
+            // __variant_replaced 只附掛在回傳值上供呼叫端組非阻塞提示，不是資料表欄位，
+            // 在 insert() 之後才合併進來，不會被誤寫進 ALTNAME_DATA／operations／audit_log。
+            return array_merge($data, ['__variant_replaced' => $variantReplaced]);
         });
     }
 
@@ -3606,6 +3652,12 @@ class BiogMainRepository {
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment']);
         // 括號正規化：全角→半角（中文）、全角→半角+空格（拼音）
         $data = BracketNormalizer::normalizeAltname($data);
+
+        // 異體字落地替換（嚴格模式）：須在組出 $newPk3 之前，讓衝突檢查用的是替換後的
+        // 值（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 3 修正段落）。
+        if (array_key_exists('c_alt_name_chn', $data)) {
+            $data['c_alt_name_chn'] = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn'])['text'];
+        }
 
         // 計算更新後的 3-key，若與原 PK 不同則檢查是否會與既有記錄衝突
         $newPk3 = [

--- a/app/Services/CharVariantMapService.php
+++ b/app/Services/CharVariantMapService.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 異體字落地替換服務
+ *
+ * 查詢 char_variant_map 表，把文字裡的異體字替換成參考字。與 VariantCharNormalizer
+ * 的差異：VariantCharNormalizer 只影響拼音查詢、不改動原始資料；本服務會實際改寫
+ * 呼叫端傳入的文字（呼叫端自行決定要不要把回傳的 text 存進資料庫）。
+ *
+ * 寬鬆模式（replaceLenient）：表裡任何一筆對照都套用，忽略 c_strict_excluded。
+ * 嚴格模式（replaceStrict）：只套用 c_strict_excluded = 0 的記錄，用於 BIOG_MAIN／
+ * ALTNAME_DATA 等人名相關欄位。
+ */
+class CharVariantMapService {
+    /**
+     * 寬鬆模式對照表快取（異體字 => 參考字）。
+     *
+     * @var array<string,string>|null
+     */
+    protected static ?array $lenientMap = null;
+
+    /**
+     * 嚴格模式對照表快取（異體字 => 參考字，僅 c_strict_excluded = 0）。
+     *
+     * @var array<string,string>|null
+     */
+    protected static ?array $strictMap = null;
+
+    /**
+     * 寬鬆模式：對整段文字做落地替換，表裡任何一筆都套用（忽略 c_strict_excluded）。
+     *
+     * @return array{text: string, replaced: array<string,string>}
+     */
+    public static function replaceLenient(string $text): array {
+        return self::replaceUsing($text, self::lenientMap());
+    }
+
+    /**
+     * 嚴格模式：對整段文字做落地替換，只套用 c_strict_excluded = 0 的記錄。
+     *
+     * @return array{text: string, replaced: array<string,string>}
+     */
+    public static function replaceStrict(string $text): array {
+        return self::replaceUsing($text, self::strictMap());
+    }
+
+    /**
+     * 清除靜態快取（測試用，比照 VariantCharNormalizer::reset() 慣例）。
+     */
+    public static function reset(): void {
+        self::$lenientMap = null;
+        self::$strictMap = null;
+    }
+
+    /**
+     * 把 replaceLenient()/replaceStrict() 回傳的 replaced 組成非阻塞通知文字（見
+     * docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 5）。多個呼叫端
+     * （BIOG_MAIN create／update、ALTNAME_DATA create／update 等）共用同一份措辭，
+     * 避免各自組字造成用語不一致。
+     *
+     * @param array<string,string> $replaced 異體字 => 參考字
+     * @return array<int,string> 空陣列代表無需通知
+     */
+    public static function buildNotices(array $replaced): array {
+        if ($replaced === []) {
+            return [];
+        }
+
+        $pairs = [];
+        foreach ($replaced as $variant => $reference) {
+            $pairs[] = "「{$variant}」已正規化為「{$reference}」";
+        }
+
+        return ['異體字：'.implode('、', $pairs)];
+    }
+
+    /**
+     * 把 buildNotices() 的結果併入一個已組好的 JsonResponse（頂層新增可選的
+     * notices 欄位）。給那些回應結構固定在共用抽象類別裡、子類只能事後
+     * decode／重新包裝的呼叫端使用（例如 AltnameCreateHandler／
+     * AltnameMutationHandler 繼承 AbstractPersonSubresource*Handler 的
+     * handleDirect()／handleProposal()，回應在父類別內組好，子類無法在建構時
+     * 插入額外欄位，只能對已完成的 JsonResponse 再加工）。
+     *
+     * 注意：這裡是重新組一個全新的 JsonResponse，不是複製／修改原始 `$response`，
+     * 所以不會帶到原始回應上可能設定的自訂 header／cookie。目前所有呼叫端
+     * （AbstractPersonSubresourceCreateHandler／AbstractPersonSubresourceMutationHandler
+     * 的 handleDirect()／handleProposal()）都只用 response()->json([...]) 組出單純的
+     * JSON 回應，沒有額外 header／cookie，故現階段無影響；若未來這些父類別新增了
+     * header／cookie，需要重新評估這裡是否要改用 `$response->setData($data)` 保留原始
+     * response 物件（含 header）而非重建。
+     *
+     * @param array<string,string> $replaced
+     */
+    public static function withNotices(JsonResponse $response, array $replaced): JsonResponse {
+        $notices = self::buildNotices($replaced);
+        if ($notices === []) {
+            return $response;
+        }
+
+        $data = $response->getData(true);
+        $data['notices'] = $notices;
+
+        return response()->json($data, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string,string> $map
+     * @return array{text: string, replaced: array<string,string>}
+     */
+    protected static function replaceUsing(string $text, array $map): array {
+        if ($text === '' || empty($map)) {
+            return ['text' => $text, 'replaced' => []];
+        }
+
+        $replaced = [];
+        foreach ($map as $variant => $reference) {
+            // c_variant_char 只在 DB 層是 NOT NULL，不保證非空字串；空字串會讓
+            // str_contains() 恆為 true、且讓 strtr() 對空字串 key 發出 PHP 警告。
+            if ($variant !== '' && str_contains($text, $variant)) {
+                $replaced[$variant] = $reference;
+            }
+        }
+
+        if (empty($replaced)) {
+            return ['text' => $text, 'replaced' => []];
+        }
+
+        return ['text' => strtr($text, $replaced), 'replaced' => $replaced];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    protected static function lenientMap(): array {
+        if (self::$lenientMap === null) {
+            self::$lenientMap = DB::table('char_variant_map')
+                ->pluck('c_reference_char', 'c_variant_char')
+                ->all();
+        }
+
+        return self::$lenientMap;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    protected static function strictMap(): array {
+        if (self::$strictMap === null) {
+            self::$strictMap = DB::table('char_variant_map')
+                ->where('c_strict_excluded', 0)
+                ->pluck('c_reference_char', 'c_variant_char')
+                ->all();
+        }
+
+        return self::$strictMap;
+    }
+}

--- a/app/Services/Mutations/AbstractCodeTableMutationHandler.php
+++ b/app/Services/Mutations/AbstractCodeTableMutationHandler.php
@@ -158,38 +158,48 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
         $operation = null;
         $newArray = [];
 
-        DB::transaction(function () use ($table, $pk, $resourceId, $updateData, $originalArray, $comment, $operationId, $personId, &$operation, &$newArray) {
-            $this->whereByPk(DB::table($table), $pk)->update($updateData);
+        try {
+            DB::transaction(function () use ($table, $pk, $resourceId, $updateData, $originalArray, $comment, $operationId, $personId, &$operation, &$newArray) {
+                $this->whereByPk(DB::table($table), $pk)->update($updateData);
 
-            $updatedRow = $this->findByPk($pk);
-            $newArray = $this->auditLogService->normalizeRow($updatedRow);
+                $updatedRow = $this->findByPk($pk);
+                $newArray = $this->auditLogService->normalizeRow($updatedRow);
 
-            $resourceData = array_merge($newArray, ['__operation_id' => $operationId]);
-            if ($comment !== '') {
-                $resourceData['__note'] = $comment;
+                $resourceData = array_merge($newArray, ['__operation_id' => $operationId]);
+                if ($comment !== '') {
+                    $resourceData['__note'] = $comment;
+                }
+
+                $operation = $this->operationRepository->store(
+                    Auth::id(),
+                    $personId,
+                    Operation::TYPE_UPDATE,
+                    $table,
+                    $resourceId,
+                    $resourceData,
+                    $originalArray
+                );
+
+                $this->auditLogService->write(
+                    $table,
+                    'UPDATE',
+                    $pk,
+                    $originalArray,
+                    $newArray,
+                    'user',
+                    (string) Auth::id(),
+                    $operationId
+                );
+            });
+        } catch (\Illuminate\Database\QueryException $e) {
+            // 部分表（如 char_variant_map 的 c_variant_char）在非主鍵欄位上另有唯一鍵；
+            // 更新撞到該唯一鍵須回 409（可重試/可提示），不能讓資料庫層例外冒出成 500。
+            if ($this->isUniqueConstraintViolation($e)) {
+                return $this->errorResponse('修改後的值與其他記錄的唯一鍵衝突', 409, ['changes' => ['conflict']]);
             }
 
-            $operation = $this->operationRepository->store(
-                Auth::id(),
-                $personId,
-                Operation::TYPE_UPDATE,
-                $table,
-                $resourceId,
-                $resourceData,
-                $originalArray
-            );
-
-            $this->auditLogService->write(
-                $table,
-                'UPDATE',
-                $pk,
-                $originalArray,
-                $newArray,
-                'user',
-                (string) Auth::id(),
-                $operationId
-            );
-        });
+            throw $e;
+        }
 
         return response()->json([
             'ok' => true,
@@ -246,14 +256,29 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
     }
 
     /**
-     * 欄位值校驗：預設對每個白名單欄做「字串或 null、長度 ≤ 255」檢查。
-     * 需要更嚴格規則的表可覆寫。
+     * 允許以整數值更新的欄位（預設無）。這組欄位存在的原因：本基底原本假設所有已登錄表的
+     * allowed_fields 都是拼音／文字欄，一律要求 string|null；char_variant_map 的
+     * c_strict_excluded 是第一個整數旗標欄，JSON 呼叫端會送整數（非字串）。刻意不對「所有」
+     * 欄位一律放寬接受 int，避免其他表原本合法的「送整數應被拒絕」行為被意外放寬
+     * （例如某拼音欄位不該接受數字型別）。需要整數欄位的子類／設定應覆寫或提供此清單。
+     *
+     * @return array<int,string>
+     */
+    protected function integerFields(): array {
+        return [];
+    }
+
+    /**
+     * 欄位值校驗：預設對每個白名單欄做「字串或 null、長度 ≤ 255」檢查；
+     * integerFields() 內列出的欄位額外接受整數。需要更嚴格規則的表可覆寫。
      */
     protected function validateFields(array $data): array {
         $errors = [];
+        $integerFields = $this->integerFields();
         foreach ($data as $field => $value) {
-            if ($value !== null && !is_string($value)) {
-                $errors[$field] = [$field . ' 必須為字串或 null'];
+            $allowInt = in_array($field, $integerFields, true);
+            if ($value !== null && !is_string($value) && !($allowInt && is_int($value))) {
+                $errors[$field] = [$field . ($allowInt ? ' 必須為字串、整數或 null' : ' 必須為字串或 null')];
             } elseif (is_string($value) && mb_strlen($value) > 255) {
                 $errors[$field] = [$field . ' 長度不可超過 255 字元'];
             }
@@ -285,5 +310,15 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
         }
 
         return $query;
+    }
+
+    private function isUniqueConstraintViolation(\Illuminate\Database\QueryException $e): bool {
+        $code = (int) ($e->errorInfo[1] ?? 0);
+        if (in_array($code, [1062, 19], true)) {
+            return true;
+        }
+        $msg = $e->getMessage();
+
+        return str_contains($msg, 'UNIQUE') || str_contains($msg, 'Duplicate entry');
     }
 }

--- a/app/Services/Mutations/AltnameCreateHandler.php
+++ b/app/Services/Mutations/AltnameCreateHandler.php
@@ -5,12 +5,22 @@ namespace App\Services\Mutations;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\PinyinUmlaut;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Schema;
 
 class AltnameCreateHandler extends AbstractPersonSubresourceCreateHandler {
     protected NameSearchIndexService $nameSearchIndexService;
+
+    /**
+     * 本次 preprocessCreateData() 對 c_alt_name_chn 實際套用的異體字替換
+     * （異體字 => 參考字）。handleDirect()／handleProposal() 併入回應的 notices。
+     *
+     * @var array<string,string>
+     */
+    protected array $variantReplaced = [];
 
     public function __construct(
         OperationRepository $operationRepository,
@@ -67,17 +77,39 @@ class AltnameCreateHandler extends AbstractPersonSubresourceCreateHandler {
         $data = $this->normalizeSentinelValues($data, ['c_alt_name_type_code', 'c_source']);
 
         // #71：非 PK 碼欄 c_source 完全幂等（null/''/-999→0），對齊已修的 AltnameMutationHandler。
-        return $this->normalizeEmptyCodeFields($data, ['c_source']);
-    }
+        $data = $this->normalizeEmptyCodeFields($data, ['c_source']);
 
-    protected function handleDirect(int $personId, array $actualPk, array $rowData, string $comment): \Illuminate\Http\JsonResponse {
-        $response = parent::handleDirect($personId, $actualPk, $rowData, $comment);
-
-        if ($response->getStatusCode() === 200) {
-            $this->syncAltnameIndexAfterCreate($rowData);
+        // 異體字落地替換（嚴格模式）。發生在 extractPkFromRow() 之前（見
+        // AbstractPersonSubresourceCreateHandler::handle() 119-122 行），替換後的值
+        // 自然成為新 PK 的一部分（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+        // 待決事項 3）。
+        if (array_key_exists('c_alt_name_chn', $data)) {
+            $replaced = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn']);
+            $data['c_alt_name_chn'] = $replaced['text'];
+            $this->variantReplaced = $replaced['replaced'];
         }
 
-        return $response;
+        return $data;
+    }
+
+    protected function handleDirect(int $personId, array $actualPk, array $rowData, string $comment): JsonResponse {
+        $response = parent::handleDirect($personId, $actualPk, $rowData, $comment);
+
+        if ($response->getStatusCode() !== 200) {
+            return $response;
+        }
+
+        $this->syncAltnameIndexAfterCreate($rowData);
+
+        return CharVariantMapService::withNotices($response, $this->variantReplaced);
+    }
+
+    protected function handleProposal(int $personId, array $actualPk, array $rowData, string $comment): JsonResponse {
+        $response = parent::handleProposal($personId, $actualPk, $rowData, $comment);
+
+        return $response->getStatusCode() === 200
+            ? CharVariantMapService::withNotices($response, $this->variantReplaced)
+            : $response;
     }
 
     protected function syncAltnameIndexAfterCreate(array $rowData): void {

--- a/app/Services/Mutations/AltnameMutationHandler.php
+++ b/app/Services/Mutations/AltnameMutationHandler.php
@@ -5,13 +5,23 @@ namespace App\Services\Mutations;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\PinyinUmlaut;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
     protected NameSearchIndexService $nameSearchIndexService;
+
+    /**
+     * 本次 preprocessUpdateData() 對 c_alt_name_chn 實際套用的異體字替換
+     * （異體字 => 參考字）。handleDirect()／handleProposal() 併入回應的 notices。
+     *
+     * @var array<string,string>
+     */
+    protected array $variantReplaced = [];
 
     public function __construct(
         OperationRepository $operationRepository,
@@ -70,6 +80,18 @@ class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
         // sentinel 完全幂等：c_source（legacy 哨兵 0=Unknown）的 null/'' 也→0（normalizeSentinelValues 只做 -999）。
         $data = $this->normalizeEmptyCodeFields($data, ['c_source']);
 
+        // 異體字落地替換（嚴格模式）。發生在 buildNewPk() 之前（見
+        // AbstractPersonSubresourceMutationHandler::handle() 135 行早於 handleDirect()
+        // 內 212 行的 buildNewPk()），替換後的值自然成為新 PK 的一部分，
+        // performUpdate() 的 PK 衝突偵測與 syncAltnameIndexAfterUpdate() 都讀取
+        // 替換後的 updateData（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+        // 待決事項 3）。
+        if (array_key_exists('c_alt_name_chn', $data)) {
+            $replaced = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn']);
+            $data['c_alt_name_chn'] = $replaced['text'];
+            $this->variantReplaced = $replaced['replaced'];
+        }
+
         return $data;
     }
 
@@ -97,18 +119,30 @@ class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
         parent::performUpdate($targetPk, $updateData);
     }
 
-    protected function handleDirect(int $personId, array $targetPk, array $updateData, array $originalArray, string $comment): \Illuminate\Http\JsonResponse {
+    protected function handleDirect(int $personId, array $targetPk, array $updateData, array $originalArray, string $comment): JsonResponse {
         // 記錄原始狀態以便更新搜尋索引
         $originalObject = $this->findOriginalRow($targetPk);
 
         $response = parent::handleDirect($personId, $targetPk, $updateData, $originalArray, $comment);
 
+        if ($response->getStatusCode() !== 200) {
+            return $response;
+        }
+
         // 更新搜尋索引
-        if ($response->getStatusCode() === 200 && $originalObject) {
+        if ($originalObject) {
             $this->syncAltnameIndexAfterUpdate($originalObject, $updateData, $targetPk);
         }
 
-        return $response;
+        return CharVariantMapService::withNotices($response, $this->variantReplaced);
+    }
+
+    protected function handleProposal(int $personId, array $targetPk, array $updateData, array $originalArray, string $comment): JsonResponse {
+        $response = parent::handleProposal($personId, $targetPk, $updateData, $originalArray, $comment);
+
+        return $response->getStatusCode() === 200
+            ? CharVariantMapService::withNotices($response, $this->variantReplaced)
+            : $response;
     }
 
     /**

--- a/app/Services/Mutations/BiogMainCreateHandler.php
+++ b/app/Services/Mutations/BiogMainCreateHandler.php
@@ -4,6 +4,7 @@ namespace App\Services\Mutations;
 
 use App\Models\BiogMain;
 use App\Repositories\BiogMainRepository;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use Illuminate\Http\JsonResponse;
@@ -148,10 +149,13 @@ class BiogMainCreateHandler extends AbstractMutationHandler {
         $proxy = Request::create('/api/v2/create', 'POST', $rowData);
 
         try {
-            $flight = $this->biogMainRepository->store($proxy);
+            $storeResult = $this->biogMainRepository->store($proxy);
         } catch (\Throwable $e) {
             return $this->errorResponse('新增失敗：'.$e->getMessage(), 500);
         }
+
+        $flight = $storeResult['model'];
+        $variantReplaced = $storeResult['replaced'];
 
         if ($flight && Schema::hasTable('CBDB__NAME_FTS')) {
             $this->nameSearchIndexService->reindexPerson($flight);
@@ -159,7 +163,7 @@ class BiogMainCreateHandler extends AbstractMutationHandler {
 
         $row = BiogMain::find($personId);
 
-        return response()->json([
+        $response = [
             'ok' => true,
             'resource' => 'basicinformation',
             'mode' => 'direct',
@@ -168,7 +172,14 @@ class BiogMainCreateHandler extends AbstractMutationHandler {
                 'pk' => ['c_personid' => $personId],
                 'row' => $row ? $row->toArray() : ($flight ? $flight->toArray() : null),
             ],
-        ]);
+        ];
+
+        $notices = CharVariantMapService::buildNotices($variantReplaced);
+        if ($notices !== []) {
+            $response['notices'] = $notices;
+        }
+
+        return response()->json($response);
     }
 
     /**

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -9,6 +9,7 @@ use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\Services\BracketNormalizer;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use App\Support\PinyinUmlaut;
@@ -117,7 +118,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
             $this->nameSearchIndexService->reindexPerson($updated);
         }
 
-        return response()->json([
+        $response = [
             'ok' => true,
             'resource' => 'basicinformation',
             'mode' => 'direct',
@@ -128,11 +129,18 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
                 'operation_id' => $result['operation_id'] ?? null,
                 'row' => $updated ? $updated->toArray() : null,
             ],
-        ]);
+        ];
+
+        $notices = CharVariantMapService::buildNotices($result['variant_replaced'] ?? []);
+        if ($notices !== []) {
+            $response['notices'] = $notices;
+        }
+
+        return response()->json($response);
     }
 
     protected function handleProposalUpdate(int $personId, array $updatedFields, array $merged, BiogMain $original, array $meta): JsonResponse {
-        $proposalData = $this->prepareProposalPayload($merged);
+        ['payload' => $proposalData, 'replaced' => $variantReplaced] = $this->prepareProposalPayload($merged);
         $validator = Validator::make($proposalData, $this->validationRules($original), $this->validationMessages());
         if ($validator->fails()) {
             return $this->errorResponse('參數校驗失敗', 422, $validator->errors()->toArray());
@@ -164,7 +172,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
             $original->toArray()
         );
 
-        return response()->json([
+        $response = [
             'ok' => true,
             'resource' => 'basicinformation',
             'mode' => 'proposal',
@@ -175,7 +183,14 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
                 'status' => 'proposal_updated',
                 'operation_id' => $operation?->id,
             ],
-        ]);
+        ];
+
+        $notices = CharVariantMapService::buildNotices($variantReplaced);
+        if ($notices !== []) {
+            $response['notices'] = $notices;
+        }
+
+        return response()->json($response);
     }
 
     protected function buildMergedPayload(BiogMain $original, array $changes): array {
@@ -193,8 +208,20 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         return [$payload, array_keys($allowedChanges)];
     }
 
+    /**
+     * @return array{payload: array, replaced: array<string,string>}
+     */
     protected function prepareProposalPayload(array $payload): array {
-        $payload['c_name_chn'] = ($payload['c_surname_chn'] ?? '').($payload['c_mingzi_chn'] ?? '');
+        // 異體字落地替換（嚴格模式）：先替換姓／名分欄，再組出 c_name_chn，維持
+        // c_name_chn === c_surname_chn.c_mingzi_chn 的既有 invariant（見
+        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
+        $surnameReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_surname_chn'] ?? ''));
+        $mingziReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_mingzi_chn'] ?? ''));
+        $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+        $payload['c_surname_chn'] = $surnameReplaced['text'];
+        $payload['c_mingzi_chn'] = $mingziReplaced['text'];
+
+        $payload['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];
         $payload['c_name'] = trim(($payload['c_surname'] ?? '').' '.($payload['c_mingzi'] ?? ''));
         $payload['c_name_proper'] = trim(($payload['c_mingzi_proper'] ?? '').' '.($payload['c_surname_proper'] ?? ''));
         $payload['c_name_rm'] = trim(($payload['c_mingzi_rm'] ?? '').' '.($payload['c_surname_rm'] ?? ''));
@@ -212,7 +239,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         $payload['c_dy_intercalary'] = (int) ($payload['c_dy_intercalary'] ?? 0);
         $payload = BiogMainRepository::nullifyEmptyForeignKeys($payload);
 
-        return (new ToolsRepository())->timestamp($payload);
+        return ['payload' => (new ToolsRepository())->timestamp($payload), 'replaced' => $variantReplaced];
     }
 
     protected function validationRules(BiogMain $original): array {

--- a/app/Services/Mutations/ConfigCodeTableMutationHandler.php
+++ b/app/Services/Mutations/ConfigCodeTableMutationHandler.php
@@ -86,6 +86,10 @@ class ConfigCodeTableMutationHandler extends AbstractCodeTableMutationHandler {
         return $this->active['allowed_fields'];
     }
 
+    protected function integerFields(): array {
+        return $this->active['integer_fields'] ?? [];
+    }
+
     /**
      * §D-6 保存止血：對本表的 **Tier 1** 拼音欄靜默套用 v→ü 歸一化。
      * Tier 2（混西文）欄**不**在此轉——由前端 altname 式彈窗讓使用者決定（後端原樣寫入）。

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -182,6 +182,9 @@ class CompositePrimaryKey {
         'ADDR_CODES' => [
             'c_addr_id',
         ],
+        'CHAR_VARIANT_MAP' => [
+            'id',
+        ],
     ];
 
     /**

--- a/config/code_table_mutations.php
+++ b/config/code_table_mutations.php
@@ -15,6 +15,10 @@
  *   - tier1_fields：保存時**後端靜默** v→ü 歸一化的欄（定義上即漢語拼音、無西文）。
  *   - tier2_fields：**可能含西文**的混合欄——後端**不**靜默轉（由前端 altname 式彈窗讓使用者決定）。
  *     tier1_fields ∪ tier2_fields 必等於 allowed_fields。依 §D-6 Tier 登錄表（實測定案）。
+ *   - integer_fields（可選，預設無）：allowed_fields 中允許以整數值更新的欄（見
+ *     AbstractCodeTableMutationHandler::validateFields()）。預設所有欄一律要求 string|null；
+ *     只有非拼音／文字的整數旗標欄（如 char_variant_map.c_strict_excluded）才需要登記，
+ *     且僅登記該欄本身——不影響同一張表或其他表未登記欄位仍要求 string|null 的既有行為。
  *
  * 目前僅 update；c_personid 一律 0（code 表為全域代碼）。
  */
@@ -150,6 +154,20 @@ return [
             'allowed_fields' => ['c_name'],
             'tier1_fields' => [],
             'tier2_fields' => ['c_name'],
+        ],
+        [
+            'resource' => 'char_variant_map',
+            'table' => 'char_variant_map',
+            'aliases' => ['char_variant_map', 'char-variant-map', 'charvariantmap'],
+            'display_name' => '異體字落地替換對照',
+            'key_columns' => ['id'],
+            'allowed_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+            'tier1_fields' => [],
+            'tier2_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+            // c_strict_excluded 是整數旗標欄（tinyint 0/1），非本檔其餘表清一色的拼音／文字欄；
+            // AbstractCodeTableMutationHandler::validateFields() 預設只接受 string|null，
+            // 這裡明確登記允許整數，且僅限這一欄——不影響本檔其他表仍要求 string|null 的既有行為。
+            'integer_fields' => ['c_strict_excluded'],
         ],
     ],
 ];

--- a/config/code_table_writes.php
+++ b/config/code_table_writes.php
@@ -29,5 +29,14 @@ return [
                 'c_url_api', 'c_url_api_coda', 'c_url_homepage', 'c_notes', 'c_title_alt_chn',
             ],
         ],
+        'char_variant_map' => [
+            'resource' => 'char-variant-map',
+            'aliases' => ['char-variant-map', 'char_variant_map', 'charvariantmap'],
+            'table' => 'char_variant_map',
+            'display_name' => '異體字落地替換對照表',
+            'key_column' => 'id',
+            'auto_assign_id' => true,
+            'allowed_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+        ],
     ],
 ];

--- a/config/codes.php
+++ b/config/codes.php
@@ -59,6 +59,7 @@ return [
         'BIOG_TEXT_DATA' => '傳記文本資料表',
         'CBDB__NAME_FTS' => '人名全文檢索表',
         'CBDB__TRAD_SIMP_MAP' => '繁簡字對照表',
+        'char_variant_map' => '異體字落地替換對照表',
         'CHORONYM_CODES' => '郡望代碼表',
         'COUNTRY_CODES' => '國家地區代碼表',
         'DYNASTIES' => '朝代信息表',

--- a/database/migrations/2026_07_17_000000_add_audit_columns_to_char_variant_map_table.php
+++ b/database/migrations/2026_07_17_000000_add_audit_columns_to_char_variant_map_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * char_variant_map 註冊進 config/code_table_writes.php 後，CodeTableCreateHandler
+ * 透過 ToolsRepository::timestamp() 無條件寫入 c_created_by/c_created_date（既有
+ * CBDB 代碼表慣例欄位），但本表建表時只加了 Laravel 標準 timestamps()、沒有這 4 欄，
+ * 導致 /api/v2/create 對 char-variant-map 一定會因 SQL 錯誤失敗。
+ * 見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 7。
+ */
+return new class () extends Migration {
+    public function up(): void {
+        Schema::table('char_variant_map', function (Blueprint $table) {
+            column_comment($table->string('c_created_by', 255)->nullable(), '建檔者');
+            column_comment($table->dateTime('c_created_date')->nullable(), '建檔時間');
+            column_comment($table->string('c_modified_by', 255)->nullable(), '最後修改者');
+            column_comment($table->dateTime('c_modified_date')->nullable(), '最後修改時間');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('char_variant_map', function (Blueprint $table) {
+            $table->dropColumn(['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date']);
+        });
+    }
+};

--- a/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
@@ -230,9 +230,15 @@ class CharVariantMapService {
 ```
 ```php
 // app/Http/Controllers/OperationsController.php resourceKeyColumns()
-'CHAR_VARIANT_MAP' => ['id'],
+'char_variant_map' => ['id'],
 ```
-（比照既有 `TEXT_CODES`／`NIAN_HAO` 等 Phase B code 表的登錄方式，三處主鍵定義——`config/code_table_mutations.php` 的 `key_columns`、`CompositePrimaryKey::SCHEMAS`、`OperationsController::resourceKeyColumns()`——欄位順序須完全一致，這是 `AGENTS.md`「複合主鍵」一節與既有多張 Phase B 表共同遵守的規則。）
+（比照既有 `TEXT_CODES`／`NIAN_HAO` 等 Phase B code 表的登錄方式，三處主鍵定義——`config/code_table_mutations.php` 的 `key_columns`、`CompositePrimaryKey::SCHEMAS`、`OperationsController::resourceKeyColumns()`——欄位順序須完全一致，這是 `AGENTS.md`「複合主鍵」一節與既有多張 Phase B 表共同遵守的規則。**大小寫例外**：`CompositePrimaryKey::SCHEMAS` 的鍵須用大寫 `CHAR_VARIANT_MAP`（其 lookup 方法內部會 `strtoupper($table)` 正規化再查表），但 `OperationsController::resourceKeyColumns()` 的鍵須用小寫 `char_variant_map`（這裡是直接 `$map[$resource]` 字面值查表、不做大小寫正規化，而 `$resource` 實際上就是 `AbstractCodeTableMutationHandler::tableName()`／`CodeTableCreateHandler` 傳給 `OperationRepository::store()` 的原始表名字串，對本表而言就是小寫 `char_variant_map`）。原計畫草稿曾誤寫成兩處都用大寫，經 review agent／codex 覆核程式碼後確認並修正；之後若再登記新表，這一步都要重新確認兩處各自的大小寫慣例，不能照抄同一種寫法。）
+
+**Step 7 review 階段額外發現並修正兩個 `AbstractCodeTableMutationHandler`（`app/Services/Mutations/AbstractCodeTableMutationHandler.php`）共用基底類別的既存缺陷**（影響所有已登錄 Phase B 表，不只 `char_variant_map`，但是本表的欄位特性第一個踩到）：
+- **`validateFields()` 原本只接受 `string|null`**：`c_strict_excluded` 是本表新增的第一個整數旗標欄（其餘既有表的 `allowed_fields` 清一色是拼音／文字欄），JSON 呼叫端送整數 `0`/`1`（而非字串 `"0"`/`"1"`）會被誤擋 422，與 create 路徑（`CodeTableCreateHandler` 無此型別限制）行為不一致。**初版修正曾對「所有」表的「所有」欄位一律放寬接受 int**（`is_int($value)`），經 codex 覆核指出這會讓其他 12 張既有表（皆為拼音／文字欄）原本合法的「送整數應被拒絕」行為被意外放寬——已修正為新增 `integerFields()` 方法（預設回傳空陣列）＋ `config/code_table_mutations.php` 新增可選欄位 `integer_fields`，只有明確登記在該表 `integer_fields` 內的欄位才接受整數，`char_variant_map` 只登記 `c_strict_excluded` 一欄，不影響本表其他欄位或其他 12 張表仍要求 `string|null` 的既有行為。已補回歸測試（`ApiV2MutateCodeTablesTest::testGanzhiDirectUpdateStillRejectsIntegerValueForTextField`）驗證放寬沒有波及既有表。
+- **`handleDirect()` 的 `DB::transaction(...)` 原本沒有包 `try/catch`**：`c_variant_char` 是本表第一個「非主鍵、但有唯一鍵約束」且被列入 `allowed_fields` 的欄位（其餘既有表的可更新欄位都不帶唯一鍵約束），更新撞到唯一鍵衝突時原本會讓 `QueryException` 直接冒出成 500，而非像 create 路徑那樣友善轉成 409。已比照 `CodeTableCreateHandler::isUniqueConstraintViolation()` 的既有模式，在 `handleDirect()` 補上 try/catch，唯一鍵衝突回 409。
+
+兩項修正都已補上對應回歸測試（`tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php`），並確認既有 12 張 Phase B 表的既有測試（`tests/Feature/ApiV2MutateCodeTablesTest.php`、`ApiV2MutateCodeTableTextCodesTest.php`）不受影響。
 
 **`tier1_fields`/`tier2_fields` 分派說明**：`config/code_table_mutations.php` 的 docblock 明訂 `tier1_fields ∪ tier2_fields` 必須等於 `allowed_fields`（見該檔案第 17 行），且這組欄位是為 §D-6 拼音 v→ü 歸一化設計——tier1 = 保存時後端靜默做 v→ü 轉換的純拼音欄，tier2 = 可能混西文、後端不靜默轉、由前端彈窗讓使用者決定的欄。`char_variant_map` 的 4 個欄位全部**都不是**拼音／羅馬字欄（`c_variant_char`/`c_reference_char` 是漢字、`c_strict_excluded` 是整數、`c_notes` 是自由文字），嚴格來說沒有一個真正符合 tier1 或 tier2 原始設計的欄位語意。**決定**：全部 4 欄位放進 `tier2_fields`（而非 `tier1_fields`），理由：
   - tier1 語意是「後端保存時靜默套用 v→ü 轉換規則」，對非拼音欄套用是語意錯誤，且有極小機率誤傷（例如 `c_notes` 若剛好寫入含小寫 `v` 的文字，靜默轉換可能不是使用者原意）；tier2 語意是「不靜默轉、只在偵測到 v→ü pattern 時彈窗讓使用者選擇」——對這 4 個欄位而言，由於內容本來就不含拼音 pattern，彈窗實務上幾乎不會觸發，是更安全的預設。
@@ -260,3 +266,7 @@ class CharVariantMapService {
 - `VariantCharNormalizer` 類別本身的刪除清理（見前一份文件「不在本次範圍內」，依賴條件已滿足但屬於獨立任務）。
 - `CBDB__TRAD_SIMP_MAP` 繁簡轉換機制（與本表功能層次不同，見前一份文件）。
 - 對既有資料庫裡「已經含有這些異體字」的既有人物/書名記錄做批次回溯更新——本階段只處理「往後新增/修改時」的落地替換，不做歷史資料的批次校正（批次校正若有需要，屬於另一個獨立任務，且需要更謹慎的影響評估，不應該隨這次呼叫點串接一併做）。
+- **本階段只涵蓋 BIOG_MAIN 姓名欄、ALTNAME_DATA 別名欄、TITLE_VARIANT_MAP（書名）三類欄位，未涵蓋其他任意文本錄入入口**（使用者於 goal 執行中途提出、待下一階段評估，本階段刻意不處理）：
+  - Codes UI（`/codes/{table}`、`/app/codes/{table}`）對「所有」代碼表的「所有」文本欄位——目前落地替換只掛在 `char_variant_map` 本身被查詢的三個特定呼叫點，並未掛在 `CodesController` 通用的 `store()`/`update()` 寫入路徑上，也就是說透過 Codes UI 編輯任何其他代碼表（例如 `TEXT_CODES.c_title`、`OFFICE_CODES.c_office_chn` 等）時，若使用者輸入了這 7 個異體字之一，**不會**被落地替換。
+  - 各人物子資源 editor（複合主鍵子資源，如 `BIOG_SOURCE_DATA`／`POSTING_DATA`／`EVENTS_DATA`／`KIN_DATA` 等）中泛用的 `c_notes`／`c_pages` 等自由文字欄位——這些欄位目前完全沒有掛任何落地替換邏輯，使用者若在筆記或頁碼欄位輸入這些異體字，會原樣存入。
+  - 下一階段若要處理，需要先盤點：(1) 哪些欄位屬於「應該落地替換」的範疇（人名/書名等有明確歸一化需求的欄位）vs.「不應該替換」的範疇（例如 `c_notes` 這類引用原始文獻用字、逐字抄錄的欄位，替換後可能反而扭曲史料原貌，需要另外評估是否該用寬鬆或嚴格模式、甚至完全不替換）；(2) 是否要在 `CodesController`／各子資源 mutation handler 的通用寫入路徑上加一個「按欄位類型套用替換」的機制，而非像本階段一樣為每個呼叫點個別手動掛鉤（如果欄位範圍擴大到「所有代碼表所有文本欄位」的量級，個別手動掛鉤的作法會難以維護，值得重新評估是否要換一個更通用的機制，例如寫入前置中介層）。

--- a/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
@@ -185,9 +185,12 @@ class CharVariantMapService {
 ```php
 'char_variant_map' => '異體字落地替換對照表',
 ```
-新增／更新測試（`tests/Feature/CodesControllerAuditTest.php` 或新建對應測試）：
-- 透過 `/app/codes/char_variant_map` UI 新增一筆對照，確認寫入 `audit_log`（比照現行 `CodesController` 對其他表的既有稽核測試模式，不需要新寫稽核邏輯，只需確認註冊後既有機制對這張新表也生效）。
-- 確認 `/app/codes/char_variant_map` 列表頁可正常顯示 7 筆種子資料。
+新增／更新測試（`tests/Feature/CodesCharVariantMapAuditTest.php`，比照 `tests/Feature/CodesControllerAuditTest.php` 既有模式新建）：
+- 透過 `/codes/char_variant_map` UI 新增一筆對照，確認寫入 `audit_log`（比照現行 `CodesController` 對其他表的既有稽核測試模式，不需要新寫稽核邏輯，只需確認註冊後既有機制對這張新表也生效）。
+- 確認 `/codes/char_variant_map` 列表頁可正常顯示 7 筆種子資料。
+
+**副作用（非缺陷，但需明確記錄）**：`config('codes.tables')` 同時也是 Query Playground／Natural Language Query／MCP 唯讀查詢工具的白名單來源（見 `app/Services/QueryPlaygroundService.php`、`NaturalLanguageQueryService.php`、`NlQueryToolsService.php`、`DatabaseSchemaService.php`、`app/Http/Controllers/QueryPlaygroundController.php` 對 `config('codes.tables')` 的讀取）。本步驟把 `char_variant_map` 加進 `codes.tables` 後，這張表會自動一併開放給上述唯讀查詢管道存取——這是預期且可接受的副作用（純參照對照表、無 PII、無風險），沿用現有其他代碼表註冊後的既有行為，不需要額外白名單或授權處理，僅在此明確記錄避免日後誤以為是意外暴露。
+- `resources/lang/zh-TW/codes.php`、`resources/lang/en/codes.php` 的 `table_desc` 陣列須同步加入 `char_variant_map` 對應翻譯（`tests/Feature/CodesControllerTest.php::testCodesTableDescKeysStayInParityWithConfig` 會擋下遺漏，兩份語言檔缺一都會讓該測試失敗）。
 
 ### 步驟 7：受 token API 的機器化寫入管道註冊
 

--- a/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
@@ -1,0 +1,259 @@
+# 異體字對照表 Work Plan（第二階段）：串接 `char_variant_map` 呼叫點
+
+> **前置文件**：[CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md](./CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md)（第一階段，已完成：`char_variant_map` 資料表 schema 設計與 migration）。該文件的「呼叫點串接方向」一節只記錄**方向**，本文件把那一節展開成具體、可逐步驗收的實作步驟，並對其中列出的「待決事項」給出明確決定。
+
+## 背景
+
+`char_variant_map` 表已存在（7 筆種子資料），但目前完全沒有程式碼查詢它——`TITLE_VARIANT_MAP` 仍是 `AdminBatchLoadBookTitlesController` 內建的陣列，BIOG_MAIN／ALTNAME_DATA 寫入路徑完全沒有異體字落地替換。本階段把這些呼叫點改接到 `char_variant_map`，並補上治理面（Codes UI + token API 的可稽核增修管道）。
+
+## 範圍
+
+本文件涵蓋前一份計畫文件「呼叫點串接方向」的全部 5 點，拆成 7 個實作環節（見下方「實作步驟」），每個環節各自過完整 review 才進下一個。**不涉及** `VariantCharNormalizer` 類別本身的刪除清理（那是前一份文件標註的、依賴條件已滿足但仍獨立於本階段之外的另一個任務）。
+
+## 待決事項的決定
+
+### 1. BIOG_MAIN 落地替換的欄位替換順序
+
+前一份計畫文件已標註待決：替換順序是「先替換 `c_surname_chn`/`c_mingzi_chn` 分欄、再組出 `c_name_chn`」還是「只替換組合後的 `c_name_chn`」。
+
+**決定**：採用前者——先替換分欄、再組字。理由：
+- 維持現行 `c_name_chn === c_surname_chn.c_mingzi_chn` invariant，這個 invariant 被 `BiogMainRepository::namesByQuery()`、`c_name_chn` 相關的 LIKE 查詢等多處依賴，破壞它的影響面難以窮舉。
+- `c_surname_chn`/`c_mingzi_chn` 本身也是使用者看得到、可獨立編輯的欄位（表單有各自的輸入框），只替換組合欄會讓表單顯示的姓/名與資料庫組合出的全名不一致，使用者會看到「我沒改姓氏欄，但存檔後全名變了」的困惑局面；分欄替換則兩邊一致。
+
+### 2. BIOG_MAIN create／update 是否用同一個掛鉤點
+
+**決定**：不用同一個掛鉤點，維持 create／update 分開實作（前一份文件已指出兩者不對稱，這裡是延續該結論的具體作法）：
+- Update／proposal 路徑：在 `BiogMainMutationHandler::prepareProposalPayload()` 與 `BiogMainRepository::updateById()` 現有的組字那一行**之前**，各自插入一行「替換 `c_surname_chn`/`c_mingzi_chn`」。
+- Create 路徑：在 `BiogMainRepository::store()` 內，`$data = $request->all()` 之後、`auto_pinyin($data)` 之前，新增一段「若 `c_surname_chn`/`c_mingzi_chn` 存在則替換，並同步重新組出 `c_name_chn`（若客戶端沒有另外組好的話——但為了與 update 路徑行為一致，一律由後端重新組字，不採信客戶端傳來的 `c_name_chn`）」。
+
+  **子決定**：create 路徑要不要無條件由後端重組 `c_name_chn`（即忽略前端傳來的 `c_name_chn`，一律用替換後的 `c_surname_chn`+`c_mingzi_chn` 重新組字）？
+  **決定**：**當請求裡出現 `c_surname_chn` 或 `c_mingzi_chn` 任一分欄鍵時**，是，無條件重組（用 `array_key_exists()` 判斷鍵是否存在，不是判斷值是否為空字串）。理由：這是能保證 create／update 兩條路徑「儲存後 `c_name_chn` 是否含有已落地替換的異體字」行為一致的做法；如果只在「前端沒傳 `c_name_chn`」時才重組，會出現「前端有沒有多送一個欄位」這種前端行為決定後端正規化結果的不一致局面。
+
+  **實作時發現需要修正的例外**：v2 API 的 `BiogMainCreateHandler::ALLOWED_FIELDS`（`app/Services/Mutations/BiogMainCreateHandler.php:33-84`）把 `c_name_chn` 與 `c_surname_chn`/`c_mingzi_chn` 列為三個各自獨立、呼叫端可自由選擇送或不送的欄位——`tests/Feature/ApiV2CreateBiogMainTest.php` 的既有測試就是只送 `c_name_chn`（不送分欄）的真實使用情境，對應「無明確姓氏可拆分的歷史人物」這種資料。若不分情況、永遠假設分欄存在並無條件用兩個分欄相加覆寫 `c_name_chn`，當分欄根本沒出現在請求裡時，`(string) ($data['c_surname_chn'] ?? '')` 會靜默退回空字串，導致 `c_name_chn` 被覆寫成空字串——這不是「重組出正確值」，是把有效資料清空的資料損毀 bug（已於 review 前的測試跑驗中發現並修正，見下方測試小節）。**修正後的規則**：`c_surname_chn`／`c_mingzi_chn` 兩個鍵**只要有任一個**出現在請求裡（不論值是否為空字串），才視為「這次是分欄模式」，套用上方的無條件重組；兩個鍵都不存在時，改為只對 `c_name_chn` 本身做嚴格模式替換，不做任何組字/覆寫。這與「無條件重組」的決定精神並不衝突——「無條件」原本要擋的是「前端傳了分欄卻也傳了不同的 `c_name_chn`、該信哪個」的歧義，不是要在分欄根本不存在時憑空生出一個空字串組合。
+
+### 3. ALTNAME_DATA 的複合主鍵欄位替換
+
+**決定**：在 `AltnameCreateHandler::preprocessCreateData()` 與 `AltnameMutationHandler::preprocessUpdateData()` 內，對 `data['c_alt_name_chn']`（若存在）做嚴格模式替換，不需要額外處理——這兩個掛鉤點都發生在各自 handler 決定「新 PK 為何」**之前**：
+- Update 路徑：已於程式碼確認 `AbstractPersonSubresourceMutationHandler::handle()` 第 135 行呼叫 `preprocessUpdateData()`，早於該方法第 152 行才 dispatch 到 `handleDirect()`，而 `buildNewPk()` 是 `handleDirect()` 內第 212 行才呼叫的——`preprocessUpdateData()` 與 `buildNewPk()` 分屬 `handle()`／`handleDirect()` 兩個方法，但呼叫順序上前者確實早於後者。
+- Create 路徑：對應的是 `AbstractPersonSubresourceCreateHandler::extractPkFromRow()`（呼叫於 `app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php:122`，方法定義於 314 行），不是 `buildNewPk()`（那是 mutation/update handler 的方法名，create handler 沒有這個方法）；`preprocessCreateData()`（119 行呼叫）同樣早於 `extractPkFromRow()`（122 行呼叫）執行，結論一致：替換後的值才是決定 PK 的依據。
+
+所以替換後的值會自然成為新 PK 的一部分，`AltnameMutationHandler::performUpdate()` 既有的 PK 衝突偵測（79-95 行）與 `syncAltnameIndexAfterUpdate()` 的搜尋索引同步也都讀取替換後的 `updateData`，不需要修改這兩段既有邏輯。
+
+**修正（盤點擴大）：ALTNAME_DATA 還有第二條完全獨立的寫入路徑，必須一併掛鉤，否則兩條路徑行為會不一致**：`AltnameCreateHandler`／`AltnameMutationHandler` 是 v2 API 路徑；legacy Blade 路徑（`BasicInformationAltnamesController::store()`／`update()`）**不會**呼叫這兩個 handler，而是各自直接呼叫 `BiogMainRepository::altnameStoreById()`（`app/Repositories/BiogMainRepository.php:3558-3597`）與 `BiogMainRepository::altnameUpdateById()`。這與 BIOG_MAIN 的情況不同——BIOG_MAIN 的 legacy Blade（非眾包分支）與 v2 API 剛好共用同一個 `BiogMainRepository::store()`／`updateById()`，所以掛一次鉤兩邊都受益；但 ALTNAME_DATA 的 legacy Blade 與 v2 API 是**兩份平行、互不相關的實作**，只掛 v2 handler 會讓 legacy Blade 路徑（目前仍是 flag-gated、非死碼，見 `AGENTS.md`）完全沒有落地替換，造成「同一張人物別名資料，走新版 React 頁面存會被替換、走舊版 Blade 頁面存不會被替換」的不一致。**決定**：`altnameStoreById()`（在重複檢查 `DB::table('ALTNAME_DATA')->where(...)` 之前）與 `altnameUpdateById()`（在組出 `$newPk3` 的邏輯——`app/Repositories/BiogMainRepository.php:3611-3615`——之前）也要各自呼叫 `CharVariantMapService::replaceStrict()`，與 v2 handler 的掛鉤點行為對齊。
+
+### 4. `CharVariantMapService` 的介面設計
+
+新增 `app/Services/CharVariantMapService.php`，介面：
+
+```php
+class CharVariantMapService {
+    /**
+     * 寬鬆模式：對整段文字做落地替換，表裡任何一筆都套用（忽略 c_strict_excluded）。
+     *
+     * @return array{text: string, replaced: array<string,string>} text 為替換後文字；
+     *   replaced 為「這次呼叫實際套用了哪些對照」（僅列出輸入文字裡真的出現過的異體字，
+     *   不是整張表），鍵為異體字、值為參考字，例如 ['峯' => '峰']。呼叫端據此決定要不要
+     *   顯示非阻塞提示；不需要提示的呼叫端可以只取 ['text']，忽略 replaced。
+     */
+    public static function replaceLenient(string $text): array;
+
+    /**
+     * 嚴格模式：對整段文字做落地替換，只套用 c_strict_excluded = 0 的記錄。
+     *
+     * @return array{text: string, replaced: array<string,string>} 同上。
+     */
+    public static function replaceStrict(string $text): array;
+
+    /** 清除靜態快取（測試用，比照 VariantCharNormalizer::reset() 慣例）。 */
+    public static function reset(): void;
+
+    /**
+     * 把 replaced 組成非阻塞通知文字（待決事項 5）。實作時發現 BIOG_MAIN
+     * update／create 與 legacy Blade 各自的呼叫端都需要同一份措辭，抽成這個共用
+     * 方法，避免重複程式碼各自維護造成用語不一致（原始介面設計未列出，實作階段
+     * 新增）。
+     *
+     * @param array<string,string> $replaced
+     * @return array<int,string> 空陣列代表無需通知
+     */
+    public static function buildNotices(array $replaced): array;
+}
+```
+
+**回傳形狀的決定**：兩個方法都回傳 `array{text, replaced}` 而非單純 `string`，是為了同時滿足「落地替換」與「讓錄入者知悉」兩個需求（後者見下方「待決事項 5」）——`replaced` 只列出這次呼叫**實際命中**的對照（用輸入文字逐一檢查 map 裡的異體字是否出現，而非回傳整張表），呼叫端可以直接用 `!empty($replaced)` 判斷要不要組出通知文字，不需要自己重新比對前後字串差異。
+
+- 內部用一個靜態陣列快取（`$lenientMap`、`$strictMap`），第一次呼叫時各自查一次 `char_variant_map` 全表（`replaceLenient` 用全部記錄，`replaceStrict` 用 `WHERE c_strict_excluded = 0` 的子集），之後同一個 request 生命週期內重複呼叫不重複查表。快取邏輯比照 `VariantCharNormalizer::$loaded`/`ensureLoaded()` 的既有慣例，但這裡快取的是「兩個表全量已知不大（目前 7 筆，預期成長也是以十為單位）」的資料表，不做分頁或限制筆數。
+- 用 `strtr($text, $map)` 做替換（與 `AdminBatchLoadBookTitlesController::standardizeTitleVariants()` 現行做法一致，`strtr` 對多字元 key 的陣列會自動處理成單一字元對單一字元的替換，這裡每個 key 恰好都是單一 CJK 字元，行為等同逐字元替換）；`replaced` 則另外用一次簡單迴圈（檢查輸入文字是否包含每個 map key）算出，不影響 `strtr` 本身的效能特性。
+- 不做 request-scoped DI／不做 facade，維持靜態方法呼叫風格，與 `VariantCharNormalizer`、`PinyinDictionary`、`BracketNormalizer` 等現有工具類別的呼叫慣例一致（呼叫端都是 `XxxService::method()`，不注入建構子）。
+- 測試時透過 `CharVariantMapService::reset()` 清快取，並在 `RefreshDatabase` 環境下對 `char_variant_map` 表插入/修改測試資料後呼叫 `reset()` 確保下次呼叫重新查表。
+
+### 5. 落地替換通知機制（非阻塞，不彈窗）
+
+**背景**：步驟 3／4／5（BIOG_MAIN、ALTNAME_DATA）是全新行為，上線後任何人物姓名／別名含這些異體字，儲存時會被**靜默**改寫。使用者體驗上應該讓錄入者至少知悉「系統幫你把字改了」，但**不需要**像既有 `PinyinUmlautConfirmDialog`（Tier 2 v→ü 彈窗）那樣要求使用者做決定——落地替換是無條件套用、沒有「轉換／保留」選項，跳出一個要使用者選擇的 modal 反而是誤導（看起來像可以拒絕，實際上不行）。因此本次採用**非阻塞、免互動**的提示通道，比照現有 codebase 已經在用的「flash 一則訊息、幾秒後自動消失」慣例，不新增彈窗或新的 UI 元件。
+
+**各介面的通知通道決定**：
+
+1. **Legacy Blade（`BasicInformationController`／`BasicInformationAltnamesController` 的 direct 儲存路徑）**：沿用既有 `laracasts/flash` 套件的 `info` 等級（`flash($msg, 'info')`），與現有 `flash(..., 'success'/'error')` 呼叫並列（見 `app/Http/Controllers/BasicInformationController.php` 既有多處 `flash()` 呼叫），渲染為 Bootstrap `alert-info`（`vendor/laracasts/flash/src/views/message.blade.php`，兩個 layout 都已 `@include`），非 modal、不需要新元件。若 `$replaced` 非空，組出類似「已將姓名中的「峯」正規化為「峰」」的訊息，`flash($msg, 'info')`。
+
+2. **v2 JSON API（`BiogMainMutationHandler`、`AltnameCreateHandler`、`AltnameMutationHandler` 的 direct／proposal 回應）**：現行成功回應是 `{ok, resource, mode, operation, result}` 這個 envelope（`AbstractPersonSubresourceMutationHandler.php` 285-298 行、350-358 行附近），目前沒有任何 `notices`／`warnings` 欄位。**新增**一個**可選**（僅在有替換時才出現）的頂層 `notices` 陣列欄位，例如 `{"ok": true, ..., "notices": ["c_surname_chn：「峯」已正規化為「峰」"]}`。這是**新增欄位**、不影響既有回應結構，既有前端呼叫端若不讀取 `notices` 也不受影響（向後相容）。
+
+3. **前端編輯器（`BasicInfoEditor.tsx`、`AltnameEditor.tsx`）**：兩個元件都已有「非阻塞、自動消失」的既有慣例可以直接複用，不需要新元件：
+   - `BasicInfoEditor.tsx` 已有 `pinyinKinshipHint`（96 行）這個**非阻塞提示**的先例（400 行渲染為 `<div style={gWarnStyle}>...</div>`）。**注意**：需要使用者做決定的 `umlautPrompt` 彈窗機制**不在這個檔案裡**——`umlautPrompt` 實際定義在 `AltnameEditor.tsx`（90 行，213-231 行渲染為真正的 modal，`role="dialog" aria-modal="true"`），`BasicInfoEditor.tsx` 本身目前沒有任何彈窗式拼音確認機制可以對照；「非阻塞 vs. 需要使用者決定」的對比案例是跨檔案的（`BasicInfoEditor.tsx` 的 `pinyinKinshipHint` vs. `AltnameEditor.tsx` 的 `umlautPrompt`），不是同一檔案內兩種機制並存。新增邏輯：儲存成功後，若回應 `notices` 非空，比照 `pinyinKinshipHint` 的模式設一個新的 state（例如 `variantReplacedNotice`），渲染同樣的 `gWarnStyle` 提示列，可以跟 `flashSaved()`（86 行）的既有訊息一樣幾秒後自動消失，或維持顯示直到下次儲存（比照 `pinyinKinshipHint` 目前的行為，實作時二擇一，不需要新設計一套顯示邏輯）。
+   - `AltnameEditor.tsx` 已有同構的 `message`/`flashSaved()`（68-69 行）**非阻塞**訊息機制，做法比照。
+
+4. **書名批次匯入（`AdminBatchLoadBookTitlesController::store()`）**：這裡是寬鬆模式（`CharVariantMapService::replaceLenient()`），套用點在 `parseEntries()` 組 `$rows[]` 那一行（目前呼叫 `standardizeTitleVariants()`）。批次匯入的結果頁本來就會列出每一筆匯入結果（`$results[]`，132-174 行，含 `title`／`title_pinyin` 等欄位），**新增**一個 `variant_replacements` 欄位到每筆 `$results[]`（例如 `[['from' => '峯', 'to' => '峰']]`，無替換則為空陣列），交給既有的批次結果頁（`with('batch_results', $results)`）逐列顯示——這本來就是非互動的列表頁，不需要額外彈窗或提示元件，只是多顯示一欄／一個小標籤。
+
+**這個通知機制不影響步驟 3／4／5 的核心邏輯**，純粹是「呼叫 `CharVariantMapService` 後，把回傳的 `replaced` 接到既有通知通道」，四個介面各自的接法可以在對應步驟（步驟 2、3、4、5）內各自完成，不需要額外開一個步驟。
+
+## 實作步驟（每步完成後跑 review 機制才能進下一步）
+
+> Review 機制同前一份文件：每個步驟完成後，先派一組會讀程式碼與讀改動的 review agent 檢查，直到沒有嚴重 issue；再用 `codex exec --dangerously-bypass-approvals-and-sandbox`（PowerShell + `Write-Output "..." |` 管道傳 prompt）做第二輪檢查，直到沒有嚴重 issue，才進下一步。**本輪要求：review 全部通過後先不 commit，待使用者確認再進行版本控制操作。**
+
+### 步驟 0：本文件
+
+先過 review 機制（review agent + codex）確認本文件的決定與既有程式碼流程描述無誤，再進入下一步。
+
+### 步驟 1：`CharVariantMapService`
+
+新增 `app/Services/CharVariantMapService.php`（見上方介面設計，`replaceLenient()`／`replaceStrict()` 回傳 `array{text, replaced}`）與對應單元測試 `tests/Unit/CharVariantMapServiceTest.php`（仿 `tests/Unit/VariantCharNormalizerTest.php` 的測試風格），至少涵蓋：
+- 寬鬆模式：`c_strict_excluded=1` 的「峯」也會被替換成「峰」，且回傳的 `replaced` 含 `['峯' => '峰']`。
+- 嚴格模式：「峯」不被替換（`text` 保持原樣、`replaced` 不含「峯」這個鍵），其餘 6 筆會被替換且各自出現在 `replaced`。
+- `replaced` 只列出輸入文字裡「實際出現過」的異體字：例如輸入只含「峯」與「淸」兩個異體字時，`replaced` 只有這兩筆，不是整張表 7 筆。
+- 快取：修改資料庫後、`reset()` 前後查詢結果應有差異（驗證快取確實生效、`reset()` 確實清除）。
+- 空字串／不含任何對照字元的文字：`text` 原樣返回，`replaced` 為空陣列。
+
+### 步驟 2：`AdminBatchLoadBookTitlesController::TITLE_VARIANT_MAP` 改接
+
+移除 `TITLE_VARIANT_MAP` 常數與 `standardizeTitleVariants()` 內的 `strtr()` 呼叫，改為呼叫 `CharVariantMapService::replaceLenient()`（保留其 `text` 部分供 `parseEntries()` 組 `$rows[]` 用，`replaced` 部分依「待決事項 5」第 4 點存進該筆 `$row['variant_replacements']`，最終在 `store()` 132-174 行組 `$results[]` 時一併帶出）。更新／新增測試（`tests/Feature/AdminBatchLoadBookTitlesTest.php`），確認：
+- 現行 3 筆書名替換（峯→峰、靑→青、頴→穎）行為不變。
+- 新增的「淸→清」「厰→廠」在書名匯入時現在**也會**被替換（這是本次真正的行為擴張——這兩筆原本不在 `TITLE_VARIANT_MAP` 裡）。
+- 「愼→慎」「槀→稿」（原僅用於拼音的 2 筆）現在**也會**改寫書名本身（這是寬鬆模式的定義：表裡任何一筆都套用，不分原本是哪個舊機制的資料）。
+- 批次匯入結果（`$results[]`）裡，發生替換的列有非空 `variant_replacements`（例如 `[['from' => '峯', 'to' => '峰']]`），沒發生替換的列 `variant_replacements` 為空陣列；批次結果頁（Inertia）能正確渲染這個欄位（哪怕只是簡單文字列出，不需要特別設計 UI）。
+
+### 步驟 3：BIOG_MAIN update／proposal 路徑改接
+
+依「待決事項 1」的決定，在 `BiogMainMutationHandler::prepareProposalPayload()`（`app/Services/Mutations/BiogMainMutationHandler.php:196-200`）與 `BiogMainRepository::updateById()`（`app/Repositories/BiogMainRepository.php:246`）組字那一行之前，各自對 `c_surname_chn`/`c_mingzi_chn` 呼叫 `CharVariantMapService::replaceStrict()`。依「待決事項 5」，把兩個呼叫回傳的 `replaced` 合併後接上通知通道：v2 API direct／proposal 回應加上 `notices` 欄位；legacy Blade 路徑（`BasicInformationController::update()`，同檔案 1774 行呼叫 `biogMainRepository->updateById($request, $id)`，即本步驟掛鉤的同一個方法）比照該方法既有的 `flash(..., 'info')` 慣例（1778 行「無實質更新，資料未變更」即為一例）補上一則 `flash($msg, 'info')`；`BasicInfoEditor.tsx` 讀取 `notices` 並比照 `pinyinKinshipHint` 顯示非阻塞提示列。（訊息組字邏輯最初各自寫在 `BiogMainMutationHandler`/`BasicInformationController` 內；步驟 4 實作時發現同一段邏輯要在第三處重複，已回頭抽成 `CharVariantMapService::buildNotices()` 共用方法，見「待決事項 4」補充，步驟 3 的既有測試不受影響、行為不變，僅程式碼去重。）
+
+**實作時發現的第三個掛鉤點（原計畫未列出）**：legacy Blade 的提案路徑（`action=proposal`，`BasicInformationController::update()` 1743-1772 行 → `BasicInformationProposalController::proposalUpdateWithPk()` → `doProposalUpdate()`）**不會**呼叫 `BiogMainMutationHandler::prepareProposalPayload()`，而是走這條 controller 自己的 `normalizePayloadForTable()`（`app/Http/Controllers/BasicInformationProposalController.php:490-508`，這裡本來就有 `BIOG_SOURCE_DATA`／`ASSOC_DATA` 的逐表特例，屬於既有慣例）。這與 ALTNAME_DATA 發現的情況同構：若只掛 v2 API 的 `prepareProposalPayload()`，legacy Blade 提案路徑會漏掉異體字落地替換，造成「同一份輸入，走 v2 API 提案會替換、走 legacy Blade 提案不會替換」的不一致。**已修正**：在 `normalizePayloadForTable()` 新增 `$table === 'BIOG_MAIN'` 分支，複製與 `prepareProposalPayload()`／`updateById()` 相同的「先替換分欄、再組 `c_name_chn`」邏輯（`BasicInformationController::update()` 1748 行本身也有一份更早、未替換的組字邏輯，但 `normalizePayloadForTable()` 在更後面執行、會用替換後的值覆蓋掉，順序上不構成問題）。這個掛鉤點沒有額外的 notice 需求（`doProposalUpdate()` 已經有「已提交修改提案，等待管理員審核」的 `flash(..., 'info')`，未疊加異體字專屬訊息，屬於接受的最小實作）。
+
+新增／更新測試（`tests/Feature/ApiV2MutateTest.php`、`tests/Feature/BiogMainProposalTest.php`、`tests/Feature/BiogMainBasicInfoNameMergeTest.php`、`tests/Feature/BasicInformationUpdateTest.php`）：
+- 更新一筆人物，姓氏或名字含「峯」：因 `c_strict_excluded=1`，儲存後 `c_surname_chn`/`c_mingzi_chn`/`c_name_chn` 都仍是「峯」，不被替換，回應／flash 不出現任何替換通知。
+- 更新一筆人物，姓氏或名字含「淸」：儲存後三個欄位都變成「清」，且 `c_name_chn === c_surname_chn.c_mingzi_chn` 成立；v2 API 回應含 `notices`（提及「淸」→「清」），legacy Blade 直接儲存路徑則觸發對應的 `flash(..., 'info')`。
+- Proposal 模式（v2 API）同上，驗證 `prepareProposalPayload()` 產出的 payload，以及 proposal 回應的 `notices`。
+- Proposal 模式（legacy Blade，`action=proposal`）：驗證 `normalizePayloadForTable()` 的替換結果同樣進了 `operations.resource_data`，且與 v2 API 提案結果一致（同一份輸入不會因為走哪條路徑而有不同落地結果）。
+- 4 個既有測試檔（`ApiV2MutateTest`、`BiogMainProposalTest`、`BiogMainBasicInfoNameMergeTest`、`BasicInformationUpdateTest`）原本手動建表的 setUp 都需要補上 `char_variant_map` 表與 7 筆種子資料（比照 migration），否則 `updateById()`／`normalizePayloadForTable()` 查詢該表會因表不存在而整批噴錯。
+
+### 步驟 4：BIOG_MAIN create 路徑改接
+
+依「待決事項 2」的決定，在 `BiogMainRepository::store()`（`app/Repositories/BiogMainRepository.php:353-365`）內 `$data = $request->all()` 之後、`auto_pinyin($data)` 之前，新增替換邏輯，依「待決事項 2」修正後的規則分兩種情況：`c_surname_chn`／`c_mingzi_chn` 兩鍵**任一個**存在於請求裡（`array_key_exists()`，不是判斷空字串）時，替換兩個分欄並無條件重組 `c_name_chn`；兩鍵都不存在時，只對 `c_name_chn` 本身做替換，不組字、不覆寫。**`store()` 回傳形狀需要跟著調整，才能把 `replaced` 傳給呼叫端**：`store()`（`app/Repositories/BiogMainRepository.php:353-379`）目前回傳 `DB::transaction()` 內建立的 `BiogMain` model 實例（`$flight`），沒有現成通道夾帶額外資訊。**決定**：把回傳值改成 `['model' => $flight, 'replaced' => $replaced]`（陣列，取代單一 model 實例），並同步修改兩個既有呼叫端解構這個新形狀：
+- v2 API：`BiogMainCreateHandler::handle()`（`app/Services/Mutations/BiogMainCreateHandler.php:151`，`$flight = $this->biogMainRepository->store($proxy);`）——改為 `['model' => $flight, 'replaced' => $replaced] = $this->biogMainRepository->store($proxy);`，後續 156 行 `Schema::hasTable(...)` 與 `reindexPerson($flight)` 改用解構出的 `$flight`；`replaced` 併入 JSON 回應的 `notices` 欄位。
+- Legacy Blade：`BasicInformationController::store()`（同檔案 1605 行，`$flight = $this->biogMainRepository->store($request);`）——同樣改為解構寫法，`replaced` 非空時呼叫 `flash($msg, 'info')`。
+
+這是本步驟範圍內的必要連鎖修改（`store()` 只有這兩個呼叫端，已於前面「呼叫點串接方向」與本文件盤點過，沒有第三個呼叫端），不需要另外調查。
+
+新增／更新測試（`tests/Feature/ApiV2CreateBiogMainTest.php`、`tests/Unit/BiogMainRepositoryTest.php`）：
+- 新增人物，姓氏或名字含「峯」：不被替換。
+- 新增人物，姓氏或名字含「淸」：`c_surname_chn`/`c_mingzi_chn`/`c_name_chn` 皆被替換成「清」。
+- 新增人物，前端刻意送一個與「替換後分欄組字結果」不同的 `c_name_chn`：驗證後端仍以重組結果為準（覆蓋前端送來的值），確認「無條件重組」的決定確實生效。
+- Legacy Blade 路徑（`BasicInformationController::store()`）**非眾包使用者**分支走同一個 `BiogMainRepository::store()`（`app/Http/Controllers/BasicInformationController.php:1603-1605`），不需要另開測試，但需在 review 時確認沒有在 `store()` 之外另有一份重複的組字邏輯繞過這個掛鉤點。
+
+  **已知缺口（本階段不處理，僅記錄）**：`BasicInformationController::store()` 對**眾包使用者**（`Auth::user()->isCrowdsourcingUser()`）有獨立分支（同檔案 1596-1602 行）——這條分支完全不呼叫 `BiogMainRepository::store()`，只呼叫 `operationRepository->store(..., 'BIOG_MAIN', ..., $data, '', 2)` 把整包 `$data` 記成一筆待審 operation（`c_status=2` 眾包待審），從未寫入 `BIOG_MAIN` 本身。也就是說眾包使用者新增人物時，本步驟新增的異體字落地替換邏輯**完全不會被觸發**——這批資料要等到管理員審核／回填時才可能落地（回填路徑不在本次盤點範圍內，需要另外確認回填時是否經過 `store()` 或其他路徑）。這是本階段刻意不處理的已知缺口，不在本次「BIOG_MAIN create 路徑」的驗收範圍內，若日後要補齊，需要另外盤點眾包審核回填的實際寫入路徑再評估掛鉤點。
+
+### 步驟 5：ALTNAME_DATA create／update 路徑改接
+
+依「待決事項 3」，在 `AltnameCreateHandler::preprocessCreateData()`（`app/Services/Mutations/AltnameCreateHandler.php:61-71`）與 `AltnameMutationHandler::preprocessUpdateData()`（`app/Services/Mutations/AltnameMutationHandler.php:61-74`）內，對 `data['c_alt_name_chn']`（若存在）呼叫 `CharVariantMapService::replaceStrict()`。
+
+**同時處理「待決事項 3」修正段落記錄的第二條寫入路徑**：`BiogMainRepository::altnameStoreById()`（`app/Repositories/BiogMainRepository.php:3558-3597`，`BasicInformationAltnamesController::store()` 呼叫）與 `BiogMainRepository::altnameUpdateById()`（`BasicInformationAltnamesController::update()` 呼叫）也要各自對 `c_alt_name_chn` 呼叫 `CharVariantMapService::replaceStrict()`——`altnameStoreById()` 掛鉤點在 3564 行 `BracketNormalizer::normalizeAltname($data)` 之後、3565 行重複檢查 `DB::table('ALTNAME_DATA')->where(...)` 之前（讓重複檢查看到的是替換後的值，避免替換前後各自查出不同的重複判定結果）；`altnameUpdateById()` 的掛鉤點在組出 `$newPk3` 的邏輯（`app/Repositories/BiogMainRepository.php:3611-3615`）之前——該方法 3604 行取得 `$data = $request->all()`，3608 行 `BracketNormalizer::normalizeAltname($data)` 之後即可插入替換呼叫，早於 3611 行組 `$newPk3` 與 3616-3625 行的衝突檢查（`if ($newPk3 !== $pk) { ... 查 ALTNAME_DATA 是否已有相同 3-key ... }`），確保衝突檢查用的是替換後的值。
+
+依「待決事項 5」，四個掛鉤點（v2 API 的 create／update、legacy Blade 的 create／update）都要把 `CharVariantMapService::replaceStrict()` 回傳的 `replaced` 接上對應通知通道：v2 API 回應加 `notices`（實作時發現 `AltnameCreateHandler`/`AltnameMutationHandler` 繼承的抽象基底類別把回應結構固定寫在 `handleDirect()`/`handleProposal()` 內，子類無法在建構時插入額外欄位，因此新增 `CharVariantMapService::withNotices(JsonResponse, array): JsonResponse` 共用方法，對已組好的 `JsonResponse` 事後 decode／重新包裝加入 `notices`，僅在狀態碼 200 時套用，避免把 409 等錯誤回應也誤標成功替換）；legacy Blade 的 `BasicInformationAltnamesController::store()`／`update()` 比照既有 `flash(..., 'success'/'error')` 慣例（85-153、224-296 行附近）補上 `flash($msg, 'info')`；`AltnameEditor.tsx` 讀取 `notices` 並比照既有 `message`/`flashSaved()`（68-69 行）顯示非阻塞提示。
+
+**實作時發現的第四個掛鉤點（原計畫未列出）**：`BasicInformationAltnamesController` 除了 resource 路由的 `update()` 外，還有一個獨立的查詢參數模式方法 `updateQuery()`（`routes/web.php:169-170` 註冊為 `basicinformation.altnames.update.query`，供 `/basicinformation/{id}/altnames/update?c_personid=...&c_alt_name_chn=...` 這種以 query string 帶 PK 的請求使用），內部同樣呼叫 `BiogMainRepository::altnameUpdateById()`，是與 `update()` 平行的第三個呼叫端。**修正前的既有邏輯還有一個獨立於本計畫的潛在 bug**：`update()`／`updateQuery()` 在更新後決定要不要同步 `CBDB__NAME_FTS` 搜尋索引時，原本都重新讀取 `$request->all()`（替換前的原始輸入）來判斷「名字是否變更」與「該索引哪個值」，而不是用 `altnameUpdateById()` 回傳的 `$newPk`（已含落地替換後的值）——這代表即使資料庫裡的 `ALTNAME_DATA.c_alt_name_chn` 已經正確替換，搜尋索引仍可能被建成替換前的舊字形，兩者不一致。**已一併修正**：兩個方法的索引同步邏輯改用 `$newPk['c_alt_name_chn']`/`$newPk['c_alt_name_type_code']`（信任 repository 回傳的權威值），不再重新讀取 `$request->all()`；`update()` 額外透過 `$request->input('c_alt_name_chn')` 對提交值單獨呼叫一次 `CharVariantMapService::replaceStrict()`（快取命中、無額外查表成本）取得 `replaced` 供 flash 訊息使用（`altnameUpdateById()`／`altnameStoreById()` 的既有回傳形狀受 `CompositePrimaryKey::buildUrl()` 以 `http_build_query()` 組 URL 查詢字串的限制，不能塞入陣列型別的 `replaced` 值，否則會把陣列序列化進 URL；`altnameStoreById()` 的回傳值不受此限制，改為直接在回傳陣列裡多帶一個 `__variant_replaced` key，於 `insert()` 呼叫**之後**才合併進去，避免被誤寫進資料表本身）。
+
+新增／更新測試：
+- v2 API（`tests/Feature/ApiV2CreateAltnameTest.php`、`tests/Feature/ApiV2MutateAltnameTest.php`）：
+  - 新增別名「峯□」：不被替換。
+  - 新增別名「淸□」：被替換成「清□」，回應含 `notices`。
+  - 更新別名的 `c_alt_name_chn` 為含「淸」的新值：確認替換後的值成為新 PK 的一部分，回應含 `notices`。
+  - 更新別名時，替換後的新 `c_alt_name_chn`+`c_alt_name_type_code` 與同一人物下另一筆既有別名衝突：確認既有的 PK 衝突偵測（`AltnameMutationHandler::performUpdate()` 79-95 行）仍正確觸發（用替換後的值判斷衝突，而非替換前的原始輸入）。
+- Legacy Blade（`tests/Feature/BasicInformationAltnamesControllerTest.php`，涵蓋 `store()`／`update()`／`updateQuery()` 三個方法）：
+  - 透過 `store()`／`updateQuery()` 新增／更新含「淸」的別名，確認 `ALTNAME_DATA` 落地的是替換後的值（而非 v2 API 才會替換、legacy Blade 路徑仍是原字），且觸發對應 `flash(..., 'info')`。這條測試特別驗證「待決事項 3」修正段落指出的問題已解決：同一份輸入，走 legacy Blade 與走 v2 API，`ALTNAME_DATA` 最終落地的 `c_alt_name_chn` 必須一致（都已替換），不能一個換一個沒換。
+  - 透過 `updateQuery()` 更新別名為含「淸」的新值，且與同人物下另一筆既有別名（已是替換後的字形）衝突：確認既有的括號衝突偵測邏輯用替換後的值判斷、正確擋下並回 flash 錯誤。
+
+### 步驟 6：`config/codes.php` 註冊（Codes UI 可增修）
+
+在 `config/codes.php` 的 `'tables'` 陣列加入：
+```php
+'char_variant_map' => '異體字落地替換對照表',
+```
+新增／更新測試（`tests/Feature/CodesControllerAuditTest.php` 或新建對應測試）：
+- 透過 `/app/codes/char_variant_map` UI 新增一筆對照，確認寫入 `audit_log`（比照現行 `CodesController` 對其他表的既有稽核測試模式，不需要新寫稽核邏輯，只需確認註冊後既有機制對這張新表也生效）。
+- 確認 `/app/codes/char_variant_map` 列表頁可正常顯示 7 筆種子資料。
+
+### 步驟 7：受 token API 的機器化寫入管道註冊
+
+在 `config/code_table_writes.php` 的 `'tables'` 加入：
+```php
+'char_variant_map' => [
+    'resource' => 'char-variant-map',
+    'aliases' => ['char-variant-map', 'char_variant_map', 'charvariantmap'],
+    'table' => 'char_variant_map',
+    'display_name' => '異體字落地替換對照表',
+    'key_column' => 'id',
+    'auto_assign_id' => true,
+    'allowed_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+],
+```
+在 `config/code_table_mutations.php` 加入對應 update 定義：
+```php
+[
+    'resource' => 'char_variant_map',
+    'table' => 'char_variant_map',
+    'aliases' => ['char_variant_map', 'char-variant-map', 'charvariantmap'],
+    'display_name' => '異體字落地替換對照',
+    'key_columns' => ['id'],
+    'allowed_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+    'tier1_fields' => [],
+    'tier2_fields' => ['c_variant_char', 'c_reference_char', 'c_strict_excluded', 'c_notes'],
+],
+```
+**`aliases` 須與 `code_table_writes.php` 的 create/delete 定義同步**：`code_table_writes.php` 側的 canonical resource 是 `char-variant-map`（連字號），`aliases` 含 `char-variant-map`／`char_variant_map`／`charvariantmap` 三種寫法；`code_table_mutations.php` 側（update）若只登記 `char_variant_map` 一種別名，會讓「用 create 那個 resource 字串打 update」的呼叫方拿到 501（`MutationController` 只做小寫正規化，不做連字號／底線互轉）。因此上面的 `aliases` 三種寫法都要列，與 create/delete 定義完全對齊，不能各自只挑一種。
+
+**Step 7 還需要同步登記主鍵，否則 update API 會失敗**：`ConfigCodeTableMutationHandler` 走 `AbstractCodeTableMutationHandler::handle()`，內部會呼叫 `CompositePrimaryKey::validateOrFail($targetPk, $table)`（`app/Support/CompositePrimaryKey.php`），要求該表已在 `CompositePrimaryKey::SCHEMAS` 登錄、且欄位與 `config/code_table_mutations.php` 的 `key_columns` 完全一致。因此除了上面兩個 config，本步驟還要新增：
+```php
+// app/Support/CompositePrimaryKey.php SCHEMAS 陣列
+'CHAR_VARIANT_MAP' => [
+    'id',
+],
+```
+```php
+// app/Http/Controllers/OperationsController.php resourceKeyColumns()
+'CHAR_VARIANT_MAP' => ['id'],
+```
+（比照既有 `TEXT_CODES`／`NIAN_HAO` 等 Phase B code 表的登錄方式，三處主鍵定義——`config/code_table_mutations.php` 的 `key_columns`、`CompositePrimaryKey::SCHEMAS`、`OperationsController::resourceKeyColumns()`——欄位順序須完全一致，這是 `AGENTS.md`「複合主鍵」一節與既有多張 Phase B 表共同遵守的規則。）
+
+**`tier1_fields`/`tier2_fields` 分派說明**：`config/code_table_mutations.php` 的 docblock 明訂 `tier1_fields ∪ tier2_fields` 必須等於 `allowed_fields`（見該檔案第 17 行），且這組欄位是為 §D-6 拼音 v→ü 歸一化設計——tier1 = 保存時後端靜默做 v→ü 轉換的純拼音欄，tier2 = 可能混西文、後端不靜默轉、由前端彈窗讓使用者決定的欄。`char_variant_map` 的 4 個欄位全部**都不是**拼音／羅馬字欄（`c_variant_char`/`c_reference_char` 是漢字、`c_strict_excluded` 是整數、`c_notes` 是自由文字），嚴格來說沒有一個真正符合 tier1 或 tier2 原始設計的欄位語意。**決定**：全部 4 欄位放進 `tier2_fields`（而非 `tier1_fields`），理由：
+  - tier1 語意是「後端保存時靜默套用 v→ü 轉換規則」，對非拼音欄套用是語意錯誤，且有極小機率誤傷（例如 `c_notes` 若剛好寫入含小寫 `v` 的文字，靜默轉換可能不是使用者原意）；tier2 語意是「不靜默轉、只在偵測到 v→ü pattern 時彈窗讓使用者選擇」——對這 4 個欄位而言，由於內容本來就不含拼音 pattern，彈窗實務上幾乎不會觸發，是更安全的預設。
+  - 滿足該檔案宣告的 `tier1_fields ∪ tier2_fields = allowed_fields` 硬性 invariant，不需要新增例外分支。
+  - 對 `php artisan cbdb:migrate-code-pinyin-v --tables=all` 批次遷移工具的影響侷限且可預期：以 `--tier=tier1`（或未指定 `--tier` 時的預設批次）執行時，`columnsForTier($def, 'tier1')` 對 `char_variant_map` 回傳空陣列，指令會 `continue` 跳過（見 `app/Console/Commands/MigrateCodeTablePinyinV.php:72-75`），完全不產生報告項目。但明確以 `--tier=tier2` 或 `--tier=all` 執行時，**確實會**掃描到這 4 個非拼音欄——目前種子資料 7 筆 `c_notes` 裡有 5 筆分別引用了 `VariantCharNormalizer`／`TITLE_VARIANT_MAP` 這類含大寫 `V` 的類別/常數名稱，會被 `CodeTablePinyinScanner`（`app/Services/Pinyin/CodeTablePinyinScanner.php:34-61`）的 `LIKE '%v%'` 預篩選中，經 `PinyinUmlaut::normalize()` 判定不符合拼音轉換規則後歸類進 `otherVs`（安全網清單，供人眼確認，非資料異動候選）。**這不是本表真的有內容跑歷史留存 v→ü 轉換需求，只是變數/類別名稱字面剛好含 `V`**——預期 `mutations`（實際會被改寫的候選）恆為 0 筆，但 `otherVs`（需人工過目、確認無需轉換）不會是 0，執行 `--tables=all` 的人需要知道這是預期內的雜訊，不是本表資料有問題。
+
+新增測試（仿 `tests/Feature/ApiV2MutateCodeTableTextCodesTest.php` 對 `TEXT_CODES` 的測試結構，改為對 `char_variant_map`）：
+- `/api/v2/*` create／update 可正常運作，並各自寫入 `operations` + `audit_log`。**delete「成功」不在測試範圍內，但需要補一則 delete 恆回 403 的負向回歸測試**：`CodeTableDeleteHandler::handle()`（`app/Services/Mutations/CodeTableDeleteHandler.php:44-49`）目前對**所有**已註冊的 code 表一律回傳 403（「代碼表刪除已停用（防止級聯刪除人物資料）」），這是系統性的既有安全閘門，不是針對特定表的開關，`char_variant_map` 註冊進 `code_table_writes.php` 後同樣會被這道閘門擋下、與其他表行為一致。因此本表的 token API 事實上只開放 create／update，delete 端點存在但恆 403——測試要驗證「delete 回 403」這個負向行為（確認閘門對新表同樣生效），而不是嘗試驗證「delete 成功」，且這是預期行為，不需要（也不應該）為了讓 char_variant_map 可刪除而去鬆綁這道全域閘門。
+- 驗證 create 時 `c_variant_char` 唯一鍵衝突會被正確擋下並回傳合理錯誤（而非資料庫層 500）。
+
+## 風險與待決事項（延續自前一份文件、本階段新增）
+
+- **`CharVariantMapService` 的行程內快取（per-request static cache）在同一個 PHP-FPM worker 跨請求間可能殘留舊資料**：與 `VariantCharNormalizer::$loaded` 的既有模式相同（該類別也是行程內快取、從未過期），這是專案既有慣例、非本次新增風險，但因為 `char_variant_map` 未來會透過 Codes UI 被管理員頻繁增修（不像 `VariantCharNormalizer::$fallbackMap` 是寫死陣列），快取陳舊的實際影響面更大：管理員在 Codes UI 新增一筆對照後，同一個長駐 worker 處理的下一個請求可能仍讀到舊快取，直到該 worker 重啟或收到新的 PHP 請求觸發類別重新載入（若部署方式是 opcache + 短生命週期 worker，此問題輕微；若是常駐 worker，需要額外評估）。**本階段先比照 `VariantCharNormalizer` 的既有慣例、不特別處理**；如果日後發現快取陳舊造成實際問題，可另外評估在 `CodesController` 的 `char_variant_map` update／destroy 路徑呼叫 `CharVariantMapService::reset()`，或改用 request-scoped 而非行程內快取。
+- **步驟 2（TITLE_VARIANT_MAP 改接）是行為擴張，不是純重構**：寬鬆模式套用全部 7 筆而非原本的 3 筆，代表「淸→清」「厰→廠」「愼→慎」「槀→稿」這 4 筆從此也會改寫書名。這是本計畫從一開始就設計好的目標（見前一份文件「這次的重大改動」一節），但仍需在 review／測試時明確驗證這個擴張是預期行為、不是意外副作用。
+- **步驟 3／4（BIOG_MAIN）是全新行為，非重構**：目前完全沒有對人物姓名做過任何異體字落地替換，上線後任何既有人物若透過 update 觸碰到姓名欄位、或任何新建人物姓名含這 6 個嚴格模式字元，會被靜默改寫。需要在 PR 描述中明確標註這是「新行為」而非「修 bug」，避免使用者誤以為是既有行為的意外改動。
+- **既有測試不會因本次改動而假設舊行為失敗**：已搜尋現有測試對這 7 個異體字的引用，僅 `tests/Feature/AdminBatchLoadBookTitlesTest.php` 與 `tests/Unit/VariantCharNormalizerTest.php` 有相關斷言（分別對應步驟 2 的既有 3 筆書名替換行為、與 `VariantCharNormalizer` 本身，兩者皆不受本計畫影響或會依步驟 2 同步更新），BIOG_MAIN／ALTNAME_DATA 相關測試目前完全沒有針對這幾個字元的斷言，故不會有「舊測試斷言未替換、新程式碼替換了」的回歸衝突。
+- **ALTNAME_DATA 有 legacy Blade／v2 API 兩條平行寫入路徑，只掛一條會造成兩版行為不一致**：見「待決事項 3」修正段落與步驟 5——`BasicInformationAltnamesController::store()`／`update()` 直接呼叫 `BiogMainRepository::altnameStoreById()`／`altnameUpdateById()`，完全不經過 `AltnameCreateHandler`／`AltnameMutationHandler`。若只改 v2 handler、漏掉這兩個 legacy Blade 呼叫的 repository 方法，會出現「新版 React 頁面存別名會落地替換、舊版 Blade 頁面存同一筆別名卻不會」的不一致，且因為 `AGENTS.md` 允許把頁面 flag 改回 `old` 觸發回退，這個不一致在 flag 切換情境下會實際發生，不是純理論風險。
+- **BIOG_MAIN 的 legacy Blade 提案路徑是第三個需要掛鉤的地方，原計畫未列出**：見步驟 3 實作時發現的段落——`action=proposal` 的 legacy Blade 路徑不經過 `BiogMainMutationHandler::prepareProposalPayload()`，而是走 `BasicInformationProposalController::normalizePayloadForTable()` 自己的邏輯。與 ALTNAME_DATA 的情況同構，已在實作時發現並補上，記錄於此供之後盤點類似「一個資源、多條寫入路徑」的模式時參考——BIOG_MAIN／ALTNAME_DATA 這兩張表目前都至少有 v2 API 與 legacy Blade 兩條路徑，且兩條路徑的程式碼是各自獨立實作、不共用同一份組字/替換邏輯，這是這次盤點過程中反覆出現的模式，不是單一個案。
+- **落地替換通知機制（待決事項 5）新增了兩個既有函式的回傳形狀變更，屬於本階段內部的連鎖修改**：`BiogMainRepository::store()` 從回傳單一 `BiogMain` model 改為回傳 `['model' => ..., 'replaced' => ...]` 陣列，兩個既有呼叫端（`BiogMainCreateHandler::handle()`、`BasicInformationController::store()`）都要同步改寫解構方式；若只改 `store()` 內部邏輯、漏改其中一個呼叫端，會直接造成該呼叫端把整個陣列當成 model 使用而壞掉（例如 `Schema::hasTable(...)` 判斷後對陣列呼叫 `reindexPerson($flight)` 會因型別不符而報錯）。這不是「錦上添花可以晚點做」的項目，而是步驟 4 沒做完就會直接讓既有功能壞掉的變更，實作與 review 時需要當作同一個原子變更檢查，不能只驗證新邏輯、忽略舊呼叫端有沒有同步更新。
+- **ALTNAME_DATA legacy Blade 端有第四個掛鉤點（`updateQuery()`），且既有索引同步邏輯有一個獨立於本計畫的既存 bug**：見步驟 5「實作時發現的第四個掛鉤點」段落——`update()`／`updateQuery()` 原本都用替換前的 `$request->all()` 判斷是否要同步 `CBDB__NAME_FTS` 搜尋索引與該索引哪個字形，這與落地替換無關、原本就存在（即使沒有這次的異體字功能，任何未來對 `c_alt_name_chn` 的正規化都會踩到同一個問題），只是這次新增落地替換後才讓「索引字形與資料庫實際字形不一致」這個既存缺陷變得更容易被觀察到。已隨手修正（改用 `altnameUpdateById()` 回傳的 `$newPk` 而非重新讀取請求），但這提醒之後若還有類似「controller 重新讀取原始 request 而非信任 repository 回傳值」的模式，需要個案盤查，不能假設只有這兩處。
+- **legacy Blade 提案更新路徑（`action=proposal`）在送出提案時不會預先檢查落地替換後的新 PK 是否已與既有別名衝突，v2 API 會**（codex review 於步驟 5 review 階段發現）：`BasicInformationProposalController::normalizePayloadForTable()` 對 `c_alt_name_chn` 做替換後直接記錄提案，不像 `AltnameMutationHandler::performUpdate()` 那樣在送出當下就查詢衝突並回 409。實際影響有限——`OperationsProposalController` 在**核准**提案時仍會查重複並擋下（`資料已存在，無法再次新增`／衝突偵測），不會造成資料損毀，只是使用者要等到管理員核准時才會被告知衝突，而非提交當下。這是 legacy Blade 提案路徑本身既有的、獨立於落地替換功能的行為落差（任何會改變 PK 的提案式更新都有這個問題，不是本次新增的缺陷），本階段不處理，記錄於此供之後盤點「legacy 提案路徑補送出時衝突檢查」時參考。
+
+## 不在本次範圍內
+
+- `VariantCharNormalizer` 類別本身的刪除清理（見前一份文件「不在本次範圍內」，依賴條件已滿足但屬於獨立任務）。
+- `CBDB__TRAD_SIMP_MAP` 繁簡轉換機制（與本表功能層次不同，見前一份文件）。
+- 對既有資料庫裡「已經含有這些異體字」的既有人物/書名記錄做批次回溯更新——本階段只處理「往後新增/修改時」的落地替換，不做歷史資料的批次校正（批次校正若有需要，屬於另一個獨立任務，且需要更謹慎的影響評估，不應該隨這次呼叫點串接一併做）。

--- a/docs/CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.en.md
+++ b/docs/CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.en.md
@@ -2,7 +2,7 @@
 
 > 中文版：[CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md](./CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md)
 
-> **Status: Planning**. This document currently covers only the new table's schema design, migration design, and the migration of the existing 7 rows of data. The "Call-site integration direction" section describes the **future** direction for rewiring `AdminBatchLoadBookTitlesController::TITLE_VARIANT_MAP` and the BIOG_MAIN/ALTNAME_DATA person-name write paths onto this table; that has not been implemented yet and will be a separate follow-up task.
+> **Status: Phase 1 (schema design, migration) complete**. This document covers the new table's schema design, migration design, and the migration of the existing 7 rows of data. The direction described in the "Call-site integration direction" section has been expanded into a concrete implementation plan — see [CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md](./CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md) (Phase 2, Chinese only).
 
 ## Background and Goals
 

--- a/docs/CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.md
@@ -2,7 +2,7 @@
 
 > English version: [CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.en.md](./CHAR_VARIANT_MAP_CONSOLIDATION_PLAN.en.md)
 
-> **狀態：規劃中**。本文件目前只涵蓋新表的 schema 設計、migration 設計與現有 7 筆資料的遷移方式；「呼叫點串接方向」一節描述的是**未來**要把 `AdminBatchLoadBookTitlesController::TITLE_VARIANT_MAP` 與 BIOG_MAIN／ALTNAME_DATA 人名相關寫入路徑改接這張表的方向，尚未實作，將於後續另開任務執行。
+> **狀態：第一階段（schema 設計、migration）已完成**。本文件涵蓋新表的 schema 設計、migration 設計與現有 7 筆資料的遷移方式；「呼叫點串接方向」一節描述的呼叫點改接方向，已展開為具體實作計畫，見 [CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md](./CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md)（第二階段）。
 
 ## 背景與目標
 

--- a/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
@@ -9,6 +9,11 @@ import { getCsrfToken } from '../../../components/PersonBrowser/shared/csrf';
 import type { SharedProps } from '../../../types/page';
 import { cn } from '../../../lib/utils';
 
+interface VariantReplacement {
+    from: string;
+    to: string;
+}
+
 interface ResultRow {
     line: number;
     author_id: string | number;
@@ -20,6 +25,7 @@ interface ResultRow {
     created_by: string | null;
     created_date: string | null;
     c_textid: number;
+    variant_replacements?: VariantReplacement[];
 }
 
 interface Toast {
@@ -391,7 +397,16 @@ export default function BatchLoadBookTitles() {
                                         <tr key={`${r.line}-${r.c_textid}`} className="border-t border-border">
                                             <td className="px-3 py-1.5">{r.line}</td>
                                             <td className="px-3 py-1.5">{r.author_id}</td>
-                                            <td className="px-3 py-1.5">{r.title}</td>
+                                            <td className="px-3 py-1.5">
+                                                <div>{r.title}</div>
+                                                {r.variant_replacements && r.variant_replacements.length > 0 && (
+                                                    <div className="text-xs text-muted-foreground">
+                                                        {t('batch_variant_replaced_hint', {
+                                                            pairs: r.variant_replacements.map((v) => `${v.from}→${v.to}`).join('、'),
+                                                        })}
+                                                    </div>
+                                                )}
+                                            </td>
                                             <td className="px-3 py-1.5">
                                                 {batch_id && editId === r.c_textid ? (
                                                     <div className="flex flex-col gap-1">

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -94,6 +94,8 @@ export default function BasicInfoEditor({
     const [pinyinDone, setPinyinDone] = useState(false);
     // 非阻塞提示：生成拼音時偵測到關係稱謂，但括號內之人不在此人親屬名單中（後端已改用一般拼音轉換）。
     const [pinyinKinshipHint, setPinyinKinshipHint] = useState(false);
+    // 非阻塞提示：儲存時姓名含異體字，後端已落地替換為參考字（char_variant_map 嚴格模式）。
+    const [variantReplacedNotice, setVariantReplacedNotice] = useState<string | null>(null);
     const [comment, setComment] = useState('');
     const [deleting, setDeleting] = useState(false);
 
@@ -222,7 +224,7 @@ export default function BasicInfoEditor({
 
     // 回傳 boolean：成功 true、驗證失敗／無變更／出錯 false。供切分頁「儲存並繼續」判斷是否可放行導航。
     const save = async (mode: 'direct' | 'proposal'): Promise<boolean> => {
-        setSaving(true); setError(null); setMessage(null);
+        setSaving(true); setError(null); setMessage(null); setVariantReplacedNotice(null);
         const initial: Fields = JSON.parse(savedSnapshot);
         // 名（中）／拼音名「不可清空」（direct 與 proposal 一致，後端同規則）：
         // 原值非空、現值清空即阻擋；原本即為空的人物可維持空、照常編輯其他欄位。
@@ -260,6 +262,8 @@ export default function BasicInfoEditor({
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);
             flashSaved(mode === 'proposal' ? tr('proposal_submitted', '已提交建議') : tr('save_success', '已儲存'));
+            const notices = Array.isArray(json?.notices) ? json.notices as string[] : [];
+            setVariantReplacedNotice(notices.length > 0 ? notices.join('；') : null);
             // direct 儲存後，從回傳列即時刷新「唯讀/後端重算」欄位，不必重整頁面：
             // 派生姓名（c_name*，後端 updateById 由姓/名重算）＋ 稽核欄（建檔/更新）。
             // 以函式式合併（保留請求期間使用者新輸入，修正 race：不可用已捕捉的舊 fields 覆寫）；
@@ -398,6 +402,7 @@ export default function BasicInfoEditor({
             {error ? <div style={gErrStyle}>{error}</div> : null}
             {pinyinDone ? <div style={gOkStyle}>{tr('basicinfo_pinyin_alert', '「生成拼音」已完成')}</div> : null}
             {pinyinKinshipHint ? <div style={gWarnStyle}>{tr('pinyin_kinship_unmatched_hint', '偵測到親屬關係詞，但此人親屬名單中查無此人，已改用一般拼音轉換。')}</div> : null}
+            {variantReplacedNotice ? <div style={gWarnStyle}>{variantReplacedNotice}</div> : null}
             {nameWarning ? <div style={gWarnStyle}>{tr('name_required_warning', '請確認「名（中）」與「拼音名」是否填寫。')}</div> : null}
 
             {/* 區塊一：姓名（資料流分組）。自上而下一條線、按鈕作橋：中文姓名 →〔生成姓名拼音〕→ 拼音 → 外文/羅馬字 → 自動生成框。 */}

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -145,6 +145,7 @@ return [
     'batch_col_line' => 'Line',
     'batch_col_author_id' => 'Author ID',
     'batch_col_title_cleaned' => 'Title (cleaned)',
+    'batch_variant_replaced_hint' => 'Variant characters normalized: :pairs',
     'batch_col_title_pinyin' => 'Title Pinyin',
     'batch_col_source_textid' => 'Source TEXT_ID',
     'batch_col_dynasty' => 'Dynasty',

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -45,6 +45,7 @@ return [
         'BIOG_TEXT_DATA' => 'Biographical Text Data',
         'CBDB__NAME_FTS' => 'Person Name Full-Text Index',
         'CBDB__TRAD_SIMP_MAP' => 'Traditional-Simplified Character Map',
+        'char_variant_map' => 'Variant Character Landing-Replacement Map',
         'CHORONYM_CODES' => 'Choronym Codes',
         'COUNTRY_CODES' => 'Country / Region Codes',
         'DYNASTIES' => 'Dynasty Information',

--- a/resources/lang/zh-TW/admin.php
+++ b/resources/lang/zh-TW/admin.php
@@ -145,6 +145,7 @@ return [
     'batch_col_line' => '行號',
     'batch_col_author_id' => '作者 ID',
     'batch_col_title_cleaned' => '書名（已清理）',
+    'batch_variant_replaced_hint' => '異體字已正規化：:pairs',
     'batch_col_title_pinyin' => '書名拼音',
     'batch_col_source_textid' => '來源 TEXT_ID',
     'batch_col_dynasty' => '書籍朝代',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -43,6 +43,7 @@ return [
         'BIOG_TEXT_DATA' => '傳記文本資料表',
         'CBDB__NAME_FTS' => '人名全文檢索表',
         'CBDB__TRAD_SIMP_MAP' => '繁簡字對照表',
+        'char_variant_map' => '異體字落地替換對照表',
         'CHORONYM_CODES' => '郡望代碼表',
         'COUNTRY_CODES' => '國家地區代碼表',
         'DYNASTIES' => '朝代信息表',

--- a/tests/Feature/AdminBatchLoadBookTitlesTest.php
+++ b/tests/Feature/AdminBatchLoadBookTitlesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use App\Services\PinyinDictionary;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -87,6 +88,30 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
             $table->unique(['c_chn', 'c_lastname']);
         });
 
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 standardizeTitleVariants() 走 CharVariantMapService::replaceLenient()。
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+
         // 書名逐字轉拼音走一般轉換路徑，需要真實字典資料才能跟現行
         // Pinyin::$dic 行為一致（見 docs/PINYIN_TABLE_CONSOLIDATION_PLAN.md 步驟4）。
         $this->seedPinyinDictionary();
@@ -94,6 +119,7 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
 
     protected function tearDown(): void {
         Schema::dropIfExists('pinyin');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('TEXT_CODES');
@@ -600,6 +626,82 @@ class AdminBatchLoadBookTitlesTest extends TestCase {
         $this->assertSame('穎集', $record->c_title_chn);
         $this->assertStringNotContainsString('頴', $record->c_title_chn);
         $this->assertSame('ying ji', $record->c_title);
+    }
+
+    #[Test]
+    public function test_newly_added_variant_glyph_qing_ti_is_standardized_in_stored_title(): void {
+        // 淸（U+6DF8）與厰（U+53B0）是 char_variant_map 新增收錄的 2 筆對照，原本不在
+        // 舊版 TITLE_VARIANT_MAP（僅峯／靑／頴 3 筆）裡；改接 CharVariantMapService::replaceLenient()
+        // 後，寬鬆模式套用全表 7 筆，這兩筆現在也會改寫書名本身——這是本步驟的行為擴張驗證。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 295, 'c_dy' => '6']);
+        DB::table('TEXT_CODES')->insert(['c_textid' => 795, 'c_title_chn' => '來源']);
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "295\t淸厰集\t795",
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+        $this->assertEmpty($response->getSession()->get('batch_errors', []));
+
+        $record = DB::table('TEXT_CODES')->where('c_textid', '>', 795)->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('清廠集', $record->c_title_chn);
+        $this->assertStringNotContainsString('淸', $record->c_title_chn);
+        $this->assertStringNotContainsString('厰', $record->c_title_chn);
+    }
+
+    #[Test]
+    public function test_formerly_pinyin_only_variant_shen_now_also_rewrites_stored_title(): void {
+        // 愼（U+613C）原本只在 VariantCharNormalizer::$fallbackMap 裡、只影響拼音查詢，
+        // 不改動書名本身。char_variant_map 收錄後，寬鬆模式下這筆對照現在也會改寫書名——
+        // 這是「不分原本是哪個舊機制的資料，表裡任何一筆都套用」的行為擴張驗證。
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 296, 'c_dy' => '6']);
+        DB::table('TEXT_CODES')->insert(['c_textid' => 796, 'c_title_chn' => '來源']);
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => "296\t愼獄集\t796",
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+        $this->assertEmpty($response->getSession()->get('batch_errors', []));
+
+        $record = DB::table('TEXT_CODES')->where('c_textid', '>', 796)->orderByDesc('c_textid')->first();
+        $this->assertNotNull($record);
+        $this->assertSame('慎獄集', $record->c_title_chn);
+        $this->assertStringNotContainsString('愼', $record->c_title_chn);
+    }
+
+    #[Test]
+    public function test_batch_results_include_variant_replacements_per_row(): void {
+        $user = $this->makeUser();
+        $this->actingAs($user);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 297, 'c_dy' => '6']);
+        DB::table('TEXT_CODES')->insert(['c_textid' => 797, 'c_title_chn' => '來源']);
+
+        $entries = "297\t東坡集峯卷一\t797\n297\t普通書名\t797";
+
+        $response = $this->post(route('admin.batch-load-book-titles.store'), [
+            'entries' => $entries,
+        ]);
+
+        $response->assertRedirect(route('admin.batch-load-book-titles'));
+        $this->assertEmpty($response->getSession()->get('batch_errors', []));
+
+        $results = $response->getSession()->get('batch_results', []);
+        $this->assertCount(2, $results);
+
+        $withVariant = collect($results)->firstWhere('line', 1);
+        $this->assertSame([['from' => '峯', 'to' => '峰']], $withVariant['variant_replacements']);
+
+        $withoutVariant = collect($results)->firstWhere('line', 2);
+        $this->assertSame([], $withoutVariant['variant_replacements']);
     }
 
     #[Test]

--- a/tests/Feature/ApiV2CreateAltnameTest.php
+++ b/tests/Feature/ApiV2CreateAltnameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -29,6 +30,7 @@ class ApiV2CreateAltnameTest extends TestCase {
         $this->createOperationsTable();
         $this->createAuditLogTable();
         $this->createAltnameTable();
+        $this->createCharVariantMapTable();
     }
 
     protected function tearDown(): void {
@@ -36,8 +38,37 @@ class ApiV2CreateAltnameTest extends TestCase {
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
+    }
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+     * 相同的 7 筆種子資料，供 AltnameCreateHandler 的異體字落地替換測試使用。
+     */
+    protected function createCharVariantMapTable(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     // ── Table Setup ─────────────────────────────────────────
@@ -221,6 +252,71 @@ class ApiV2CreateAltnameTest extends TestCase {
             $stored = DB::table($T)->where(['c_personid' => 1000, 'c_alt_name_chn' => $chn, 'c_alt_name_type_code' => 5])->value('c_source');
             $this->assertSame($sent, (int) $stored, '合法非 0 值不得被誤清：'.$sent);
         }
+    }
+
+    // ── Variant-Character Landing Replacement (strict mode) ─
+
+    #[Test]
+    public function testDirectAltnameCreateDoesNotReplaceStrictExcludedVariant(): void {
+        $this->actingAs($this->makeUser(email: 'altname-variant-excluded@example.com'));
+
+        // 峯（c_strict_excluded=1）僅寬鬆模式可替換，嚴格模式（人名相關）須排除。
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'target' => ['pk' => ['c_alt_name_chn' => '峯X']],
+        ]))->assertOk();
+
+        $this->assertArrayNotHasKey('notices', $response->json());
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '峯X',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectAltnameCreateReplacesStrictModeVariantAndReturnsNotice(): void {
+        $this->actingAs($this->makeUser(email: 'altname-variant-replace@example.com'));
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'target' => ['pk' => ['c_alt_name_chn' => '淸X']],
+        ]))->assertOk();
+
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '清X',
+        ]);
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '淸X',
+        ]);
+    }
+
+    #[Test]
+    public function testProposalAltnameCreateReplacesStrictModeVariantAndReturnsNotice(): void {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'altname-variant-proposal-create@example.com');
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'mode' => 'proposal',
+            'target' => ['pk' => ['c_alt_name_chn' => '淸Y']],
+            'meta' => ['comment' => '提案新增別名（異體字）'],
+        ]))->assertOk();
+
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $operation = DB::table('operations')
+            ->where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE)
+            ->first();
+        $resourceData = json_decode($operation->resource_data, true);
+        $this->assertSame('清Y', $resourceData['c_alt_name_chn']);
     }
 
     // ── Direct Create Tests ─────────────────────────────────

--- a/tests/Feature/ApiV2CreateBiogMainTest.php
+++ b/tests/Feature/ApiV2CreateBiogMainTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -33,6 +34,7 @@ class ApiV2CreateBiogMainTest extends TestCase {
         $this->createAuditLogTable();
         $this->createBiogMainTable();
         $this->createPinyinTable();
+        $this->createCharVariantMapTable();
     }
 
     protected function tearDown(): void {
@@ -41,8 +43,37 @@ class ApiV2CreateBiogMainTest extends TestCase {
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
+    }
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+     * 相同的 7 筆種子資料，供 BiogMainRepository::store() 的異體字落地替換測試使用。
+     */
+    protected function createCharVariantMapTable(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     // ── Table Setup ─────────────────────────────────────────
@@ -261,6 +292,96 @@ class ApiV2CreateBiogMainTest extends TestCase {
         $response = $this->postJson('/api/v2/create', $this->createPayload());
 
         $response->assertOk()->assertJson(['ok' => true]);
+    }
+
+    // ── Variant-Character Landing Replacement (strict mode) ─
+
+    #[Test]
+    public function testDirectBiogMainCreateDoesNotReplaceStrictExcludedVariant(): void {
+        $user = $this->makeUser(email: 'create-biog-variant-excluded@example.com');
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'changes' => ['c_surname_chn' => '張', 'c_mingzi_chn' => '峯'],
+        ]));
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('notices', $response->json());
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 2000,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '峯',
+            'c_name_chn' => '張峯',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectBiogMainCreateReplacesStrictModeVariantAndReturnsNotice(): void {
+        $user = $this->makeUser(email: 'create-biog-variant-replace@example.com');
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'changes' => ['c_surname_chn' => '張', 'c_mingzi_chn' => '淸'],
+        ]));
+
+        $response->assertOk();
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 2000,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '清',
+            'c_name_chn' => '張清',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectBiogMainCreateWithSurnamePartsIgnoresClientSuppliedNameChn(): void {
+        // 前端同時送 c_surname_chn/c_mingzi_chn 與一個不一致的 c_name_chn：
+        // 後端須無條件用替換後的分欄重組，覆蓋前端送來的值。
+        $user = $this->makeUser(email: 'create-biog-variant-override@example.com');
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'changes' => [
+                'c_surname_chn' => '張',
+                'c_mingzi_chn' => '淸',
+                'c_name_chn' => '完全不同的名字',
+            ],
+        ]));
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 2000,
+            'c_name_chn' => '張清',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectBiogMainCreateWithOnlyNameChnDoesNotClearItWhenPartsAreAbsent(): void {
+        // 迴歸測試：只送 c_name_chn、完全不送 c_surname_chn/c_mingzi_chn（無明確姓氏
+        // 可拆分的歷史人物），c_name_chn 本身仍要落地替換，但不能被「不存在的兩個
+        // 分欄相加」覆寫成空字串。
+        $user = $this->makeUser(email: 'create-biog-name-only@example.com');
+        $this->actingAs($user);
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'changes' => ['c_name_chn' => '淸公'],
+        ]));
+
+        $response->assertOk();
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 2000,
+            'c_name_chn' => '清公',
+        ]);
     }
 
     // ── Validation Error Cases ──────────────────────────────

--- a/tests/Feature/ApiV2MutateAltnameTest.php
+++ b/tests/Feature/ApiV2MutateAltnameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -29,6 +30,7 @@ class ApiV2MutateAltnameTest extends TestCase {
         $this->createOperationsTable();
         $this->createAuditLogTable();
         $this->createAltnameTable();
+        $this->createCharVariantMapTable();
     }
 
     protected function tearDown(): void {
@@ -36,8 +38,37 @@ class ApiV2MutateAltnameTest extends TestCase {
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
+    }
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+     * 相同的 7 筆種子資料，供 AltnameMutationHandler 的異體字落地替換測試使用。
+     */
+    protected function createCharVariantMapTable(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     // ── Table Setup ─────────────────────────────────────────
@@ -167,6 +198,109 @@ class ApiV2MutateAltnameTest extends TestCase {
         ];
 
         return array_replace_recursive($payload, $overrides);
+    }
+
+    // ── Variant-Character Landing Replacement (strict mode) ─
+
+    #[Test]
+    public function testDirectAltnameUpdateDoesNotReplaceStrictExcludedVariant(): void {
+        $user = $this->makeUser(email: 'altname-variant-excluded@example.com');
+        $this->actingAs($user);
+        $this->seedAltname();
+
+        $response = $this->postJson('/api/v2/mutate', $this->altnamePayload([
+            'changes' => ['c_alt_name_chn' => '峯X'],
+        ]))->assertOk();
+
+        $this->assertArrayNotHasKey('notices', $response->json());
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '峯X',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectAltnameUpdateReplacesStrictModeVariantAndReturnsNotice(): void {
+        $user = $this->makeUser(email: 'altname-variant-replace@example.com');
+        $this->actingAs($user);
+        $this->seedAltname();
+
+        $response = $this->postJson('/api/v2/mutate', $this->altnamePayload([
+            'changes' => ['c_alt_name_chn' => '淸X'],
+        ]))->assertOk();
+
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+        // 替換後的值成為新 PK 的一部分。
+        $this->assertSame('清X', $body['result']['pk']['c_alt_name_chn']);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '清X',
+        ]);
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '淸X',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectAltnameUpdateDetectsPkConflictUsingReplacedValue(): void {
+        // 替換後的新 c_alt_name_chn（淸X → 清X）與同一人物下另一筆既有別名衝突：
+        // 既有 PK 衝突偵測須用替換後的值判斷，而非替換前的原始輸入。
+        $user = $this->makeUser(email: 'altname-variant-conflict@example.com');
+        $this->actingAs($user);
+        $this->seedAltname();
+        $this->seedAltname([
+            'c_alt_name_chn' => '清X',
+            'c_alt_name_type_code' => 4,
+            'c_source' => 5,
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', $this->altnamePayload([
+            'changes' => ['c_alt_name_chn' => '淸X'],
+        ]));
+
+        $response->assertStatus(409)
+            ->assertJson(['ok' => false, 'errors' => ['target.pk' => ['conflict']]]);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '子美',
+        ]);
+    }
+
+    #[Test]
+    public function testProposalAltnameUpdateReplacesStrictModeVariantAndReturnsNotice(): void {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'altname-variant-proposal-update@example.com');
+        $this->actingAs($user);
+        $this->seedAltname();
+
+        $response = $this->postJson('/api/v2/mutate', $this->altnamePayload([
+            'mode' => 'proposal',
+            'changes' => ['c_alt_name_chn' => '淸X'],
+            'meta' => ['comment' => '提案修改別名（異體字）'],
+        ]))->assertOk();
+
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $operation = DB::table('operations')
+            ->where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+        $resourceData = json_decode($operation->resource_data, true);
+        $this->assertSame('清X', $resourceData['c_alt_name_chn']);
+
+        // 原始資料表不應被直接改動
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1000,
+            'c_alt_name_chn' => '子美',
+        ]);
     }
 
     // ── Direct Update Tests ─────────────────────────────────

--- a/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * code 表 mutation（resource=char-variant-map/char_variant_map → char_variant_map）回歸測試。
+ * 見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 7。
+ *
+ * 驗證 config 驅動的 CodeTableCreate/DeleteHandler、ConfigCodeTableMutationHandler：
+ * - create 顯式主鍵 / 自動分配（max+1）/ c_variant_char 唯一鍵撞號回合理錯誤（非 500）
+ * - update 可修改 allowed_fields
+ * - delete 恆 403（全域碼表刪除閘門，非本表特例）
+ */
+class ApiV2MutateCodeTableCharVariantMapTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('app.env', 'testing');
+        $this->app['env'] = 'testing';
+        config()->set('prometheus.enabled', false);
+        config()->set('prometheus.storage_adapter', 'memory');
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            // 見 database/migrations/2026_07_17_000000_add_audit_columns_to_char_variant_map_table.php：
+            // CodeTableCreateHandler 透過 ToolsRepository::timestamp() 無條件寫入這 4 欄。
+            $table->string('c_created_by', 255)->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('char_variant_map');
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'cvm@example.com'): User {
+        return User::create([
+            'name' => 'Code Tester',
+            'email' => $email,
+            'confirmation_token' => 'tok',
+            'is_active' => $status,
+            'is_admin' => $role,
+        ]);
+    }
+
+    #[Test]
+    public function testCreateWithExplicitId(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-explicit@example.com'));
+
+        $res = $this->postJson('/api/v2/create', [
+            'resource' => 'char-variant-map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 500]],
+            'changes' => ['c_variant_char' => '試', 'c_reference_char' => '试', 'c_strict_excluded' => 1],
+        ]);
+
+        $res->assertOk()->assertJson([
+            'ok' => true,
+            'resource' => 'char-variant-map',
+            'operation' => 'create',
+            'result' => ['pk' => ['id' => 500]],
+        ]);
+        $this->assertDatabaseHas('char_variant_map', ['id' => 500, 'c_variant_char' => '試']);
+        $this->assertSame(1, DB::table('operations')->where('resource', 'char_variant_map')->count());
+        $this->assertSame(1, DB::table('audit_log')->where('table_name', 'char_variant_map')->count());
+    }
+
+    #[Test]
+    public function testCreateAutoAssignsNextId(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-auto@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 10, 'c_variant_char' => '甲', 'c_reference_char' => '乙', 'c_strict_excluded' => 1]);
+
+        $res = $this->postJson('/api/v2/create', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'target' => ['pk' => []],
+            'changes' => ['c_variant_char' => '丙', 'c_reference_char' => '丁', 'c_strict_excluded' => 1],
+        ]);
+
+        $res->assertOk()->assertJson(['ok' => true, 'result' => ['pk' => ['id' => 11]]]);
+        $this->assertDatabaseHas('char_variant_map', ['id' => 11, 'c_variant_char' => '丙']);
+    }
+
+    #[Test]
+    public function testCreateDuplicateVariantCharReturns409NotServerError(): void {
+        // c_variant_char 有唯一鍵，重複值須被友善攔下（409），不能讓資料庫層 QueryException 冒出成 500。
+        $this->actingAs($this->makeUser(email: 'cvm-dup@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 20, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0]);
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'charvariantmap',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 21]],
+            'changes' => ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ])->assertStatus(409);
+
+        $this->assertSame(1, DB::table('char_variant_map')->where('c_variant_char', '淸')->count());
+    }
+
+    #[Test]
+    public function testDisallowedFieldReturns422(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-bad@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'char-variant-map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 30]],
+            'changes' => ['c_variant_char' => '試', 'c_not_a_column' => 'y'],
+        ])->assertStatus(422);
+        $this->assertSame(0, DB::table('char_variant_map')->count());
+    }
+
+    #[Test]
+    public function testUpdateModifiesAllowedField(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-update@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 40, 'c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'operation' => 'update',
+            'target' => ['pk' => ['id' => 40]],
+            'changes' => ['c_notes' => '補充說明'],
+        ])->assertOk()->assertJson(['ok' => true]);
+
+        $this->assertDatabaseHas('char_variant_map', ['id' => 40, 'c_notes' => '補充說明']);
+        $this->assertSame(1, DB::table('audit_log')->where('table_name', 'char_variant_map')->where('operation', 'UPDATE')->count());
+    }
+
+    #[Test]
+    public function testUpdateAcceptsIntegerValueForStrictExcludedFlag(): void {
+        // c_strict_excluded 是整數旗標欄（本表是第一個註冊進來的整數欄），
+        // AbstractCodeTableMutationHandler::validateFields() 原本只接受 string|null，
+        // JSON 呼叫端送整數 0/1 會被誤擋 422；已放寬為同時接受 int。
+        $this->actingAs($this->makeUser(email: 'cvm-update-int@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 41, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'operation' => 'update',
+            'target' => ['pk' => ['id' => 41]],
+            'changes' => ['c_strict_excluded' => 0],
+        ])->assertOk()->assertJson(['ok' => true]);
+
+        $this->assertDatabaseHas('char_variant_map', ['id' => 41, 'c_strict_excluded' => 0]);
+    }
+
+    #[Test]
+    public function testUpdateDuplicateVariantCharReturns409NotServerError(): void {
+        // c_variant_char 唯一鍵：更新撞到既有值須回 409，不能讓 QueryException 冒出成 500。
+        $this->actingAs($this->makeUser(email: 'cvm-update-dup@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 42, 'c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0]);
+        DB::table('char_variant_map')->insert(['id' => 43, 'c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'operation' => 'update',
+            'target' => ['pk' => ['id' => 43]],
+            'changes' => ['c_variant_char' => '槀'],
+        ])->assertStatus(409);
+
+        $this->assertDatabaseHas('char_variant_map', ['id' => 43, 'c_variant_char' => '靑']);
+    }
+
+    #[Test]
+    public function testDeleteIsDisabled(): void {
+        // 安全：碼表刪除已停用（防級聯刪除人物資料）——回 403、不刪列、不寫 DELETE 審計。
+        // 這是全域閘門，char_variant_map 註冊進 code_table_writes.php 後同樣受此規則約束，
+        // 不是本表特例、也不應為了讓本表可刪除而鬆綁這道閘門。
+        $this->actingAs($this->makeUser(email: 'cvm-del@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 50, 'c_variant_char' => '待刪', 'c_reference_char' => '刪除', 'c_strict_excluded' => 1]);
+
+        $this->postJson('/api/v2/delete', [
+            'resource' => 'char-variant-map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 50]],
+        ])->assertStatus(403);
+
+        $this->assertSame(1, DB::table('char_variant_map')->count());
+        $this->assertSame(0, DB::table('audit_log')->where('operation', 'DELETE')->count());
+    }
+}

--- a/tests/Feature/ApiV2MutateCodeTablesTest.php
+++ b/tests/Feature/ApiV2MutateCodeTablesTest.php
@@ -169,6 +169,26 @@ class ApiV2MutateCodeTablesTest extends TestCase {
     }
 
     #[Test]
+    public function testGanzhiDirectUpdateStillRejectsIntegerValueForTextField(): void {
+        // 迴歸：validateFields() 為 char_variant_map.c_strict_excluded 開放了 integer_fields 白名單機制，
+        // 但只限該表登記的欄位——其他表（如本表 c_ganzhi_py，一般拼音文字欄，未登記 integer_fields）
+        // 仍必須拒絕整數值，確認放寬沒有波及全域。
+        $this->actingAs($this->makeUser(email: 'ganzhi-int-reject@example.com'));
+        DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 3, 'c_ganzhi_chn' => '丙寅', 'c_ganzhi_py' => null]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'ganzhi_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_ganzhi_code' => 3]],
+            'changes' => ['c_ganzhi_py' => 123],
+        ])->assertStatus(422);
+
+        $this->assertDatabaseHas('GANZHI_CODES', ['c_ganzhi_code' => 3, 'c_ganzhi_py' => null]);
+    }
+
+    #[Test]
     public function testCodeTableForcesPersonIdZeroEvenIfCallerSendsNonZero(): void {
         $this->actingAs($this->makeUser(email: 'ganzhi-pid@example.com'));
         DB::table('GANZHI_CODES')->insert(['c_ganzhi_code' => 2, 'c_ganzhi_chn' => '乙丑', 'c_ganzhi_py' => null]);

--- a/tests/Feature/ApiV2MutateTest.php
+++ b/tests/Feature/ApiV2MutateTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -32,6 +33,7 @@ class ApiV2MutateTest extends TestCase {
         $this->createAltnameTable();
         $this->createSourceTable();
         $this->createTextCodesTable();
+        $this->createCharVariantMapTable();
     }
 
     protected function tearDown(): void {
@@ -39,11 +41,40 @@ class ApiV2MutateTest extends TestCase {
         Schema::dropIfExists('BIOG_SOURCE_DATA');
         Schema::dropIfExists('ALTNAME_DATA');
         Schema::dropIfExists('BIOG_MAIN');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('personal_access_tokens');
         Schema::dropIfExists('users');
         parent::tearDown();
+    }
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+     * 相同的 7 筆種子資料，供 BIOG_MAIN 異體字落地替換測試使用。
+     */
+    protected function createCharVariantMapTable(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function createUsersTable(): void {
@@ -489,6 +520,136 @@ class ApiV2MutateTest extends TestCase {
         $this->assertSame('Lü', $payload['c_surname']);    // 提交時歸一化
         $this->assertSame('Lü Zhong', $payload['c_name']); // c_name 由分量重算後亦為 ü
         $this->assertSame('Lv', $payload['c_surname_rm']); // Wade-Giles：不轉
+    }
+
+    #[Test]
+    public function testDirectBiogMainUpdateDoesNotReplaceStrictExcludedVariant() {
+        $user = $this->makeUser(email: 'biog-variant-strict-excluded@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        // 峯（c_strict_excluded=1）僅在寬鬆模式可替換，嚴格模式（人名）須排除。
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'biogmain',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => [
+                'c_mingzi_chn' => '峯',
+            ],
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonMissing(['notices' => []]);
+        $this->assertArrayNotHasKey('notices', $response->json());
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 138841,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '峯',
+            'c_name_chn' => '張峯',
+        ]);
+    }
+
+    #[Test]
+    public function testDirectBiogMainUpdateReplacesStrictModeVariantAndReturnsNotice() {
+        $user = $this->makeUser(email: 'biog-variant-strict-replace@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        // 淸（c_strict_excluded=0）在嚴格模式也可替換：分欄先替換，再組出 c_name_chn，
+        // 維持 c_name_chn === c_surname_chn.c_mingzi_chn 的 invariant。
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'biogmain',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => [
+                'c_mingzi_chn' => '淸',
+            ],
+        ]);
+
+        $response->assertOk();
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 138841,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '清',
+            'c_name_chn' => '張清',
+        ]);
+    }
+
+    #[Test]
+    public function testProposalBiogMainUpdateReplacesStrictModeVariantInPayloadAndReturnsNotice() {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-proposal-variant@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => [
+                'c_mingzi_chn' => '淸',
+            ],
+            'meta' => ['comment' => '提案修正名字異體字'],
+        ]);
+
+        $response->assertOk();
+        $body = $response->json();
+        $this->assertArrayHasKey('notices', $body);
+        $this->assertStringContainsString('淸', $body['notices'][0]);
+        $this->assertStringContainsString('清', $body['notices'][0]);
+
+        $operation = DB::table('operations')
+            ->where('resource', 'BIOG_MAIN')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('清', $payload['c_mingzi_chn']);
+        $this->assertSame('張清', $payload['c_name_chn']);
+        // 提案未核准前，BIOG_MAIN 本身不應變更。
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_mingzi_chn' => '忠']);
+    }
+
+    #[Test]
+    public function testProposalBiogMainUpdateDoesNotReplaceStrictExcludedVariantInPayload() {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-proposal-variant-excluded@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => [
+                'c_mingzi_chn' => '峯',
+            ],
+            'meta' => ['comment' => '提案修正名字'],
+        ]);
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('notices', $response->json());
+
+        $operation = DB::table('operations')
+            ->where('resource', 'BIOG_MAIN')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('峯', $payload['c_mingzi_chn']);
+        $this->assertSame('張峯', $payload['c_name_chn']);
     }
 
     #[Test]

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\TextCode;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -115,6 +116,31 @@ class BasicInformationAltnamesControllerTest extends TestCase {
             'c_name_type_code' => 1,
             'c_name_type_desc_chn' => '測試別名類型',
         ]);
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 altnameStoreById()/altnameUpdateById() 的異體字落地替換查詢使用。
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
@@ -124,6 +150,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         Schema::dropIfExists('ALTNAME_CODES');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
     }
@@ -172,6 +199,71 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $this->assertNotNull($log->operation_id);
         $new_data = json_decode($log->new_data, true);
         $this->assertEquals('新增別名', $new_data['c_alt_name_chn']);
+    }
+
+    #[Test]
+    public function testStoreReplacesStrictModeVariantAndFlashesNotice(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-store-variant@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+
+        $response = $this->actingAs($user)->post('/basicinformation/1/altnames', [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '淸X',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response->assertStatus(302);
+
+        // legacy Blade 與 v2 API 走的是平行的兩條寫入路徑（見計畫文件待決事項 3 修正段落）：
+        // 落地驗證同一份輸入在 legacy Blade 路徑也確實替換，不能只有 v2 API 有效。
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '清X',
+        ]);
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '淸X',
+        ]);
+
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_column($flash, 'message');
+        $this->assertTrue(
+            (bool) array_filter($messages, static fn ($m) => str_contains($m, '淸') && str_contains($m, '清')),
+            '應有一則含異體字落地替換內容的 flash 訊息'
+        );
+    }
+
+    #[Test]
+    public function testStoreDoesNotReplaceStrictExcludedVariant(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-store-excluded@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+
+        $this->actingAs($user)->post('/basicinformation/1/altnames', [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '峯X',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ])->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '峯X',
+        ]);
     }
 
     #[Test]
@@ -433,6 +525,182 @@ class BasicInformationAltnamesControllerTest extends TestCase {
         $this->assertNotNull($operation);
         $resourceData = json_decode($operation->resource_data, true);
         $this->assertEquals('測試備註', $resourceData['__note'] ?? null);
+    }
+
+    #[Test]
+    public function testUpdateQueryReplacesStrictModeVariantAndFlashesNotice(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-update-variant@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->patch(
+            '/basicinformation/1/altnames/update?c_personid=1&c_sequence=1&c_alt_name_chn=舊別名&c_alt_name_type_code=1',
+            [
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '淸X',
+                'c_alt_name_type_code' => '1',
+                'c_source' => 0,
+            ]
+        );
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '清X',
+        ]);
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '淸X',
+        ]);
+
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_column($flash, 'message');
+        $this->assertTrue(
+            (bool) array_filter($messages, static fn ($m) => str_contains($m, '淸') && str_contains($m, '清')),
+            '應有一則含異體字落地替換內容的 flash 訊息'
+        );
+    }
+
+    #[Test]
+    public function testUpdateQueryDoesNotReplaceStrictExcludedVariant(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-update-excluded@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $this->actingAs($user)->patch(
+            '/basicinformation/1/altnames/update?c_personid=1&c_sequence=1&c_alt_name_chn=舊別名&c_alt_name_type_code=1',
+            [
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '峯X',
+                'c_alt_name_type_code' => '1',
+                'c_source' => 0,
+            ]
+        )->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '峯X',
+        ]);
+    }
+
+    #[Test]
+    public function testUpdateReplacesStrictModeVariantAndFlashesNotice(): void {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-update-path-variant@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->patch('/basicinformation/1/altnames/1-舊別名-1', [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '淸X',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '清X',
+        ]);
+        $this->assertDatabaseMissing('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '淸X',
+        ]);
+
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_column($flash, 'message');
+        $this->assertTrue(
+            (bool) array_filter($messages, static fn ($m) => str_contains($m, '淸') && str_contains($m, '清')),
+            '應有一則含異體字落地替換內容的 flash 訊息'
+        );
+    }
+
+    #[Test]
+    public function testUpdateQueryDetectsPkConflictUsingReplacedValue(): void {
+        // 替換後的新 c_alt_name_chn（淸X → 清X）與同一人物下另一筆既有別名衝突：
+        // 既有的括號衝突偵測邏輯須用替換後的值判斷，而非替換前的原始輸入。
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'altname-legacy-update-conflict@example.com',
+            'password' => bcrypt('password'),
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 1, 'c_name_chn' => '測試人物']);
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '舊別名',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 2,
+            'c_alt_name_chn' => '清X',
+            'c_alt_name_type_code' => '1',
+            'c_source' => 0,
+        ]);
+
+        $response = $this->actingAs($user)->patch(
+            '/basicinformation/1/altnames/update?c_personid=1&c_sequence=1&c_alt_name_chn=舊別名&c_alt_name_type_code=1',
+            [
+                'c_sequence' => 1,
+                'c_alt_name_chn' => '淸X',
+                'c_alt_name_type_code' => '1',
+                'c_source' => 0,
+            ]
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('flash_notification');
+
+        // 原始「舊別名」未被替換覆蓋（衝突擋下，未更新）。
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '舊別名',
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/BasicInformationProposalTest.php
+++ b/tests/Feature/BasicInformationProposalTest.php
@@ -7,6 +7,7 @@ use App\Models\Operation;
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
+use App\Services\CharVariantMapService;
 use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -132,6 +133,32 @@ class BasicInformationProposalTest extends TestCase {
             $table->string('c_possession_desc')->nullable();
             $table->string('c_possession_desc_chn')->nullable();
         });
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 BasicInformationProposalController::normalizePayloadForTable()
+        // 對 BIOG_MAIN／ALTNAME_DATA 提案 payload 做異體字落地替換查詢使用。
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
@@ -145,6 +172,7 @@ class BasicInformationProposalTest extends TestCase {
         Schema::dropIfExists('KINSHIP_CODES');
         Schema::dropIfExists('POSSESSION_DATA');
         Schema::dropIfExists('ALTNAME_DATA');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('users');
@@ -388,6 +416,67 @@ class BasicInformationProposalTest extends TestCase {
         $this->assertSame('pending', $payload['__review_status']);
         $this->assertSame('新增測試別名', $payload['__proposal_meta']['comment']);
         $this->assertSame(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'], $payload['__key_columns']);
+    }
+
+    #[Test]
+    public function testProposalStoreReplacesVariantCharInAltNameChn() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.proposal.store', [
+            'personid' => 1,
+            'resource' => 'altnames',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '愼之',
+            'c_alt_name' => 'Test Name',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '新增測試別名（異體字）',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE)
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('慎之', $payload['c_alt_name_chn']);
+    }
+
+    #[Test]
+    public function testProposalUpdateReplacesVariantCharInAltNameChn() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1,
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '既有別名',
+            'c_alt_name_type_code' => 1,
+        ]);
+
+        $response = $this->post(route('basicinformation.proposal.update', [
+            'personid' => 1,
+            'resource' => 'altnames',
+            'id' => '1-既有別名-1',
+        ]), [
+            'c_sequence' => 1,
+            'c_alt_name_chn' => '愼之',
+            'c_alt_name_type_code' => 1,
+            '__proposal_comment' => '更新測試別名（異體字）',
+        ]);
+
+        $response->assertRedirect();
+
+        $operation = Operation::where('resource', 'ALTNAME_DATA')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('慎之', $payload['c_alt_name_chn']);
     }
 
     #[Test]

--- a/tests/Feature/BasicInformationUpdateTest.php
+++ b/tests/Feature/BasicInformationUpdateTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -99,12 +100,38 @@ class BasicInformationUpdateTest extends TestCase {
             $table->json('old_data')->nullable();
             $table->json('new_data')->nullable();
         });
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 BiogMainRepository::updateById() 的異體字落地替換查詢使用。
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
     }

--- a/tests/Feature/BiogMainBasicInfoNameMergeTest.php
+++ b/tests/Feature/BiogMainBasicInfoNameMergeTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -103,12 +104,38 @@ class BiogMainBasicInfoNameMergeTest extends TestCase {
             $table->smallInteger('is_admin')->default(0);
             $table->timestamps();
         });
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 BiogMainRepository::updateById() 的異體字落地替換查詢使用。
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
         Schema::dropIfExists('operations');
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
     }

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -92,6 +93,31 @@ class BiogMainProposalTest extends TestCase {
             $table->tinyInteger('c_lastname')->default(0);
             $table->unique(['c_chn', 'c_lastname']);
         });
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 legacy Blade 提案路徑（BasicInformationProposalController::
+        // normalizePayloadForTable()）的異體字落地替換測試使用。
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
@@ -99,6 +125,7 @@ class BiogMainProposalTest extends TestCase {
         Schema::dropIfExists('operations');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('pinyin');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
     }
@@ -162,6 +189,176 @@ class BiogMainProposalTest extends TestCase {
 
         // 驗證數據庫原始資料未變更
         $this->assertSame('Original notes', DB::table('BIOG_MAIN')->where('c_personid', $personId)->value('c_notes'));
+    }
+
+    #[Test]
+    public function testLegacyBladeProposalReplacesStrictModeVariantAndKeepsNameChnInSync() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $personId = 2;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '張忠',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '忠',
+        ]);
+
+        // legacy Blade 提案路徑（action=proposal）不經過 BiogMainMutationHandler::
+        // prepareProposalPayload()，走 BasicInformationProposalController::
+        // normalizePayloadForTable() 的另一個掛鉤點；淸（c_strict_excluded=0）在
+        // 嚴格模式應被替換，且 c_name_chn 須跟著分欄重組，不能維持前端送來的舊值。
+        $response = $this->patch(route('basicinformation.update', $personId), [
+            'action' => 'proposal',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '淸',
+            'c_name_chn' => '張淸',
+            '__proposal_comment' => '修改名字',
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', $personId));
+
+        $operation = Operation::where('resource', 'BIOG_MAIN')
+            ->where('c_personid', $personId)
+            ->first();
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('清', $payload['c_mingzi_chn']);
+        $this->assertSame('張清', $payload['c_name_chn']);
+        $this->assertStringNotContainsString('淸', $payload['c_name_chn']);
+
+        // 原始資料未變更（提案未核准）。
+        $this->assertSame('忠', DB::table('BIOG_MAIN')->where('c_personid', $personId)->value('c_mingzi_chn'));
+    }
+
+    #[Test]
+    public function testLegacyBladeProposalDoesNotReplaceStrictExcludedVariant() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $personId = 3;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '張忠',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '忠',
+        ]);
+
+        // 峯（c_strict_excluded=1）僅寬鬆模式可替換，嚴格模式（人名）須排除。
+        $response = $this->patch(route('basicinformation.update', $personId), [
+            'action' => 'proposal',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '峯',
+            'c_name_chn' => '張峯',
+            '__proposal_comment' => '修改名字',
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', $personId));
+
+        $operation = Operation::where('resource', 'BIOG_MAIN')
+            ->where('c_personid', $personId)
+            ->first();
+        $this->assertNotNull($operation);
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('峯', $payload['c_mingzi_chn']);
+        $this->assertSame('張峯', $payload['c_name_chn']);
+    }
+
+    #[Test]
+    public function testLegacyBladeDirectUpdateReplacesStrictModeVariantAndFlashesNotice() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $personId = 4;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '張忠',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '忠',
+        ]);
+
+        $response = $this->patch(route('basicinformation.update', $personId), [
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '淸',
+            'c_mingzi' => 'Qing',
+            'c_by_intercalary' => 0,
+            'c_dy_intercalary' => 0,
+            'c_female' => 0,
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', $personId));
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_mingzi_chn' => '清',
+            'c_name_chn' => '張清',
+        ]);
+
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_column($flash, 'message');
+        $this->assertTrue(
+            (bool) array_filter($messages, static fn ($m) => str_contains($m, '淸') && str_contains($m, '清')),
+            '應有一則含異體字落地替換內容的 flash 訊息'
+        );
+    }
+
+    #[Test]
+    public function testLegacyBladeCreateReplacesStrictModeVariantAndFlashesNotice() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.store'), [
+            'c_personid' => 5,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '淸',
+            'c_mingzi' => 'Qing',
+            'c_by_intercalary' => 0,
+            'c_dy_intercalary' => 0,
+            'c_female' => 0,
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', 5));
+
+        // 只斷言 c_name_chn（不斷言 auto_pinyin() 事後用姓氏字典重新拆出的
+        // c_surname_chn/c_mingzi_chn——那是既有、與本次改動無關的姓氏比對邏輯，
+        // 本測試環境未種入姓氏字典資料，拆分結果不在本測試驗證範圍內）。
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 5,
+            'c_name_chn' => '張清',
+        ]);
+        $this->assertStringNotContainsString('淸', (string) DB::table('BIOG_MAIN')->where('c_personid', 5)->value('c_name_chn'));
+
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_column($flash, 'message');
+        $this->assertTrue(
+            (bool) array_filter($messages, static fn ($m) => str_contains($m, '淸') && str_contains($m, '清')),
+            '應有一則含異體字落地替換內容的 flash 訊息'
+        );
+    }
+
+    #[Test]
+    public function testLegacyBladeCreateDoesNotReplaceStrictExcludedVariant() {
+        $user = $this->makeActiveUser();
+        $this->actingAs($user);
+
+        $response = $this->post(route('basicinformation.store'), [
+            'c_personid' => 6,
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '峯',
+            'c_mingzi' => 'Feng',
+            'c_by_intercalary' => 0,
+            'c_dy_intercalary' => 0,
+            'c_female' => 0,
+        ]);
+
+        $response->assertRedirect(route('basicinformation.edit', 6));
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 6,
+            'c_name_chn' => '張峯',
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/CodesCharVariantMapAuditTest.php
+++ b/tests/Feature/CodesCharVariantMapAuditTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 步驟 6：char_variant_map 註冊進 config('codes.tables') 後，確認 Codes UI
+ * 既有的增修／稽核／列表機制對這張新表同樣生效（不需要新寫稽核邏輯）。
+ * 見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 6。
+ */
+class CodesCharVariantMapAuditTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiled = sys_get_temp_dir().'/cbdb-test-views-codes-charvariantmap';
+        if (!is_dir($compiled)) {
+            mkdir($compiled, 0777, true);
+        }
+        config(['view.compiled' => $compiled]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+        config(['codes.tables' => ['char_variant_map' => '異體字落地替換對照表']]);
+        config(['codes.ui_hidden' => []]);
+
+        Schema::create('users', function ($t) {
+            $t->increments('id');
+            $t->string('name');
+            $t->string('email')->unique();
+            $t->string('password');
+            $t->string('confirmation_token')->nullable();
+            $t->tinyInteger('is_active')->default(0);
+            $t->tinyInteger('is_admin')->default(0);
+            $t->timestamps();
+        });
+
+        Schema::create('char_variant_map', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('c_variant_char', 10);
+            $t->string('c_reference_char', 10);
+            $t->tinyInteger('c_strict_excluded')->default(1);
+            $t->string('c_notes', 255)->nullable();
+            $t->timestamps();
+
+            $t->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        Schema::create('operations', function ($t) {
+            $t->increments('id');
+            $t->unsignedBigInteger('user_id')->nullable();
+            $t->integer('c_personid')->default(0);
+            $t->string('resource')->nullable();
+            $t->text('resource_id')->nullable();
+            $t->string('op_type')->nullable();
+            $t->longText('resource_data')->nullable();
+            $t->longText('resource_original')->nullable();
+            $t->integer('crowdsourcing_status')->default(0);
+            $t->timestamps();
+        });
+
+        Schema::create('audit_log', function ($t) {
+            $t->bigIncrements('id');
+            $t->dateTime('occurred_at');
+            $t->dateTime('created_at');
+            $t->string('table_name', 64);
+            $t->string('operation', 16);
+            $t->string('actor_type', 32);
+            $t->string('actor_id', 128);
+            $t->string('operation_id', 64);
+            $t->text('row_pk');
+            $t->string('row_pk_text', 512)->nullable();
+            $t->longText('old_data')->nullable();
+            $t->longText('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        foreach (['audit_log', 'operations', 'char_variant_map', 'users'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    private function activeUser(): User {
+        return User::create([
+            'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    private function seedSevenRows(): void {
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+    }
+
+    #[Test]
+    public function show_lists_all_seven_seed_rows(): void {
+        $this->actingAs($this->activeUser());
+        $this->seedSevenRows();
+
+        $response = $this->get('/codes/char_variant_map');
+
+        $response->assertOk();
+        foreach (['愼', '槀', '峯', '靑', '頴', '淸', '厰'] as $variant) {
+            $response->assertSee($variant);
+        }
+    }
+
+    #[Test]
+    public function store_writes_audit_log_insert(): void {
+        $this->actingAs($this->activeUser());
+
+        $response = $this->post('/codes/char_variant_map', [
+            'id' => 100,
+            'c_variant_char' => '試',
+            'c_reference_char' => '试',
+            'c_strict_excluded' => 1,
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('char_variant_map', [
+            'id' => 100,
+            'c_variant_char' => '試',
+        ]);
+
+        $audit = DB::table('audit_log')->where('table_name', 'char_variant_map')->first();
+        $this->assertNotNull($audit);
+        $this->assertSame('INSERT', $audit->operation);
+        $this->assertSame('試', json_decode($audit->new_data, true)['c_variant_char']);
+    }
+
+    #[Test]
+    public function update_writes_audit_log_update_with_old_and_new(): void {
+        $this->actingAs($this->activeUser());
+        DB::table('char_variant_map')->insert([
+            'id' => 101,
+            'c_variant_char' => '舊',
+            'c_reference_char' => '旧',
+            'c_strict_excluded' => 1,
+        ]);
+
+        $response = $this->put('/codes/char_variant_map/101', [
+            'id' => 101,
+            'c_variant_char' => '舊',
+            'c_reference_char' => '新參考字',
+            'c_strict_excluded' => 0,
+        ]);
+
+        $response->assertStatus(302);
+
+        $audit = DB::table('audit_log')->where('table_name', 'char_variant_map')->where('operation', 'UPDATE')->first();
+        $this->assertNotNull($audit);
+        $this->assertSame('旧', json_decode($audit->old_data, true)['c_reference_char']);
+        $this->assertSame('新參考字', json_decode($audit->new_data, true)['c_reference_char']);
+    }
+}

--- a/tests/Feature/FormUrlEncodingTest.php
+++ b/tests/Feature/FormUrlEncodingTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use App\Support\CompositePrimaryKey;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -197,6 +198,31 @@ class FormUrlEncodingTest extends TestCase {
         // 注意：ASSOC_DATA 相關表不需要創建，因為我們只測試編解碼邏輯
         // 完整的 ASSOC_DATA 編輯頁面依賴太多外部表（SOCIAL_INSTITUTION_CODES、ADDR_CODES 等）
         // 無法在 in-memory SQLite 中輕鬆測試
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 altname 表單走真實 BasicInformationAltnamesController 時，
+        // BiogMainRepository::altnameStoreById()/altnameUpdateById() 的異體字落地替換查詢使用。
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function seedTestData(): void {

--- a/tests/Feature/NameSearchIndexAutoSyncTest.php
+++ b/tests/Feature/NameSearchIndexAutoSyncTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\BiogMain;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use App\Support\CompositePrimaryKey;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -148,6 +149,31 @@ class NameSearchIndexAutoSyncTest extends TestCase {
             ['c_name_type_code' => 4, 'c_name_type_desc' => 'zi', 'c_name_type_desc_chn' => '字'],
             ['c_name_type_code' => 5, 'c_name_type_desc' => 'hao', 'c_name_type_desc_chn' => '號'],
         ]);
+
+        // char_variant_map：與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+        // 相同的 7 筆種子資料，供 BiogMainRepository::altnameStoreById()/altnameUpdateById() 的
+        // 異體字落地替換查詢使用（本測試走真實 controller，會實際觸發該查詢）。
+        Schema::create('char_variant_map', function ($table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
     }
 
     protected function tearDown(): void {
@@ -158,6 +184,7 @@ class NameSearchIndexAutoSyncTest extends TestCase {
         Schema::dropIfExists('BIOG_MAIN');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('users');
         parent::tearDown();
     }
@@ -355,6 +382,89 @@ class NameSearchIndexAutoSyncTest extends TestCase {
             ->exists();
 
         $this->assertTrue($newExists, '新別名索引應該被創建');
+    }
+
+    #[Test]
+    public function test_creating_altname_with_variant_char_indexes_replaced_value(): void {
+        // 迴歸測試：CBDB__NAME_FTS 索引須與 ALTNAME_DATA 實際落地的值一致（都是異體字
+        // 落地替換後的值），而不是替換前的原始輸入——見
+        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 步驟 5「實作時發現的第四個
+        // 掛鉤點」段落記錄的既存索引同步 bug。
+        $user = $this->createActiveExpert();
+
+        BiogMain::create([
+            'c_personid' => 2010,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/basicinformation/2010/altnames', [
+                'c_sequence' => 1,
+                'c_alt_name_type_code' => 4,
+                'c_alt_name_chn' => '淸公',
+            ])
+            ->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 2010,
+            'c_alt_name_chn' => '清公',
+        ]);
+
+        $indexedReplaced = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 2010)
+            ->where('name_type_code', 4)
+            ->where('search_term', '清公')
+            ->exists();
+        $indexedOriginal = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 2010)
+            ->where('search_term', '淸公')
+            ->exists();
+
+        $this->assertTrue($indexedReplaced, '索引應以落地替換後的字形建立');
+        $this->assertFalse($indexedOriginal, '索引不應殘留替換前的字形');
+    }
+
+    #[Test]
+    public function test_updating_altname_with_variant_char_reindexes_replaced_value(): void {
+        $user = $this->createActiveExpert();
+
+        BiogMain::create([
+            'c_personid' => 2011,
+            'c_name_chn' => '測試人物',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/basicinformation/2011/altnames', [
+                'c_sequence' => 1,
+                'c_alt_name_type_code' => 5,
+                'c_alt_name_chn' => '舊號',
+            ])
+            ->assertStatus(302);
+
+        $this->actingAs($user)
+            ->put('/basicinformation/2011/altnames/2011-1-舊號-5', [
+                'c_sequence' => 1,
+                'c_alt_name_type_code' => 5,
+                'c_alt_name_chn' => '厰記',
+            ])
+            ->assertStatus(302);
+
+        $this->assertDatabaseHas('ALTNAME_DATA', [
+            'c_personid' => 2011,
+            'c_alt_name_chn' => '廠記',
+        ]);
+
+        $indexedReplaced = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 2011)
+            ->where('search_term', '廠記')
+            ->exists();
+        $indexedOriginal = DB::table('CBDB__NAME_FTS')
+            ->where('c_personid', 2011)
+            ->where('search_term', '厰記')
+            ->exists();
+
+        $this->assertTrue($indexedReplaced, '更新後索引應以落地替換後的字形重建');
+        $this->assertFalse($indexedOriginal, '索引不應殘留替換前的字形');
     }
 
     #[Test]

--- a/tests/Unit/CharVariantMapServiceTest.php
+++ b/tests/Unit/CharVariantMapServiceTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CharVariantMapService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * CharVariantMapService 測試
+ *
+ * 手動建表（比照 AuditLogServiceTest 慣例，避免 RefreshDatabase 在 SQLite 上
+ * 因外鍵不符而失敗），種入與 2026_07_15_000000_create_char_variant_map_table.php
+ * 相同的 7 筆種子資料。
+ */
+class CharVariantMapServiceTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        CharVariantMapService::reset();
+
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+    }
+
+    #[Test]
+    public function lenient_mode_replaces_strict_excluded_char(): void {
+        $result = CharVariantMapService::replaceLenient('峯先生');
+
+        $this->assertSame('峰先生', $result['text']);
+        $this->assertSame(['峯' => '峰'], $result['replaced']);
+    }
+
+    #[Test]
+    public function strict_mode_does_not_replace_strict_excluded_char(): void {
+        $result = CharVariantMapService::replaceStrict('峯先生');
+
+        $this->assertSame('峯先生', $result['text']);
+        $this->assertArrayNotHasKey('峯', $result['replaced']);
+    }
+
+    #[Test]
+    public function strict_mode_replaces_the_other_six_rows(): void {
+        $testCases = [
+            ['愼', '慎'],
+            ['槀', '稿'],
+            ['靑', '青'],
+            ['頴', '穎'],
+            ['淸', '清'],
+            ['厰', '廠'],
+        ];
+
+        foreach ($testCases as [$variant, $reference]) {
+            $result = CharVariantMapService::replaceStrict("姓{$variant}名");
+            $this->assertSame("姓{$reference}名", $result['text']);
+            $this->assertSame([$variant => $reference], $result['replaced']);
+        }
+    }
+
+    #[Test]
+    public function replaced_only_lists_characters_actually_present_in_input(): void {
+        $result = CharVariantMapService::replaceLenient('峯淸兩字');
+
+        $this->assertSame(['峯' => '峰', '淸' => '清'], $result['replaced']);
+        $this->assertCount(2, $result['replaced']);
+    }
+
+    #[Test]
+    public function cache_is_cleared_by_reset(): void {
+        $before = CharVariantMapService::replaceLenient('厰');
+        $this->assertSame('廠', $before['text']);
+
+        DB::table('char_variant_map')->where('c_variant_char', '厰')->update(['c_reference_char' => '厂']);
+
+        // Cache not yet reset: still returns the stale mapping.
+        $stillCached = CharVariantMapService::replaceLenient('厰');
+        $this->assertSame('廠', $stillCached['text']);
+
+        CharVariantMapService::reset();
+
+        $afterReset = CharVariantMapService::replaceLenient('厰');
+        $this->assertSame('厂', $afterReset['text']);
+    }
+
+    #[Test]
+    public function empty_or_unmatched_text_is_returned_unchanged(): void {
+        $empty = CharVariantMapService::replaceLenient('');
+        $this->assertSame('', $empty['text']);
+        $this->assertSame([], $empty['replaced']);
+
+        $unmatched = CharVariantMapService::replaceStrict('普通文字沒有異體字');
+        $this->assertSame('普通文字沒有異體字', $unmatched['text']);
+        $this->assertSame([], $unmatched['replaced']);
+    }
+
+    #[Test]
+    public function blank_variant_char_in_table_is_skipped_without_warning(): void {
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '',
+            'c_reference_char' => '空字串防呆',
+            'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        $result = CharVariantMapService::replaceLenient('普通文字');
+
+        $this->assertSame('普通文字', $result['text']);
+        $this->assertArrayNotHasKey('', $result['replaced']);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the variant-character (異體字) consolidation project: wires the previously-unused `char_variant_map` DB table (7 seed rows, Phase 1 already merged) into all identified call sites, plus the governance layer.

- **CharVariantMapService**（新）：查 `char_variant_map` 表，提供寬鬆模式（全表 7 筆）／嚴格模式（`c_strict_excluded=0`）落地替換，以及非阻塞通知組字共用邏輯（`buildNotices()`/`withNotices()`）。
- **TITLE_VARIANT_MAP 改接**：`AdminBatchLoadBookTitlesController` 原本硬編碼的 3 筆對照改為查全表 7 筆（行為擴張，書名匯入會多正規化 4 個異體字）。
- **BIOG_MAIN**：v2 API／legacy Blade 的 create、update、proposal 四條路徑，在組出 `c_name_chn` 前對 `c_surname_chn`/`c_mingzi_chn` 做嚴格模式替換（全新行為，非重構）。
- **ALTNAME_DATA**：v2 API、legacy Blade 直接保存（`store`/`update`/`updateQuery`）、legacy Blade 提案，共五個掛鉤點對 `c_alt_name_chn` 做嚴格模式替換；一併修正 `update()`/`updateQuery()` 誤用替換前原始值建 `CBDB__NAME_FTS` 搜尋索引的既存 bug。
- **前端非阻塞提示**：`BasicInfoEditor.tsx`、`BatchLoadBookTitles/Index.tsx` 顯示 `notices`，讓錄入者知悉系統靜默替換了哪些字，不跳窗。
- **治理面**：`char_variant_map` 註冊進 `/app/codes` 代碼表清單（沿用既有 audit_log 稽核機制）與受 token 認證的 `/api/v2/{create,update,delete,batch_mutate}` 機器化寫入管道；過程中修正共用基底類別 `AbstractCodeTableMutationHandler` 的兩個既存缺陷（整數欄位型別校驗過嚴、唯一鍵衝突未轉 409），已限定影響範圍不波及其他 12 張既有 Phase B 代碼表。

每個實作環節皆經過 review agent + codex 兩輪審查，全部確認無嚴重問題後才進下一環節；過程中發現並修正的資料損毀風險（BIOG_MAIN create 空字串覆寫 bug）、索引不同步 bug、測試 fixture 誤置 bug 均詳細記錄於 `docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md`。

文件也記錄了下一階段待評估的範圍缺口：本次落地替換僅涵蓋 BIOG_MAIN／ALTNAME_DATA／TITLE_VARIANT_MAP，未涵蓋 Codes UI 對其他代碼表的泛用寫入路徑，也未涵蓋各子資源 editor 的 `c_notes`/`c_pages` 等自由文字欄位。

## Test plan

- [x] `./vendor/bin/phpunit`（本次涉及的所有測試檔案，累計 1195 tests / 5342 assertions 通過，涵蓋 BIOG_MAIN、ALTNAME_DATA、Codes UI、token API、書名批次匯入、office、pinyin 等既有回歸測試）
- [x] `./vendor/bin/php-cs-fixer fix`（全專案格式化，無需修正）
- [x] 每個環節皆有 review agent + codex 兩輪 review，確認無嚴重問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)