### PR TITLE
去級聯 Phase 1 批次 3——其餘 35 張小詞表入邊 FK 翻 RESTRICT

### DIFF
--- a/app/Services/Mutations/EntityAggregateDeleteHandler.php
+++ b/app/Services/Mutations/EntityAggregateDeleteHandler.php
@@ -3,6 +3,7 @@
 namespace App\Services\Mutations;
 
 use App\Services\Mutations\EntityAggregate\AbstractEntityAggregateHandler;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 
@@ -41,12 +42,28 @@ class EntityAggregateDeleteHandler extends AbstractEntityAggregateHandler {
             return $this->errorResponse($guard[0], $guard[1], $guard[2]);
         }
 
-        $result = DB::transaction(fn () => $definition->result(
-            'delete',
-            $id,
-            [],
-            $definition->service()->delete($id, $personId)
-        ));
+        try {
+            $result = DB::transaction(fn () => $definition->result(
+                'delete',
+                $id,
+                [],
+                $definition->service()->delete($id, $personId)
+            ));
+        } catch (QueryException $e) {
+            // 詞表入邊外鍵已陸續翻成 ON DELETE RESTRICT（去級聯 Phase 1，OFFICE_CODES 在批次 3）：
+            // definition::guardWrite 的引用護欄若有漏網引用（如 POSTED_TO_ADDR_DATA 殘留列），
+            // DELETE 會被 DB 以 1451 擋下、交易回滾（含 operations 記錄）。fail-closed、
+            // 零資料損失，這裡轉為友好訊息。
+            if (($e->errorInfo[1] ?? null) !== 1451) {
+                throw $e;
+            }
+
+            return $this->errorResponse(
+                '此記錄仍被其他資料引用，無法刪除。請先移除引用後再試。',
+                409,
+                [$pkField => ['referenced_by_other_records']]
+            );
+        }
 
         return $this->envelope($definition->resourceName(), 'delete', $result);
     }

--- a/database/migrations/2026_07_23_000000_restrict_fks_referencing_small_code_tables.php
+++ b/database/migrations/2026_07_23_000000_restrict_fks_referencing_small_code_tables.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 去級聯 Phase 1 — 批次 3：把「引用其餘小詞表」的外鍵由 ON DELETE CASCADE 翻成 RESTRICT。
+ *
+ * 依 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md（批次單位＝被引用表、兩條 ALTER、
+ * foreign_key_checks=0、SQLite no-op），範式同批次 1／2。
+ *
+ * 本批＝剩餘全部小詞表／類型表／樹表（入邊多為 1–6 條，含自引用 pair FK 與 *_TYPE_REL 關聯表入邊）。
+ * 名單為顯式鎖定（受控分批）；實際入邊由 information_schema 於執行時讀取，
+ * 已被後續 migration 移除的 FK（如 OFFICE_CATEGORIES、APPOINTMENT_TYPES 入邊）自然不會出現。
+ *
+ * 本批「不含」：
+ * - BIOG_MAIN——末批，需配套顯式級聯刪除服務；
+ * - SOCIAL_INSTITUTION_CODES／SOCIAL_INSTITUTION_NAME_CODES——「一機構多名」安全前提未完成
+ *   （社會機構 step 4）；其 *_TYPES 類型詞表無此顧慮，照常納入本批；
+ * - 資料表 POSTING_DATA／POSSESSION_DATA／EVENTS_DATA——app 有活刪除路徑依賴其子表級聯
+ *   （OperationsProposalController、OfficePostingRepository、BiogMainRepository、EVENTS_ADDR 複合 FK），
+ *   需改為顯式級聯後另批處理。
+ *
+ * 前置（app-layer-first）：本批詞表經 UI 的刪除路徑均已封堵（CodesController::performDestroy、
+ * CodeTableDeleteHandler 皆無條件擋下），app 內亦無其他硬刪呼叫點；唯一活路徑
+ * OfficeDeleteHandler → OfficeImportService::delete()（先刪 OFFICE_CODE_TYPE_REL、且有
+ * POSTED_TO_OFFICE_DATA 引用護欄），已同步補上 errno 1451 友好報錯垫片（同 commit），
+ * 涵蓋 POSTED_TO_ADDR_DATA 殘留引用等漏網情形。翻轉後任何漏網硬刪一律 fail-closed（1451），
+ * 零資料損失。
+ */
+return new class () extends Migration {
+    private const REFERENCED_TABLES = [
+        // 入邊 2 條以上
+        'KINSHIP_CODES',
+        'ASSOC_CODES',
+        'OFFICE_CODES',
+        'EVENT_CODES',
+        'TEXT_BIBLCAT_CODES',
+        'STATUS_CODES',
+        'ENTRY_CODES',
+        'COUNTRY_CODES',
+        'APPOINTMENT_CODES',
+        'OFFICE_TYPE_TREE',
+        'ADMIN_CAT_CODES',
+        // 入邊 1 條
+        'ADMIN_CAT_TYPES',
+        'ALTNAME_CODES',
+        'APPOINTMENT_TYPES',
+        'ASSOC_TYPES',
+        'ASSUME_OFFICE_CODES',
+        'BIOG_ADDR_CODES',
+        'BIOG_INST_CODES',
+        'CHORONYM_CODES',
+        'ENTRY_TYPES',
+        'ETHNICITY_TRIBE_CODES',
+        'EXTANT_CODES',
+        'HOUSEHOLD_STATUS_CODES',
+        'LITERARYGENRE_CODES',
+        'MEASURE_CODES',
+        'OCCASION_CODES',
+        'OFFICE_CATEGORIES',
+        'PARENTAL_STATUS_CODES',
+        'POSSESSION_ACT_CODES',
+        'SCHOLARLYTOPIC_CODES',
+        'SOCIAL_INSTITUTION_ADDR_TYPES',
+        'SOCIAL_INSTITUTION_TYPES',
+        'STATUS_TYPES',
+        'TEXT_BIBLCAT_TYPES',
+        'TEXT_ROLE_CODES',
+    ];
+
+    public function up(): void {
+        $this->flip('RESTRICT', ['CASCADE']);
+    }
+
+    public function down(): void {
+        $this->flip('CASCADE', ['RESTRICT', 'NO ACTION']);
+    }
+
+    /**
+     * @param string $onDelete 目標 ON DELETE 行為
+     * @param array<int,string> $fromRules 只翻目前為這些 DELETE_RULE 的 FK
+     */
+    private function flip(string $onDelete, array $fromRules): void {
+        if (!is_mysql()) {
+            return; // SQLite 無外鍵
+        }
+
+        $inRefs = implode(',', array_fill(0, count(self::REFERENCED_TABLES), '?'));
+        $inRules = implode(',', array_fill(0, count($fromRules), '?'));
+
+        $fks = DB::select(
+            'SELECT rc.CONSTRAINT_NAME AS name, rc.TABLE_NAME AS tbl,
+                    rc.REFERENCED_TABLE_NAME AS ref_tbl, rc.UPDATE_RULE AS update_rule
+             FROM information_schema.REFERENTIAL_CONSTRAINTS rc
+             WHERE rc.CONSTRAINT_SCHEMA = DATABASE()
+               AND rc.REFERENCED_TABLE_NAME IN ('.$inRefs.')
+               AND rc.DELETE_RULE IN ('.$inRules.')',
+            array_merge(self::REFERENCED_TABLES, $fromRules)
+        );
+
+        DB::statement('SET SESSION foreign_key_checks = 0');
+        $flipped = 0;
+
+        try {
+            foreach ($fks as $fk) {
+                $cols = DB::select(
+                    'SELECT COLUMN_NAME AS col, REFERENCED_COLUMN_NAME AS ref_col
+                     FROM information_schema.KEY_COLUMN_USAGE
+                     WHERE CONSTRAINT_SCHEMA = DATABASE()
+                       AND CONSTRAINT_NAME = ? AND TABLE_NAME = ?
+                       AND REFERENCED_TABLE_NAME IS NOT NULL
+                     ORDER BY ORDINAL_POSITION',
+                    [$fk->name, $fk->tbl]
+                );
+                $fkCols = implode(', ', array_map(fn ($x) => "`{$x->col}`", $cols));
+                $refCols = implode(', ', array_map(fn ($x) => "`{$x->ref_col}`", $cols));
+
+                DB::statement("ALTER TABLE `{$fk->tbl}` DROP FOREIGN KEY `{$fk->name}`");
+                DB::statement(
+                    "ALTER TABLE `{$fk->tbl}` ADD CONSTRAINT `{$fk->name}` ".
+                    "FOREIGN KEY ({$fkCols}) REFERENCES `{$fk->ref_tbl}` ({$refCols}) ".
+                    "ON DELETE {$onDelete} ON UPDATE {$fk->update_rule}"
+                );
+                $flipped++;
+            }
+        } finally {
+            DB::statement('SET SESSION foreign_key_checks = 1');
+        }
+
+        echo "[restrict-batch-3] {$onDelete}: flipped {$flipped} FK(s) referencing ".
+             count(self::REFERENCED_TABLES).' small code table(s)'.PHP_EOL;
+    }
+};

--- a/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
+++ b/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
@@ -1,6 +1,6 @@
 # CASCADE → RESTRICT：翻轉 migration 的機制與分批 rollout（MariaDB 10.3）
 
-> 狀態：實作中（分批進行）｜ 批次 1 已落地並實測
+> 狀態：實作中（分批進行）｜ 批次 1–3 已落地並實測（詞表入邊全數翻畢，剩 SOCIAL_INSTITUTION_*／資料表／BIOG_MAIN）
 > 上位文件：[docs/ON_DELETE_CASCADE_RISK.md](./ON_DELETE_CASCADE_RISK.md)（§6「RESTRICT 先行、按被引用表分批」）
 > 目的：把 §6.1 的翻轉方案落成可執行、可分批、可回滾的 migration，並記錄 §6.1 範例 SQL 在
 > **prod 版本 MariaDB 10.3** 上跑不起來的實測修正（該文件是在 10.11 驗的）。
@@ -95,8 +95,9 @@ GROUP BY REFERENCED_TABLE_NAME, DELETE_RULE;
 |---|---|---|---|
 | **1** | NIAN_HAO(24)、YEAR_RANGE_CODES(23)、DYNASTIES(10)、GANZHI_CODES(9)＝**66 條** | `2026_07_20_000000_restrict_fks_referencing_dynasty_batch` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9） |
 | **2** | TEXT_CODES(21)、ADDR_CODES(11)＝**32 條**（TEXT_CODES 另 1 條 `SET NULL` 本已正確、未觸碰） | `2026_07_21_000000_restrict_fks_referencing_text_addr_codes` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.1）；同 commit 為唯一活硬刪路徑 `AdminBatchLoadBookTitlesController::undo()` 補 1451 友好報錯垫片 |
-| 3… | 其餘小詞表（KINSHIP_CODES(6)、ASSOC_CODES(4)、OFFICE_CODES(3)、EVENT_CODES(3)…） | 待做 | — |
-| n | SOCIAL_INSTITUTION_CODES(5) | 待做——「一機構多名」安全前提（[SOCIAL_INSTITUTION_ENTITY_MODEL §5.9](./SOCIAL_INSTITUTION_ENTITY_MODEL.md)）；**前置**：先封 codes UI 對該表的刪除（社會機構 step 4） | — |
+| **3** | 其餘全部小詞表／類型表／樹表 35 張＝**52 條**（KINSHIP_CODES(6)、ASSOC_CODES(4)、OFFICE_CODES(3)、TEXT_BIBLCAT_CODES／STATUS_CODES／ENTRY_CODES／COUNTRY_CODES／APPOINTMENT_CODES／OFFICE_TYPE_TREE／ADMIN_CAT_CODES(各 2)、其餘各 1，含自引用 pair FK 與 *_TYPE_REL 入邊） | `2026_07_23_000000_restrict_fks_referencing_small_code_tables` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.2）；同 commit 為唯一活硬刪路徑（office 實體刪除，經通用 `EntityAggregateDeleteHandler`）補 1451 友好報錯垫片 |
+| n | SOCIAL_INSTITUTION_CODES(5)＋SOCIAL_INSTITUTION_NAME_CODES(5) | 待做——「一機構多名」安全前提（社會機構實體模型 §5.9）；**前置**：先封 codes UI 對該表的刪除（社會機構 step 4）。其 *_TYPES 類型詞表無此顧慮，已納入批次 3 | — |
+| n+1 | 資料表 POSTING_DATA(2)、POSSESSION_DATA(1) | 待做——app 有活刪除路徑依賴其子表級聯（`OperationsProposalController`、`OfficePostingRepository`、`BiogMainRepository`），需先改為顯式級聯刪除 | — |
 | 末 | BIOG_MAIN(25)＋operations→BIOG_MAIN | 待做——需配套顯式級聯刪除服務 | — |
 
 **節奏（§6.1「app-layer-first」）**：翻一批 → 觀察 1–2 週盯 1451（1451 會把漏網的 cascade
@@ -140,6 +141,36 @@ migration，再套用批次 1：
 > 硬刪路徑（只刪自己批次建立的列）。翻轉後批內列若已被引用，DELETE 撞 1451、整批交易回滾（含
 > operations 清理一併回滾）；已捕捉 errno 1451 轉為友好 toast（「整批撤回已取消，未刪除任何資料」），
 > 其他 QueryException 照舊上拋。`/codes` destroy 與 mutation `CodeTableDeleteHandler` 先前已無條件封堵，無需處理。
+
+### 9.2 批次 3 端到端實測（fresh MariaDB 10.3，2026-07-23）
+
+同 §9 流程（乾淨 10.3.39 容器、全量 `php artisan migrate`）：
+
+| 檢查 | 結果 |
+|---|---|
+| 批次 3 翻轉 | ✅ `flipped 52`（35 張小詞表／類型表／樹表的全部現存 CASCADE 入邊） |
+| 全庫 | ✅ `CASCADE 38`／`NO ACTION 150`／`SET NULL 1`（90−52＝38） |
+| 剩餘 CASCADE 被引用表 | ✅ 僅 BIOG_MAIN(25)、SOCIAL_INSTITUTION_NAME_CODES(5)、SOCIAL_INSTITUTION_CODES(5)、POSTING_DATA(2)、POSSESSION_DATA(1)——與計畫排除項完全一致 |
+| 行為：刪被引用列 | ✅ 刪被自引用 pair FK 引用的 ASSOC_CODES → 1451 擋下；刪被 OFFICE_CODE_TYPE_REL 引用的 OFFICE_CODES → 1451 擋下；資料一列不少 |
+| 行為：零引用刪除 | ✅ 引用移除後 DELETE 正常成功 |
+| 可逆 | ✅ `migrate:rollback --step=1` 翻回 CASCADE（52 條、全庫回到 CASCADE 90），re-migrate 恢復 RESTRICT |
+
+> 註 1：本批入邊數與 baseline grep 對不上是正常的——若干入邊 FK 已被後續 migration 移除
+> （如 OFFICE_CATEGORIES、APPOINTMENT_TYPES 的入邊），資料驅動範式自然只翻現存者。
+>
+> 註 2：實測中發現既有問題（非本批引入）：`EVENTS_ADDR_ibfk_3`（EVENTS_ADDR→EVENT_CODES）
+> 已不存在——`2026_02_12_000001_convert_fields_to_smallint` 為改型別先卸下相關 FK，但重建
+> 清單漏了這條，該 FK 自此靜默遺失。EVENTS_DATA 亦無任何入邊 FK（EVENTS_ADDR→EVENTS_DATA
+> 複合 FK 同樣不在最終 schema）。是否補回（補回前需先清洗 `c_event_code=0` 等孤兒值）另案處理。
+>
+> 應用層垫片（同 commit）：office 實體刪除是本批詞表唯一活硬刪路徑
+> （`OfficeImportService::delete()`：先刪 OFFICE_CODE_TYPE_REL、有 POSTED_TO_OFFICE_DATA
+> 引用護欄回 409；bespoke `OfficeDeleteHandler` 已收斂進通用 `EntityAggregateDeleteHandler`
+> ＋`OfficeAggregateDefinition::guardWrite`，見 3e9f012d）。翻轉後若仍有漏網引用（如
+> POSTED_TO_ADDR_DATA 殘留列），DELETE 撞 1451、交易回滾；已在 `EntityAggregateDeleteHandler`
+> 捕捉 errno 1451 轉友好 409（office／social-institution 等聚合實體通用），其他 QueryException
+> 照舊上拋。`/codes` destroy 與 `CodeTableDeleteHandler` 先前已無條件封堵；app 內無其他硬刪
+> 呼叫點（含 console commands）。
 
 ## 10. 對 `ON_DELETE_CASCADE_RISK.md` 的修正建議
 


### PR DESCRIPTION
把引用其餘全部小詞表／類型表／樹表（KINSHIP_CODES、ASSOC_CODES、OFFICE_CODES、 EVENT_CODES、OFFICE_TYPE_TREE、ADMIN_CAT_*、*_TYPES 等 35 張）的 52 條入邊外鍵 由 ON DELETE CASCADE 翻成 RESTRICT（ON UPDATE 保留 CASCADE）。範式同批次 1／2 （資料驅動、範圍鎖定 REFERENCED_TABLES、兩條 ALTER、foreign_key_checks=0、 SQLite no-op、down 可逆）。

- 本批不含：BIOG_MAIN（末批）、SOCIAL_INSTITUTION_CODES／NAME_CODES（「一機構 多名」前置未完成）、資料表 POSTING_DATA／POSSESSION_DATA（app 活刪除路徑 依賴其子表級聯，需先改顯式級聯）。
- 應用層垫片：office 實體刪除是本批詞表唯一活硬刪路徑（bespoke OfficeDeleteHandler 已於 3e9f012d 收斂進通用 EntityAggregateDeleteHandler， 垫片隨 rebase 移植至通用 handler）：definition::guardWrite 引用護欄若有漏網 引用，DELETE 撞 1451、交易回滾；已捕捉 errno 1451 轉友好 409（聚合實體 通用），其他 QueryException 照舊上拋。/codes destroy 與 CodeTableDeleteHandler 先前已無條件封堵。
- MariaDB 10.3 端到端實測：flipped 52、全庫 CASCADE 90→38（剩餘與計畫排除項 完全一致）、刪被引用 ASSOC_CODES／OFFICE_CODES → 1451 擋下且資料一列不少、 零引用刪除照常成功、rollback 可逆（詳見 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §9.2）。
- 實測另發現既有問題並記錄於 §9.2：EVENTS_ADDR_ibfk_3（→EVENT_CODES）已被 2026_02_12 smallint 遷移靜默弄丟，是否補回另案處理。
- rebase 後已執行 ./vendor/bin/phpunit tests/Feature/ApiV2MutateOfficeImportTest.php tests/Feature/ApiV2MutateSocialInstituteEntityTest.php tests/Feature/ApiV2DeleteSocialInstitutionTest.php（27 tests 全綠） 與 ./vendor/bin/php-cs-fixer fix。