### PR TITLE
提交建議按鈕新增「直接保存」二次確認選項

### DIFF
--- a/resources/js/inertia/Pages/Codes/Create.tsx
+++ b/resources/js/inertia/Pages/Codes/Create.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { FormField } from '../../components/ui/FormField';
 import { PinyinUmlautConfirmDialog } from '../../components/PinyinUmlautConfirmDialog';
+import { ProposalModeDialog } from '../../components/ui/ProposalModeDialog';
 import { collectUmlautConversions, type Tier2UmlautHit } from '../../utils/pinyinUmlaut';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { SharedProps } from '../../types/page';
@@ -46,6 +47,9 @@ export default function CodesCreate() {
 
     const form = useForm<Record<string, string>>(initial);
     const [umlautPrompt, setUmlautPrompt] = useState<{ hits: Tier2UmlautHit[]; run: (overrides?: Record<string, string>) => void } | null>(null);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
+    // 具直接保存權限者（非眾包用戶）點擊「提交提案」前先確認是否改為直接保存。
+    const canWriteDirectly = !!props.auth.user?.can.write_directly;
 
     // 送出（Tier 2 確認後）：overrides 以 transform 保證此次提交送出使用者選擇的值，避免 setData 非同步問題。
     const submitPost = (url: string, overrides?: Record<string, string>) => {
@@ -65,6 +69,8 @@ export default function CodesCreate() {
         run();
     };
     const tableHints = COLUMN_HINTS[table] ?? {};
+    const saveDirect = () => gate((ov) => submitPost(urls.store, ov));
+    const propose = () => gate((ov) => submitPost(urls.propose, ov));
 
     return (
         <DashboardLayout
@@ -74,7 +80,7 @@ export default function CodesCreate() {
             <form
                 onSubmit={(e) => {
                     e.preventDefault();
-                    gate((ov) => submitPost(urls.store, ov));
+                    saveDirect();
                 }}
                 className="max-w-3xl space-y-3 rounded-lg border border-border bg-card p-4"
             >
@@ -120,7 +126,7 @@ export default function CodesCreate() {
 
                         <div className="flex gap-2">
                             <Button type="submit" disabled={form.processing}>{t('save_direct')}</Button>
-                            <Button type="button" variant="secondary" disabled={form.processing} onClick={() => gate((ov) => submitPost(urls.propose, ov))}>
+                            <Button type="button" variant="secondary" disabled={form.processing} onClick={() => (canWriteDirectly ? setConfirmProposalMode(true) : propose())}>
                                 {t('submit_proposal')}
                             </Button>
                         </div>
@@ -141,6 +147,19 @@ export default function CodesCreate() {
                     p.hits.forEach((h) => { overrides[h.field] = h.converted; form.setData(h.field, h.converted); });
                     p.run(overrides);
                 }}
+            />
+
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={t('direct_save_prompt_title')}
+                description={t('direct_save_prompt_desc')}
+                saveDirectLabel={t('save_direct')}
+                submitProposalLabel={t('submit_proposal')}
+                cancelLabel={tc('cancel')}
+                loading={form.processing}
+                onSaveDirect={() => { setConfirmProposalMode(false); saveDirect(); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); propose(); }}
             />
         </DashboardLayout>
     );

--- a/resources/js/inertia/Pages/Codes/Edit.tsx
+++ b/resources/js/inertia/Pages/Codes/Edit.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { FormField } from '../../components/ui/FormField';
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { ProposalModeDialog } from '../../components/ui/ProposalModeDialog';
 import { PinyinUmlautConfirmDialog } from '../../components/PinyinUmlautConfirmDialog';
 import { collectUmlautConversions, type Tier2UmlautHit } from '../../utils/pinyinUmlaut';
 import { useTranslation } from '../../hooks/useTranslation';
@@ -42,7 +43,10 @@ export default function CodesEdit() {
 
     const form = useForm<Record<string, string>>(initial);
     const [confirmDelete, setConfirmDelete] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [umlautPrompt, setUmlautPrompt] = useState<{ hits: Tier2UmlautHit[]; run: (overrides?: Record<string, string>) => void } | null>(null);
+    // 具直接保存權限者（非眾包用戶）點擊「提交提案」前先確認是否改為直接保存。
+    const canWriteDirectly = !!props.auth.user?.can.write_directly;
 
     // 送出（Tier 2 確認後）：overrides 以 transform 保證此次提交使用者選擇的值，避免 setData 非同步問題。
     const submitVia = (method: 'patch' | 'post', url: string, overrides?: Record<string, string>) => {
@@ -62,10 +66,11 @@ export default function CodesEdit() {
         run();
     };
 
+    // app.codes.update 接受 PUT/PATCH；useForm.patch 直接送出。
+    const saveDirect = () => gate((ov) => submitVia('patch', urls.update, ov));
     const submit = (e: React.FormEvent) => {
         e.preventDefault();
-        // app.codes.update 接受 PUT/PATCH；useForm.patch 直接送出。
-        gate((ov) => submitVia('patch', urls.update, ov));
+        saveDirect();
     };
     const propose = () => gate((ov) => submitVia('post', urls.propose, ov));
 
@@ -110,7 +115,7 @@ export default function CodesEdit() {
                 <div className="flex flex-wrap gap-2">
                     <Button type="submit" disabled={form.processing}>{t('save_direct')}</Button>
                     {can_propose && (
-                        <Button type="button" variant="secondary" disabled={form.processing} onClick={propose}>
+                        <Button type="button" variant="secondary" disabled={form.processing} onClick={() => (canWriteDirectly ? setConfirmProposalMode(true) : propose())}>
                             {t('submit_proposal')}
                         </Button>
                     )}
@@ -151,6 +156,19 @@ export default function CodesEdit() {
                     p.hits.forEach((h) => { overrides[h.field] = h.converted; form.setData(h.field, h.converted); });
                     p.run(overrides);
                 }}
+            />
+
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={t('direct_save_prompt_title')}
+                description={t('direct_save_prompt_desc')}
+                saveDirectLabel={t('save_direct')}
+                submitProposalLabel={t('submit_proposal')}
+                cancelLabel={tc('cancel')}
+                loading={form.processing}
+                onSaveDirect={() => { setConfirmProposalMode(false); saveDirect(); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); propose(); }}
             />
         </DashboardLayout>
     );

--- a/resources/js/inertia/components/AddressEditor.tsx
+++ b/resources/js/inertia/components/AddressEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import { router } from '@inertiajs/react';
 import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
@@ -63,6 +64,7 @@ export default function AddressEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -277,13 +279,25 @@ export default function AddressEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/AltnameEditor.tsx
+++ b/resources/js/inertia/components/AltnameEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
@@ -65,6 +66,7 @@ export default function AltnameEditor({
     );
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -280,13 +282,25 @@ export default function AltnameEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -5,6 +5,7 @@ import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import AiCodeLookupPanel, { AiCandidate } from './PersonEditorShared/AiCodeLookupPanel';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import MirrorConflictNotice, { MirrorConflict } from './PersonEditorShared/MirrorConflictNotice';
 import MirrorSuspectedNotice, { MirrorSuspected } from './PersonEditorShared/MirrorSuspectedNotice';
@@ -107,6 +108,7 @@ export default function AssocEditor({
     })));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [sourceHighlight, setSourceHighlight] = useState(false);
@@ -630,7 +632,7 @@ export default function AssocEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -638,6 +640,18 @@ export default function AssocEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/BasicInfoEditor.tsx
+++ b/resources/js/inertia/components/BasicInfoEditor.tsx
@@ -4,6 +4,7 @@ import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import {
     gridCardStyle, gGrid, gFull, gLabelStyle, gCodeStyle, gInputStyle, gHintStyle,
     gReadonlyStyle, gOkStyle, gErrStyle, gWarnStyle, gAuditWrapStyle,
@@ -98,6 +99,7 @@ export default function BasicInfoEditor({
     const [variantReplacedNotice, setVariantReplacedNotice] = useState<string | null>(null);
     const [comment, setComment] = useState('');
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
 
     const dirty = useMemo(() => JSON.stringify(fields) !== savedSnapshot, [fields, savedSnapshot]);
     const dynastyCode = useMemo(() => {
@@ -531,7 +533,7 @@ export default function BasicInfoEditor({
             <div style={gSubmitRow}>
                 {/* 主要動作靠左 */}
                 {canEdit ? <button type="button" disabled={saving || !dirty} style={gPrimaryBtn} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" disabled={saving || !dirty} style={gInfoBtn} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" disabled={saving || !dirty} style={gInfoBtn} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 {/* 近按鈕即時回饋（Q3）：儲存中轉圈 / ✓ 已儲存 / ✗ 失敗，緊鄰按鈕，不必抬頭看頂部 flash。 */}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 {/* 危險/另存動作靠右（對齊 legacy 的 float-right 分組） */}
@@ -543,6 +545,19 @@ export default function BasicInfoEditor({
                     </div>
                 ) : null}
             </div>
+
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/EntryEditor.tsx
+++ b/resources/js/inertia/components/EntryEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
@@ -78,6 +79,7 @@ export default function EntryEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -334,7 +336,7 @@ export default function EntryEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -342,6 +344,18 @@ export default function EntryEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/EventEditor.tsx
+++ b/resources/js/inertia/components/EventEditor.tsx
@@ -4,6 +4,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
@@ -72,6 +73,7 @@ export default function EventEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [sourceHighlight, setSourceHighlight] = useState(false);
@@ -305,7 +307,7 @@ export default function EventEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -313,6 +315,18 @@ export default function EventEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/KinEditor.tsx
+++ b/resources/js/inertia/components/KinEditor.tsx
@@ -3,6 +3,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import MirrorConflictNotice, { MirrorConflict } from './PersonEditorShared/MirrorConflictNotice';
 import MirrorSuspectedNotice, { MirrorSuspected } from './PersonEditorShared/MirrorSuspectedNotice';
@@ -72,6 +73,7 @@ export default function KinEditor({
     })));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [sourceHighlight, setSourceHighlight] = useState(false);
@@ -402,7 +404,7 @@ export default function KinEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -410,6 +412,18 @@ export default function KinEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
@@ -95,6 +96,7 @@ export default function OfficeEditor({
     });
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -424,7 +426,7 @@ export default function OfficeEditor({
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
                 {mode === 'edit' && canEdit ? <button type="button" style={gSuccessBtn} disabled={saving} onClick={() => void save('direct', true)}>{tr('save_as', '另存新檔')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -432,6 +434,18 @@ export default function OfficeEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/PossessionEditor.tsx
+++ b/resources/js/inertia/components/PossessionEditor.tsx
@@ -4,6 +4,7 @@ import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import {
     gridCardStyle, gGrid, gInputStyle, gReadonlyStyle, gOkStyle, gErrStyle,
@@ -72,6 +73,7 @@ export default function PossessionEditor({
     const originalPk = useRef<Record<string, number>>({ c_possession_record_id: Number(initialFields.c_possession_record_id ?? 0) });
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [sourceHighlight, setSourceHighlight] = useState(false);
@@ -289,7 +291,7 @@ export default function PossessionEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -297,6 +299,18 @@ export default function PossessionEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/SocialInstEditor.tsx
+++ b/resources/js/inertia/components/SocialInstEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
@@ -65,6 +66,7 @@ export default function SocialInstEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -272,7 +274,7 @@ export default function SocialInstEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -280,6 +282,18 @@ export default function SocialInstEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/SourceEditor.tsx
+++ b/resources/js/inertia/components/SourceEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import { getCsrfToken } from './PersonBrowser/shared/csrf';
@@ -76,6 +77,7 @@ export default function SourceEditor({
     });
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -265,7 +267,7 @@ export default function SourceEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -273,6 +275,18 @@ export default function SourceEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/StatusEditor.tsx
+++ b/resources/js/inertia/components/StatusEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import EraTimeField, { EraTimeFieldValues } from './EraTimeField';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
@@ -84,6 +85,7 @@ export default function StatusEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -309,7 +311,7 @@ export default function StatusEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
@@ -317,6 +319,18 @@ export default function StatusEditor({
                 </div>
             </div>
             {dirty ? <div style={{ marginTop: 8, color: 'var(--warning-subtle-foreground)', fontSize: '0.8rem' }}>{tr('unsaved_changes', '有未儲存的變更')}</div> : null}
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/TextEditor.tsx
+++ b/resources/js/inertia/components/TextEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ActionStatus, { BtnSpinner } from './PersonEditorShared/ActionStatus';
+import { ProposalModeDialog } from './ui/ProposalModeDialog';
 import { redirectAfterSubresourceCreate } from './PersonEditorShared/afterCreate';
 import CodeAutocomplete from './PersonBrowser/shared/CodeAutocomplete';
 import TextpersonPair from './PersonEditorShared/TextpersonPair';
@@ -53,6 +54,7 @@ export default function TextEditor({
     const originalPk = useRef<Record<string, number>>(Object.fromEntries(PK.map((k) => [k, Number(initialFields[k] ?? (k === 'c_personid' ? personId : 0))])));
     const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [confirmProposalMode, setConfirmProposalMode] = useState(false);
     const [message, setMessage] = useState<string | null>(null);
     const flashSaved = (m: string) => { setMessage(m); if (msgTimer.current) window.clearTimeout(msgTimer.current); msgTimer.current = window.setTimeout(() => setMessage(null), 3000); };
     useEffect(() => () => { if (msgTimer.current) window.clearTimeout(msgTimer.current); }, []);
@@ -229,13 +231,25 @@ export default function TextEditor({
 
             <div style={gSubmitRow}>
                 {canEdit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('proposal')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
+                {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => (canEdit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('submit_proposal', '提交建議')}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
                     {mode === 'edit' && canEdit && deleteEndpoint ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>
             </div>
+            <ProposalModeDialog
+                open={confirmProposalMode}
+                onOpenChange={setConfirmProposalMode}
+                title={tr('direct_save_prompt_title', '直接保存還是提交提案？')}
+                description={tr('direct_save_prompt_desc', '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。')}
+                saveDirectLabel={tr('save_directly', '直接保存')}
+                submitProposalLabel={tr('submit_proposal', '提交建議')}
+                cancelLabel={tr('cancel', '取消')}
+                loading={saving}
+                onSaveDirect={() => { setConfirmProposalMode(false); void save('direct'); }}
+                onSubmitProposal={() => { setConfirmProposalMode(false); void save('proposal'); }}
+            />
         </form>
     );
 }

--- a/resources/js/inertia/components/ui/ProposalModeDialog.tsx
+++ b/resources/js/inertia/components/ui/ProposalModeDialog.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+interface ProposalModeDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    saveDirectLabel: string;
+    submitProposalLabel: string;
+    cancelLabel: string;
+    loading?: boolean;
+    onSaveDirect: () => void;
+    onSubmitProposal: () => void;
+}
+
+/**
+ * 有直接保存權限的使用者點擊「提交建議」時的確認彈窗：
+ * 讓使用者在「直接保存」與「仍要提交建議（等待審核）」之間二次確認選擇，
+ * 避免有權限的使用者誤送出不必要的審核提案。取代 window.confirm，a11y 較佳。
+ */
+export function ProposalModeDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    saveDirectLabel,
+    submitProposalLabel,
+    cancelLabel,
+    loading,
+    onSaveDirect,
+    onSubmitProposal,
+}: ProposalModeDialogProps) {
+    return (
+        <Modal
+            open={open}
+            onOpenChange={onOpenChange}
+            title={title}
+            description={description}
+            footer={
+                <>
+                    <Button variant="outline" disabled={loading} onClick={() => onOpenChange(false)}>
+                        {cancelLabel}
+                    </Button>
+                    <Button variant="secondary" disabled={loading} onClick={onSubmitProposal}>
+                        {submitProposalLabel}
+                    </Button>
+                    <Button variant="default" disabled={loading} onClick={onSaveDirect}>
+                        {saveDirectLabel}
+                    </Button>
+                </>
+            }
+        />
+    );
+}

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -5,6 +5,8 @@ return [
     'save_directly' => 'Save Directly',
     'submit_proposal' => 'Submit Proposal',
     'save_as' => 'Save As',
+    'direct_save_prompt_title' => 'Save directly or submit a proposal?',
+    'direct_save_prompt_desc' => 'You have permission to save directly. Saving directly applies your changes immediately; submitting a proposal instead requires review by a colleague before it takes effect. Please choose how you would like to proceed.',
 
     // ─── Modification note ─────────────────────────────────────────
     'modification_note_label' => 'Modification Note / Proposal Reason (optional)',

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -116,6 +116,8 @@ return [
     'proposal_desc_hint' => 'Fill only when submitting a proposal (optional)',
     'save_direct' => 'Save Directly',
     'submit_proposal' => 'Submit Proposal',
+    'direct_save_prompt_title' => 'Save directly or submit a proposal?',
+    'direct_save_prompt_desc' => 'You have permission to save directly. Saving directly applies your changes immediately; submitting a proposal instead requires review by a colleague before it takes effect. Please choose how you would like to proceed.',
 
     // codes/edit.blade.php hint texts and JS strings
     'author_label' => 'Author',

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -5,6 +5,8 @@ return [
     'save_directly' => '直接儲存',
     'submit_proposal' => '提交提案',
     'save_as' => '另存新檔',
+    'direct_save_prompt_title' => '直接保存還是提交提案？',
+    'direct_save_prompt_desc' => '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。',
 
     // ─── Modification note ─────────────────────────────────────────
     'modification_note_label' => '修改說明 / 提案理由（可選）',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -114,6 +114,8 @@ return [
     'proposal_desc_hint' => '僅在提交提案時填寫（選填）',
     'save_direct' => '直接儲存',
     'submit_proposal' => '提交提案',
+    'direct_save_prompt_title' => '直接保存還是提交提案？',
+    'direct_save_prompt_desc' => '您具有直接保存的權限。直接保存會立即套用變更；提交提案則需等待其他同事審核後才會套用。請選擇您想要的方式。',
 
     // codes/edit.blade.php 說明文字與 JS 字串
     'author_label' => '作者',


### PR DESCRIPTION
## Summary
- 具直接保存權限（非眾包）的使用者點擊任何「提交建議」按鈕時，先彈出確認框，可選擇改為「直接保存」，或維持「提交建議」等待審核；眾包用戶（僅可提案）行為不變。
- 新增共用元件 `resources/js/inertia/components/ui/ProposalModeDialog.tsx`，並接入 13 個人物子資源編輯器（Address/Altname/Assoc/BasicInfo/Entry/Event/Kin/Office/Possession/SocialInst/Source/Status/Text）與 Codes 模組的 Create/Edit 頁面（依全站共用的 `auth.user.can.write_directly` 判斷）。
- 新增中英文字串 `direct_save_prompt_title` / `direct_save_prompt_desc`（`biogmains.php`、`codes.php`）。

## Test plan
- [x] `npm run build` 通過
- [x] `npx tsc --noEmit` 未新增型別錯誤（既有無關錯誤維持不變）
- [x] 每個環節皆通過獨立 review agent 檢查與 codex 覆查，無嚴重 issue
- [x] `deploy.sh` + `php artisan migrate` + `php artisan serve` 本地驗證通過
- [ ] 使用者本地手動點擊驗證：具直接保存權限帳號點擊「提交建議」出現確認框，可選直接保存/仍提交建議/取消；眾包帳號行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)