### PR TITLE
feat(proposal): 段二: postings／possessions／events 提案核准全面收斂到 v2 handler 重放

### DIFF
--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -4,12 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
-use App\Repositories\OfficePostingRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
-use App\Services\ExplicitCascadeLogger;
 use App\Services\NameSearchIndexService;
-use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -50,15 +47,23 @@ class OperationsProposalController extends Controller {
     ];
 
     /**
-     * 段一：以 v2 mutation handler 重放核准的人物子資源提案（表名 → API resource）。
+     * 段一／段二：以 v2 mutation handler 重放核准的人物子資源提案（表名 → API resource）。
      *
-     * 這些表的提案原本落到通用行覆寫（applyCreate/Update/DeleteProposal），繞過聚合的
-     * 派生／護欄／audit／索引同步——「核准」退化成盲寫一行、與「直接編輯」行為分歧。
+     * 這些表的提案原本落到通用行覆寫（applyCreate/Update/DeleteProposal）或 legacy repository
+     * 委派（applyOffice/PossessionCreate/PossessionUpdate/EventProposal），繞過聚合的
+     * 派生／護欄／audit／索引同步，或與 direct 編輯是兩份獨立實作。
      * 改為重建 {resource, 'direct', operation, personId, targetPk, changes} 重放 direct handler，
      * 使核准與直接編輯逐位一致（見 docs/ENTITY_AGGREGATE_ARCHITECTURE.md §4.5）。
      *
-     * 不含：委派檔（KIN_DATA／ASSOC_DATA／POSTED_TO_OFFICE_DATA／POSSESSION_DATA／EVENTS_DATA）
-     * 已走 legacy repository 委派、行為已對齊；code 表提案走 CodesController 自己的核准路徑、不經此。
+     * 段二（postings／possessions／events）額外把 $auxiliaryPayload（地址副表意圖，
+     * c_addr／c_addr_id／c_addr_cleared，見 applyViaMutationHandler）併入 changes——這些欄位
+     * 從不屬於主表白名單，只存在 __proposal_aux，handler 的 handle() 本就會從 changes 抽出它們
+     * （對齊 PostingMutationHandler／PossessionMutationHandler／EventMutationHandler／
+     * *CreateHandler 既有的 direct 地址副表同步邏輯）。
+     *
+     * 不含：委派檔 KIN_DATA／ASSOC_DATA（兩人互為鏡像的親屬／社會關係，核准時的鏡像衝突語義
+     * 仍在 legacy 那側、需先裁定域邏輯才能收斂，見 docs/PERSON_PROPOSAL_PATHS.md §5.1）；
+     * code 表提案走 CodesController 自己的核准路徑、不經此。
      * auth 無礙：canReviewProposals() 與 canWriteDirectly() 為同一謂詞，能到核准端點者必過 authorizeDirect()。
      */
     protected const HANDLER_ROUTED_RESOURCES = [
@@ -69,6 +74,9 @@ class OperationsProposalController extends Controller {
         'BIOG_TEXT_DATA' => 'texts',
         'BIOG_SOURCE_DATA' => 'sources',
         'BIOG_INST_DATA' => 'social_institutions',
+        'POSTED_TO_OFFICE_DATA' => 'postings',
+        'POSSESSION_DATA' => 'possessions',
+        'EVENTS_DATA' => 'events',
     ];
 
     public function __construct(
@@ -397,7 +405,7 @@ class OperationsProposalController extends Controller {
         // handleProposal() 內、direct 路徑不經過，故不受影響；SourceMutationHandler 的護欄在 mode 分派之前、
         // direct 亦會跑，故以 meta.__approving_operation_id 排除「正在核准的自己」（見 applyViaMutationHandler）。
         if (isset(self::HANDLER_ROUTED_RESOURCES[$table])) {
-            return [$this->applyViaMutationHandler($operation, $table, $data, $keyColumns, $original), true];
+            return [$this->applyViaMutationHandler($operation, $table, $data, $keyColumns, $original, $auxiliaryPayload), true];
         }
 
         if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_DELETE) {
@@ -412,22 +420,6 @@ class OperationsProposalController extends Controller {
             return [$this->applyAssocProposal($operation, $data, $original, $auxiliaryPayload), true];
         }
 
-        if ($table === 'POSTED_TO_OFFICE_DATA') {
-            return [$this->applyOfficeProposal($operation, $data, $original, $auxiliaryPayload), true];
-        }
-
-        if ($table === 'POSSESSION_DATA' && (int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
-            return [$this->applyPossessionCreateProposal($operation, $data, $auxiliaryPayload), true];
-        }
-
-        if ($table === 'POSSESSION_DATA' && (int) $operation->op_type === Operation::TYPE_PROPOSAL_UPDATE) {
-            return [$this->applyPossessionUpdateProposal($operation, $data, $original, $auxiliaryPayload), true];
-        }
-
-        if ($table === 'EVENTS_DATA') {
-            return [$this->applyEventProposal($operation, $data, $original, $auxiliaryPayload), true];
-        }
-
         if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
             return [$this->applyCreateProposal($table, $data, $keyColumns), false];
         }
@@ -439,20 +431,38 @@ class OperationsProposalController extends Controller {
      * 段一核准重放：把提案還原成一次 direct mutation，交回同一個 v2 handler 落庫。
      *
      * 存的 resource_data 是「合併後的行快照」（update 時 data = original ∪ updateData），據此還原意圖：
-     *  - create：targetPk = data 的鍵欄；changes = data 去鍵欄（handler 內以 merge(targetPk, changes) 組回整列）。
+     *  - create：targetPk = data 的鍵欄；changes = data 全量（**含**鍵欄，不剔除）。鍵欄同時留在
+     *            changes 對 AbstractPersonSubresourceCreateHandler 系handler 是 no-op（其
+     *            allowedFields() 本含鍵欄，且 handle() 固定 merge(targetPk, changes) 組回整列）；
+     *            但對 bespoke 的 PostingCreateHandler 是必要的——c_office_id 既是 POSTED_TO_OFFICE_DATA
+     *            複合鍵之一，也是該 handler 直接從 changes 讀取（未經 targetPk 合併）的必填欄位，
+     *            剔除會導致「缺少 c_office_id」（段二踩坑，見下方 changes 賦值處註解）。
      *  - update：targetPk = original 的鍵欄；changes = data 相對 original 有差異的欄位（含被改動的鍵欄，
      *            handler 內以 buildNewPk 處理改鍵）。因 data＝original∪updateData，差集恰為使用者變更。
      *  - delete：targetPk = original 的鍵欄；changes = []。
+     *
+     * $auxiliaryPayload（postings／possessions／events 專用）：地址副表意圖（c_addr／c_addr_id／
+     * c_addr_cleared）從不屬於主表欄位白名單，提案送出時只存進 __proposal_aux（見
+     * PostingMutationHandler::proposalAuxiliaryPayload() 等），故 data/original 的差集抓不到它，
+     * 需顯式併入 changes——handler 的 handle() 本就會從 changes 抽出這些鍵（對齊其 direct 路徑）。
+     * 只挑 ADDRESS_AUX_KEYS 這幾個已知鍵合併，不整包塞入：__proposal_aux 舊資料可能還帶著
+     * legacy applyOfficeProposal() 時代寫入的 _id／_postingid／_officeid（僅供已刪除的 legacy
+     * 委派方法定位記錄用），這些鍵不是 handler 認得的欄位，整包合併會被白名單擋下（422／
+     * RuntimeException）。其餘 7 張已收斂的表無此類欄，過濾後恆為 []，合併為 no-op。
      */
+    private const ADDRESS_AUX_KEYS = ['c_addr', 'c_addr_id', 'c_addr_cleared'];
+
     protected function applyViaMutationHandler(
         Operation $operation,
         string $table,
         array $data,
         array $keyColumns,
-        array $original
+        array $original,
+        array $auxiliaryPayload = []
     ): array {
         $resource = self::HANDLER_ROUTED_RESOURCES[$table];
         $opType = (int) $operation->op_type;
+        $addressAux = array_intersect_key($auxiliaryPayload, array_flip(self::ADDRESS_AUX_KEYS));
         // 這些子資源以 row 內 c_personid 為權威人物（handler 會校驗 target.pk.c_personid 與 person_id 一致）；
         // operation->c_personid 對舊/測試資料可能為 0，故不可優先。用 null 合併避免 `0 ?? x` 的陷阱。
         $personId = (int) ($data['c_personid'] ?? $original['c_personid'] ?? ($operation->c_personid ?: 0));
@@ -468,7 +478,7 @@ class OperationsProposalController extends Controller {
         if ($opType === Operation::TYPE_PROPOSAL_CREATE) {
             $handlerOperation = 'create';
             $targetPk = $this->pickColumns($data, $keyColumns);
-            $changes = array_diff_key($data, array_flip($keyColumns));
+            $changes = array_merge($data, $addressAux);
         } elseif ($opType === Operation::TYPE_PROPOSAL_DELETE) {
             $handlerOperation = 'delete';
             $targetPk = $this->pickColumns($original, $keyColumns);
@@ -476,7 +486,7 @@ class OperationsProposalController extends Controller {
         } else {
             $handlerOperation = 'update';
             $targetPk = $this->pickColumns($original, $keyColumns);
-            $changes = $this->diffChangedColumns($original, $data);
+            $changes = array_merge($this->diffChangedColumns($original, $data), $addressAux);
         }
 
         /** @var \App\Services\Mutations\MutationHandlerRegistry $registry */
@@ -631,146 +641,6 @@ class OperationsProposalController extends Controller {
         ]) ?? array_merge($original, $result);
     }
 
-    protected function applyOfficeProposal(
-        Operation $operation,
-        array $data,
-        array $original,
-        array $auxiliaryPayload
-    ): array {
-        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
-
-        // 更新提案：officeUpdateById() 需要表單隱藏欄位 _id, _postingid, _officeid 來定位原始記錄。
-        // 早期提案可能未將這些欄位存入 __proposal_aux，需從 $original 補齊。
-        if ((int) $operation->op_type !== Operation::TYPE_PROPOSAL_CREATE) {
-            if (!isset($auxiliaryPayload['_id'])) {
-                $auxiliaryPayload['_id'] = $personId;
-            }
-            if (!isset($auxiliaryPayload['_postingid'])) {
-                $auxiliaryPayload['_postingid'] = $original['c_posting_id'] ?? $data['c_posting_id'] ?? null;
-            }
-            if (!isset($auxiliaryPayload['_officeid'])) {
-                $auxiliaryPayload['_officeid'] = $original['c_office_id'] ?? null;
-            }
-        }
-
-        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
-
-        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
-            $resourceId = $this->biogMainRepository->officeStoreById($request, $personId);
-        } else {
-            if (empty($original)) {
-                throw new \RuntimeException('缺少原始資料，無法更新。');
-            }
-
-            $result = $this->biogMainRepository->officeUpdateById(
-                $request,
-                $this->buildLegacyOfficeId($original),
-                $personId
-            );
-            $resourceId = is_array($result) ? ($result['id'] ?? null) : $result;
-        }
-
-        if (!is_string($resourceId) || $resourceId === '') {
-            throw new \RuntimeException('官名提案套用後無法取得主鍵。');
-        }
-
-        $pk = CompositePrimaryKey::parseStoredResourceId($resourceId, 'POSTED_TO_OFFICE_DATA');
-        if ($pk === null) {
-            throw new \RuntimeException('官名提案套用後無法解析主鍵。');
-        }
-
-        $row = $this->fetchAppliedRow('POSTED_TO_OFFICE_DATA', $pk);
-        if ($row === null) {
-            throw new \RuntimeException('官名提案套用後讀取資料失敗。');
-        }
-
-        return $row;
-    }
-
-    /**
-     * 財產新增提案核准：委派 possessionStoreById 配發 c_possession_record_id（交易內 max+1），
-     * 連帶寫主表 POSSESSION_DATA + 副表 POSSESSION_ADDR + operation + audit_log。
-     * 地址陣列存於 __proposal_aux['c_addr_id']；usedDirectWorkflow=true 由委派端自行寫 operation/audit，
-     * approve() 不再重複寫，避免 operation/audit 重複（比照 applyOfficeProposal）。
-     */
-    protected function applyPossessionCreateProposal(
-        Operation $operation,
-        array $data,
-        array $auxiliaryPayload
-    ): array {
-        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? 0);
-
-        $addr = $auxiliaryPayload['c_addr_id'] ?? [];
-        if (!is_array($addr)) {
-            $addr = [$addr];
-        }
-
-        $request = Request::create('/', 'POST', array_merge($data, ['c_addr_id' => array_values($addr)]));
-
-        $newId = $this->biogMainRepository->possessionStoreById($request, $personId);
-
-        $row = $this->fetchAppliedRow('POSSESSION_DATA', ['c_possession_record_id' => $newId]);
-        if ($row === null) {
-            throw new \RuntimeException('財產提案套用後讀取資料失敗。');
-        }
-
-        return $row;
-    }
-
-    /**
-     * 套用財產更新提案：連帶同步 POSSESSION_ADDR（修補先前 update 提案走泛型單表套用、漏掉地址副表的缺口）。
-     * aux 帶 c_addr_id（陣列）時 possessionUpdateById 同步副表；未帶則保留既有地址（is_array 守衛）。
-     */
-    protected function applyPossessionUpdateProposal(
-        Operation $operation,
-        array $data,
-        array $original,
-        array $auxiliaryPayload
-    ): array {
-        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
-        $recordId = (int) ($data['c_possession_record_id'] ?? $original['c_possession_record_id'] ?? 0);
-
-        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
-        $this->biogMainRepository->possessionUpdateById($request, $personId, $recordId);
-
-        $row = $this->fetchAppliedRow('POSSESSION_DATA', ['c_possession_record_id' => $recordId]);
-        if ($row === null) {
-            throw new \RuntimeException('財產提案套用後讀取資料失敗。');
-        }
-
-        return $row;
-    }
-
-    protected function applyEventProposal(
-        Operation $operation,
-        array $data,
-        array $original,
-        array $auxiliaryPayload
-    ): array {
-        $personId = (int) ($operation->c_personid ?? $data['c_personid'] ?? $original['c_personid'] ?? 0);
-        $request = Request::create('/', 'POST', array_merge($data, $auxiliaryPayload));
-
-        if ((int) $operation->op_type === Operation::TYPE_PROPOSAL_CREATE) {
-            $result = $this->biogMainRepository->eventStoreById($request, $personId);
-        } else {
-            if (empty($original)) {
-                throw new \RuntimeException('缺少原始資料，無法更新。');
-            }
-
-            $result = $this->biogMainRepository->eventUpdateById(
-                $request,
-                $personId,
-                $this->buildLegacyEventId($original)
-            );
-        }
-
-        return $this->fetchAppliedRow('EVENTS_DATA', [
-            'c_personid' => $personId,
-            'c_sequence' => $result['c_sequence'] ?? $original['c_sequence'] ?? null,
-            'c_event_code' => $result['c_event_code'] ?? $original['c_event_code'] ?? null,
-        ]) ?? array_merge($original, $result);
-    }
-
     protected function buildLegacyKinshipId(array $original): string {
         foreach (['c_personid', 'c_kin_id', 'c_kin_code'] as $column) {
             if (!array_key_exists($column, $original)) {
@@ -806,26 +676,6 @@ class OperationsProposalController extends Controller {
             $this->biogMainRepository->unionPKDef($original['c_text_title'] ?? ''),
             str_replace('-', '(minus)', $assocFirstYear),
         ]);
-    }
-
-    protected function buildLegacyOfficeId(array $original): string {
-        foreach (['c_office_id', 'c_posting_id'] as $column) {
-            if (!array_key_exists($column, $original)) {
-                throw new \RuntimeException("缺少 {$column}，無法更新官名提案。");
-            }
-        }
-
-        return $original['c_office_id'].'-'.$original['c_posting_id'];
-    }
-
-    protected function buildLegacyEventId(array $original): string {
-        foreach (['c_sequence', 'c_event_code'] as $column) {
-            if (!array_key_exists($column, $original)) {
-                throw new \RuntimeException("缺少 {$column}，無法更新事件提案。");
-            }
-        }
-
-        return $original['c_sequence'].'-'.$original['c_event_code'];
     }
 
     protected function fetchAppliedRow(string $table, array $conditions): ?array {
@@ -977,7 +827,9 @@ class OperationsProposalController extends Controller {
 
     /**
      * 套用刪除提案：以 __key_columns + original 的 PK 值定位目標列並刪除。
-     * offices(POSTED_TO_OFFICE_DATA)/possession(POSSESSION_DATA) 連帶刪除副表。
+     * POSTED_TO_OFFICE_DATA／POSSESSION_DATA 已收斂至 HANDLER_ROUTED_RESOURCES（段二），
+     * 副表連帶刪除改由 PostingDeleteHandler／PossessionDeleteHandler 委派既有 repository
+     * 方法處理，此處不再需要特例。
      * 回傳被刪除前的原始列（供 logFinalOperation/audit 使用）；目標列不存在則回傳空陣列。
      */
     protected function applyDeleteProposal(string $table, array $keyColumns, array $original): array {
@@ -998,28 +850,7 @@ class OperationsProposalController extends Controller {
 
         $deletedRow = $this->convertRowToArray($row);
 
-        // 連帶刪除副表（顯式級聯）：子列先於父列。POSSESSION_ADDR 是 POSSESSION_DATA 的子表，
-        // 故於主列刪除前清掉；POSTING_DATA 反之是 POSTED_TO_OFFICE_DATA 的**父列**，必須等主列
-        // 刪掉之後才輪到它（見下方 deleteOfficeAuxiliaryTables／deletePostingParentIfUnreferenced）。
-        if ($table === 'POSTED_TO_OFFICE_DATA') {
-            $this->deleteOfficeAuxiliaryTables($deletedRow);
-        } elseif ($table === 'POSSESSION_DATA') {
-            $this->deletePossessionAuxiliaryTables($deletedRow);
-        }
-
         DB::table($table)->where($conditions)->delete();
-
-        if ($table === 'POSTED_TO_OFFICE_DATA') {
-            $deletedPosting = OfficePostingRepository::deletePostingIfUnreferenced($deletedRow['c_posting_id'] ?? null);
-            if ($deletedPosting !== null) {
-                (new ExplicitCascadeLogger())->logDeletedRows(
-                    'POSTING_DATA',
-                    (string) ($deletedRow['c_posting_id'] ?? ''),
-                    [$deletedPosting],
-                    (int) ($deletedRow['c_personid'] ?? 0)
-                );
-            }
-        }
 
         // 注意：社會關係反向鏡像刪除移至 approve() 於 logFinalOperation 之後執行，
         // 以便鏡像 audit 掛 final delete operation id（見 approve()）。
@@ -1029,71 +860,6 @@ class OperationsProposalController extends Controller {
         }
 
         return $deletedRow;
-    }
-
-    /**
-     * POSTED_TO_OFFICE_DATA 核准刪除時連帶刪除 POSTED_TO_ADDR_DATA。
-     *
-     * 注意 POSTING_DATA **不在此處刪除**：它是 POSTED_TO_OFFICE_DATA／POSTED_TO_ADDR_DATA 的
-     * 父列，去級聯（ON DELETE RESTRICT）後必須等主列刪完、且確認無其他列共用該 posting 之後
-     * 才能刪，見 applyDeleteProposal() 末尾的 deletePostingIfUnreferenced()。
-     */
-    protected function deleteOfficeAuxiliaryTables(array $row): void {
-        $officeId = $row['c_office_id'] ?? null;
-        $postingId = $row['c_posting_id'] ?? null;
-        $personId = $row['c_personid'] ?? null;
-
-        if ($officeId === null || $postingId === null) {
-            return;
-        }
-
-        if (Schema::hasTable('POSTED_TO_ADDR_DATA')) {
-            $addrQuery = DB::table('POSTED_TO_ADDR_DATA')
-                ->where('c_office_id', $officeId)
-                ->where('c_posting_id', $postingId);
-            if ($personId !== null) {
-                $addrQuery->where('c_personid', $personId);
-            }
-
-            // 刪除前先取出，連帶刪除的每一列都要留下 operations／audit_log 痕跡。
-            $addrRows = (clone $addrQuery)->get();
-            $addrQuery->delete();
-
-            (new ExplicitCascadeLogger())->logDeletedRows(
-                'POSTED_TO_ADDR_DATA',
-                CompositePrimaryKey::buildStoredResourceId([
-                    'c_office_id' => $officeId,
-                    'c_posting_id' => $postingId,
-                ]),
-                $addrRows,
-                (int) ($personId ?? 0)
-            );
-        }
-    }
-
-    /**
-     * POSSESSION_DATA 核准刪除時連帶刪除 POSSESSION_ADDR。
-     */
-    protected function deletePossessionAuxiliaryTables(array $row): void {
-        $recordId = $row['c_possession_record_id'] ?? null;
-        if ($recordId === null) {
-            return;
-        }
-
-        if (Schema::hasTable('POSSESSION_ADDR')) {
-            $addrQuery = DB::table('POSSESSION_ADDR')->where('c_possession_record_id', $recordId);
-
-            // 刪除前先取出，連帶刪除的每一列都要留下 operations／audit_log 痕跡。
-            $addrRows = (clone $addrQuery)->get();
-            $addrQuery->delete();
-
-            (new ExplicitCascadeLogger())->logDeletedRows(
-                'POSSESSION_ADDR',
-                (string) $recordId,
-                $addrRows,
-                (int) ($row['c_personid'] ?? 0)
-            );
-        }
     }
 
     /**

--- a/docs/PERSON_PROPOSAL_PATHS.md
+++ b/docs/PERSON_PROPOSAL_PATHS.md
@@ -27,7 +27,7 @@ direct 與 proposal 因此天然對等，不需要兩邊各自維護。
 | # | 路徑 | 實作 | 寫入方式 | 派生／護欄／正規化 | operations＋audit | 對等性 |
 |---|---|---|---|---|---|---|
 | **A** | **handler 重放**（本次收斂到的目標） | `applyViaMutationHandler()` → `MutationHandlerRegistry` | 呼叫 v2 handler 的 direct 路徑 | ✅ 全部（與直接編輯同一份程式） | ✅ handler 自寫 | ✅ **逐位一致** |
-| **B** | **legacy 委派** | `applyKinship/Assoc/Office/Possession/EventProposal()` | 重建假 `Request` → `BiogMainRepository::*StoreById/*UpdateById` | ⚠ legacy 那一份（與 v2 handler 是**兩份實作**） | ✅ 委派端自寫 | ⚠ 靠測試與共用 mirror helper 手動維持 |
+| **B** | **legacy 委派** | `applyKinship/AssocProposal()` | 重建假 `Request` → `BiogMainRepository::*StoreById/*UpdateById` | ⚠ legacy 那一份（與 v2 handler 是**兩份實作**） | ✅ 委派端自寫 | ⚠ 靠測試與共用 mirror helper 手動維持 |
 | **C** | **通用行覆寫** | `applyCreate/Update/DeleteProposal()` | `DB::table()->insert/update/delete` 蓋行快照 | ❌ 全部繞過 | ⚠ 由 `approve()` 事後補記 | ❌ **盲寫，會落殘缺資料** |
 
 > 路徑 C 是原始狀態：核准把 `resource_data` 當成「這一列該長的樣子」直接蓋上去。
@@ -48,16 +48,16 @@ direct 與 proposal 因此天然對等，不需要兩邊各自維護。
 | texts | `BIOG_TEXT_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
 | sources | `BIOG_SOURCE_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
 | social_institutions | `BIOG_INST_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
+| postings | `POSTED_TO_OFFICE_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
+| possessions | `POSSESSION_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
+| events | `EVENTS_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
 | kinship | `KIN_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 鏡像同步 |
 | associations | `ASSOC_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 鏡像同步 |
-| postings | `POSTED_TO_OFFICE_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 副表清理 |
-| possessions | `POSSESSION_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 副表清理 |
-| events | `EVENTS_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** |
 | **biogmain** | `BIOG_MAIN` | v2 handler | ❌ **C** | ❌ **C**（Eloquent＋不可清空守衛） | ❌ **C** |
 
-**注意分派順序**：`applyProposal()` 先判 A（已路由的 7 張表，三種操作全收），再判 DELETE→C，
-才輪到 B 的各表分支。所以**委派檔（B）的 DELETE 其實不走 B、而是掉進 C**，
-只是 `approve()` 另外替 ASSOC／KIN 補了反向鏡像刪除、替 office／possession 補了副表清理。
+**注意分派順序**：`applyProposal()` 先判 A，再判 DELETE→C，才輪到 B（kinship／associations）的
+兩個分支。委派檔（B）的 DELETE 因此其實不走 B、而是掉進 C，只是 `approve()` 另外替 ASSOC／KIN
+補了反向鏡像刪除。
 
 ---
 
@@ -101,21 +101,58 @@ direct 與 proposal 因此天然對等，不需要兩邊各自維護。
 | update／delete 缺 `resource_original` | **保留**舊訊息「缺少原始資料，無法更新／刪除。」，在路由前先擋 | 比 handler 的「主鍵格式不正確」更有指向性；此檢查只是定位目標，不重複 handler 邏輯 |
 | create 目標主鍵已存在 | **改用** handler 訊息「目標主鍵已存在」 | handler 於 `preprocessCreateData` 正規化後才比對主鍵（如 -999→0）；在控制器補一份預檢查會與正規化分歧，是真的正確性風險。行為契約（擋下／維持待審／無副作用）不變 |
 
+### 4.5 段二：postings／possessions／events（單人屬性、無鏡像）收斂到路徑 A
+
+這 3 張表的委派實作（`applyOfficeProposal`／`applyPossessionCreateProposal`／
+`applyPossessionUpdateProposal`／`applyEventProposal`）與 kinship／associations 不同，
+**不涉及「兩人互為鏡像」**——地址副表（`POSTED_TO_ADDR_DATA`／`POSSESSION_ADDR`）是單一人物
+記錄自己的子表，不是另一個人身上的鏡像列，故遷到路徑 A 不需要重新裁定鏡像語義。
+
+**唯一需要解決的落差**：地址副表意圖（`c_addr`／`c_addr_id`／`c_addr_cleared`）從不屬於主表
+欄位白名單，提案送出時只存進 `__proposal_aux`（`data`/`original` 的行快照抓不到）。解法：
+`applyViaMutationHandler()` 新增 `$auxiliaryPayload` 參數，create／update 皆將其併入 `changes`——
+`PostingMutationHandler`／`PossessionMutationHandler`／`EventMutationHandler`／對應
+`*CreateHandler` 的 `handle()` 本就會從 `changes` 抽出這些鍵（direct 路徑既有邏輯），故此舉
+只是把「地址意圖從哪裡讀」對齊到 handler 既有的讀取點，不是新邏輯。其餘 7 張已收斂的表
+無此類副表，`$auxiliaryPayload` 恆為 `[]`，合併為 no-op。
+
+DELETE 一併收斂（非本文先前建議的「最後做」）：這 3 張表的 `*DeleteHandler` 於 direct 模式
+委派既有的 `BiogMainRepository::officeDeleteById()`／`possessionDeleteById()`——與去級聯
+Phase 1 末批前置（見 `docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md` §11）同一批修正過的
+「先子後父」「父列僅在無剩餘引用時才刪」邏輯，本就是目前生產環境 direct API／Blade 表單共用
+的路徑，比路徑 C 另外维護的 `deleteOfficeAuxiliaryTables`／`deletePossessionAuxiliaryTables`
+更貼近實際使用的程式碼，故一併移除、不再分階段。
+
+移除的死碼：`applyOfficeProposal`／`applyPossessionCreateProposal`／
+`applyPossessionUpdateProposal`／`applyEventProposal`、`buildLegacyOfficeId`／
+`buildLegacyEventId`、`applyDeleteProposal()` 內的 office／possession 特例、
+`deleteOfficeAuxiliaryTables`／`deletePossessionAuxiliaryTables`（`applyProposal()` 的
+`HANDLER_ROUTED_RESOURCES` 判斷在這些分支之前，加入後這些分支恆不可達）。
+
+`BiogMainRepository::officeStoreById/officeUpdateById/possessionStoreById/possessionUpdateById/
+eventStoreById/eventUpdateById` **未刪除**：Blade 版 `BasicInformationOfficesController`／
+`BasicInformationPossessionController`／`BasicInformationEventsController` 仍在用（AGENTS.md
+所述 flag-gated 回退頁面），這幾個 repository 方法繼續服務直接編輯，只是核准不再另外呼叫它們。
+
 ---
 
 ## 5. 還沒做什麼
 
-### 5.1 委派檔 5 個資源（路徑 B）——create／update 仍是兩份實作
+### 5.1 委派檔 2 個資源（路徑 B）——kinship／associations，暫緩
 
-`kinship`／`associations`／`postings`／`possessions`／`events` 的核准走 legacy repository，
-而**直接編輯走 v2 handler**（例如 `AssociationMutationHandler` 自己 `DB::table('ASSOC_DATA')` 寫，
-只共用 `syncAssocMirrorOnUpdate` 這個 mirror helper）。兩者是**獨立的寫實作**，
+`kinship`／`associations` 的核准仍走 legacy repository，而**直接編輯走 v2 handler**
+（例如 `AssociationMutationHandler` 自己 `DB::table('ASSOC_DATA')` 寫，只共用
+`syncAssocMirrorOnUpdate` 這個 mirror helper）。兩者是**獨立的寫實作**，
 靠測試與共用 helper 手動維持對齊——程式註解可見這個持續校準的痕跡
 （如 `#82：核准 CREATE 啟用鏡像衝突/疑似偵測（對齊 v2 direct create）`）。
 
-**為何比段一難**：核准路徑的鏡像語義（`MirrorConflictException`／`MirrorSuspectedException`／
-`MirrorIntegrityException`、缺鏡像 backfill、刪除時的 `$force=true` 廣集孤兒語義）都實作在 legacy 那側，
-有十餘個測試釘著。遷到 A 等於**在語義層重新裁定「核准時採用哪一套鏡像行為」**——是領域決策，不只是接線。
+**為何暫緩**：`KIN_DATA`／`ASSOC_DATA` 每筆記錄描述的是**兩個人之間**的關係，資料庫裡各自
+存一份互為鏡像的列（正向／反向）。核准路徑的鏡像語義（`MirrorConflictException`／
+`MirrorSuspectedException`／`MirrorIntegrityException`、缺鏡像 backfill、刪除時的
+`$force=true` 廣集孤兒語義）都實作在 legacy 那側，有十餘個測試釘著。這與 §4.5 的地址副表
+不同——地址副表是單一人物自己的子表，鏡像卻是**另一個人身上的另一列**，兩人若分別從各自
+頁面獨立提案／編輯同一組關係，核准時要怎麼判定衝突、要不要覆寫對面、由誰的版本為準，
+是尚未理清的領域決策，遷到路徑 A 前需要先裁定清楚，不只是接線。**本輪刻意不動**。
 
 ### 5.2 `BIOG_MAIN`（路徑 C）——人物主記錄的核准仍是盲寫
 
@@ -123,33 +160,33 @@ direct 與 proposal 因此天然對等，不需要兩邊各自維護。
 直接編輯卻走 `BiogMainMutationHandler`。要收斂需先確認 handler 側具備等價於
 `NO_CLEAR_COLUMNS_ON_APPLY`（`c_mingzi_chn`／`c_mingzi` 不可被清空）的護欄，否則會失去這道保護。
 
-### 5.3 DELETE（依指示暫不處理）
+**現況更新**：查證 `BiogMainMutationHandler::validationRules()`（自 2026-07-15 起）已存在等價
+護欄（原值非空才掛 required，註解明寫「direct 與 proposal 一致」），§5.2 原本要求的前置確認
+**已滿足**——收斂到路徑 A 目前僅剩「路由＋驗證」，是下一個可做的項目（BIOG_MAIN 無鏡像、
+無地址副表，形狀比 §4.5 更簡單；但 CREATE／DELETE 語義需另外確認：人物「刪除」是軟刪除
+而非物理 DELETE，「新增」是否有對應的 create 提案流程需先查證再收斂，不能照抄 update 的做法）。
 
-委派檔 5 個資源的 DELETE 目前掉進路徑 C，另由 `approve()` 補鏡像刪除與副表清理。
-這是鏡像機制最敏感的部分，本輪刻意不動。
-
-### 5.4 提交端的第二條路徑（legacy）
+### 5.3 提交端的第二條路徑（legacy）
 
 `BasicInformationProposalController`（`POST basicinformation/{personid}/{resource}/proposal`）是
 Blade 時代的提案提交入口，涵蓋全部 13 個資源，**直接 `recordProposalOperation()` 存行快照、
 繞過 v2 handler 的驗證**。React 編輯器已全部改走 `/api/v2`，但這些路由**仍然掛著、未下架**。
 只要它還在，就可能繞過提交端驗證產生「存量壞提案」——目前靠核准端的 handler 重放（路徑 A）兜住，
-但路徑 B／C 的資源沒有這層保護。
+但路徑 B 的 kinship／associations 沒有這層保護。
 
 ---
 
 ## 6. 建議順序
 
-1. **`BIOG_MAIN` 收斂到 A**（範圍小、風險可控）：先在 `BiogMainMutationHandler` 補上「不可清空」等價護欄，再路由。
-2. **委派檔 create／update 收斂到 A**（需先裁定鏡像語義）：建議單獨開分支、單獨 review，
-   因為它改的是核准時的鏡像衝突行為。
-3. **DELETE 收斂**：最後做，鏡像刪除與副表清理需逐一對齊。
-4. **下架 legacy 提交路徑**：確認 Blade 頁全數不再使用後移除路由，消滅繞過提交端驗證的入口。
+1. **`BIOG_MAIN` update 收斂到 A**：guard 已確認存在（§5.2），先查清 CREATE／DELETE 的實際語義
+   （軟刪除、是否有 create 提案）再決定三種操作各自怎麼路由，不要照抄 update 的形狀硬套。
+2. **kinship／associations 收斂到 A**（需先裁定鏡像語義）：建議單獨開分支、單獨 review，
+   因為它改的是核准時的鏡像衝突行為——這是唯一還需要「重新裁定域邏輯」而非單純接線的項目。
+3. **下架 legacy 提交路徑**：確認 Blade 頁全數不再使用後移除路由，消滅繞過提交端驗證的入口。
 
-完成 1–3 後，`OperationsProposalController` 的路徑 B／C 可整段移除
-（含 `applyKinship/Assoc/Office/Possession/EventProposal`、`applyCreate/Update/DeleteProposal`、
-`deleteOfficeAuxiliaryTables`、`deletePossessionAuxiliaryTables` 等重複實作），
-控制器塌成「decode → resolve → handle → updateStatus」。
+完成 1–2 後，`OperationsProposalController` 的路徑 B／C 可整段移除
+（含 `applyKinship/AssocProposal`、`applyCreate/Update/DeleteProposal`、`tableModelMap` 等
+重複實作），控制器塌成「decode → resolve → handle → updateStatus」。
 
 ---
 
@@ -160,5 +197,9 @@ Blade 時代的提案提交入口，涵蓋全部 13 個資源，**直接 `record
 - [app/Services/Mutations/MutationHandlerRegistry.php](../app/Services/Mutations/MutationHandlerRegistry.php)
 - [app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php](../app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php)
   ／[…MutationHandler.php](../app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php)
+- [app/Services/Mutations/PostingMutationHandler.php](../app/Services/Mutations/PostingMutationHandler.php)
+  ／[PossessionMutationHandler.php](../app/Services/Mutations/PossessionMutationHandler.php)
+  ／[EventMutationHandler.php](../app/Services/Mutations/EventMutationHandler.php)（地址副表 direct 同步邏輯）
+- [app/Services/Mutations/BiogMainMutationHandler.php](../app/Services/Mutations/BiogMainMutationHandler.php)（§5.2 不可清空護欄）
 - [app/Http/Controllers/BasicInformationProposalController.php](../app/Http/Controllers/BasicInformationProposalController.php)（legacy 提交端）
 - 測試：`tests/Feature/OperationsProposalControllerTest.php`、`tests/Feature/BasicInformationProposalTest.php`

--- a/tests/Feature/OperationsProposalControllerTest.php
+++ b/tests/Feature/OperationsProposalControllerTest.php
@@ -111,6 +111,10 @@ class OperationsProposalControllerTest extends TestCase {
             $table->integer('c_office_id');
             $table->integer('c_posting_id');
             $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
         });
 
         Schema::dropIfExists('POSTED_TO_ADDR_DATA');
@@ -119,6 +123,10 @@ class OperationsProposalControllerTest extends TestCase {
             $table->integer('c_posting_id');
             $table->integer('c_office_id');
             $table->integer('c_addr_id')->default(0);
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
         });
 
         Schema::dropIfExists('POSTING_DATA');
@@ -1246,6 +1254,68 @@ class OperationsProposalControllerTest extends TestCase {
             'resource' => 'POSTED_TO_OFFICE_DATA',
             'op_type' => Operation::TYPE_DELETE,
         ]);
+    }
+
+    /**
+     * 段二收斂回歸：postings 走 HANDLER_ROUTED_RESOURCES 重放 PostingMutationHandler 之後，
+     * 地址副表意圖（c_addr）從 __proposal_aux（而非主表欄位快照）正確合併進 changes 並同步
+     * POSTED_TO_ADDR_DATA——這是 applyViaMutationHandler() 新增 $auxiliaryPayload 合併要保住的行為。
+     */
+    #[Test]
+    public function testApproveOfficeUpdateProposalSyncsAddressAuxiliaryTable(): void {
+        DB::table('POSTED_TO_OFFICE_DATA')->insert([
+            'c_personid' => 1000,
+            'c_office_id' => 50,
+            'c_posting_id' => 7,
+            'c_notes' => 'original notes',
+        ]);
+        DB::table('POSTED_TO_ADDR_DATA')->insert([
+            'c_personid' => 1000, 'c_posting_id' => 7, 'c_office_id' => 50, 'c_addr_id' => 130,
+        ]);
+
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $original = [
+            'c_personid' => 1000,
+            'c_office_id' => 50,
+            'c_posting_id' => 7,
+            'c_notes' => 'original notes',
+        ];
+        $data = array_merge($original, ['c_notes' => 'updated notes']);
+
+        $resourceData = array_merge($data, [
+            '__key_columns' => ['c_office_id', 'c_posting_id'],
+            '__review_status' => 'pending',
+            '__proposal_meta' => ['action' => 'update'],
+            '__proposal_aux' => ['c_addr' => [140, 200]],
+        ]);
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'POSTED_TO_OFFICE_DATA',
+            'resource_id' => '50_._7',
+            'resource_data' => $resourceData,
+            'resource_original' => $original,
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $response = $this->post(route('operations.proposals.approve', $operation));
+        $response->assertRedirect();
+
+        $this->assertSame(
+            'updated notes',
+            DB::table('POSTED_TO_OFFICE_DATA')->where(['c_office_id' => 50, 'c_posting_id' => 7])->value('c_notes')
+        );
+
+        $addrIds = DB::table('POSTED_TO_ADDR_DATA')->where('c_posting_id', 7)
+            ->pluck('c_addr_id')->map(fn ($v) => (int) $v)->sort()->values()->all();
+        $this->assertSame([140, 200], $addrIds, '__proposal_aux 的 c_addr 應合併進 changes 並同步副表，而非被丟棄');
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
     }
 
     #[Test]


### PR DESCRIPTION
延續段一（7 張人物子資源表）的收斂：postings／possessions／events 這 3 張表雖也走委派檔 （legacy repository），但和 kinship／associations 不同——地址副表（POSTED_TO_ADDR_DATA／ POSSESSION_ADDR）是單一人物自己的子表，不涉及「兩人互為鏡像」，故不需要重新裁定鏡像語義， 可直接收斂：CREATE／UPDATE／DELETE 三種操作一次到位（DELETE 未如原計畫留待最後，因 PostingDeleteHandler／PossessionDeleteHandler 的 direct 路徑本就委派 officeDeleteById／ possessionDeleteById——與去級聯末批前置同一批修正過的「先子後父、無引用才刪父列」邏輯， 比路徑 C 另外維護的 deleteOfficeAuxiliaryTables／deletePossessionAuxiliaryTables 更貼近實際 使用的程式碼）。

- HANDLER_ROUTED_RESOURCES 新增 3 筆對照；移除變為不可達的 applyOffice/PossessionCreate/PossessionUpdate/EventProposal、buildLegacyOfficeId／ buildLegacyEventId、applyDeleteProposal() 內的 office/possession 特例，以及 deleteOfficeAuxiliaryTables／deletePossessionAuxiliaryTables。
- applyViaMutationHandler() 新增 $auxiliaryPayload：地址副表意圖（c_addr／c_addr_id／ c_addr_cleared）只存在 __proposal_aux、data/original 差集抓不到，需顯式併入 changes。 只挑 ADDRESS_AUX_KEYS 白名單合併，不整包塞入——__proposal_aux 舊資料可能還帶著 legacy 時代的 _id/_postingid/_officeid，整包合併會被 handler 白名單擋下。
- CREATE 的 changes 改為含鍵欄的 data 全量（不再 diff_key 剔除）：postings 的 c_office_id 既是複合鍵一部分，也是 PostingCreateHandler（bespoke、未經 targetPk/changes 合併）直接從 changes 讀取的必填欄位，先前的剔除邏輯會導致「缺少 c_office_id」；對已收斂的 7 張表／ events 無副作用（其 allowedFields() 本含鍵欄，handler 內固定 merge(targetPk, changes)）。
- BiogMainRepository::office/possession/event{Store,Update}ById 未刪除：Blade 版 BasicInformationOffices/Possession/EventsController 仍在用，繼續服務直接編輯。
- 新增回歸測試鎖住地址副表合併行為；docs/PERSON_PROPOSAL_PATHS.md 同步現況、差異清單與 下一步建議順序（kinship／associations 因兩人鏡像語義未裁定，暫緩；BIOG_MAIN 的「不可清空」 護欄已確認存在，是下一個可做項目）。
- 已執行 ./vendor/bin/phpunit（2360 tests，扣除環境缺 Vite build manifest 導致的既有頁面 渲染失敗後全綠）與 ./vendor/bin/php-cs-fixer fix。