### PR TITLE
補回 EVENTS_ADDR_ibfk_3 外鍵（EVENTS_ADDR.c_event_code → EVENT_CODES）

### DIFF
--- a/database/migrations/2026_07_24_000000_restore_events_addr_event_code_fk.php
+++ b/database/migrations/2026_07_24_000000_restore_events_addr_event_code_fk.php
@@ -1,0 +1,131 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 補回 EVENTS_ADDR_ibfk_3（EVENTS_ADDR.c_event_code → EVENT_CODES.c_event_code）。
+ *
+ * 背景：`2026_02_12_000001_convert_fields_to_smallint` 為改 EVENTS_ADDR.c_event_code
+ * 型別，於 dropForeignKeys() 動態刪除此 FK，但 restoreForeignKeys() 的靜態白名單漏了
+ * 這一條，導致該 FK 自此靜默遺失（見 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §9.2）。
+ *
+ * ON DELETE 採 RESTRICT（而非原本的 CASCADE）：EVENT_CODES 已是 CASCADE→RESTRICT
+ * 分批翻轉（批次 3，見同上文件）的被引用表之一，同表另一入邊 EVENTS_DATA_ibfk_3 亦已
+ * 翻為 RESTRICT，此處直接補為終態，避免補回 CASCADE 後又要再翻一次。
+ */
+return new class () extends Migration {
+    private const CONSTRAINT_NAME = 'EVENTS_ADDR_ibfk_3';
+
+    public function up(): void {
+        if (!is_mysql()) {
+            return; // SQLite 無外鍵，測試環境本就無此問題
+        }
+
+        $state = $this->currentConstraintState();
+
+        if ($state !== null) {
+            if (!$this->isExpectedState($state)) {
+                throw new \RuntimeException($this->mismatchMessage($state));
+            }
+
+            return; // 已是目標定義，冪等跳過
+        }
+
+        $orphanCount = DB::selectOne('
+            SELECT COUNT(*) AS c
+            FROM `EVENTS_ADDR` ea
+            LEFT JOIN `EVENT_CODES` ec ON ea.c_event_code = ec.c_event_code
+            WHERE ec.c_event_code IS NULL
+        ')->c;
+
+        if ($orphanCount > 0) {
+            throw new \RuntimeException(
+                "無法補回 EVENTS_ADDR_ibfk_3：EVENTS_ADDR 中有 {$orphanCount} 筆 c_event_code ".
+                '在 EVENT_CODES 找不到對應值，需先清洗孤兒資料才能重建外鍵。'
+            );
+        }
+
+        DB::statement('
+            ALTER TABLE `EVENTS_ADDR`
+            ADD CONSTRAINT `'.self::CONSTRAINT_NAME.'`
+            FOREIGN KEY (`c_event_code`) REFERENCES `EVENT_CODES` (`c_event_code`)
+            ON DELETE RESTRICT ON UPDATE CASCADE
+        ');
+    }
+
+    public function down(): void {
+        if (!is_mysql()) {
+            return;
+        }
+
+        $state = $this->currentConstraintState();
+
+        if ($state === null) {
+            return;
+        }
+
+        if (!$this->isExpectedState($state)) {
+            throw new \RuntimeException(
+                '無法回滾 EVENTS_ADDR_ibfk_3：同名約束存在，但定義與本 migration 補上的不符，'.
+                '不確定是否為同一條約束，拒絕自動刪除。'.$this->mismatchMessage($state)
+            );
+        }
+
+        DB::statement('ALTER TABLE `EVENTS_ADDR` DROP FOREIGN KEY `'.self::CONSTRAINT_NAME.'`');
+    }
+
+    /**
+     * 目前定義是否等於本 migration 意圖建立／回滾的目標狀態
+     * （EVENTS_ADDR.c_event_code -> EVENT_CODES.c_event_code, RESTRICT/CASCADE）。
+     */
+    private function isExpectedState(object $state): bool {
+        return $state->column_name === 'c_event_code'
+            && $state->ref_table === 'EVENT_CODES'
+            && $state->ref_column === 'c_event_code'
+            && in_array($state->delete_rule, ['RESTRICT', 'NO ACTION'], true)
+            && $state->update_rule === 'CASCADE';
+    }
+
+    private function mismatchMessage(object $state): string {
+        return "（column={$state->column_name}, ref={$state->ref_table}.{$state->ref_column}, ".
+            "delete={$state->delete_rule}, update={$state->update_rule}）需人工確認後再處理。";
+    }
+
+    /**
+     * 讀取同名約束目前的完整定義（欄位、被引用表欄、刪除／更新規則），
+     * 而非只查名稱是否存在——避免同名但定義不符時被誤判為「已補回」或被誤刪。
+     * 要求剛好 1 筆：若同名約束是多欄位複合外鍵，视为定義不符（非本 migration 預期形狀）。
+     */
+    private function currentConstraintState(): ?object {
+        $rows = DB::select('
+            SELECT
+                kcu.COLUMN_NAME AS column_name,
+                kcu.REFERENCED_TABLE_NAME AS ref_table,
+                kcu.REFERENCED_COLUMN_NAME AS ref_column,
+                rc.DELETE_RULE AS delete_rule,
+                rc.UPDATE_RULE AS update_rule
+            FROM information_schema.KEY_COLUMN_USAGE kcu
+            JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+                ON rc.CONSTRAINT_SCHEMA = kcu.TABLE_SCHEMA
+                AND rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+                AND rc.TABLE_NAME = kcu.TABLE_NAME
+            WHERE kcu.TABLE_SCHEMA = DATABASE()
+            AND kcu.TABLE_NAME = ?
+            AND kcu.CONSTRAINT_NAME = ?
+            ORDER BY kcu.ORDINAL_POSITION
+        ', ['EVENTS_ADDR', self::CONSTRAINT_NAME]);
+
+        if (count($rows) !== 1) {
+            return count($rows) === 0 ? null : (object) [
+                'column_name' => 'MULTI_COLUMN('.count($rows).')',
+                'ref_table' => $rows[0]->ref_table,
+                'ref_column' => 'MULTI_COLUMN',
+                'delete_rule' => $rows[0]->delete_rule,
+                'update_rule' => $rows[0]->update_rule,
+            ];
+        }
+
+        return $rows[0];
+    }
+};

--- a/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
+++ b/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
@@ -163,6 +163,12 @@ migration，再套用批次 1：
 > 清單漏了這條，該 FK 自此靜默遺失。EVENTS_DATA 亦無任何入邊 FK（EVENTS_ADDR→EVENTS_DATA
 > 複合 FK 同樣不在最終 schema）。是否補回（補回前需先清洗 `c_event_code=0` 等孤兒值）另案處理。
 >
+> **已補回**（`database/migrations/2026_07_24_000000_restore_events_addr_event_code_fk.php`）：
+> 補回前先查 orphan（`c_event_code` 在 `EVENT_CODES` 找不到對應值）， 若有則丟例外中止、
+> fail-closed，不靜默清資料；補回時直接落終態 `ON DELETE RESTRICT ON UPDATE CASCADE`，
+> 與同表已翻轉的 `EVENTS_DATA_ibfk_3` 一致（本批 `flip()` 只翻當下存在的 FK，事後補回的
+> CASCADE 邊不會被追溯翻轉，故直接落終態而非補回原 CASCADE 再等下一批）。
+>
 > 應用層垫片（同 commit）：office 實體刪除是本批詞表唯一活硬刪路徑
 > （`OfficeImportService::delete()`：先刪 OFFICE_CODE_TYPE_REL、有 POSTED_TO_OFFICE_DATA
 > 引用護欄回 409；bespoke `OfficeDeleteHandler` 已收斂進通用 `EntityAggregateDeleteHandler`


### PR DESCRIPTION
## Summary
- `2026_02_12_000001_convert_fields_to_smallint` 改型別時動態卸下 `EVENTS_ADDR_ibfk_3`（EVENTS_ADDR.c_event_code → EVENT_CODES.c_event_code），但重建外鍵的靜態清單漏了這條，該 FK 自此靜默遺失（詳見 `docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §9.2）。
- 新增 migration `2026_07_24_000000_restore_events_addr_event_code_fk.php` 補回，直接落地為終態 `ON DELETE RESTRICT ON UPDATE CASCADE`，與同表已翻轉的 `EVENTS_DATA_ibfk_3` 一致（避免補回 CASCADE 後還要再等下一批翻轉）。
- 補回前檢查孤兒資料（`c_event_code` 對不到 `EVENT_CODES`），有孤兒就拋例外中止、fail-closed，不靜默清資料。
- `up()`/`down()` 皆先讀 `information_schema` 核對完整定義（欄位、被引用表欄、刪除／更新規則），避免同名但定義不符時被誤判為已補回或被誤刪。
- 同步更新 `docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §9.2，補上「已補回」說明。

## 驗證過程
- 在本機 MariaDB 10.3 實測：`php artisan migrate` → 確認 FK 出現且為 (RESTRICT, CASCADE) → `migrate:rollback --step=1` 確認正確移除 → 重新 `migrate` → 再次 `migrate`（冪等 no-op，無錯誤）。
- `./vendor/bin/phpunit --filter "EventsAddr|Event|Migration"`：61+23 測試全綠燈（SQLite 對此 migration 為 no-op，用來確認未影響其他既有測試）。
- `php -l` 語法檢查、`php-cs-fixer` 格式化皆通過。
- Review 流程：先派 subagent 通讀相關 migration／文件與程式碼路徑做審查（無阻斷性問題），再用 `codex exec` 做兩輪獨立審查，依建議加固 `up()`/`down()` 的定義比對邏輯後，最終確認無中高風險問題。

## Test plan
- [x] `php artisan migrate` / `migrate:rollback` / 重跑 冪等驗證（本機 MariaDB 10.3）
- [x] `./vendor/bin/phpunit --filter "EventsAddr|Event|Migration"`
- [x] `php -l` + `php-cs-fixer fix`（0 處需修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)