### PR TITLE
feat(mcp): 新增 search_person_by_name 工具（別名感知人名搜尋）

### DIFF
--- a/app/Mcp/Servers/CbdbReadOnlyServer.php
+++ b/app/Mcp/Servers/CbdbReadOnlyServer.php
@@ -8,6 +8,7 @@ use App\Mcp\Tools\ListAllowedTablesTool;
 use App\Mcp\Tools\QueryReadOnlySqlTool;
 use App\Mcp\Tools\QueryTableSchemaTool;
 use App\Mcp\Tools\QueryTableTool;
+use App\Mcp\Tools\SearchPersonByNameTool;
 use Laravel\Mcp\Server;
 
 class CbdbReadOnlyServer extends Server {
@@ -24,5 +25,6 @@ class CbdbReadOnlyServer extends Server {
         GetSampleDataTool::class,
         QueryTableTool::class,
         QueryReadOnlySqlTool::class,
+        SearchPersonByNameTool::class,
     ];
 }

--- a/app/Mcp/Tools/SearchPersonByNameTool.php
+++ b/app/Mcp/Tools/SearchPersonByNameTool.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Services\NameSearchService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class SearchPersonByNameTool extends Tool {
+    public string $name = 'search_person_by_name';
+
+    public string $description = 'Find CBDB persons by name — matches the main name AND courtesy names (字), style names (号), aliases, and other alternate names, the same way the CBDB homepage person search does. Prefer this over query_table on BIOG_MAIN when looking someone up by any form of their name, because BIOG_MAIN only holds the main name (字/号/别名 live in ALTNAME_DATA). Returns each matching person once (personid, main name, dynasty, index address) with the alternate-name forms that matched and their type. A numeric keyword is treated as an exact personid. Latin/pinyin keywords fall back to romanized-name columns.';
+
+    public function schema(JsonSchema $schema): array {
+        return [
+            'keyword' => $schema->string()->description('Name to search: Chinese main name / 字 / 号 / alias, or a numeric personid.')->required(),
+            'name_type_codes' => $schema->array()->description('Optional filter by alternate-name type code (ALTNAME_CODES): 4=字, 5=室名/别号, 3=别名/曾用名, 6=谥号, 7=行第, 9/10=小名/小字, 18=本姓… Omit to search all names incl. main name. Only affects Chinese matches.'),
+            'dynasty' => $schema->integer()->description('Optional dynasty filter on BIOG_MAIN.c_dy (e.g. 19=明, 15=宋).'),
+            'limit' => $schema->integer()->description('Max persons to return (1-100).')->default(20),
+            'offset' => $schema->integer()->description('Persons to skip (pagination).')->default(0),
+        ];
+    }
+
+    public function handle(Request $request): Response {
+        $service = app(NameSearchService::class);
+
+        $typeCodes = $request->get('name_type_codes', []);
+        if (!is_array($typeCodes)) {
+            $typeCodes = [];
+        }
+
+        $dynasty = $request->get('dynasty');
+        $dynasty = ($dynasty === null || $dynasty === '') ? null : (int) $dynasty;
+
+        return Response::text(json_encode(
+            $service->searchPersons(
+                (string) $request->get('keyword', ''),
+                $dynasty,
+                $typeCodes,
+                (int) $request->get('limit', 20),
+                (int) $request->get('offset', 0)
+            ),
+            JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
+        ));
+    }
+}

--- a/app/Services/NameSearchService.php
+++ b/app/Services/NameSearchService.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Services;
+
+use App\Support\PinyinSearchNormalizer;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 人名搜尋（別名感知）共用服務。
+ *
+ * 首頁人物瀏覽器（PersonBrowserService）與唯讀 MCP 工具（search_person_by_name）共用此處的
+ * FTS 命中邏輯，避免兩套實現漂移。名字的「主名＋字／號／別名 union、繁簡雙寫、後綴展開」已在
+ * 建索引階段烘焙進 CBDB__NAME_FTS（見 RebuildNameSearchIndex / NameSearchIndexService），
+ * 故查詢端只需對 search_term 做前綴 LIKE（走 idx_cbdb__name_search_term 索引）。
+ *
+ * 註：異體字（潁/穎/頴、璵/嶼）目前不做歸一——與首頁行為一致；命中某異體寫法需該寫法本身
+ * 已作為一條名字存在於索引中。
+ */
+class NameSearchService {
+    /**
+     * 從 CBDB__NAME_FTS 倒排索引以前綴匹配取得 person id（含主名與各類別名）。
+     *
+     * @param  int[]  $typeCodes  限定 name_type_code（如 [4] 只搜字、[5] 只搜號）；空＝不限
+     * @return int[]  依相關度（search_term 長度升冪）去重後的 person id
+     */
+    public function ftsPersonIds(string $q, array $typeCodes = [], int $limit = 500): array {
+        if ($q === '') {
+            return [];
+        }
+
+        $query = DB::table('CBDB__NAME_FTS')
+            ->where('search_term', 'LIKE', $q . '%');
+
+        $typeCodes = array_values(array_unique(array_map('intval', $typeCodes)));
+        if (!empty($typeCodes)) {
+            $query->whereIn('name_type_code', $typeCodes);
+        }
+
+        return $query
+            ->orderByRaw('LENGTH(search_term) ASC')
+            ->limit($limit)
+            ->pluck('c_personid')
+            ->unique()
+            ->map(fn ($id) => (int) $id)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 拼音／拉丁字母查詢的回退：對 BIOG_MAIN 多欄位 LIKE（不含別名）。與 PersonBrowserService 同口徑。
+     *
+     * @return int[]
+     */
+    public function fallbackPersonIds(string $rawQ, int $limit = 500): array {
+        $qForms = PinyinSearchNormalizer::expand($rawQ);
+        if (empty($qForms)) {
+            return [];
+        }
+
+        return DB::table('BIOG_MAIN')
+            ->select('c_personid')
+            ->where(function ($sub) use ($qForms) {
+                foreach ($qForms as $form) {
+                    $sub->orWhere('c_name_chn', 'like', '%' . $form . '%')
+                        ->orWhere('c_name', 'like', '%' . $form . '%')
+                        ->orWhere('c_surname', 'like', $form)
+                        ->orWhere('c_mingzi', 'like', $form)
+                        ->orWhere('c_name_proper', 'like', '%' . $form . '%')
+                        ->orWhere('c_name_rm', 'like', '%' . $form . '%');
+                }
+            })
+            ->limit($limit)
+            ->pluck('c_personid')
+            ->map(fn ($id) => (int) $id)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 別名感知的人名搜尋（MCP 用）。支援 personid、主名、字、號、別名等，效果對齊首頁人物瀏覽器。
+     *
+     * @param  int[]  $typeCodes  限定別名類型（僅對中文 FTS 路徑有效；拼音回退只查主名欄位）
+     * @return array{keyword:string,total:int,limit:int,offset:int,rows:array<int,array<string,mixed>>}
+     */
+    public function searchPersons(string $keyword, ?int $dynasty = null, array $typeCodes = [], int $limit = 20, int $offset = 0): array {
+        $rawQ = trim($keyword);
+        $q = PinyinSearchNormalizer::umlautToV($rawQ);
+        $limit = max(1, min($limit, (int) config('mcp.cbdb.max_limit', 100)));
+        $offset = max(0, $offset);
+
+        // 1. 解析候選 person id（三分支，與 PersonBrowserService::search 同口徑）
+        $ids = [];
+        $usedFts = false;
+        if ($q !== '') {
+            if (ctype_digit($q)) {
+                $ids = [(int) $q];
+            } elseif (PinyinSearchNormalizer::isChineseQuery($q)) {
+                $ids = $this->ftsPersonIds($q, $typeCodes, 500);
+                $usedFts = true;
+                if (empty($ids) && empty($typeCodes)) {
+                    // 中文查詢在 FTS 無命中時回退多欄位 LIKE（涵蓋 FTS 尚未索引的情況）。
+                    // 注意：回退只查 BIOG_MAIN 主名欄位、無法尊重 name_type_codes，故僅在未限定類型時啟用。
+                    $ids = $this->fallbackPersonIds($rawQ, 500);
+                    $usedFts = false;
+                }
+            } else {
+                $ids = $this->fallbackPersonIds($rawQ, 500);
+            }
+        }
+
+        if ($q !== '' && empty($ids)) {
+            return ['keyword' => $rawQ, 'total' => 0, 'limit' => $limit, 'offset' => $offset, 'rows' => []];
+        }
+
+        // 2. 朝代過濾 + 保序（保留候選相關度順序）
+        $filtered = $this->applyDynastyFilter($ids, $dynasty, $q === '');
+        $total = count($filtered);
+        $pageIds = array_slice($filtered, $offset, $limit);
+        if (empty($pageIds)) {
+            return ['keyword' => $rawQ, 'total' => $total, 'limit' => $limit, 'offset' => $offset, 'rows' => []];
+        }
+
+        // 3. 補全展示欄位
+        $rows = $this->hydrate($pageIds);
+
+        // 4. 附上命中的名字類型（僅中文 FTS 路徑）
+        if ($usedFts) {
+            $this->attachMatchedTerms($rows, $pageIds, $q, $typeCodes);
+        }
+
+        return ['keyword' => $rawQ, 'total' => $total, 'limit' => $limit, 'offset' => $offset, 'rows' => array_values($rows)];
+    }
+
+    /**
+     * 依朝代過濾候選 id 並保持原順序；$openList=true（空查詢）時直接依 id 排序取全體。
+     *
+     * @param  int[]  $ids
+     * @return int[]
+     */
+    private function applyDynastyFilter(array $ids, ?int $dynasty, bool $openList): array {
+        if ($openList) {
+            $query = DB::table('BIOG_MAIN')->select('c_personid');
+            if ($dynasty !== null) {
+                $query->where('c_dy', '=', $dynasty);
+            }
+
+            return $query->orderBy('c_personid')
+                ->limit(500)
+                ->pluck('c_personid')
+                ->map(fn ($id) => (int) $id)
+                ->values()
+                ->all();
+        }
+
+        if (empty($ids)) {
+            return [];
+        }
+
+        // 始終回 BIOG_MAIN 核實存在（順帶套朝代過濾），避免 numeric 指到不存在的 id 令 total 與 rows 不一致。
+        $query = DB::table('BIOG_MAIN')->whereIn('c_personid', $ids);
+        if ($dynasty !== null) {
+            $query->where('c_dy', '=', $dynasty);
+        }
+        $allowed = $query
+            ->pluck('c_personid')
+            ->map(fn ($id) => (int) $id)
+            ->flip();
+
+        return array_values(array_filter($ids, fn ($id) => $allowed->has($id)));
+    }
+
+    /**
+     * 補全 person 展示欄位（主名／拼音／朝代／籍貫），並保持 $pageIds 順序。
+     *
+     * @param  int[]  $pageIds
+     * @return array<int,array<string,mixed>>
+     */
+    private function hydrate(array $pageIds): array {
+        $records = DB::table('BIOG_MAIN')
+            ->select([
+                'BIOG_MAIN.c_personid',
+                'BIOG_MAIN.c_name_chn',
+                'BIOG_MAIN.c_name',
+                'BIOG_MAIN.c_dy',
+                'DYNASTIES.c_dynasty_chn',
+                'ADDR_CODES.c_name_chn AS index_addr_chn',
+            ])
+            ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
+            ->leftJoin('ADDR_CODES', 'ADDR_CODES.c_addr_id', '=', 'BIOG_MAIN.c_index_addr_id')
+            ->whereIn('BIOG_MAIN.c_personid', $pageIds)
+            ->get()
+            ->keyBy('c_personid');
+
+        $rows = [];
+        foreach ($pageIds as $id) {
+            $r = $records->get($id);
+            if (!$r) {
+                continue;
+            }
+            $rows[$id] = [
+                'c_personid' => (int) $r->c_personid,
+                'c_name_chn' => $r->c_name_chn,
+                'c_name' => $r->c_name,
+                'c_dy' => $r->c_dy !== null ? (int) $r->c_dy : null,
+                'dynasty_chn' => $r->c_dynasty_chn,
+                'index_addr_chn' => $r->index_addr_chn,
+                'matched_terms' => [],
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * 為每個 person 附上「命中的名字」（主名／字／號／別名…及其類型），來自 FTS。
+     *
+     * @param  array<int,array<string,mixed>>  $rows  by reference
+     * @param  int[]  $pageIds
+     * @param  int[]  $typeCodes
+     */
+    private function attachMatchedTerms(array &$rows, array $pageIds, string $q, array $typeCodes): void {
+        $query = DB::table('CBDB__NAME_FTS')
+            ->select(['c_personid', 'full_name', 'name_type_code', 'name_type_desc_chn', 'source'])
+            ->whereIn('c_personid', $pageIds)
+            ->where('search_term', 'LIKE', $q . '%');
+
+        $typeCodes = array_values(array_unique(array_map('intval', $typeCodes)));
+        if (!empty($typeCodes)) {
+            $query->whereIn('name_type_code', $typeCodes);
+        }
+
+        $hits = $query->get();
+        $seen = [];
+        foreach ($hits as $h) {
+            $pid = (int) $h->c_personid;
+            if (!isset($rows[$pid])) {
+                continue;
+            }
+            $key = $pid . '|' . $h->full_name . '|' . $h->name_type_code;
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $rows[$pid]['matched_terms'][] = [
+                'term' => $h->full_name,
+                'name_type_code' => $h->name_type_code !== null ? (int) $h->name_type_code : null,
+                'name_type_desc_chn' => $h->name_type_desc_chn,
+                'source' => $h->source,
+            ];
+        }
+    }
+}

--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -64,17 +64,11 @@ class PersonBrowserService {
                 $idQuery->where('BIOG_MAIN.c_personid', '=', (int) $q)
                     ->orderBy('BIOG_MAIN.c_personid', $sortDirection);
             } else {
-                // 先嘗試倒排索引（僅中文查詢；拼音／拉丁查詢直接走下方 LIKE 回退）
+                // 先嘗試倒排索引（僅中文查詢；拼音／拉丁查詢直接走下方 LIKE 回退）。
+                // FTS 命中邏輯與 MCP 人名搜尋共用 NameSearchService::ftsPersonIds，避免兩套實現漂移。
                 $ftsIds = [];
                 if ($this->queryUsesFtsIndex($q)) {
-                    $ftsIds = DB::table('CBDB__NAME_FTS')
-                        ->where('search_term', 'LIKE', $q . '%')
-                        ->orderByRaw('LENGTH(search_term) ASC')
-                        ->limit(500)
-                        ->pluck('c_personid')
-                        ->unique()
-                        ->values()
-                        ->toArray();
+                    $ftsIds = app(NameSearchService::class)->ftsPersonIds($q);
 
                     if ($dynasty !== '' && !empty($ftsIds)) {
                         // 倒排索引結果需要過濾朝代
@@ -203,14 +197,7 @@ class PersonBrowserService {
                 // 否則朝代側欄會沿用 FTS 雜訊命中而與人物列表（已回退）不一致。
                 $ftsIds = [];
                 if ($this->queryUsesFtsIndex($q)) {
-                    $ftsIds = DB::table('CBDB__NAME_FTS')
-                        ->where('search_term', 'LIKE', $q . '%')
-                        ->orderByRaw('LENGTH(search_term) ASC')
-                        ->limit(500)
-                        ->pluck('c_personid')
-                        ->unique()
-                        ->values()
-                        ->toArray();
+                    $ftsIds = app(NameSearchService::class)->ftsPersonIds($q);
                 }
 
                 if (!empty($ftsIds)) {

--- a/tests/Feature/McpSearchPersonByNameTest.php
+++ b/tests/Feature/McpSearchPersonByNameTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\NameSearchService;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 別名感知人名搜尋（MCP search_person_by_name 底層 NameSearchService）回歸。
+ * 驗證：字／號／別名命中同一 personid、name_type_codes 過濾、dynasty 過濾、numeric personid。
+ */
+class McpSearchPersonByNameTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $this->createTables();
+        $this->seed();
+    }
+
+    private function createTables(): void {
+        DB::statement('PRAGMA foreign_keys = OFF');
+        DB::statement('CREATE TABLE IF NOT EXISTS BIOG_MAIN (
+            c_personid INTEGER PRIMARY KEY,
+            c_name VARCHAR(255), c_name_chn VARCHAR(255),
+            c_name_proper VARCHAR(255), c_name_rm VARCHAR(255),
+            c_surname VARCHAR(255), c_mingzi VARCHAR(255),
+            c_dy INTEGER, c_index_addr_id INTEGER
+        )');
+        DB::statement('CREATE TABLE IF NOT EXISTS DYNASTIES (c_dy INTEGER PRIMARY KEY, c_dynasty_chn VARCHAR(255))');
+        DB::statement('CREATE TABLE IF NOT EXISTS ADDR_CODES (c_addr_id INTEGER PRIMARY KEY, c_name_chn VARCHAR(255))');
+        DB::statement('CREATE TABLE IF NOT EXISTS CBDB__NAME_FTS (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            c_personid INTEGER, name_type_code INTEGER,
+            name_type_desc VARCHAR(32), name_type_desc_chn VARCHAR(32),
+            search_term VARCHAR(100), full_name VARCHAR(100),
+            source VARCHAR(32), is_simplified SMALLINT DEFAULT 0
+        )');
+    }
+
+    private function seed(): void {
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 15, 'c_dynasty_chn' => '宋'],
+            ['c_dy' => 19, 'c_dynasty_chn' => '明'],
+        ]);
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 1, 'c_name_chn' => '臨川']);
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 100, 'c_name_chn' => '王安石', 'c_name' => 'Wang Anshi',
+            'c_dy' => 15, 'c_index_addr_id' => 1,
+        ]);
+
+        $fts = fn ($term, $full, $code, $descChn, $src) => [
+            'c_personid' => 100, 'name_type_code' => $code, 'name_type_desc' => '', 'name_type_desc_chn' => $descChn,
+            'search_term' => $term, 'full_name' => $full, 'source' => $src, 'is_simplified' => 0,
+        ];
+        DB::table('CBDB__NAME_FTS')->insert([
+            $fts('王安石', '王安石', null, '本名', 'BIOG_MAIN'),
+            $fts('安石', '王安石', null, '本名', 'BIOG_MAIN'),
+            $fts('介甫', '介甫', 4, '字', 'ALTNAME_DATA'),
+            $fts('甫', '介甫', 4, '字', 'ALTNAME_DATA'),
+            $fts('半山', '半山', 5, '室名、別號', 'ALTNAME_DATA'),
+        ]);
+    }
+
+    private function svc(): NameSearchService {
+        return app(NameSearchService::class);
+    }
+
+    #[Test]
+    public function it_finds_person_by_courtesy_name(): void {
+        $res = $this->svc()->searchPersons('介甫');
+        $this->assertSame(1, $res['total']);
+        $this->assertSame(100, $res['rows'][0]['c_personid']);
+        $this->assertSame('王安石', $res['rows'][0]['c_name_chn']);
+        $terms = collect($res['rows'][0]['matched_terms']);
+        $this->assertTrue($terms->contains(fn ($t) => $t['term'] === '介甫' && $t['name_type_code'] === 4));
+    }
+
+    #[Test]
+    public function it_finds_person_by_style_name(): void {
+        $this->assertSame(100, $this->svc()->searchPersons('半山')['rows'][0]['c_personid']);
+    }
+
+    #[Test]
+    public function it_finds_person_by_main_name(): void {
+        $this->assertSame(1, $this->svc()->searchPersons('王安石')['total']);
+    }
+
+    #[Test]
+    public function name_type_codes_filter_restricts_matches(): void {
+        // 半山 是號(5)；限定只搜字(4) 應查不到
+        $this->assertSame(0, $this->svc()->searchPersons('半山', null, [4])['total']);
+        // 限定號(5) 應命中
+        $this->assertSame(1, $this->svc()->searchPersons('半山', null, [5])['total']);
+    }
+
+    #[Test]
+    public function dynasty_filter_applies(): void {
+        $this->assertSame(0, $this->svc()->searchPersons('介甫', 19)['total']);
+        $this->assertSame(1, $this->svc()->searchPersons('介甫', 15)['total']);
+    }
+
+    #[Test]
+    public function numeric_keyword_is_exact_personid(): void {
+        $res = $this->svc()->searchPersons('100');
+        $this->assertSame(1, $res['total']);
+        $this->assertSame(100, $res['rows'][0]['c_personid']);
+    }
+
+    #[Test]
+    public function unknown_name_returns_empty(): void {
+        $this->assertSame(0, $this->svc()->searchPersons('不存在的名字')['total']);
+    }
+}

--- a/tests/Feature/McpSearchPersonByNameTest.php
+++ b/tests/Feature/McpSearchPersonByNameTest.php
@@ -15,7 +15,7 @@ class McpSearchPersonByNameTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
         $this->createTables();
-        $this->seed();
+        $this->seedFixtures();
     }
 
     private function createTables(): void {
@@ -38,7 +38,7 @@ class McpSearchPersonByNameTest extends TestCase {
         )');
     }
 
-    private function seed(): void {
+    private function seedFixtures(): void {
         DB::table('DYNASTIES')->insert([
             ['c_dy' => 15, 'c_dynasty_chn' => '宋'],
             ['c_dy' => 19, 'c_dynasty_chn' => '明'],


### PR DESCRIPTION
MCP 原有工具只能查 BIOG_MAIN 主名，字/號/別名（存 ALTNAME_DATA）查不到。新增 search_person_by_name，效果對齊首頁人物瀏覽器：一個關鍵詞同時命中主名＋字＋號＋別名。

- 新增 App\Services\NameSearchService：抽出首頁 FTS 命中邏輯（ftsPersonIds），首頁 PersonBrowserService 與 MCP 共用同一實現，杜絕兩套漂移；searchPersons() 為 MCP 提供 三分支解析（personid/中文FTS/拼音回退）＋朝代過濾＋分頁＋matched_terms（命中的名字類型）。
- 新增 App\Mcp\Tools\SearchPersonByNameTool 並註冊進 CbdbReadOnlyServer。工具走固定表名， 不經表白名單（prod 未把 CBDB__NAME_FTS 納入 allowlist 也能用），只讀。
- 重構 PersonBrowserService 兩處 FTS 查詢改調 NameSearchService::ftsPersonIds（行為不變）。
- 異體字（潁/穎/頴）不做歸一，與首頁一致（留作獨立議題）。
- 新增 tests/Feature/McpSearchPersonByNameTest（字/號命中、type 過濾、朝代過濾、numeric、無命中）。