### PR TITLE
feat(cascade): 去級聯 Phase 1, Batch 2: TEXT_CODES/ADDR_CODES 入邊 FK 翻 RESTRICT

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -11,6 +11,7 @@ use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\PinyinUmlaut;
 use App\Support\SimplifiedOnlyChars;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -188,24 +189,40 @@ class AdminBatchLoadBookTitlesController extends Controller {
 
         $marker = '['.$data['batch_id'].']';
 
-        $deleted = DB::transaction(function () use ($marker) {
-            $textIds = DB::table('TEXT_CODES')
-                ->where('c_notes', $marker)
-                ->pluck('c_textid')
-                ->map(fn ($v) => (string) $v)
-                ->all();
+        try {
+            $deleted = DB::transaction(function () use ($marker) {
+                $textIds = DB::table('TEXT_CODES')
+                    ->where('c_notes', $marker)
+                    ->pluck('c_textid')
+                    ->map(fn ($v) => (string) $v)
+                    ->all();
 
-            if (empty($textIds)) {
-                return 0;
+                if (empty($textIds)) {
+                    return 0;
+                }
+
+                DB::table('operations')
+                    ->where('resource', 'TEXT_CODES')
+                    ->whereIn('resource_id', $textIds)
+                    ->delete();
+
+                return DB::table('TEXT_CODES')->where('c_notes', $marker)->delete();
+            });
+        } catch (QueryException $e) {
+            // TEXT_CODES 入邊外鍵已翻成 ON DELETE RESTRICT（去級聯 Phase 1 批次 2）：
+            // 批內書目若已被其他資料引用（出處/著述/別名來源等），DELETE 會被 DB 以 1451 擋下、
+            // 整批交易回滾（含 operations 清理）。fail-closed、零資料損失，這裡轉為友好訊息。
+            if (($e->errorInfo[1] ?? null) !== 1451) {
+                throw $e;
             }
 
-            DB::table('operations')
-                ->where('resource', 'TEXT_CODES')
-                ->whereIn('resource_id', $textIds)
-                ->delete();
-
-            return DB::table('TEXT_CODES')->where('c_notes', $marker)->delete();
-        });
+            return redirect()
+                ->route($this->listRouteName($request))
+                ->with('toast', [
+                    'msg' => "批次 {$data['batch_id']} 中已有書目被其他資料引用，整批撤回已取消（未刪除任何資料）。請先移除引用，或改由管理員單筆處理。",
+                    'type' => 'error',
+                ]);
+        }
 
         return redirect()
             ->route($this->listRouteName($request))

--- a/database/migrations/2026_07_21_000000_restrict_fks_referencing_text_addr_codes.php
+++ b/database/migrations/2026_07_21_000000_restrict_fks_referencing_text_addr_codes.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 去級聯 Phase 1 — 批次 2：把「引用 TEXT_CODES／ADDR_CODES」的外鍵由 ON DELETE CASCADE 翻成 RESTRICT。
+ *
+ * 依 docs/ON_DELETE_CASCADE_RISK.md §6.1 與 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
+ * （批次單位＝被引用表、兩條 ALTER、foreign_key_checks=0、SQLite no-op），範式同批次 1
+ * （2026_07_20_000000_restrict_fks_referencing_dynasty_batch.php）。
+ *
+ * 本批＝入邊數次高的兩張詞表（baseline 共 33 條入邊 FK，皆單欄、皆 CASCADE）：
+ *   TEXT_CODES(22)、ADDR_CODES(11)。
+ *
+ * 前置（app-layer-first）：兩表經 UI 的刪除路徑均已封堵（CodesController::performDestroy、
+ * CodeTableDeleteHandler 皆無條件擋下）；唯一活路徑 AdminBatchLoadBookTitlesController::undo()
+ * 只刪本批次剛建立的 TEXT_CODES 列，已同步補上 1451 友好報錯垫片（同 commit）。翻轉後任何
+ * 漏網硬刪一律 fail-closed（1451），零資料損失。
+ */
+return new class () extends Migration {
+    private const REFERENCED_TABLES = ['TEXT_CODES', 'ADDR_CODES'];
+
+    public function up(): void {
+        $this->flip('RESTRICT', ['CASCADE']);
+    }
+
+    public function down(): void {
+        $this->flip('CASCADE', ['RESTRICT', 'NO ACTION']);
+    }
+
+    /**
+     * @param string $onDelete 目標 ON DELETE 行為
+     * @param array<int,string> $fromRules 只翻目前為這些 DELETE_RULE 的 FK
+     */
+    private function flip(string $onDelete, array $fromRules): void {
+        if (!is_mysql()) {
+            return; // SQLite 無外鍵
+        }
+
+        $inRefs = implode(',', array_fill(0, count(self::REFERENCED_TABLES), '?'));
+        $inRules = implode(',', array_fill(0, count($fromRules), '?'));
+
+        $fks = DB::select(
+            'SELECT rc.CONSTRAINT_NAME AS name, rc.TABLE_NAME AS tbl,
+                    rc.REFERENCED_TABLE_NAME AS ref_tbl, rc.UPDATE_RULE AS update_rule
+             FROM information_schema.REFERENTIAL_CONSTRAINTS rc
+             WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+               AND rc.REFERENCED_TABLE_NAME IN ('.$inRefs.')
+               AND rc.DELETE_RULE IN ('.$inRules.')',
+            array_merge(self::REFERENCED_TABLES, $fromRules)
+        );
+
+        DB::statement('SET SESSION foreign_key_checks = 0');
+        $flipped = 0;
+
+        try {
+            foreach ($fks as $fk) {
+                $cols = DB::select(
+                    'SELECT COLUMN_NAME AS col, REFERENCED_COLUMN_NAME AS ref_col
+                     FROM information_schema.KEY_COLUMN_USAGE
+                     WHERE CONSTRAINT_SCHEMA = DATABASE()
+                       AND CONSTRAINT_NAME = ? AND TABLE_NAME = ?
+                       AND REFERENCED_TABLE_NAME IS NOT NULL
+                     ORDER BY ORDINAL_POSITION',
+                    [$fk->name, $fk->tbl]
+                );
+                $fkCols = implode(', ', array_map(fn ($x) => "`{$x->col}`", $cols));
+                $refCols = implode(', ', array_map(fn ($x) => "`{$x->ref_col}`", $cols));
+
+                DB::statement("ALTER TABLE `{$fk->tbl}` DROP FOREIGN KEY `{$fk->name}`");
+                DB::statement(
+                    "ALTER TABLE `{$fk->tbl}` ADD CONSTRAINT `{$fk->name}` ".
+                    "FOREIGN KEY ({$fkCols}) REFERENCES `{$fk->ref_tbl}` ({$refCols}) ".
+                    "ON DELETE {$onDelete} ON UPDATE {$fk->update_rule}"
+                );
+                $flipped++;
+            }
+        } finally {
+            DB::statement('SET SESSION foreign_key_checks = 1');
+        }
+
+        echo "[restrict-batch-2] {$onDelete}: flipped {$flipped} FK(s) referencing ".
+             implode('/', self::REFERENCED_TABLES).PHP_EOL;
+    }
+};

--- a/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
+++ b/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
@@ -94,7 +94,8 @@ GROUP BY REFERENCED_TABLE_NAME, DELETE_RULE;
 | 批次 | 被引用表（入邊數） | migration | 狀態 |
 |---|---|---|---|
 | **1** | NIAN_HAO(24)、YEAR_RANGE_CODES(23)、DYNASTIES(10)、GANZHI_CODES(9)＝**66 條** | `2026_07_20_000000_restrict_fks_referencing_dynasty_batch` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9） |
-| 2… | TEXT_CODES(22)、ADDR_CODES(11)、其餘詞表 | 待做 | — |
+| **2** | TEXT_CODES(21)、ADDR_CODES(11)＝**32 條**（TEXT_CODES 另 1 條 `SET NULL` 本已正確、未觸碰） | `2026_07_21_000000_restrict_fks_referencing_text_addr_codes` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.1）；同 commit 為唯一活硬刪路徑 `AdminBatchLoadBookTitlesController::undo()` 補 1451 友好報錯垫片 |
+| 3… | 其餘小詞表（KINSHIP_CODES(6)、ASSOC_CODES(4)、OFFICE_CODES(3)、EVENT_CODES(3)…） | 待做 | — |
 | n | SOCIAL_INSTITUTION_CODES(5) | 待做——「一機構多名」安全前提（[SOCIAL_INSTITUTION_ENTITY_MODEL §5.9](./SOCIAL_INSTITUTION_ENTITY_MODEL.md)）；**前置**：先封 codes UI 對該表的刪除（社會機構 step 4） | — |
 | 末 | BIOG_MAIN(25)＋operations→BIOG_MAIN | 待做——需配套顯式級聯刪除服務 | — |
 
@@ -118,6 +119,27 @@ migration，再套用批次 1：
 > 註：全庫共 188 條 CASCADE（baseline 186 ＋後續 migration 新增 2，如 events_data 複合 FK／admin_cat）；
 > 另有 1 條既有正確的 `SET NULL`（`fk_merged_person_source`），全程未觸碰。
 > 翻轉近乎即時（`foreign_key_checks=0` 免掃描）、完全可逆。
+
+### 9.1 批次 2 端到端實測（fresh MariaDB 10.3，2026-07-21）
+
+同 §9 流程（乾淨 10.3 容器、app 容器全量 `php artisan migrate`）：
+
+| 檢查 | 結果 |
+|---|---|
+| 批次 2 翻轉 | ✅ `flipped 32`（TEXT_CODES 21＋ADDR_CODES 11；`fk_merged_person_source`→TEXT_CODES 的 `SET NULL` 未觸碰） |
+| 兩表入邊 `DELETE_RULE` | ✅ 全 `NO ACTION`（10.3 顯示，§3），CASCADE 歸零 |
+| 全庫 | ✅ `CASCADE 90`／`NO ACTION 98`／`SET NULL 1`（122−32＝90，其他批未動） |
+| 行為：刪被引用列 | ✅ 刪被 BIOG_SOURCE_DATA 引用的 TEXT_CODES → 1451 擋下；刪被 BIOG_ADDR_DATA 引用的 ADDR_CODES → 1451 擋下；資料一列不少 |
+| 行為：零引用刪除 | ✅ 引用移除後 DELETE 正常成功（物理刪除僅限零引用的目標行為成立） |
+| 可逆 | ✅ `migrate:rollback --step=1` 翻回 CASCADE（32 條），re-migrate 恢復 RESTRICT |
+
+> 註：風險文件附錄 A 稱 TEXT_CODES 有「22 CASCADE＋1 SET NULL」，實際 baseline 為 **21 CASCADE＋1 SET NULL**
+> （grep 的 22 次 `REFERENCES TEXT_CODES` 已含 SET NULL 那條）。以 information_schema 實測為準。
+>
+> 應用層垫片（同 commit）：`AdminBatchLoadBookTitlesController::undo()` 是 TEXT_CODES 唯一未封堵的
+> 硬刪路徑（只刪自己批次建立的列）。翻轉後批內列若已被引用，DELETE 撞 1451、整批交易回滾（含
+> operations 清理一併回滾）；已捕捉 errno 1451 轉為友好 toast（「整批撤回已取消，未刪除任何資料」），
+> 其他 QueryException 照舊上拋。`/codes` destroy 與 mutation `CodeTableDeleteHandler` 先前已無條件封堵，無需處理。
 
 ## 10. 對 `ON_DELETE_CASCADE_RISK.md` 的修正建議
 


### PR DESCRIPTION
把引用 TEXT_CODES(21)/ADDR_CODES(11) 的 32 條入邊外鍵由 ON DELETE CASCADE 翻成 RESTRICT（ON UPDATE 保留 CASCADE；fk_merged_person_source 的 SET NULL 本已正確、未觸碰）。範式同批次 1（資料驅動、範圍鎖定 REFERENCED_TABLES、兩條 ALTER、foreign_key_checks=0、SQLite no-op、down 可逆）。

- 應用層垫片：AdminBatchLoadBookTitlesController::undo() 是 TEXT_CODES 唯一未封堵的硬刪路徑，翻轉後批內書目若已被引用會撞 1451；已捕捉 errno 1451 轉友好 toast（整批交易回滾、未刪除任何資料），其他 QueryException 照舊上拋。/codes destroy 與 CodeTableDeleteHandler 先前已無條件封堵，無需處理。
- MariaDB 10.3 端到端實測：flipped 32、全庫 CASCADE 122→90、刪被引用 TEXT_CODES/ADDR_CODES → 1451 擋下且資料一列不少、零引用刪除照常 成功、rollback 可逆（詳見 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §9.1）。
- 已執行 ./vendor/bin/phpunit tests/Feature/AdminBatchLoadBookTitlesTest.php tests/Feature/BatchLoadBookTitlesInertiaTest.php（56 tests 全綠）