### PR TITLE
修正社會關係／社會區分 AI 智能識別存檔後日誌誤顯示「未提交」

### DIFF
--- a/app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php
+++ b/app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php
@@ -26,6 +26,8 @@ use Illuminate\Support\Str;
  * - 統一 response shape
  */
 abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\RecordsAiFillSubmission;
+
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
 
@@ -134,7 +136,15 @@ abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHa
             return $this->handleProposal($personId, $actualPk, $rowData, $comment);
         }
 
-        return $this->handleDirect($personId, $actualPk, $rowData, $comment);
+        $response = $this->handleDirect($personId, $actualPk, $rowData, $comment);
+
+        // AI 智能識別：direct 新增成功後回寫 ai_fill_logs（見 RecordsAiFillSubmission）。
+        // 提交資料＝正規化後完整 row（PK + 白名單欄）；僅 aiFillCategory() 非 null 的資源實際回寫。
+        if ($response->getStatusCode() === 200) {
+            $this->recordAiFillSubmission($meta, $personId, $rowData);
+        }
+
+        return $response;
     }
 
     /**

--- a/app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php
+++ b/app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php
@@ -26,6 +26,8 @@ use Illuminate\Support\Str;
  * - 統一 response shape
  */
 abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\RecordsAiFillSubmission;
+
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
 
@@ -149,7 +151,20 @@ abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutation
             return $this->handleProposal($personId, $targetPk, $updateData, $originalArray, $comment);
         }
 
-        return $this->handleDirect($personId, $targetPk, $updateData, $originalArray, $comment);
+        $response = $this->handleDirect($personId, $targetPk, $updateData, $originalArray, $comment);
+
+        // AI 智能識別：direct 更新成功後回寫 ai_fill_logs（見 RecordsAiFillSubmission）。
+        // 提交資料＝更新後 PK + 使用者實際變更欄位（$updateData 尚未注入 c_modified_*，那是 handleDirect 內的本地副本）；
+        // 僅 aiFillCategory() 非 null 的資源實際回寫。
+        if ($response->getStatusCode() === 200) {
+            $this->recordAiFillSubmission(
+                $meta,
+                $personId,
+                array_merge($this->buildNewPk($targetPk, $updateData), $updateData)
+            );
+        }
+
+        return $response;
     }
 
     /**

--- a/app/Services/Mutations/AssociationCreateHandler.php
+++ b/app/Services/Mutations/AssociationCreateHandler.php
@@ -188,6 +188,11 @@ class AssociationCreateHandler extends AbstractPersonSubresourceCreateHandler {
         ];
     }
 
+    /** 社會關係 create 經 AI 智能識別（category='assoc'）時，回寫 ai_fill_logs（見 RecordsAiFillSubmission）。 */
+    protected function aiFillCategory(): ?string {
+        return 'assoc';
+    }
+
     protected function resourceName(): string {
         return 'associations';
     }

--- a/app/Services/Mutations/AssociationMutationHandler.php
+++ b/app/Services/Mutations/AssociationMutationHandler.php
@@ -279,6 +279,11 @@ class AssociationMutationHandler extends AbstractPersonSubresourceMutationHandle
         return $query->first();
     }
 
+    /** 社會關係 update 經 AI 智能識別（category='assoc'）時，回寫 ai_fill_logs（見 RecordsAiFillSubmission）。 */
+    protected function aiFillCategory(): ?string {
+        return 'assoc';
+    }
+
     protected function resourceName(): string {
         return 'associations';
     }

--- a/app/Services/Mutations/Concerns/RecordsAiFillSubmission.php
+++ b/app/Services/Mutations/Concerns/RecordsAiFillSubmission.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Mutations\Concerns;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v2 direct mutation 成功後，把使用者實際提交的資料回寫 ai_fill_logs（user_submitted + submitted_at），
+ * 使 /admin/ai-fill-logs 正確顯示「已提交」。
+ *
+ * 背景：AI 智能識別代碼（AiCodeLookupPanel → CodeLookupController@suggest）於識別當下建立 ai_fill_logs 一筆；
+ * 舊 Blade store/update 以 ai_fill_log_id 回寫 user_submitted。React 遷移後 /app 路徑改走 v2 mutation，
+ * 遺漏此步 → 上線後所有經 AI 識別的社會關係（assoc）／社會區分（status）日誌一律誤顯示「未提交」，
+ * 與是否人工修改 AI 建議無關（以 log id 連結、不比對欄位值）。任官（offices）已於 PostingCreateHandler 修復，
+ * 此 trait 讓子資源 create／update handler 共用同一套回寫與守衛。
+ *
+ * 用法：handler 覆寫 {@see aiFillCategory()} 回傳自身 category（'assoc' / 'status'）；
+ * 抽象基底類於 direct 成功後呼叫 {@see recordAiFillSubmission()}。預設 category=null＝該資源無 AI 識別、不回寫（no-op）。
+ *
+ * 守衛（對齊 PostingCreateHandler::recordAiFillSubmission）：
+ * - log id 由前端經 meta.ai_fill_log_id 傳入；非正整數則略過。
+ * - WHERE 以 id + user_id(Auth) + category + c_personid 四重限定：user_id 防覆寫他人日誌；
+ *   category 防誤寫他類日誌；c_personid（handler 權威值）確保只回寫「同一人物」的日誌。
+ * - Schema::hasTable 守衛，使無 ai_fill_logs 的既有測試不受影響。
+ * - 任何例外只記 warning、不影響主流程（主資料已成功寫入）。
+ * - 僅 direct 模式呼叫；proposal 於核准時才落庫、提交當下不回寫（另計）。
+ */
+trait RecordsAiFillSubmission {
+    /**
+     * 此資源對應的 ai_fill_logs.category；null＝無 AI 識別、不回寫。
+     * 子類覆寫回傳 'assoc' / 'status' 以啟用回寫。
+     */
+    protected function aiFillCategory(): ?string {
+        return null;
+    }
+
+    /**
+     * 回寫 ai_fill_logs：使用者實際提交的資料落 user_submitted、時間落 submitted_at。
+     *
+     * @param array $meta      mutation meta（含 ai_fill_log_id）
+     * @param int   $personId  handler 權威人物 ID（用於 c_personid 守衛）
+     * @param array $submitted 使用者實際提交、已正規化的欄位資料（原樣記錄，不比對 AI 建議）
+     */
+    protected function recordAiFillSubmission(array $meta, int $personId, array $submitted): void {
+        $category = $this->aiFillCategory();
+        if ($category === null) {
+            return;
+        }
+
+        $logId = $meta['ai_fill_log_id'] ?? null;
+        if (!is_numeric($logId) || (int) $logId <= 0) {
+            return;
+        }
+
+        if (!Schema::hasTable('ai_fill_logs')) {
+            return;
+        }
+
+        try {
+            DB::table('ai_fill_logs')
+                ->where('id', (int) $logId)
+                ->where('user_id', Auth::id())
+                ->where('category', $category)
+                ->where('c_personid', $personId)
+                ->update([
+                    'user_submitted' => json_encode($submitted, JSON_UNESCAPED_UNICODE),
+                    'submitted_at' => Carbon::now(),
+                    'updated_at' => Carbon::now(),
+                ]);
+        } catch (\Throwable $e) {
+            Log::warning('[AI Fill Log] v2 '.$category.' 提交回寫失敗: '.$e->getMessage());
+        }
+    }
+}

--- a/app/Services/Mutations/StatusCreateHandler.php
+++ b/app/Services/Mutations/StatusCreateHandler.php
@@ -13,6 +13,11 @@ class StatusCreateHandler extends AbstractPersonSubresourceCreateHandler {
         parent::__construct($operationRepository, $auditLogService);
     }
 
+    /** 社會區分 create 經 AI 智能識別（category='status'）時，回寫 ai_fill_logs（見 RecordsAiFillSubmission）。 */
+    protected function aiFillCategory(): ?string {
+        return 'status';
+    }
+
     protected function resourceName(): string {
         return 'statuses';
     }

--- a/app/Services/Mutations/StatusMutationHandler.php
+++ b/app/Services/Mutations/StatusMutationHandler.php
@@ -13,6 +13,11 @@ class StatusMutationHandler extends AbstractPersonSubresourceMutationHandler {
         parent::__construct($operationRepository, $auditLogService);
     }
 
+    /** 社會區分 update 經 AI 智能識別（category='status'）時，回寫 ai_fill_logs（見 RecordsAiFillSubmission）。 */
+    protected function aiFillCategory(): ?string {
+        return 'status';
+    }
+
     protected function resourceName(): string {
         return 'statuses';
     }

--- a/resources/js/inertia/components/AssocEditor.tsx
+++ b/resources/js/inertia/components/AssocEditor.tsx
@@ -293,7 +293,11 @@ export default function AssocEditor({
         setMessage(tr('update_source_success', '已自動回填出處與頁碼'));
     };
 
-    const applyAiCode = (c: AiCandidate) => {
+    // AI 識別建立的 ai_fill_logs id：套用候選碼時記下，存檔時經 meta.ai_fill_log_id 回傳後端回寫
+    // user_submitted（否則 /admin/ai-fill-logs 恆顯示「未提交」）；存檔成功後清除，避免後續無關存檔誤標。
+    const aiFillLogId = useRef<number | null>(null);
+    const applyAiCode = (c: AiCandidate, logId: number | null) => {
+        aiFillLogId.current = logId;
         set('c_assoc_code', String(c.code_id));
         setLabel('c_assoc_code', `${c.code_id} ${c.desc_chn ?? ''} ${c.desc_en ?? ''}`.trim());
         setAssocHighlight(true);
@@ -374,10 +378,12 @@ export default function AssocEditor({
             }
         }
         try {
-            // #66：meta 可帶 comment（proposal）與 force（衝突警告中選「強制覆寫」時）。
+            // #66：meta 可帶 comment（proposal）與 force（衝突警告中選「強制覆寫」時）；
+            // 曾用 AI 智能識別（direct/proposal 皆可）時附帶 ai_fill_log_id 供後端回寫 user_submitted。
             const meta: Record<string, unknown> = {};
             if (comment) meta.comment = comment;
             if (force) meta.force = true;
+            if (aiFillLogId.current) meta.ai_fill_log_id = aiFillLogId.current;
             const res = await fetch(endpoint, {
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
@@ -402,6 +408,7 @@ export default function AssocEditor({
             if (Object.keys(auditPatch).length > 0) setFields((prev) => ({ ...prev, ...auditPatch }));
             setSavedSnapshot(JSON.stringify({ ...fields, ...auditPatch }));
             setPairTouched(false); setKinPairTouched(false); setAssocKinPairTouched(false); // #88：存檔成功後重置三組配對 touched。
+            aiFillLogId.current = null; // 存檔成功後清除：後續無關存檔不再重複回寫此日誌（create 會 redirect，主要保護 edit）。
             if (mode === 'create') { redirectAfterSubresourceCreate(indexUrl, json, sm === 'direct'); } else if (sm === 'direct') {
                 // 改鍵後以實際送出的 PK 變更覆寫 originalPk（不可用 fields 重建，避免清空 Number('')=0 失準）。
                 const nextPk = { ...originalPk.current };

--- a/resources/js/inertia/components/PersonEditorShared/AiCodeLookupPanel.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/AiCodeLookupPanel.tsx
@@ -29,8 +29,12 @@ interface Props {
     title: string;
     placeholder?: string;
     hint?: string;
-    /** 點擊候選代碼後回填到對應欄位。 */
-    onApply: (c: AiCandidate) => void;
+    /**
+     * 點擊候選代碼後回填到對應欄位。第二參數 aiFillLogId 為本次 AI 識別（extract/suggest）建立的
+     * ai_fill_logs 記錄 id：父編輯器須於存檔時經 v2 mutation meta.ai_fill_log_id 回傳後端，後端據此
+     * 回寫 user_submitted，使 /admin/ai-fill-logs 正確顯示「已提交」（缺此回傳＝整條鏈斷、恆顯示未提交）。
+     */
+    onApply: (c: AiCandidate, aiFillLogId: number | null) => void;
     disabled?: boolean;
 }
 
@@ -59,6 +63,9 @@ export default function AiCodeLookupPanel({
         const q = query.trim();
         if (!q) { setError(t('ai_enter_description')); return; }
         if (!aiSuggestEndpoint) return;
+        // 每次重新識別先清空上一輪的 log id：若本輪回應未帶有效 ai_fill_log_id（如後端 insert 失敗回 null），
+        // 套用本輪候選不得沿用上一輪的舊 id（否則會把上一輪的日誌誤標為已提交）。
+        aiFillLogId.current = null;
         setBusy(true); setError(null); setCandidates(null); setNotFound([]); setSummary('');
         try {
             const res = await fetch(aiSuggestEndpoint, {
@@ -109,7 +116,7 @@ export default function AiCodeLookupPanel({
                                 {candidates.map((c) => (
                                     <button key={String(c.code_id)} type="button" title={c.reason}
                                         style={{ ...candidateBtnStyle, borderColor: relevanceColor(c.relevance) }}
-                                        onClick={() => onApply(c)}>
+                                        onClick={() => onApply(c, aiFillLogId.current)}>
                                         <strong>{c.code_id}</strong> {c.desc_chn ?? ''} {c.desc_en ? <small style={{ color: 'var(--muted-foreground)' }}>({c.desc_en})</small> : null}
                                     </button>
                                 ))}

--- a/resources/js/inertia/components/StatusEditor.tsx
+++ b/resources/js/inertia/components/StatusEditor.tsx
@@ -125,7 +125,11 @@ export default function StatusEditor({
     };
 
     // === AI 智能識別社會區分類別代碼（對齊 legacy btn-ai-code-lookup） ===
-    const applyAiCode = (c: AiCandidate) => {
+    // AI 識別建立的 ai_fill_logs id：套用候選碼時記下，存檔時經 meta.ai_fill_log_id 回傳後端回寫
+    // user_submitted（否則 /admin/ai-fill-logs 恆顯示「未提交」）；存檔成功後清除，避免後續無關存檔誤標。
+    const aiFillLogId = useRef<number | null>(null);
+    const applyAiCode = (c: AiCandidate, logId: number | null) => {
+        aiFillLogId.current = logId;
         set('c_status_code', String(c.code_id));
         setLabel('c_status_code', `${c.code_id} ${c.desc_chn} ${c.desc_en}`.trim());
         setStatusHighlight(true);
@@ -172,12 +176,16 @@ export default function StatusEditor({
             }
             if (Object.keys(changes).length === 0) { setSaving(false); setError(tr('no_change', '沒有變更')); return; }
         }
+        // meta：proposal 附帶審核備註；曾用 AI 智能識別（direct/proposal 皆可）時附帶 ai_fill_log_id 供後端回寫。
+        const meta: Record<string, unknown> = {};
+        if (comment) meta.comment = comment;
+        if (aiFillLogId.current) meta.ai_fill_log_id = aiFillLogId.current;
         try {
             const res = await fetch(endpoint, {
                 method: 'POST',
                 headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken(), 'X-Requested-With': 'XMLHttpRequest' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ resource: 'statuses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(comment ? { meta: { comment } } : {}) }),
+                body: JSON.stringify({ resource: 'statuses', person_id: personId, mode: sm, operation, target: { pk: target }, changes, ...(Object.keys(meta).length ? { meta } : {}) }),
             });
             const json = await res.json().catch(() => ({}));
             if (!res.ok || !json?.ok) throw new Error(json?.message || `HTTP ${res.status}`);
@@ -188,6 +196,7 @@ export default function StatusEditor({
             if (auditRow) { for (const k of ['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date']) { if (auditRow[k] != null) auditPatch[k] = String(auditRow[k]); } }
             if (Object.keys(auditPatch).length > 0) setFields((prev) => ({ ...prev, ...auditPatch }));
             setSavedSnapshot(JSON.stringify({ ...fields, ...auditPatch }));
+            aiFillLogId.current = null; // 存檔成功後清除：後續無關存檔不再重複回寫此日誌（create 會 redirect，主要保護 edit）。
             if (mode === 'create') { redirectAfterSubresourceCreate(indexUrl, json, sm === 'direct'); }
             // 直接儲存若改了鍵：以「實際送出的 PK 變更」覆寫 originalPk（不可用 fields 重建，避免清空 Number('')=0 失準）。
             else if (sm === 'direct') {

--- a/tests/Feature/ApiV2CreateAssociationTest.php
+++ b/tests/Feature/ApiV2CreateAssociationTest.php
@@ -31,9 +31,11 @@ class ApiV2CreateAssociationTest extends TestCase {
         $this->createAssocTable();
         $this->createAssocCodesTable();
         $this->createKinshipCodesTable();
+        $this->createAiFillLogsTable();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ai_fill_logs');
         Schema::dropIfExists('KINSHIP_CODES');
         Schema::dropIfExists('ASSOC_CODES');
         Schema::dropIfExists('ASSOC_DATA');
@@ -199,6 +201,40 @@ class ApiV2CreateAssociationTest extends TestCase {
         ], $overrides);
     }
 
+    protected function createAiFillLogsTable(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('c_personid');
+            $table->string('category', 20)->default('posting');
+            $table->string('route_name', 255)->nullable();
+            $table->string('route_url', 500)->nullable();
+            $table->text('source_text')->nullable();
+            $table->longText('ai_raw')->nullable();
+            $table->longText('ai_matched')->nullable();
+            $table->longText('user_submitted')->nullable();
+            $table->boolean('success')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /** 建立一筆待提交的 AI 填充日誌（預設 category='assoc'），回傳 log id。 */
+    protected function insertAiFillLog(int $userId, int $personId = 1000, string $category = 'assoc'): int {
+        return DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $userId,
+            'c_personid' => $personId,
+            'category' => $category,
+            'route_name' => 'app.basicinformation.assoc.editv2',
+            'route_url' => '/app/basicinformation/'.$personId.'/assoc/edit-v2',
+            'source_text' => '同年進士',
+            'ai_matched' => json_encode(['matched_codes' => [['code_id' => 100]]]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
     protected function seedAssoc(array $overrides = []): void {
         DB::table('ASSOC_DATA')->insert(array_replace($this->pk(), [
             'c_source' => 10,
@@ -227,6 +263,98 @@ class ApiV2CreateAssociationTest extends TestCase {
                 'c_notes' => '新增社會關係',
             ],
         ], $overrides);
+    }
+
+    // ── AI 智能識別回寫 ai_fill_logs（回歸：React 遷移後 v2 create 未回寫 → 全部誤顯示「未提交」）─────
+
+    #[Test]
+    public function testDirectAssociationCreateWithAiFillLogIdMarksLogSubmitted(): void {
+        $user = $this->makeUser(email: 'create-assoc-ailog@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted, 'user_submitted 應回寫（已提交）');
+        $this->assertNotNull($log->submitted_at, 'submitted_at 應回寫');
+        $submitted = json_decode($log->user_submitted, true);
+        $this->assertSame(100, (int) $submitted['c_assoc_code']);
+    }
+
+    #[Test]
+    public function testDirectAssociationCreateWithoutAiFillLogIdLeavesLogUntouched(): void {
+        $user = $this->makeUser(email: 'create-assoc-noailog@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload())->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '無 log id 不應回寫');
+        $this->assertNull($log->submitted_at);
+    }
+
+    #[Test]
+    public function testAssocAiFillLogNotOverwrittenForOtherUsersLog(): void {
+        $owner = $this->makeUser(email: 'create-assoc-ailog-owner@example.com');
+        $actor = $this->makeUser(email: 'create-assoc-ailog-actor@example.com');
+        $logId = $this->insertAiFillLog($owner->id);
+
+        $this->actingAs($actor);
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '他人日誌不得被覆寫');
+    }
+
+    #[Test]
+    public function testAssocAiFillLogNotOverwrittenForWrongCategory(): void {
+        // category 守衛：帶入非 assoc 類（如 status）的 log id 不得被 assoc handler 回寫。
+        $user = $this->makeUser(email: 'create-assoc-ailog-cat@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id, 1000, 'status');
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同 category 的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testAssocAiFillLogNotOverwrittenForDifferentPerson(): void {
+        $user = $this->makeUser(email: 'create-assoc-ailog-person@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id, 999);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'person_id' => 1000,
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同人物的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testProposalAssociationCreateDoesNotRecordAiFillSubmission(): void {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'create-assoc-ailog-proposal@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'mode' => 'proposal',
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, 'proposal 提交當下不回寫');
     }
 
     #[Test]

--- a/tests/Feature/ApiV2CreateStatusTest.php
+++ b/tests/Feature/ApiV2CreateStatusTest.php
@@ -29,9 +29,11 @@ class ApiV2CreateStatusTest extends TestCase {
         $this->createOperationsTable();
         $this->createAuditLogTable();
         $this->createStatusTable();
+        $this->createAiFillLogsTable();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ai_fill_logs');
         Schema::dropIfExists('STATUS_DATA');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
@@ -128,6 +130,40 @@ class ApiV2CreateStatusTest extends TestCase {
 
     // ── Helpers ──────────────────────────────────────────────
 
+    protected function createAiFillLogsTable(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('c_personid');
+            $table->string('category', 20)->default('posting');
+            $table->string('route_name', 255)->nullable();
+            $table->string('route_url', 500)->nullable();
+            $table->text('source_text')->nullable();
+            $table->longText('ai_raw')->nullable();
+            $table->longText('ai_matched')->nullable();
+            $table->longText('user_submitted')->nullable();
+            $table->boolean('success')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /** 建立一筆待提交的 AI 填充日誌（預設 category='status'），回傳 log id。 */
+    protected function insertAiFillLog(int $userId, int $personId = 1000, string $category = 'status'): int {
+        return DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $userId,
+            'c_personid' => $personId,
+            'category' => $category,
+            'route_name' => 'app.basicinformation.statuses.editv2',
+            'route_url' => '/app/basicinformation/'.$personId.'/statuses/edit-v2',
+            'source_text' => '儒童',
+            'ai_matched' => json_encode(['matched_codes' => [['code_id' => 60]]]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
     protected function seedStatus(array $overrides = []): void {
         DB::table('STATUS_DATA')->insert(array_replace([
             'c_personid' => 1000,
@@ -168,6 +204,102 @@ class ApiV2CreateStatusTest extends TestCase {
                 'c_notes' => '新增狀態',
             ],
         ], $overrides);
+    }
+
+    // ── AI 智能識別回寫 ai_fill_logs（回歸：React 遷移後 v2 create 未回寫 → 全部誤顯示「未提交」）─────
+
+    #[Test]
+    public function testDirectStatusCreateWithAiFillLogIdMarksLogSubmitted(): void {
+        $user = $this->makeUser(email: 'create-status-ailog@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted, 'user_submitted 應回寫（已提交）');
+        $this->assertNotNull($log->submitted_at, 'submitted_at 應回寫');
+        $submitted = json_decode($log->user_submitted, true);
+        $this->assertSame(60, (int) $submitted['c_status_code']);
+        $this->assertSame(20, (int) $submitted['c_source']);
+    }
+
+    #[Test]
+    public function testDirectStatusCreateWithoutAiFillLogIdLeavesLogUntouched(): void {
+        $user = $this->makeUser(email: 'create-status-noailog@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload())->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '無 log id 不應回寫');
+        $this->assertNull($log->submitted_at);
+    }
+
+    #[Test]
+    public function testStatusAiFillLogNotOverwrittenForOtherUsersLog(): void {
+        // 安全：只能回寫自己的日誌（WHERE user_id 守衛）。
+        $owner = $this->makeUser(email: 'create-status-ailog-owner@example.com');
+        $actor = $this->makeUser(email: 'create-status-ailog-actor@example.com');
+        $logId = $this->insertAiFillLog($owner->id);
+
+        $this->actingAs($actor);
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '他人日誌不得被覆寫');
+    }
+
+    #[Test]
+    public function testStatusAiFillLogNotOverwrittenForWrongCategory(): void {
+        // category 守衛：帶入非 status 類（如 posting）的 log id 不得被 status handler 回寫。
+        $user = $this->makeUser(email: 'create-status-ailog-cat@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id, 1000, 'posting');
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同 category 的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testStatusAiFillLogNotOverwrittenForDifferentPerson(): void {
+        // 連結完整性：只回寫「同一人物」的日誌（c_personid 守衛，$personId 為 handler 權威值）。
+        $user = $this->makeUser(email: 'create-status-ailog-person@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id, 999);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'person_id' => 1000,
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同人物的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testProposalStatusCreateDoesNotRecordAiFillSubmission(): void {
+        // 提案模式於核准時才落庫，提交當下不回寫 user_submitted（另計）。
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'create-status-ailog-proposal@example.com');
+        $this->actingAs($user);
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/create', $this->createPayload([
+            'mode' => 'proposal',
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, 'proposal 提交當下不回寫');
     }
 
     #[Test]

--- a/tests/Feature/ApiV2MutateAssociationTest.php
+++ b/tests/Feature/ApiV2MutateAssociationTest.php
@@ -31,9 +31,11 @@ class ApiV2MutateAssociationTest extends TestCase {
         $this->createAssociationTable();
         $this->createAssocCodesTable();
         $this->createKinshipCodesTable();
+        $this->createAiFillLogsTable();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ai_fill_logs');
         Schema::dropIfExists('KINSHIP_CODES');
         Schema::dropIfExists('ASSOC_CODES');
         Schema::dropIfExists('ASSOC_DATA');
@@ -207,6 +209,40 @@ class ApiV2MutateAssociationTest extends TestCase {
 
     // ── Helpers ──────────────────────────────────────────────
 
+    protected function createAiFillLogsTable(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('c_personid');
+            $table->string('category', 20)->default('posting');
+            $table->string('route_name', 255)->nullable();
+            $table->string('route_url', 500)->nullable();
+            $table->text('source_text')->nullable();
+            $table->longText('ai_raw')->nullable();
+            $table->longText('ai_matched')->nullable();
+            $table->longText('user_submitted')->nullable();
+            $table->boolean('success')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /** 建立一筆待提交的 AI 填充日誌（預設 category='assoc'），回傳 log id。 */
+    protected function insertAiFillLog(int $userId, int $personId = 1000, string $category = 'assoc'): int {
+        return DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $userId,
+            'c_personid' => $personId,
+            'category' => $category,
+            'route_name' => 'app.basicinformation.assoc.editv2',
+            'route_url' => '/app/basicinformation/'.$personId.'/assoc/edit-v2',
+            'source_text' => '同年進士',
+            'ai_matched' => json_encode(['matched_codes' => [['code_id' => 1]]]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
     protected function seedAssociation(array $overrides = []): void {
         DB::table('ASSOC_DATA')->insert(array_replace([
             'c_personid' => 1000,
@@ -258,6 +294,111 @@ class ApiV2MutateAssociationTest extends TestCase {
         ];
 
         return array_replace_recursive($payload, $overrides);
+    }
+
+    // ── AI 智能識別回寫 ai_fill_logs（回歸：React 遷移後 v2 update 未回寫 → 誤顯示「未提交」）─────
+
+    #[Test]
+    public function testDirectAssociationUpdateWithAiFillLogIdMarksLogSubmitted(): void {
+        $user = $this->makeUser(email: 'assoc-ailog@example.com');
+        $this->actingAs($user);
+        $this->seedAssociation();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted, 'user_submitted 應回寫（已提交）');
+        $this->assertNotNull($log->submitted_at, 'submitted_at 應回寫');
+        $submitted = json_decode($log->user_submitted, true);
+        $this->assertSame('更新備註', $submitted['c_notes']);
+        $this->assertArrayNotHasKey('c_modified_by', $submitted, '不應含自動蓋的稽核欄');
+    }
+
+    #[Test]
+    public function testDirectAssociationUpdateWithoutAiFillLogIdLeavesLogUntouched(): void {
+        $user = $this->makeUser(email: 'assoc-noailog@example.com');
+        $this->actingAs($user);
+        $this->seedAssociation();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'changes' => ['c_notes' => '更新備註'],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '無 log id 不應回寫');
+        $this->assertNull($log->submitted_at);
+    }
+
+    #[Test]
+    public function testAssocUpdateAiFillLogNotOverwrittenForOtherUsersLog(): void {
+        $owner = $this->makeUser(email: 'assoc-ailog-owner@example.com');
+        $actor = $this->makeUser(email: 'assoc-ailog-actor@example.com');
+        $logId = $this->insertAiFillLog($owner->id);
+        $this->actingAs($actor);
+        $this->seedAssociation();
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '他人日誌不得被覆寫');
+    }
+
+    #[Test]
+    public function testAssocUpdateAiFillLogNotOverwrittenForWrongCategory(): void {
+        $user = $this->makeUser(email: 'assoc-ailog-cat@example.com');
+        $this->actingAs($user);
+        $this->seedAssociation();
+        $logId = $this->insertAiFillLog($user->id, 1000, 'status');
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同 category 的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testAssocUpdateAiFillLogNotOverwrittenForDifferentPerson(): void {
+        // 連結完整性：只回寫「同一人物」的日誌（c_personid 守衛，$personId 為 handler 權威值）。
+        $user = $this->makeUser(email: 'assoc-ailog-person@example.com');
+        $this->actingAs($user);
+        $this->seedAssociation();
+        $logId = $this->insertAiFillLog($user->id, 999);
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同人物的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testProposalAssociationUpdateDoesNotRecordAiFillSubmission(): void {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'assoc-ailog-proposal@example.com');
+        $this->actingAs($user);
+        $this->seedAssociation();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload([
+            'mode' => 'proposal',
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, 'proposal 提交當下不回寫');
     }
 
     // ── Direct Update Tests ─────────────────────────────────

--- a/tests/Feature/ApiV2MutateStatusTest.php
+++ b/tests/Feature/ApiV2MutateStatusTest.php
@@ -29,9 +29,11 @@ class ApiV2MutateStatusTest extends TestCase {
         $this->createOperationsTable();
         $this->createAuditLogTable();
         $this->createStatusTable();
+        $this->createAiFillLogsTable();
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('ai_fill_logs');
         Schema::dropIfExists('STATUS_DATA');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('operations');
@@ -128,6 +130,40 @@ class ApiV2MutateStatusTest extends TestCase {
 
     // ── Helpers ──────────────────────────────────────────────
 
+    protected function createAiFillLogsTable(): void {
+        Schema::create('ai_fill_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->integer('c_personid');
+            $table->string('category', 20)->default('posting');
+            $table->string('route_name', 255)->nullable();
+            $table->string('route_url', 500)->nullable();
+            $table->text('source_text')->nullable();
+            $table->longText('ai_raw')->nullable();
+            $table->longText('ai_matched')->nullable();
+            $table->longText('user_submitted')->nullable();
+            $table->boolean('success')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /** 建立一筆待提交的 AI 填充日誌（預設 category='status'），回傳 log id。 */
+    protected function insertAiFillLog(int $userId, int $personId = 1000, string $category = 'status'): int {
+        return DB::table('ai_fill_logs')->insertGetId([
+            'user_id' => $userId,
+            'c_personid' => $personId,
+            'category' => $category,
+            'route_name' => 'app.basicinformation.statuses.editv2',
+            'route_url' => '/app/basicinformation/'.$personId.'/statuses/edit-v2',
+            'source_text' => '儒童',
+            'ai_matched' => json_encode(['matched_codes' => [['code_id' => 50]]]),
+            'success' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
     protected function seedStatus(array $overrides = []): void {
         DB::table('STATUS_DATA')->insert(array_replace([
             'c_personid' => 1000,
@@ -170,6 +206,113 @@ class ApiV2MutateStatusTest extends TestCase {
         ];
 
         return array_replace_recursive($payload, $overrides);
+    }
+
+    // ── AI 智能識別回寫 ai_fill_logs（回歸：React 遷移後 v2 update 未回寫 → 誤顯示「未提交」）─────
+
+    #[Test]
+    public function testDirectStatusUpdateWithAiFillLogIdMarksLogSubmitted(): void {
+        $user = $this->makeUser(email: 'status-ailog@example.com');
+        $this->actingAs($user);
+        $this->seedStatus();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNotNull($log->user_submitted, 'user_submitted 應回寫（已提交）');
+        $this->assertNotNull($log->submitted_at, 'submitted_at 應回寫');
+        $submitted = json_decode($log->user_submitted, true);
+        // 更新後 PK + 使用者變更欄位（不含自動蓋的 c_modified_*）。
+        $this->assertSame(50, (int) $submitted['c_status_code']);
+        $this->assertSame('更新備註', $submitted['c_notes']);
+        $this->assertArrayNotHasKey('c_modified_by', $submitted, '不應含自動蓋的稽核欄');
+    }
+
+    #[Test]
+    public function testDirectStatusUpdateWithoutAiFillLogIdLeavesLogUntouched(): void {
+        $user = $this->makeUser(email: 'status-noailog@example.com');
+        $this->actingAs($user);
+        $this->seedStatus();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'changes' => ['c_notes' => '更新備註'],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '無 log id 不應回寫');
+        $this->assertNull($log->submitted_at);
+    }
+
+    #[Test]
+    public function testStatusUpdateAiFillLogNotOverwrittenForOtherUsersLog(): void {
+        $owner = $this->makeUser(email: 'status-ailog-owner@example.com');
+        $actor = $this->makeUser(email: 'status-ailog-actor@example.com');
+        $logId = $this->insertAiFillLog($owner->id);
+        $this->actingAs($actor);
+        $this->seedStatus();
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '他人日誌不得被覆寫');
+    }
+
+    #[Test]
+    public function testStatusUpdateAiFillLogNotOverwrittenForWrongCategory(): void {
+        $user = $this->makeUser(email: 'status-ailog-cat@example.com');
+        $this->actingAs($user);
+        $this->seedStatus();
+        $logId = $this->insertAiFillLog($user->id, 1000, 'posting');
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同 category 的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testStatusUpdateAiFillLogNotOverwrittenForDifferentPerson(): void {
+        // 連結完整性：只回寫「同一人物」的日誌（c_personid 守衛，$personId 為 handler 權威值）。
+        $user = $this->makeUser(email: 'status-ailog-person@example.com');
+        $this->actingAs($user);
+        $this->seedStatus();
+        $logId = $this->insertAiFillLog($user->id, 999);
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, '不同人物的日誌不得被回寫');
+    }
+
+    #[Test]
+    public function testProposalStatusUpdateDoesNotRecordAiFillSubmission(): void {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'status-ailog-proposal@example.com');
+        $this->actingAs($user);
+        $this->seedStatus();
+        $logId = $this->insertAiFillLog($user->id);
+
+        $this->postJson('/api/v2/mutate', $this->statusPayload([
+            'mode' => 'proposal',
+            'changes' => ['c_notes' => '更新備註'],
+            'meta' => ['ai_fill_log_id' => $logId],
+        ]))->assertOk();
+
+        $log = DB::table('ai_fill_logs')->where('id', $logId)->first();
+        $this->assertNull($log->user_submitted, 'proposal 提交當下不回寫');
     }
 
     // ── Direct Update Tests ─────────────────────────────────


### PR DESCRIPTION
## 問題
React 遷移後，社會關係（assoc）與社會區分（statuses）的編輯改走 v2 mutation，導致「AI 智能識別 → 回寫 `ai_fill_logs`」整條鏈斷裂：

- `AiCodeLookupPanel` 在識別當下建立日誌並記下 `ai_fill_log_id`，卻未經 `onApply` 回傳給編輯器，編輯器從未把它放進 `meta`。
- v2 create／update handler **完全沒有回寫** `user_submitted`；category `assoc`/`status` 的回寫只存在於舊 Blade 控制器，React 路徑不經過。

結果自遷移上線起，所有經 AI 識別存檔的社會關係／社會區分日誌於 `/app/admin/ai-fill-logs` 一律誤顯示「未提交」，與是否人工修改 AI 建議無關。此為與任官（offices，`PostingCreateHandler` 已修）**同類的回歸**。使用者回報的 #2636 記錄（`route_url=/app/basicinformation/1/statuses/edit-v2`）即走此斷裂路徑。

## 修法
- 新增 `RecordsAiFillSubmission` trait：direct 成功後以 `id + user_id + category + c_personid` 四重守衛回寫 `user_submitted`／`submitted_at`；`Schema::hasTable` 守衛、例外只記 warning 不影響主流程；預設 `aiFillCategory()=null`（no-op），僅覆寫者回寫。
- 兩個人物子資源抽象基底（create／update）於 direct 成功（HTTP 200）後呼叫；`Status`／`Association` 的 create／mutation handler 覆寫 `aiFillCategory()` 回傳 `'status'`／`'assoc'`，涵蓋**新增與更新**兩條路徑（對齊舊 Blade parity）；proposal 於核准時才落庫、提交當下不回寫。
- 前端：`AiCodeLookupPanel.onApply` 回傳 `aiFillLogId`；`StatusEditor`／`AssocEditor` 於 create／update 帶入 `meta.ai_fill_log_id`，存檔成功後清除；每次重新識別先清空舊 log id，避免回應無有效 id 時沿用上一輪。

## 測試
新增 26 筆測試涵蓋回寫成功與 `user_id`／`category`／`c_personid`／proposal 守衛（create 與 update 四個 v2 測試檔）。相關測試套件 **181 passed**，`php-cs-fixer` 清空 cache 後 dry-run 乾淨，前端建置通過。

## 範圍外備註
任官（offices）**更新**路徑經 AI 識別存檔仍不回寫（既有行為、非本次回歸；且 OfficeEditor 於更新時本就不送 `ai_fill_log_id`），如需一併補齊可另開 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)