### PR TITLE
實作提案 revision hash 機制第一階段（BIOG_MAIN 提案更新樂觀並行控制）

### DIFF
--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -7,6 +7,7 @@ use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\NameSearchIndexService;
+use App\Services\ProposalRevisionService;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -20,6 +21,7 @@ class OperationsProposalController extends Controller {
     protected $operationRepository;
     protected $nameSearchIndexService;
     protected $biogMainRepository;
+    protected ProposalRevisionService $proposalRevisionService;
     protected array $tableColumnCache = [];
 
     /**
@@ -82,11 +84,13 @@ class OperationsProposalController extends Controller {
     public function __construct(
         OperationRepository $operationRepository,
         NameSearchIndexService $nameSearchIndexService,
-        BiogMainRepository $biogMainRepository
+        BiogMainRepository $biogMainRepository,
+        ProposalRevisionService $proposalRevisionService
     ) {
         $this->operationRepository = $operationRepository;
         $this->nameSearchIndexService = $nameSearchIndexService;
         $this->biogMainRepository = $biogMainRepository;
+        $this->proposalRevisionService = $proposalRevisionService;
     }
 
     public function approve(Request $request, Operation $operation) {
@@ -97,6 +101,13 @@ class OperationsProposalController extends Controller {
         $table = $operation->resource;
         $keyColumns = $payload['__key_columns'] ?? [];
         $opType = (int) $operation->op_type;
+        // 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md：提案若在提交時存了 base_revision
+        // （目前僅 BIOG_MAIN update 提案，見 BiogMainMutationHandler），核准時需重新比對
+        // 目前資料列，避免提案提交後、核准前資料已被他人變更卻遭盲目覆寫。未存
+        // base_revision 的提案（其他資源、或核准前存量提案）維持原行為，不受影響。
+        $baseRevision = is_string($payload['__proposal_meta']['base_revision'] ?? null)
+            ? $payload['__proposal_meta']['base_revision']
+            : null;
 
         // 實體聚合提案（§4.5）：resource 為聚合 API 名、跨多表，不走下方「單表列」機制。
         // 以 mode=direct 重放對應 EntityAggregate handler（validate→guardWrite→service），
@@ -117,14 +128,15 @@ class OperationsProposalController extends Controller {
         $comment = trim((string) $request->input('review_comment', ''));
 
         try {
-            DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original, $operation, $comment, $auxiliaryPayload) {
+            DB::transaction(function () use ($opType, $table, $data, $keyColumns, $original, $operation, $comment, $auxiliaryPayload, $baseRevision) {
                 [$appliedRow, $usedDirectWorkflow] = $this->applyProposal(
                     $operation,
                     $table,
                     $data,
                     $keyColumns,
                     $original,
-                    $auxiliaryPayload
+                    $auxiliaryPayload,
+                    $baseRevision
                 );
 
                 if (!$usedDirectWorkflow) {
@@ -395,7 +407,8 @@ class OperationsProposalController extends Controller {
         array $data,
         array $keyColumns,
         array $original,
-        array $auxiliaryPayload
+        array $auxiliaryPayload,
+        ?string $baseRevision = null
     ): array {
         // 段一：已遷移的人物子資源 CREATE／UPDATE／DELETE 一律由 v2 direct handler 重放，使核准與直接編輯
         // 逐位一致（派生／護欄／audit／索引同步）。usedDirectWorkflow=true —— handler 自寫 operation + audit，
@@ -424,7 +437,7 @@ class OperationsProposalController extends Controller {
             return [$this->applyCreateProposal($table, $data, $keyColumns), false];
         }
 
-        return [$this->applyUpdateProposal($table, $data, $keyColumns, $original), false];
+        return [$this->applyUpdateProposal($table, $data, $keyColumns, $original, $baseRevision), false];
     }
 
     /**
@@ -748,7 +761,25 @@ class OperationsProposalController extends Controller {
         }
     }
 
-    protected function applyUpdateProposal(string $table, array $data, array $keyColumns, array $original): array {
+    /**
+     * 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md：核准套用前重新計算 $currentRow 的
+     * revision，比對提案提交時記下的 base_revision。提案提交後、核准前若資料已被
+     * 他人異動，current_revision 會不同，拒絕核准（而非盲目覆寫掉較新的資料）。
+     * $baseRevision 為 null 代表此提案未走 base_revision 機制（其他資源，或本機制
+     * 上線前的存量提案），維持原行為，不做檢查。
+     */
+    protected function assertRevisionNotStale(string $table, array $currentRow, ?string $baseRevision): void {
+        if ($baseRevision === null) {
+            return;
+        }
+
+        $currentRevision = $this->proposalRevisionService->hash($table, $currentRow);
+        if (!hash_equals($currentRevision, $baseRevision)) {
+            throw new \RuntimeException('資料自提案提交後已被更新，請要求提案者重新整理並重提。');
+        }
+    }
+
+    protected function applyUpdateProposal(string $table, array $data, array $keyColumns, array $original, ?string $baseRevision = null): array {
         if (empty($original)) {
             throw new \RuntimeException('缺少原始資料，無法更新。');
         }
@@ -764,6 +795,7 @@ class OperationsProposalController extends Controller {
                 throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
             }
 
+            $this->assertRevisionNotStale($table, $model->toArray(), $baseRevision);
             $this->assertNoClearColumns($table, $data, $model->toArray());
 
             foreach ($keyColumns as $column) {
@@ -792,6 +824,7 @@ class OperationsProposalController extends Controller {
             throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
         }
 
+        $this->assertRevisionNotStale($table, (array) $current, $baseRevision);
         $this->assertNoClearColumns($table, $data, (array) $current);
 
         $updatePayload = $this->buildUpdatePayload($data, $keyColumns, $original);

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -11,6 +11,7 @@ use App\Repositories\ToolsRepository;
 use App\Services\BracketNormalizer;
 use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
+use App\Services\ProposalRevisionService;
 use App\Support\CompositePrimaryKey;
 use App\Support\PinyinUmlaut;
 use Carbon\Carbon;
@@ -36,15 +37,18 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
     protected BiogMainRepository $biogMainRepository;
     protected NameSearchIndexService $nameSearchIndexService;
     protected OperationRepository $operationRepository;
+    protected ProposalRevisionService $proposalRevisionService;
 
     public function __construct(
         BiogMainRepository $biogMainRepository,
         NameSearchIndexService $nameSearchIndexService,
-        OperationRepository $operationRepository
+        OperationRepository $operationRepository,
+        ProposalRevisionService $proposalRevisionService
     ) {
         $this->biogMainRepository = $biogMainRepository;
         $this->nameSearchIndexService = $nameSearchIndexService;
         $this->operationRepository = $operationRepository;
+        $this->proposalRevisionService = $proposalRevisionService;
     }
 
     public function supports(string $resource, string $mode, string $operation): bool {
@@ -139,7 +143,26 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         return response()->json($response);
     }
 
+    /**
+     * 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md：BIOG_MAIN proposal update 第一階段
+     * 強制要求 base_revision，於提交當下重算 current_revision 比對，避免使用者基於
+     * 舊版本提交的提案在核准時盲目覆寫掉期間已發生的變更。
+     */
     protected function handleProposalUpdate(int $personId, array $updatedFields, array $merged, BiogMain $original, array $meta): JsonResponse {
+        $baseRevision = is_string($meta['base_revision'] ?? null) ? trim($meta['base_revision']) : '';
+        if ($baseRevision === '') {
+            return $this->errorResponse('缺少 base_revision，請重新整理後再提交提案', 422, [
+                'base_revision' => ['required'],
+            ]);
+        }
+
+        $currentRevision = $this->proposalRevisionService->hash('BIOG_MAIN', $original->toArray());
+        if (!hash_equals($currentRevision, $baseRevision)) {
+            return $this->errorResponse('資料已被更新，請重新載入後再提交提案', 409, [
+                'base_revision' => ['stale'],
+            ]);
+        }
+
         ['payload' => $proposalData, 'replaced' => $variantReplaced] = $this->prepareProposalPayload($merged);
         $validator = Validator::make($proposalData, $this->validationRules($original), $this->validationMessages());
         if ($validator->fails()) {
@@ -157,6 +180,8 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
                 'submitted_by_id' => Auth::id(),
                 'submitted_at' => Carbon::now()->format('Y-m-d H:i:s'),
                 'comment' => $comment,
+                'base_revision' => $currentRevision,
+                'revision_algo' => ProposalRevisionService::ALGO,
             ],
             '__review_status' => 'pending',
             '__key_columns' => ['c_personid'],

--- a/app/Services/ProposalRevisionService.php
+++ b/app/Services/ProposalRevisionService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md。
+ *
+ * 為資料列計算「規範化形式 + hash」，供 proposal 提交／審核時做樂觀並行控制的
+ * 衝突檢測：同一資料列在不同時間點算出的 revision 若不同，代表期間已被異動。
+ */
+class ProposalRevisionService {
+    public const ALGO = 'canonical-v1';
+
+    /**
+     * 各資源的 canonicalization 規則。目前只支援 `exclude`（不參與 revision 計算的
+     * 欄位），未註冊的資源套用預設規則（不排除任何欄位）。
+     *
+     * BIOG_MAIN 排除 audit 欄位：這些欄位會因任何保存而變動，納入會讓衝突判斷
+     * 對「任何保存痕跡變動」過於敏感，第一階段只想偵測「內容衝突」。
+     */
+    protected array $resourceNormalizers = [
+        'BIOG_MAIN' => [
+            'exclude' => ['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'],
+        ],
+    ];
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    public function canonicalize(string $resource, array $row): array {
+        $exclude = $this->resourceNormalizers[$resource]['exclude'] ?? [];
+        $filtered = array_diff_key($row, array_flip($exclude));
+
+        /** @var array<string, mixed> $normalized */
+        $normalized = $this->normalizeValue($filtered);
+
+        return $normalized;
+    }
+
+    public function hash(string $resource, array $row): string {
+        $canonical = $this->canonicalize($resource, $row);
+        $serialized = json_encode($canonical, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+
+        return 'sha256:'.hash('sha256', $serialized);
+    }
+
+    /**
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     */
+    public function matches(string $resource, array $left, array $right): bool {
+        return hash_equals($this->hash($resource, $left), $this->hash($resource, $right));
+    }
+
+    /**
+     * 消除型別差異（如 1 與 "1"）與無意義空白差異；陣列遞迴正規化後依固定鍵序輸出。
+     */
+    protected function normalizeValue(mixed $value): mixed {
+        if (is_array($value)) {
+            $normalized = [];
+            foreach ($value as $key => $item) {
+                $normalized[$key] = $this->normalizeValue($item);
+            }
+            ksort($normalized);
+
+            return $normalized;
+        }
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/docs/PROPOSAL_REVISION_HASH_DESIGN.md
+++ b/docs/PROPOSAL_REVISION_HASH_DESIGN.md
@@ -1,6 +1,11 @@
 # Proposal Revision Hash 設計
 
-> **狀態：設計草案，尚未實作**（程式碼中查無 revision hash 相關實作）。
+> **狀態：第一階段已實作**（`BIOG_MAIN`、`/api/v2/mutate`、`mode=proposal`、
+> `operation=update`，提交端與審核端衝突檢查皆已完成，見下方「第一階段落地
+> 範圍」與程式碼：[ProposalRevisionService](../app/Services/ProposalRevisionService.php)、
+> [BiogMainMutationHandler](../app/Services/Mutations/BiogMainMutationHandler.php)、
+> [OperationsProposalController](../app/Http/Controllers/OperationsProposalController.php)）。
+> 其他章節描述的擴展（其他資源接入、create proposal、Web 表單）仍是未實作的未來方向。
 >
 > **前提已部分改變（2026-07）**：核准端對多數人物子資源已改為「重放 v2 handler」
 > （見 [PERSON_PROPOSAL_PATHS.md](./PERSON_PROPOSAL_PATHS.md)），核准時是把
@@ -9,7 +14,8 @@
 >
 > **仍然存在的風險**：同一欄位被並行修改時，核准仍會以提案值覆寫較新的值——
 > 這正是本設計要解決的部分，仍有價值。尚未收斂到重放路徑的資源
-> （委派檔 5 資源、`BIOG_MAIN`）則兩種風險都還在。
+> （委派檔 5 資源、`BIOG_MAIN`）則兩種風險都還在；`BIOG_MAIN` 的這部分風險
+> 已由本設計第一階段解決，其餘 5 個委派檔資源仍未處理。
 
 ## 目標
 

--- a/tests/Feature/ApiV2MutateTest.php
+++ b/tests/Feature/ApiV2MutateTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\BiogMain;
 use App\Models\Operation;
 use App\Models\User;
 use App\Services\CharVariantMapService;
+use App\Services\ProposalRevisionService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -275,6 +277,18 @@ class ApiV2MutateTest extends TestCase {
         ], $overrides));
     }
 
+    /**
+     * BIOG_MAIN proposal update 第一階段強制要求 meta.base_revision（見
+     * docs/PROPOSAL_REVISION_HASH_DESIGN.md），測試以此讀取目前 DB 資料列現算出的
+     * revision，比照 handler 內 `BiogMain::find($personId)->toArray()` 的算法。
+     */
+    protected function currentBiogMainRevision(int $personId = 138841): string {
+        $row = BiogMain::find($personId);
+        $this->assertNotNull($row, "測試前置：找不到 c_personid={$personId} 的 BIOG_MAIN 列");
+
+        return (new ProposalRevisionService())->hash('BIOG_MAIN', $row->toArray());
+    }
+
     #[Test]
     public function testBiogMainNullableFieldsSentinelFullyIdempotent() {
         // basic_info 的 nullable 欄（c_female / c_index_year 等，real schema nullable（0/值有意義））語義與子資源碼欄不同：
@@ -508,7 +522,7 @@ class ApiV2MutateTest extends TestCase {
                 'c_surname' => 'Lv',
                 'c_surname_rm' => 'Lv',
             ],
-            'meta' => ['comment' => '提案修正姓氏拼音'],
+            'meta' => ['comment' => '提案修正姓氏拼音', 'base_revision' => $this->currentBiogMainRevision()],
         ])->assertOk();
 
         $operation = DB::table('operations')
@@ -600,7 +614,7 @@ class ApiV2MutateTest extends TestCase {
             'changes' => [
                 'c_mingzi_chn' => '淸',
             ],
-            'meta' => ['comment' => '提案修正名字異體字'],
+            'meta' => ['comment' => '提案修正名字異體字', 'base_revision' => $this->currentBiogMainRevision()],
         ]);
 
         $response->assertOk();
@@ -636,7 +650,7 @@ class ApiV2MutateTest extends TestCase {
             'changes' => [
                 'c_mingzi_chn' => '峯',
             ],
-            'meta' => ['comment' => '提案修正名字'],
+            'meta' => ['comment' => '提案修正名字', 'base_revision' => $this->currentBiogMainRevision()],
         ]);
 
         $response->assertOk();
@@ -674,6 +688,7 @@ class ApiV2MutateTest extends TestCase {
             ],
             'meta' => [
                 'comment' => '提案修正姓氏',
+                'base_revision' => $this->currentBiogMainRevision(),
             ],
         ]);
 
@@ -722,10 +737,71 @@ class ApiV2MutateTest extends TestCase {
         $this->assertSame('update', $payload['__proposal_meta']['action']);
         $this->assertSame('biogmain', $payload['__proposal_meta']['resource_type']);
         $this->assertSame('提案修正姓氏', $payload['__proposal_meta']['comment']);
+        $this->assertSame($this->currentBiogMainRevision(), $payload['__proposal_meta']['base_revision']);
+        $this->assertSame(ProposalRevisionService::ALGO, $payload['__proposal_meta']['revision_algo']);
         $this->assertSame('張', $original['c_surname_chn']);
         $this->assertSame('張忠', $original['c_name_chn']);
 
         $this->assertDatabaseCount('audit_log', 0);
+    }
+
+    #[Test]
+    public function testProposalBiogMainUpdateRejectsMissingBaseRevision() {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-main-proposal-no-revision@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_surname_chn' => '章'],
+            'meta' => ['comment' => '缺少 base_revision'],
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'ok' => false,
+                'errors' => ['base_revision' => ['required']],
+            ]);
+
+        $this->assertDatabaseCount('operations', 0);
+    }
+
+    #[Test]
+    public function testProposalBiogMainUpdateRejectsStaleBaseRevision() {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-main-proposal-stale@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        // 模擬真實流程：使用者先取得當下 base_revision，
+        // 之後、送出提案前，資料列已被其他人修改。
+        $staleBaseRevision = $this->currentBiogMainRevision();
+        DB::table('BIOG_MAIN')->where('c_personid', 138841)->update(['c_surname_chn' => '李']);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_mingzi_chn' => '安'],
+            'meta' => [
+                'comment' => '基於舊版本提交',
+                'base_revision' => $staleBaseRevision,
+            ],
+        ]);
+
+        $response->assertStatus(409)
+            ->assertJson([
+                'ok' => false,
+                'errors' => ['base_revision' => ['stale']],
+            ]);
+
+        $this->assertDatabaseCount('operations', 0);
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_surname_chn' => '李', 'c_mingzi_chn' => '忠']);
     }
 
     #[Test]
@@ -734,13 +810,23 @@ class ApiV2MutateTest extends TestCase {
         $this->actingAs($this->makeUser(email: 'biog-no-clear@example.com'));
         $this->seedBiogMain();
 
+        // 三種清空嘗試皆遭拒（direct 與 proposal 皆不寫入），row 全程未變，
+        // base_revision 可在迴圈外算一次沿用；proposal 分支需帶正確值，
+        // 否則 422 會來自「缺少 base_revision」而非本測試要驗證的「不可清空」規則。
+        $baseRevision = $this->currentBiogMainRevision();
+
         foreach (['direct', 'proposal'] as $mode) {
             foreach ([['c_mingzi_chn' => ''], ['c_mingzi_chn' => null], ['c_mingzi' => '']] as $changes) {
-                $this->postJson('/api/v2/mutate', [
+                $response = $this->postJson('/api/v2/mutate', [
                     'resource' => 'basicinformation', 'person_id' => 138841, 'mode' => $mode, 'operation' => 'update',
                     'target' => ['pk' => ['c_personid' => 138841]],
                     'changes' => $changes,
-                ])->assertStatus(422);
+                    ...($mode === 'proposal' ? ['meta' => ['base_revision' => $baseRevision]] : []),
+                ]);
+                $response->assertStatus(422);
+                // 確認 422 來自「不可清空」規則本身，不是 base_revision 檢查搶先擋下
+                // （否則本測試會對 proposal 分支變成假陽性、沒有真的驗證到清空規則）。
+                $this->assertArrayNotHasKey('base_revision', $response->json('errors') ?? []);
             }
         }
 
@@ -762,7 +848,7 @@ class ApiV2MutateTest extends TestCase {
                 'resource' => 'basicinformation', 'person_id' => 138841, 'mode' => $mode, 'operation' => 'update',
                 'target' => ['pk' => ['c_personid' => 138841]],
                 'changes' => ['c_index_year' => $mode === 'direct' ? 1101 : 1102],
-                ...($mode === 'proposal' ? ['meta' => ['comment' => '僅改指數年']] : []),
+                ...($mode === 'proposal' ? ['meta' => ['comment' => '僅改指數年', 'base_revision' => $this->currentBiogMainRevision()]] : []),
             ])->assertOk();
 
             $row = DB::table('BIOG_MAIN')->where('c_personid', 138841)->first();

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\BiogMain;
 use App\Models\Operation;
 use App\Models\User;
 use App\Services\CharVariantMapService;
+use App\Services\ProposalRevisionService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -526,6 +528,131 @@ class BiogMainProposalTest extends TestCase {
         $operation->refresh();
         $payload = json_decode($operation->resource_data, true);
         $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
+    public function testApproveBiogMainProposalSucceedsWhenBaseRevisionMatchesCurrentRow() {
+        // 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md：__proposal_meta.base_revision 與核准
+        // 當下重算出的 current_revision 一致時，核准應照常套用，不應誤擋正常情況。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $personId = 6;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '陳六',
+            'c_surname_chn' => '陳',
+            'c_mingzi_chn' => '六',
+            'c_notes' => 'Old notes',
+        ]);
+
+        $baseRevision = (new ProposalRevisionService())->hash('BIOG_MAIN', BiogMain::find($personId)->toArray());
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => (string) $personId,
+            'resource_data' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '陳',
+                'c_mingzi_chn' => '六',
+                'c_notes' => 'New notes',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+                '__proposal_meta' => [
+                    'base_revision' => $baseRevision,
+                    'revision_algo' => ProposalRevisionService::ALGO,
+                ],
+            ]),
+            'resource_original' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '陳',
+                'c_mingzi_chn' => '六',
+                'c_notes' => 'Old notes',
+            ]),
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'ok',
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_notes' => 'New notes',
+        ]);
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
+    public function testApproveBiogMainProposalRejectsWhenRowChangedAfterProposalSubmitted() {
+        // 見 docs/PROPOSAL_REVISION_HASH_DESIGN.md 核准流程：提案提交後、核准前資料已被
+        // 他人修改 → current_revision 與 base_revision 不同，拒絕核准（整筆交易回滾），
+        // 而不是盲目覆寫掉期間已發生的變更。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $personId = 7;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '孫七',
+            'c_surname_chn' => '孫',
+            'c_mingzi_chn' => '七',
+            'c_notes' => 'Old notes',
+        ]);
+
+        // 提案提交時的 base_revision：對應「孫七／Old notes」這個版本。
+        $baseRevision = (new ProposalRevisionService())->hash('BIOG_MAIN', BiogMain::find($personId)->toArray());
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => (string) $personId,
+            'resource_data' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '孫',
+                'c_mingzi_chn' => '七',
+                'c_notes' => 'Proposed notes',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+                '__proposal_meta' => [
+                    'base_revision' => $baseRevision,
+                    'revision_algo' => ProposalRevisionService::ALGO,
+                ],
+            ]),
+            'resource_original' => json_encode([
+                'c_personid' => $personId,
+                'c_surname_chn' => '孫',
+                'c_mingzi_chn' => '七',
+                'c_notes' => 'Old notes',
+            ]),
+        ]);
+
+        // 提案送出後、核准前，資料已被其他人修改。
+        DB::table('BIOG_MAIN')->where('c_personid', $personId)->update(['c_notes' => 'Concurrently edited notes']);
+
+        $response = $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'try approve stale',
+        ]);
+
+        $response->assertRedirect();
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertStringContainsString('資料自提案提交後已被更新', $flash[0]['message'] ?? '');
+
+        // 整筆交易回滾：資料維持「他人修改後」的狀態、不是提案內容；提案維持 pending；無 audit_log。
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_notes' => 'Concurrently edited notes',
+        ]);
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('pending', $payload['__review_status']);
+        $this->assertDatabaseCount('audit_log', 0);
     }
 
     #[Test]

--- a/tests/Unit/ProposalRevisionServiceTest.php
+++ b/tests/Unit/ProposalRevisionServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ProposalRevisionService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ProposalRevisionServiceTest extends TestCase {
+    protected function service(): ProposalRevisionService {
+        return new ProposalRevisionService();
+    }
+
+    protected function biogMainRow(array $overrides = []): array {
+        return array_replace([
+            'c_personid' => 138841,
+            'c_name_chn' => '張忠',
+            'c_surname_chn' => '張',
+            'c_mingzi_chn' => '忠',
+            'c_female' => 0,
+            'c_index_year' => 1084,
+            'c_created_by' => 'seed',
+            'c_created_date' => '2020-01-01 00:00:00',
+            'c_modified_by' => null,
+            'c_modified_date' => null,
+        ], $overrides);
+    }
+
+    #[Test]
+    public function hash_is_prefixed_with_sha256_and_is_deterministic(): void {
+        $row = $this->biogMainRow();
+        $hash1 = $this->service()->hash('BIOG_MAIN', $row);
+        $hash2 = $this->service()->hash('BIOG_MAIN', $row);
+
+        $this->assertStringStartsWith('sha256:', $hash1);
+        $this->assertSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function hash_is_independent_of_field_order(): void {
+        $row = $this->biogMainRow();
+        $reordered = array_reverse($row, true);
+
+        $this->assertSame(
+            $this->service()->hash('BIOG_MAIN', $row),
+            $this->service()->hash('BIOG_MAIN', $reordered)
+        );
+    }
+
+    #[Test]
+    public function hash_treats_type_differences_as_equivalent(): void {
+        $intRow = $this->biogMainRow(['c_personid' => 138841, 'c_female' => 0]);
+        $stringRow = $this->biogMainRow(['c_personid' => '138841', 'c_female' => '0']);
+
+        $this->assertTrue($this->service()->matches('BIOG_MAIN', $intRow, $stringRow));
+    }
+
+    #[Test]
+    public function hash_treats_null_and_empty_string_as_equivalent(): void {
+        $nullRow = $this->biogMainRow(['c_index_year' => null]);
+        $emptyRow = $this->biogMainRow(['c_index_year' => '']);
+
+        $this->assertTrue($this->service()->matches('BIOG_MAIN', $nullRow, $emptyRow));
+    }
+
+    #[Test]
+    public function hash_trims_insignificant_whitespace(): void {
+        $plain = $this->biogMainRow(['c_name_chn' => '張忠']);
+        $padded = $this->biogMainRow(['c_name_chn' => ' 張忠 ']);
+
+        $this->assertTrue($this->service()->matches('BIOG_MAIN', $plain, $padded));
+    }
+
+    #[Test]
+    public function biog_main_excludes_audit_fields_from_hash(): void {
+        $before = $this->biogMainRow([
+            'c_created_by' => 'seed',
+            'c_created_date' => '2020-01-01 00:00:00',
+            'c_modified_by' => null,
+            'c_modified_date' => null,
+        ]);
+        $afterSave = $this->biogMainRow([
+            'c_created_by' => 'someone-else',
+            'c_created_date' => '2026-01-01 00:00:00',
+            'c_modified_by' => 'someone',
+            'c_modified_date' => '2026-01-01 00:00:00',
+        ]);
+
+        $this->assertTrue(
+            $this->service()->matches('BIOG_MAIN', $before, $afterSave),
+            '4 個 audit 欄位（c_created_by/c_created_date/c_modified_by/c_modified_date）變動皆不應影響 BIOG_MAIN 的 revision hash'
+        );
+    }
+
+    #[Test]
+    public function biog_main_detects_change_in_business_field(): void {
+        $before = $this->biogMainRow(['c_surname_chn' => '張']);
+        $after = $this->biogMainRow(['c_surname_chn' => '章']);
+
+        $this->assertFalse($this->service()->matches('BIOG_MAIN', $before, $after));
+    }
+
+    #[Test]
+    public function unregistered_resource_falls_back_to_no_exclusion(): void {
+        $before = ['c_foo' => 'bar', 'c_modified_by' => 'a'];
+        $after = ['c_foo' => 'bar', 'c_modified_by' => 'b'];
+
+        $this->assertFalse(
+            $this->service()->matches('SOME_UNKNOWN_TABLE', $before, $after),
+            '未註冊資源預設不排除任何欄位，任何差異都應反映在 hash 上'
+        );
+    }
+
+    #[Test]
+    public function hash_throws_instead_of_silently_collapsing_on_invalid_utf8(): void {
+        // json_encode() 對非法 UTF-8 會失敗；沒有 JSON_THROW_ON_ERROR 時會靜默回傳 false，
+        // (string) false === '' 會讓所有編碼失敗的列都算出同一個空字串的 hash，
+        // 兩筆內容不同但都壞掉的列會被誤判為「相同」——衝突偵測機制絕不能這樣退化。
+        $this->expectException(\JsonException::class);
+        $this->service()->hash('BIOG_MAIN', ["c_name_chn" => "\xB1\x31"]);
+    }
+
+    #[Test]
+    public function canonicalize_recursively_normalizes_and_sorts_nested_arrays(): void {
+        $row = ['c_json' => ['b' => 1, 'a' => null]];
+        $canonical = $this->service()->canonicalize('BIOG_SOURCE_DATA', $row);
+
+        $this->assertSame(['c_json' => ['a' => '', 'b' => '1']], $canonical);
+    }
+}


### PR DESCRIPTION
## Summary
- 依 `docs/PROPOSAL_REVISION_HASH_DESIGN.md` 實作第一階段：`BIOG_MAIN`、`/api/v2/mutate`、`mode=proposal`、`operation=update` 的提案提交端與審核端衝突檢查（樂觀並行控制），不涉及新資料表／新欄位。
- 新增 `ProposalRevisionService`：可擴展的資源 canonicalization 註冊表（BIOG_MAIN 排除 audit 欄位），提供 `canonicalize()`/`hash()`/`matches()`。
- 提交端（`BiogMainMutationHandler`）：proposal update 強制要求 `meta.base_revision`；缺少回 422，與當下重算的 revision 不符回 409；成功則把 `base_revision`/`revision_algo` 存入 `__proposal_meta`。
- 審核端（`OperationsProposalController::applyUpdateProposal`）：核准前重新計算目前資料列的 revision 並比對 `base_revision`，提案提交後、核准前資料已被他人異動時拒絕核准（整筆交易回滾）；未帶 `base_revision` 的提案（其他資源、或本機制上線前的存量提案）行為不變，backward compatible。

## Review 紀錄
依專案流程，三個小環節（Service → 提交端 wiring → 審核端 wiring）皆各自經過一輪 review agent（讀程式碼）與一輪 `codex exec` 獨立審閱，全部確認無嚴重問題；中間發現的 2 個問題（`json_encode` 靜默失敗風險、既有測試被 base_revision 檢查意外遮蔽而測不到原本規則）皆已修正並補迴歸測試。

## Test plan
- `./vendor/bin/phpunit`：全量 2379 tests，較 `develop` 基準新增的 14 個測試（`ProposalRevisionServiceTest` 10 個 + `ApiV2MutateTest`/`BiogMainProposalTest` 新增案例）皆通過；既有 7 errors／10 failures 經比對 `develop` 基準確認為既有問題，與本次改動無關。
- `./vendor/bin/php-cs-fixer fix`：0 fixes。

🤖 Generated with [Claude Code](https://claude.com/claude-code)