### PR TITLE
去級聯末批前置——連帶刪除搬進應用層，每列都落 operations

### DIFF
--- a/app/Http/Controllers/MergePreviewController.php
+++ b/app/Http/Controllers/MergePreviewController.php
@@ -297,21 +297,30 @@ class MergePreviewController extends Controller {
             }
         }
 
+        // 本表必須涵蓋**全部**指向 BIOG_MAIN.c_personid 的外鍵欄位（現為 25 條入邊）：腳本末尾的
+        // `DELETE FROM BIOG_MAIN` 在去級聯（ON DELETE RESTRICT）後，只要有任一欄位漏列、來源人物
+        // 仍被引用，該 DELETE 就會被 DB 以 1451 擋下（fail-closed）。翻轉前為 ON DELETE CASCADE，
+        // 漏列的後果反而更糟——那些列會被靜默連帶刪除，且腳本自帶的「確認為 0」檢查只掃本表列出的
+        // 欄位，因此檢查全過、資料照樣消失。新增指向 BIOG_MAIN 的外鍵時務必同步補進本表。
         $map = [
             'ALTNAME_DATA' => ['c_personid'],
-            'ASSOC_DATA' => ['c_personid', 'c_kin_id', 'c_assoc_id', 'c_assoc_kin_id'],
+            'ASSOC_DATA' => ['c_personid', 'c_kin_id', 'c_assoc_id', 'c_assoc_kin_id', 'c_tertiary_personid', 'c_assoc_claimer_id'],
             'BIOG_ADDR_DATA' => ['c_personid'],
             'BIOG_INST_DATA' => ['c_personid'],
             'BIOG_SOURCE_DATA' => ['c_personid'],
             'BIOG_TEXT_DATA' => ['c_personid'],
-            'ENTRY_DATA' => ['c_personid'],
+            'ENTRY_DATA' => ['c_personid', 'c_assoc_id', 'c_kin_id'],
+            'EVENTS_ADDR' => ['c_personid'],
             'EVENTS_DATA' => ['c_personid'],
             'KIN_DATA' => ['c_personid', 'c_kin_id'],
+            'POSSESSION_ADDR' => ['c_personid'],
             'POSSESSION_DATA' => ['c_personid'],
             'POSTED_TO_ADDR_DATA' => ['c_personid'],
             'POSTING_DATA' => ['c_personid'],
             'POSTED_TO_OFFICE_DATA' => ['c_personid'],
             'STATUS_DATA' => ['c_personid'],
+            // 編輯歷史隨人物一併歸併到存活者名下（該外鍵同樣會擋下 DELETE）。
+            'operations' => ['c_personid'],
         ];
 
         foreach ($map as $table => $columns) {

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
+use App\Repositories\OfficePostingRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Services\ExplicitCascadeLogger;
 use App\Services\NameSearchIndexService;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
@@ -767,7 +769,9 @@ class OperationsProposalController extends Controller {
 
         $deletedRow = $this->convertRowToArray($row);
 
-        // 連帶刪除副表
+        // 連帶刪除副表（顯式級聯）：子列先於父列。POSSESSION_ADDR 是 POSSESSION_DATA 的子表，
+        // 故於主列刪除前清掉；POSTING_DATA 反之是 POSTED_TO_OFFICE_DATA 的**父列**，必須等主列
+        // 刪掉之後才輪到它（見下方 deleteOfficeAuxiliaryTables／deletePostingParentIfUnreferenced）。
         if ($table === 'POSTED_TO_OFFICE_DATA') {
             $this->deleteOfficeAuxiliaryTables($deletedRow);
         } elseif ($table === 'POSSESSION_DATA') {
@@ -775,6 +779,18 @@ class OperationsProposalController extends Controller {
         }
 
         DB::table($table)->where($conditions)->delete();
+
+        if ($table === 'POSTED_TO_OFFICE_DATA') {
+            $deletedPosting = OfficePostingRepository::deletePostingIfUnreferenced($deletedRow['c_posting_id'] ?? null);
+            if ($deletedPosting !== null) {
+                (new ExplicitCascadeLogger())->logDeletedRows(
+                    'POSTING_DATA',
+                    (string) ($deletedRow['c_posting_id'] ?? ''),
+                    [$deletedPosting],
+                    (int) ($deletedRow['c_personid'] ?? 0)
+                );
+            }
+        }
 
         // 注意：社會關係反向鏡像刪除移至 approve() 於 logFinalOperation 之後執行，
         // 以便鏡像 audit 掛 final delete operation id（見 approve()）。
@@ -787,7 +803,11 @@ class OperationsProposalController extends Controller {
     }
 
     /**
-     * POSTED_TO_OFFICE_DATA 核准刪除時連帶刪除 POSTED_TO_ADDR_DATA 與 POSTING_DATA。
+     * POSTED_TO_OFFICE_DATA 核准刪除時連帶刪除 POSTED_TO_ADDR_DATA。
+     *
+     * 注意 POSTING_DATA **不在此處刪除**：它是 POSTED_TO_OFFICE_DATA／POSTED_TO_ADDR_DATA 的
+     * 父列，去級聯（ON DELETE RESTRICT）後必須等主列刪完、且確認無其他列共用該 posting 之後
+     * 才能刪，見 applyDeleteProposal() 末尾的 deletePostingIfUnreferenced()。
      */
     protected function deleteOfficeAuxiliaryTables(array $row): void {
         $officeId = $row['c_office_id'] ?? null;
@@ -805,11 +825,20 @@ class OperationsProposalController extends Controller {
             if ($personId !== null) {
                 $addrQuery->where('c_personid', $personId);
             }
-            $addrQuery->delete();
-        }
 
-        if (Schema::hasTable('POSTING_DATA')) {
-            DB::table('POSTING_DATA')->where('c_posting_id', $postingId)->delete();
+            // 刪除前先取出，連帶刪除的每一列都要留下 operations／audit_log 痕跡。
+            $addrRows = (clone $addrQuery)->get();
+            $addrQuery->delete();
+
+            (new ExplicitCascadeLogger())->logDeletedRows(
+                'POSTED_TO_ADDR_DATA',
+                CompositePrimaryKey::buildStoredResourceId([
+                    'c_office_id' => $officeId,
+                    'c_posting_id' => $postingId,
+                ]),
+                $addrRows,
+                (int) ($personId ?? 0)
+            );
         }
     }
 
@@ -823,7 +852,18 @@ class OperationsProposalController extends Controller {
         }
 
         if (Schema::hasTable('POSSESSION_ADDR')) {
-            DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $recordId)->delete();
+            $addrQuery = DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $recordId);
+
+            // 刪除前先取出，連帶刪除的每一列都要留下 operations／audit_log 痕跡。
+            $addrRows = (clone $addrQuery)->get();
+            $addrQuery->delete();
+
+            (new ExplicitCascadeLogger())->logDeletedRows(
+                'POSSESSION_ADDR',
+                (string) $recordId,
+                $addrRows,
+                (int) ($row['c_personid'] ?? 0)
+            );
         }
     }
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -31,6 +31,7 @@ use App\Services\AuditLogService;
 //20210625建安修改
 use App\Services\BracketNormalizer;
 use App\Services\CharVariantMapService;
+use App\Services\ExplicitCascadeLogger;
 use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\CompositePrimaryKey;
@@ -1740,8 +1741,16 @@ class BiogMainRepository {
         }
 
         DB::transaction(function () use ($id, $c_personid, $row) {
-            DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id)->delete();
+            // 顯式級聯：必須「先子後父」——POSSESSION_ADDR.c_possession_record_id 外鍵指向
+            // POSSESSION_DATA，去級聯後（ON DELETE RESTRICT）若先刪父列會被 DB 以 1451 擋下。
+            // 子列在刪除前先取出，連帶刪除的每一列都要留下 operations／audit_log 痕跡
+            // （ON_DELETE_CASCADE_RISK.md §4.4：不可把 DB 級聯的盲區原樣搬到應用層）。
+            $addrRows = DB::table('POSSESSION_ADDR')
+                ->where('c_possession_record_id', $row->c_possession_record_id)
+                ->get();
+
             DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $row->c_possession_record_id)->delete();
+            DB::table('POSSESSION_DATA')->where('c_possession_record_id', $id)->delete();
             $operation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSSESSION_DATA', $id, $row);
             (new AuditLogService())->write(
                 'POSSESSION_DATA',
@@ -1751,6 +1760,14 @@ class BiogMainRepository {
                 null,
                 'user',
                 (string) Auth::id(),
+                $operation ? (string) $operation->id : null
+            );
+
+            (new ExplicitCascadeLogger())->logDeletedRows(
+                'POSSESSION_ADDR',
+                (string) $id,
+                $addrRows,
+                (int) $c_personid,
                 $operation ? (string) $operation->id : null
             );
         });

--- a/app/Repositories/OfficePostingRepository.php
+++ b/app/Repositories/OfficePostingRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Repositories\Concerns\DetectsModelChanges;
 use App\Services\AuditLogService;
+use App\Services\ExplicitCascadeLogger;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -607,12 +608,18 @@ class OfficePostingRepository {
                 ->where('c_posting_id', $row->c_posting_id)
                 ->where('c_personid', $c_personid)
                 ->delete();
-            DB::table('POSTING_DATA')->where('c_posting_id', $row->c_posting_id)->delete();
+            // 顯式級聯：POSTING_DATA 是 POSTED_TO_OFFICE_DATA／POSTED_TO_ADDR_DATA 的父列，
+            // 且同一 c_posting_id 可能被多列共用（prod 實測有 31 個共用 posting）。去級聯後
+            // 若仍有兄弟列引用而逕刪父列，會被 DB 以 1451 擋下；翻轉前的 CASCADE 則會靜默
+            // 刪掉那些兄弟列。故僅在無剩餘引用時才刪父列。
+            $deletedPosting = self::deletePostingIfUnreferenced($row->c_posting_id);
 
-            $officeOperation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSTED_TO_OFFICE_DATA', CompositePrimaryKey::buildStoredResourceId([
+            $officeResourceId = CompositePrimaryKey::buildStoredResourceId([
                 'c_office_id' => $addr_l[0],
                 'c_posting_id' => $addr_l[1],
-            ]), $row);
+            ]);
+
+            $officeOperation = (new OperationRepository())->store(Auth::id(), $c_personid, 4, 'POSTED_TO_OFFICE_DATA', $officeResourceId, $row);
 
             $officeRowData = $auditLog->normalizeRow($row);
             $officeRowPk = $auditLog->buildRowPkFromData('POSTED_TO_OFFICE_DATA', $officeRowData);
@@ -626,15 +633,23 @@ class OfficePostingRepository {
                 $operationId
             );
 
-            foreach ($addrRows as $addrRow) {
-                $addrRowData = $auditLog->normalizeRow($addrRow);
-                $addrRowPk = $auditLog->buildRowPkFromData('POSTED_TO_ADDR_DATA', $addrRowData);
-                $auditLog->logChange(
-                    'POSTED_TO_ADDR_DATA',
-                    'DELETE',
-                    $addrRowPk,
-                    $addrRowData,
-                    null,
+            // 連帶刪除的子／父列同樣要進 operations（先前只寫了 audit_log，operations 缺席，
+            // 等於在 /operations 上看不到它們曾被刪除）。整組共用 $operationId、可整組回退。
+            $cascadeLogger = new ExplicitCascadeLogger();
+            $cascadeLogger->logDeletedRows(
+                'POSTED_TO_ADDR_DATA',
+                $officeResourceId,
+                $addrRows,
+                (int) $c_personid,
+                $operationId
+            );
+
+            if ($deletedPosting !== null) {
+                $cascadeLogger->logDeletedRows(
+                    'POSTING_DATA',
+                    (string) $row->c_posting_id,
+                    [$deletedPosting],
+                    (int) $c_personid,
                     $operationId
                 );
             }
@@ -659,5 +674,36 @@ class OfficePostingRepository {
                 ]
             );
         }
+    }
+
+    /**
+     * 僅在沒有任何 POSTED_TO_OFFICE_DATA／POSTED_TO_ADDR_DATA 列仍引用該 posting 時，才刪除
+     * POSTING_DATA 父列（顯式級聯的「最後一個引用者離開才收尾」語義）。
+     *
+     * 去級聯（ON DELETE RESTRICT）後逕刪仍被引用的父列會得到 1451；翻轉前的 CASCADE 則會
+     * 靜默刪掉共用同一 c_posting_id 的兄弟列（prod 實測 31 個 posting 被多列共用）。
+     *
+     * @return object|null 實際被刪除的 POSTING_DATA 列（供呼叫端寫 operations／audit_log）；未刪則 null
+     */
+    public static function deletePostingIfUnreferenced($postingId): ?object {
+        if ($postingId === null || $postingId === '') {
+            return null;
+        }
+
+        $stillReferenced = DB::table('POSTED_TO_OFFICE_DATA')->where('c_posting_id', $postingId)->exists()
+            || DB::table('POSTED_TO_ADDR_DATA')->where('c_posting_id', $postingId)->exists();
+
+        if ($stillReferenced) {
+            return null;
+        }
+
+        $postingRow = DB::table('POSTING_DATA')->where('c_posting_id', $postingId)->first();
+        if ($postingRow === null) {
+            return null;
+        }
+
+        DB::table('POSTING_DATA')->where('c_posting_id', $postingId)->delete();
+
+        return $postingRow;
     }
 }

--- a/app/Services/ExplicitCascadeLogger.php
+++ b/app/Services/ExplicitCascadeLogger.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Operation;
+use App\Repositories\OperationRepository;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * 「應用層顯式級聯刪除」的紀錄器：把連帶刪除的每一列都留下痕跡。
+ *
+ * 去級聯（docs/ON_DELETE_CASCADE_RISK.md §4.4）要求連帶刪除改由應用層自己做，並且
+ * **不得有任何一列在 operations／audit_log 之外悄悄消失**——DB 級聯之所以危險，正是
+ * 因為被它刪掉的列對應用層完全不可見（§3.3）。搬到應用層後若只記父列、不記子列，
+ * 等於把同一個盲區原封不動搬過來。
+ *
+ * 紀錄形式沿用專案既有慣例（AGENTS.md 高風險區備忘）：同一組子列合寫**一筆**
+ * operations（`resource_data['rows']` 放全部被刪列、resource_id 沿用父資源格式），
+ * 並**逐列**寫 audit_log（before-image）。整組共用同一個 operation_id，可整組回退。
+ */
+class ExplicitCascadeLogger {
+    protected OperationRepository $operationRepository;
+    protected AuditLogService $auditLogService;
+
+    public function __construct(?OperationRepository $operationRepository = null, ?AuditLogService $auditLogService = null) {
+        $this->operationRepository = $operationRepository ?? new OperationRepository();
+        $this->auditLogService = $auditLogService ?? new AuditLogService();
+    }
+
+    /**
+     * 記錄一組被連帶刪除的列。
+     *
+     * @param string $table 被刪表名
+     * @param string $resourceId operations.resource_id（沿用父資源格式，見類別註解）
+     * @param iterable<int,object|array> $rows 被刪除的列（**必須在 DELETE 之前取得**）
+     * @param int $personId 歸屬人物
+     * @param string|null $groupOperationId 已存在的群組 operation id；null 則以本次新建的為準
+     * @return string|null 本組使用的 operation id
+     */
+    public function logDeletedRows(string $table, string $resourceId, iterable $rows, int $personId, ?string $groupOperationId = null): ?string {
+        $normalized = [];
+        foreach ($rows as $row) {
+            $normalized[] = $this->auditLogService->normalizeRow($row);
+        }
+
+        if (empty($normalized)) {
+            return $groupOperationId;
+        }
+
+        $operation = $this->operationRepository->store(
+            Auth::id(),
+            $personId,
+            Operation::TYPE_DELETE,
+            $table,
+            $resourceId,
+            ['rows' => $normalized],
+            ['rows' => $normalized]
+        );
+
+        $operationId = $groupOperationId ?? ($operation ? (string) $operation->id : null);
+
+        foreach ($normalized as $rowData) {
+            $this->auditLogService->logChange(
+                $table,
+                'DELETE',
+                $this->auditLogService->buildRowPkFromData($table, $rowData),
+                $rowData,
+                null,
+                $operationId
+            );
+        }
+
+        return $operationId;
+    }
+}

--- a/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
+++ b/docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md
@@ -97,8 +97,7 @@ GROUP BY REFERENCED_TABLE_NAME, DELETE_RULE;
 | **2** | TEXT_CODES(21)、ADDR_CODES(11)＝**32 條**（TEXT_CODES 另 1 條 `SET NULL` 本已正確、未觸碰） | `2026_07_21_000000_restrict_fks_referencing_text_addr_codes` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.1）；同 commit 為唯一活硬刪路徑 `AdminBatchLoadBookTitlesController::undo()` 補 1451 友好報錯垫片 |
 | **3** | 其餘全部小詞表／類型表／樹表 35 張＝**52 條**（KINSHIP_CODES(6)、ASSOC_CODES(4)、OFFICE_CODES(3)、TEXT_BIBLCAT_CODES／STATUS_CODES／ENTRY_CODES／COUNTRY_CODES／APPOINTMENT_CODES／OFFICE_TYPE_TREE／ADMIN_CAT_CODES(各 2)、其餘各 1，含自引用 pair FK 與 *_TYPE_REL 入邊） | `2026_07_23_000000_restrict_fks_referencing_small_code_tables` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.2）；同 commit 為唯一活硬刪路徑（office 實體刪除，經通用 `EntityAggregateDeleteHandler`）補 1451 友好報錯垫片 |
 | **4** | SOCIAL_INSTITUTION_CODES(5)＋SOCIAL_INSTITUTION_NAME_CODES(5)＝**10 條**（含 CODES→NAME_CODES pair FK；資料表仍為 dual-key 雙單欄 FK 形態、未改複合鍵） | `2026_07_23_000001_restrict_fks_referencing_social_institution_tables` | ✅ 已實作＋MariaDB 10.3 端到端驗（見 §9.3）。前置皆已就位：codes UI 三表封寫（step 4）、實體刪除為顯式級聯（`SocialInstituteImportService::delete()`）＋引用護欄、`EntityAggregateDeleteHandler` 通用 1451 垫片 |
-| n+1 | 資料表 POSTING_DATA(2)、POSSESSION_DATA(1) | 待做——app 有活刪除路徑依賴其子表級聯（`OperationsProposalController`、`OfficePostingRepository`、`BiogMainRepository`），需先改為顯式級聯刪除 | — |
-| 末 | BIOG_MAIN(25)＋operations→BIOG_MAIN | 待做——需配套顯式級聯刪除服務 | — |
+| **末批（尚未執行）** | BIOG_MAIN(25，含 operations→BIOG_MAIN)＋POSTING_DATA(2)＋POSSESSION_DATA(1)＝**28 條** | 待做 | 🟡 **應用層前置已完成並上線（見 §11），刻意進入觀察期後才翻轉**——一支 migration 即可收尾 |
 
 **節奏（§6.1「app-layer-first」）**：翻一批 → 觀察 1–2 週盯 1451（1451 會把漏網的 cascade
 依賴刪除路徑逼出，fail-closed 零損失）→ 修應用層 → 下一批。`ON UPDATE CASCADE`（187 條）本階段一律保留。
@@ -203,3 +202,72 @@ migration，再套用批次 1：
 1. §6.1「同一 `ALTER` 內 DROP＋ADD」→ 改為「**兩條獨立 ALTER**（先 DROP 再 ADD）」，註明 10.3 的 1826 限制。
 2. 附錄 B 驗證：`DELETE_RULE='RESTRICT'` → `DELETE_RULE IN ('RESTRICT','NO ACTION')`。
 3. 標註 prod 版本待確認（10.3 vs 10.11）；兩條 ALTER 為跨版本安全選擇。
+
+## 11. 末批前置：應用層顯式級聯（已完成，觀察期中）
+
+末批（28 條）的前置不是「再寫一支 migration」，而是**把連帶刪除從 DB 搬進應用層並讓它做對**。
+本節記錄前置的盤點結論與已落地的修正；**刻意先上線觀察一段時間，再翻末批約束**（§6.1
+「app-layer-first」節奏——真實流量會把漏網路徑逼出來，此時仍有 CASCADE 兜底、不會 500）。
+
+### 11.1 盤點：28 條入邊實際上只有 3 條有活刪除路徑
+
+| 被引用表 | 入邊 | 活的硬刪路徑 | 結論 |
+|---|---|---|---|
+| `BIOG_MAIN` | 25 | **無**——人物「刪除」是軟刪除（`c_name_chn = '<待删除>'`，`BiogMainDeleteHandler`，UPDATE 非 DELETE） | 翻轉成本趨近零 |
+| `POSTING_DATA` | 2 | `OfficePostingRepository::officeDeleteById`、`OperationsProposalController::applyDeleteProposal` | 需修（見 11.2） |
+| `POSSESSION_DATA` | 1 | `BiogMainRepository::possessionDeleteById`、同上核准路徑 | 需修（見 11.2） |
+
+唯一產生 `DELETE FROM BIOG_MAIN` 的地方是 `MergePreviewController`——它**生成給人工執行的 SQL 腳本**，
+應用本身不執行（見 11.3）。
+
+### 11.2 修正一：先子後父、父列僅在無剩餘引用時才刪
+
+| 位置 | 原行為 | 翻轉後會怎樣 | 修正 |
+|---|---|---|---|
+| `BiogMainRepository::possessionDeleteById` | 先刪父列 `POSSESSION_DATA`、再刪子列 `POSSESSION_ADDR` | 第一句就 1451 | 改為先子後父 |
+| `OperationsProposalController::applyDeleteProposal` | 主列 `POSTED_TO_OFFICE_DATA` 尚未刪，就先刪它的**父列** `POSTING_DATA` | 1451 | `POSTING_DATA` 移到主列刪除**之後** |
+| `OfficePostingRepository::officeDeleteById`、上述核准路徑 | 無條件刪 `POSTING_DATA` | 1451 | 抽出 `OfficePostingRepository::deletePostingIfUnreferenced()`：確認無 `POSTED_TO_OFFICE_DATA`／`POSTED_TO_ADDR_DATA` 仍引用才刪 |
+
+最後一項不只是為了翻轉——**prod 實測有 31 個 `c_posting_id` 被多列 `POSTED_TO_OFFICE_DATA` 共用**，
+現行 CASCADE 下逕刪父列會**靜默連坐刪掉兄弟列**（既有的資料遺失風險，非翻轉引入）。
+
+### 11.3 修正二：合併腳本漏列 7 個指向 BIOG_MAIN 的欄位
+
+`MergePreviewController` 生成的合併腳本把來源人物的引用改指到存活人物後，末尾執行
+`DELETE FROM BIOG_MAIN`。但其 `$map` 只涵蓋 18 個欄位，漏掉 7 個：`ASSOC_DATA.c_tertiary_personid`／
+`c_assoc_claimer_id`、`ENTRY_DATA.c_assoc_id`／`c_kin_id`、`EVENTS_ADDR.c_personid`、
+`POSSESSION_ADDR.c_personid`、`operations.c_personid`。
+
+後果分兩種，**現況更糟**：
+
+- **現行 CASCADE**：那 7 類列在 DELETE 時被**靜默連帶刪除**；而腳本自帶的「確認以下查詢結果皆為 0」
+  檢查只掃 `$map` 列出的欄位——**檢查全過、資料照樣消失**（正是 §3.3 的審計盲區）；
+- **翻成 RESTRICT**：DELETE 被 1451 擋下，fail-closed。
+
+已把 7 個欄位補進 `$map`（re-point 與驗證 SELECT 皆自動涵蓋），並在該處加註「新增指向 BIOG_MAIN
+的外鍵時務必同步補進本表」。
+
+### 11.4 修正三：連帶刪除的每一列都要進 operations
+
+搬進應用層若只記父列，等於把 DB 級聯的盲區原樣搬過來。盤點發現三處缺口：
+`POSTED_TO_ADDR_DATA` 只有 audit_log、沒有 operations；`POSTING_DATA`／`POSSESSION_ADDR` 兩者皆無。
+
+新增 `App\Services\ExplicitCascadeLogger`，三條路徑統一使用。紀錄形式沿用專案既有慣例
+（AGENTS.md 高風險區備忘）：同一組子列合寫**一筆** operations（`resource_data['rows']` 放全部被刪
+列、resource_id 沿用父資源格式）＋**逐列** audit_log before-image，整組共用同一 `operation_id`、
+可整組回退。
+
+回歸測試：[`tests/Feature/ExplicitCascadeDeleteTest.php`](../tests/Feature/ExplicitCascadeDeleteTest.php)
+（8 tests）——涵蓋父列保留/刪除、子列清理、operations＋audit 的逐列落帳與 operation_id 分組、
+合併腳本涵蓋全部 25 條入邊。SQLite 無外鍵、驗不到 1451 本身，故鎖定的是**與外鍵無關但翻轉後
+正確性所依賴**的刪除語義。
+
+### 11.5 觀察期要盯什麼
+
+上線後（仍是 CASCADE，故任何漏網都不會 500，只會靜默）重點觀察：
+
+- `/operations` 上 `POSTED_TO_ADDR_DATA`／`POSTING_DATA`／`POSSESSION_ADDR` 的 op_type=4 紀錄是否
+  如期出現——**若某條刪除路徑沒留下紀錄，就是還沒被本次修正覆蓋的路徑**，正是翻轉前要補的；
+- 任職刪除後 `POSTING_DATA` 是否仍有孤兒（無人引用卻殘留）或誤刪（兄弟列連坐消失）；
+- 觀察無虞後，末批 migration 依 §6 範式一次翻完 28 條（`REFERENCED_TABLES = ['BIOG_MAIN',
+  'POSTING_DATA', 'POSSESSION_DATA']`），並於 MariaDB 10.3 補 §9 同規格實測。

--- a/tests/Feature/ExplicitCascadeDeleteTest.php
+++ b/tests/Feature/ExplicitCascadeDeleteTest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\MergePreviewController;
+use App\Repositories\BiogMainRepository;
+use App\Repositories\OfficePostingRepository;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 去級聯 Phase 1「應用層顯式級聯」回歸測試。
+ *
+ * 背景：詞表入邊已全數翻成 ON DELETE RESTRICT（批次 1–4），剩下的 28 條 CASCADE
+ * （BIOG_MAIN 25／POSTING_DATA 2／POSSESSION_DATA 1）在翻轉前，須先讓應用層自己
+ * 把「連帶刪除」做對——先子後父、且父列僅在無剩餘引用時才刪。
+ * 本檔鎖定翻轉**之前**就能觀察到的行為，作為上線觀察期的回歸護欄。
+ *
+ * 註：測試環境為 SQLite、無外鍵（AGENTS.md §1），因此**驗不到 1451 本身**；
+ * 1451 相關行為在 MariaDB 上驗（docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §7）。
+ * 這裡驗的是與外鍵無關、但翻轉後正確性所依賴的刪除語義。
+ */
+class ExplicitCascadeDeleteTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('POSTING_DATA', function (Blueprint $table) {
+            $table->integer('c_posting_id')->primary();
+            $table->integer('c_personid')->default(0);
+        });
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid')->default(0);
+            $table->integer('c_office_id')->default(0);
+            $table->integer('c_posting_id')->default(0);
+        });
+        Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid')->default(0);
+            $table->integer('c_office_id')->default(0);
+            $table->integer('c_posting_id')->default(0);
+            $table->integer('c_addr_id')->default(0);
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('POSTED_TO_ADDR_DATA');
+        Schema::dropIfExists('POSTED_TO_OFFICE_DATA');
+        Schema::dropIfExists('POSTING_DATA');
+        Schema::dropIfExists('POSSESSION_ADDR');
+        Schema::dropIfExists('POSSESSION_DATA');
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('operations');
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- POSTING_DATA
+
+    #[Test]
+    public function posting_parent_is_kept_while_another_office_row_still_references_it(): void {
+        // prod 實測有 31 個 c_posting_id 被多列 POSTED_TO_OFFICE_DATA 共用；翻轉前逕刪父列
+        // 會被 CASCADE 靜默連坐刪掉兄弟列，翻轉後則是 1451。兩種都不可接受——父列必須留著。
+        DB::table('POSTING_DATA')->insert(['c_posting_id' => 900, 'c_personid' => 1]);
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            ['c_personid' => 1, 'c_office_id' => 10, 'c_posting_id' => 900],
+            ['c_personid' => 1, 'c_office_id' => 11, 'c_posting_id' => 900],
+        ]);
+
+        // 模擬「其中一列已被刪除」後的收尾
+        DB::table('POSTED_TO_OFFICE_DATA')->where('c_office_id', 10)->delete();
+        OfficePostingRepository::deletePostingIfUnreferenced(900);
+
+        $this->assertDatabaseHas('POSTING_DATA', ['c_posting_id' => 900]);
+        $this->assertSame(1, DB::table('POSTED_TO_OFFICE_DATA')->where('c_posting_id', 900)->count());
+    }
+
+    #[Test]
+    public function posting_parent_is_removed_once_the_last_reference_is_gone(): void {
+        DB::table('POSTING_DATA')->insert(['c_posting_id' => 901, 'c_personid' => 1]);
+        DB::table('POSTED_TO_OFFICE_DATA')->insert(['c_personid' => 1, 'c_office_id' => 10, 'c_posting_id' => 901]);
+
+        DB::table('POSTED_TO_OFFICE_DATA')->where('c_posting_id', 901)->delete();
+        OfficePostingRepository::deletePostingIfUnreferenced(901);
+
+        $this->assertDatabaseMissing('POSTING_DATA', ['c_posting_id' => 901]);
+    }
+
+    #[Test]
+    public function posting_parent_is_kept_while_only_an_address_row_still_references_it(): void {
+        // 地址子列同樣是 POSTING_DATA 的引用者（POSTED_TO_ADDR_DATA_ibfk_4）。
+        DB::table('POSTING_DATA')->insert(['c_posting_id' => 902, 'c_personid' => 1]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1, 'c_office_id' => 10, 'c_posting_id' => 902, 'c_addr_id' => 5,
+        ]);
+
+        OfficePostingRepository::deletePostingIfUnreferenced(902);
+
+        $this->assertDatabaseHas('POSTING_DATA', ['c_posting_id' => 902]);
+    }
+
+    #[Test]
+    public function deleting_an_unreferenced_posting_id_is_a_no_op_when_null(): void {
+        DB::table('POSTING_DATA')->insert(['c_posting_id' => 903, 'c_personid' => 1]);
+
+        OfficePostingRepository::deletePostingIfUnreferenced(null);
+
+        $this->assertDatabaseHas('POSTING_DATA', ['c_posting_id' => 903]);
+    }
+
+    // ------------------------------------------------------------- POSSESSION_DATA
+
+    #[Test]
+    public function every_cascade_deleted_row_lands_in_operations_and_audit_log(): void {
+        // 核心要求：連帶刪除的每一列都要留下 operations 痕跡。DB 級聯之所以危險就是被它刪掉
+        // 的列對應用層不可見（§3.3）；搬到應用層後若只記父列，盲區等於原樣搬過來。
+        $this->createOperationsAndAuditTables();
+
+        DB::table('POSTING_DATA')->insert(['c_posting_id' => 910, 'c_personid' => 7]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            ['c_personid' => 7, 'c_office_id' => 10, 'c_posting_id' => 910, 'c_addr_id' => 41],
+            ['c_personid' => 7, 'c_office_id' => 10, 'c_posting_id' => 910, 'c_addr_id' => 42],
+        ]);
+
+        $addrRows = DB::table('POSTED_TO_ADDR_DATA')->where('c_posting_id', 910)->get();
+        DB::table('POSTED_TO_ADDR_DATA')->where('c_posting_id', 910)->delete();
+
+        $logger = new \App\Services\ExplicitCascadeLogger();
+        $groupId = $logger->logDeletedRows('POSTED_TO_ADDR_DATA', 'c_office_id=10&c_posting_id=910', $addrRows, 7);
+
+        $deletedPosting = OfficePostingRepository::deletePostingIfUnreferenced(910);
+        $this->assertNotNull($deletedPosting, '最後一個引用消失後應刪除 POSTING_DATA 父列');
+        $logger->logDeletedRows('POSTING_DATA', '910', [$deletedPosting], 7, $groupId);
+
+        // operations：兩張表各一筆刪除紀錄，且被刪列的內容都在 payload 裡
+        $addrOperation = DB::table('operations')->where('resource', 'POSTED_TO_ADDR_DATA')->first();
+        $this->assertNotNull($addrOperation, 'POSTED_TO_ADDR_DATA 的連帶刪除未寫入 operations');
+        $this->assertSame(4, (int) $addrOperation->op_type);
+        $this->assertSame(7, (int) $addrOperation->c_personid);
+        $addrPayload = json_decode($addrOperation->resource_original, true);
+        $this->assertCount(2, $addrPayload['rows'], '被刪的兩列地址都要在 operations payload 中');
+        $this->assertSame([41, 42], array_column($addrPayload['rows'], 'c_addr_id'));
+
+        $postingOperation = DB::table('operations')->where('resource', 'POSTING_DATA')->first();
+        $this->assertNotNull($postingOperation, 'POSTING_DATA 父列的連帶刪除未寫入 operations');
+        $this->assertSame(4, (int) $postingOperation->op_type);
+
+        // audit_log：逐列 before-image，且整組共用同一 operation_id（可整組回退）
+        $auditRows = DB::table('audit_log')->where('operation', 'DELETE')->get();
+        $this->assertCount(3, $auditRows, '2 列地址 + 1 列 posting，每列都要有 audit before-image');
+        $this->assertCount(1, array_unique($auditRows->pluck('operation_id')->all()), '整組應共用同一 operation_id');
+        foreach ($auditRows as $auditRow) {
+            $this->assertNotNull($auditRow->old_data);
+            $this->assertNull($auditRow->new_data);
+        }
+    }
+
+    #[Test]
+    public function logging_a_cascade_delete_with_no_child_rows_writes_nothing(): void {
+        $this->createOperationsAndAuditTables();
+
+        $groupId = (new \App\Services\ExplicitCascadeLogger())
+            ->logDeletedRows('POSTED_TO_ADDR_DATA', 'c_office_id=1&c_posting_id=2', [], 7, 'group-1');
+
+        $this->assertSame('group-1', $groupId);
+        $this->assertSame(0, DB::table('operations')->count());
+        $this->assertSame(0, DB::table('audit_log')->count());
+    }
+
+    protected function createOperationsAndAuditTables(): void {
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+    }
+
+    #[Test]
+    public function possession_delete_removes_child_address_rows_as_well(): void {
+        // 顯式級聯改為「先子後父」後，兩張表都必須清乾淨（翻轉前靠 CASCADE 代勞，
+        // 翻轉後若順序寫反會 1451）。
+        $this->createOperationsAndAuditTables();
+
+        Schema::create('POSSESSION_DATA', function (Blueprint $table) {
+            $table->integer('c_possession_record_id')->primary();
+            $table->integer('c_personid')->default(0);
+        });
+        Schema::create('POSSESSION_ADDR', function (Blueprint $table) {
+            $table->integer('c_personid')->default(0);
+            $table->integer('c_possession_record_id')->default(0);
+            $table->integer('c_addr_id')->default(0);
+        });
+
+        DB::table('POSSESSION_DATA')->insert(['c_possession_record_id' => 77, 'c_personid' => 3]);
+        DB::table('POSSESSION_ADDR')->insert([
+            ['c_personid' => 3, 'c_possession_record_id' => 77, 'c_addr_id' => 1],
+            ['c_personid' => 3, 'c_possession_record_id' => 77, 'c_addr_id' => 2],
+        ]);
+
+        (new BiogMainRepository())->possessionDeleteById(77, 3);
+
+        $this->assertDatabaseMissing('POSSESSION_DATA', ['c_possession_record_id' => 77]);
+        $this->assertSame(0, DB::table('POSSESSION_ADDR')->where('c_possession_record_id', 77)->count());
+    }
+
+    // ------------------------------------------------------- MergePreview SQL 腳本
+
+    #[Test]
+    public function merge_script_repoints_every_column_that_references_biog_main(): void {
+        // 腳本末尾的 DELETE FROM BIOG_MAIN 之所以今天「能跑通」，是因為漏列的引用會被
+        // CASCADE 靜默刪掉；翻成 RESTRICT 後漏一欄就是 1451。故 map 必須涵蓋全部 25 條入邊。
+        $controller = new MergePreviewController();
+        $method = new \ReflectionMethod($controller, 'buildSqlPreview');
+        $method->setAccessible(true);
+
+        $statements = $method->invoke($controller, 100, 200, [], false, null);
+        $sql = implode("\n", $statements);
+
+        $expected = [
+            'ALTNAME_DATA' => ['c_personid'],
+            'ASSOC_DATA' => ['c_personid', 'c_kin_id', 'c_assoc_id', 'c_assoc_kin_id', 'c_tertiary_personid', 'c_assoc_claimer_id'],
+            'BIOG_ADDR_DATA' => ['c_personid'],
+            'BIOG_INST_DATA' => ['c_personid'],
+            'BIOG_SOURCE_DATA' => ['c_personid'],
+            'BIOG_TEXT_DATA' => ['c_personid'],
+            'ENTRY_DATA' => ['c_personid', 'c_assoc_id', 'c_kin_id'],
+            'EVENTS_ADDR' => ['c_personid'],
+            'EVENTS_DATA' => ['c_personid'],
+            'KIN_DATA' => ['c_personid', 'c_kin_id'],
+            'POSSESSION_ADDR' => ['c_personid'],
+            'POSSESSION_DATA' => ['c_personid'],
+            'POSTED_TO_ADDR_DATA' => ['c_personid'],
+            'POSTED_TO_OFFICE_DATA' => ['c_personid'],
+            'POSTING_DATA' => ['c_personid'],
+            'STATUS_DATA' => ['c_personid'],
+            'operations' => ['c_personid'],
+        ];
+
+        foreach ($expected as $table => $columns) {
+            foreach ($columns as $column) {
+                $this->assertStringContainsString(
+                    sprintf('UPDATE %s SET %s = 100 WHERE %s = 200;', $table, $column, $column),
+                    $sql,
+                    "合併腳本未把 {$table}.{$column} 重新指向存活人物；翻 RESTRICT 後 DELETE FROM BIOG_MAIN 會 1451"
+                );
+                $this->assertStringContainsString(
+                    sprintf('FROM %s WHERE %s = 200;', $table, $column),
+                    $sql,
+                    "合併腳本的「確認為 0」檢查漏掉 {$table}.{$column}"
+                );
+            }
+        }
+
+        $this->assertStringContainsString('DELETE FROM BIOG_MAIN WHERE c_personid = 200;', $sql);
+    }
+}


### PR DESCRIPTION
末批（BIOG_MAIN 25＋POSTING_DATA 2＋POSSESSION_DATA 1＝28 條）的前置不是再寫一支 migration，而是把連帶刪除從 DB 搬進應用層並做對。本 commit 只做應用層，**刻意先 上線觀察一段時間再翻約束**（§6.1 app-layer-first：此時仍有 CASCADE 兜底、漏網路徑 不會 500，但會在 operations 上現形）。

盤點結論：28 條入邊實際只有 3 條有活硬刪路徑；人物「刪除」邏輯暫時保持不變：
（c_name_chn='<待删除>'，UPDATE 非 DELETE），故 BIOG_MAIN 的 25 條翻轉成本趨近零； 唯一產生 DELETE FROM BIOG_MAIN 的 MergePreviewController 是生成人工執行的 SQL 腳本。

- 先子後父：possessionDeleteById 原先刪父列 POSSESSION_DATA 再刪子列 POSSESSION_ADDR；applyDeleteProposal 在主列 POSTED_TO_OFFICE_DATA 尚未刪時就先 刪其父列 POSTING_DATA。翻轉後兩者都會 1451，已改正順序。
- 父列僅在無剩餘引用時才刪：抽出 OfficePostingRepository::deletePostingIfUnreferenced()。 這不只為翻轉——prod 實測 31 個 c_posting_id 被多列 POSTED_TO_OFFICE_DATA 共用， 現行 CASCADE 下逕刪父列會靜默連坐刪掉兄弟列（既有資料遺失風險）。
- 合併腳本補齊 7 個漏列的 BIOG_MAIN 入邊欄位（ASSOC_DATA.c_tertiary_personid／ c_assoc_claimer_id、ENTRY_DATA.c_assoc_id／c_kin_id、EVENTS_ADDR、POSSESSION_ADDR、 operations）。現行 CASCADE 下這些列在 DELETE 時被靜默刪除，而腳本自帶的「確認為 0」 檢查只掃 map 內欄位——檢查全過、資料照樣消失（§3.3 審計盲區）。
- 每列都進 operations：新增 App\Services\ExplicitCascadeLogger，三條路徑統一使用。 先前 POSTED_TO_ADDR_DATA 只有 audit_log 沒有 operations，POSTING_DATA／ POSSESSION_ADDR 兩者皆無——只記父列等於把 DB 級聯的盲區原樣搬進應用層。 形式沿用既有慣例：整組子列合寫一筆 operations（resource_data['rows']）＋逐列 audit_log before-image，共用同一 operation_id、可整組回退。
- 新增 tests/Feature/ExplicitCascadeDeleteTest.php（8 tests）；末批 migration 與 觀察期要盯的指標記於 docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §11。
- 已執行 ./vendor/bin/phpunit（2352 tests 全綠）與 ./vendor/bin/php-cs-fixer fix