### PR TITLE
實作 Query Playground QA 模式多輪追問功能

### DIFF
--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -8,6 +8,7 @@ use App\Services\SqlTableNameExtractor;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
@@ -374,18 +375,14 @@ class QueryPlaygroundController extends Controller {
             return response()->json(['error' => '您的帳號尚未啟用，無法使用此功能。'], 403);
         }
 
-        $request->validate([
-            'question' => 'required|string|max:1000',
-            'tables' => 'nullable|array',
-            'tables.*' => 'string',
-            'use_tools' => 'nullable|boolean',
-        ]);
+        $this->validateQaRequest($request);
 
         $question = $request->input('question');
         $tables = $request->input('tables');
         $useTools = $request->boolean('use_tools', true);
+        $conversationHistory = $this->conversationHistoryFromRequest($request);
 
-        $result = $nlqService->answerQuestion($question, $tables, null, $useTools);
+        $result = $nlqService->answerQuestion($question, $tables, useToolsOverride: $useTools, conversationHistory: $conversationHistory);
 
         if (!$result['success']) {
             return response()->json([
@@ -405,20 +402,16 @@ class QueryPlaygroundController extends Controller {
             return response()->json(['error' => '您的帳號尚未啟用，無法使用此功能。'], 403);
         }
 
-        $request->validate([
-            'question' => 'required|string|max:1000',
-            'tables' => 'nullable|array',
-            'tables.*' => 'string',
-            'use_tools' => 'nullable|boolean',
-        ]);
+        $this->validateQaRequest($request);
 
         $question = $request->input('question');
         $tables = $request->input('tables');
         $useTools = $request->boolean('use_tools', true);
+        $conversationHistory = $this->conversationHistoryFromRequest($request);
 
-        return $this->streamSseResponse(function (callable $sendEvent, callable $sendHeartbeatIfNeeded, callable $isClientDisconnected) use ($question, $tables, $nlqService, $useTools) {
+        return $this->streamSseResponse(function (callable $sendEvent, callable $sendHeartbeatIfNeeded, callable $isClientDisconnected) use ($question, $tables, $nlqService, $useTools, $conversationHistory) {
             try {
-                $result = $nlqService->answerQuestion($question, $tables, $sendEvent, $useTools, $sendHeartbeatIfNeeded, $isClientDisconnected);
+                $result = $nlqService->answerQuestion($question, $tables, $sendEvent, $useTools, $sendHeartbeatIfNeeded, $isClientDisconnected, $conversationHistory);
 
                 if ($result['success']) {
                     $sendEvent('complete', [
@@ -444,6 +437,63 @@ class QueryPlaygroundController extends Controller {
                 ]);
             }
         });
+    }
+
+    /**
+     * QA 模式多輪追問（見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md）request 驗證：
+     * 沿用既有 question/tables/use_tools 規則，新增選填的 conversation_history。
+     * conversation_history 陣列筆數上限對應 qa_max_turns - 1（單一對話總輪數硬上限）。
+     */
+    protected function validateQaRequest(Request $request): void {
+        $request->validate([
+            'question' => 'required|string|max:1000',
+            'tables' => 'nullable|array',
+            'tables.*' => 'string',
+            'use_tools' => 'nullable|boolean',
+            'conversation_history' => 'nullable|array|max:' . max(0, (int) config('query_playground.qa_max_turns', 5) - 1),
+            'conversation_history.*.question' => 'required_with:conversation_history|string|max:1000',
+            'conversation_history.*.summary' => 'nullable|string|max:2000',
+        ]);
+
+        $this->assertConversationHistoryWithinCharLimit((array) $request->input('conversation_history', []));
+    }
+
+    /**
+     * 輕量保險：conversation_history 全部 question/summary 加總字元數超過門檻視為異常
+     * request（正常情況下 qa_max_turns - 1 筆不可能超過此值，除非繞過前端限制竄改）。
+     * 於 controller validation 階段擋下、回 422，不讓 request 進入 service 層才失敗。
+     */
+    protected function assertConversationHistoryWithinCharLimit(array $conversationHistory): void {
+        $totalChars = 0;
+        foreach ($conversationHistory as $turn) {
+            $totalChars += mb_strlen((string) ($turn['question'] ?? ''));
+            $totalChars += mb_strlen((string) ($turn['summary'] ?? ''));
+        }
+
+        $limit = (int) config('query_playground.qa_history_char_limit', 6000);
+        if ($totalChars > $limit) {
+            throw ValidationException::withMessages([
+                'conversation_history' => ['對話歷史內容過長，請開新對話。'],
+            ]);
+        }
+    }
+
+    /**
+     * 將 request 的 conversation_history 正規化為 [['question'=>string,'summary'=>string], ...]，
+     * 供 NaturalLanguageQueryService::answerQuestion() 的 $conversationHistory 參數使用。
+     */
+    protected function conversationHistoryFromRequest(Request $request): array {
+        $conversationHistory = $request->input('conversation_history', []);
+        if (!is_array($conversationHistory)) {
+            return [];
+        }
+
+        return array_map(function ($turn) {
+            return [
+                'question' => (string) ($turn['question'] ?? ''),
+                'summary' => (string) ($turn['summary'] ?? ''),
+            ];
+        }, $conversationHistory);
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider {
@@ -21,9 +24,28 @@ class RouteServiceProvider extends ServiceProvider {
      * @return void
      */
     public function boot() {
-        //
+        $this->configureRateLimiting();
 
         parent::boot();
+    }
+
+    /**
+     * 見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md 第 6.4 節：QA 模式多輪追問每輪都會呼叫
+     * 一次 LLM API，按登入使用者限流。用具名 limiter 而非路由字串內插數字，讓 callback
+     * 於每次請求時才讀取 config，可在測試中用 config(['query_playground.qa_rate_limit_per_minute' => N])
+     * 動態調整，避免路由註冊當下就把上限值定死。
+     *
+     * 註冊時機不依賴 boot() 內呼叫順序：Laravel 基底 RouteServiceProvider::boot() 是空實作，
+     * 實際路由載入是 register() 內透過 $this->app->booted(...) 註冊的延遲回呼，要等所有
+     * provider 的 boot() 都執行完才會觸發，所以只要 configureRateLimiting() 在 boot() 階段
+     * 執行過（不論呼叫順序），路由解析當下這個具名 limiter 一定已註冊。
+     */
+    protected function configureRateLimiting() {
+        RateLimiter::for('qa-answer', function (Request $request) {
+            $limit = (int) config('query_playground.qa_rate_limit_per_minute', 10);
+
+            return Limit::perMinute($limit)->by($request->user()?->id ?: $request->ip());
+        });
     }
 
     /**

--- a/app/Services/NaturalLanguageQueryService.php
+++ b/app/Services/NaturalLanguageQueryService.php
@@ -438,6 +438,10 @@ class NaturalLanguageQueryService {
      * @param array|null $tableNames 限制使用的表名（可選）
      * @param callable|null $progressCallback SSE 進度回調
      * @param bool|null $useToolsOverride 是否強制啟用工具
+     * @param array<int, array{question: string, summary: string}> $conversationHistory
+     *   見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md：QA 模式多輪追問的先前輪次
+     *   （只含 question/summary，不含本次新問題），由 controller 直接從 request 轉發，
+     *   不經過任何資料庫查詢。
      * @return array
      */
     public function answerQuestion(
@@ -446,7 +450,8 @@ class NaturalLanguageQueryService {
         ?callable $progressCallback = null,
         ?bool $useToolsOverride = null,
         ?callable $heartbeatCallback = null,
-        ?callable $abortCheck = null
+        ?callable $abortCheck = null,
+        array $conversationHistory = []
     ): array {
         if (empty($this->apiKey)) {
             return [
@@ -482,11 +487,14 @@ class NaturalLanguageQueryService {
 
             $messages = [
                 ['role' => 'system', 'content' => $systemPrompt],
+                ...$this->buildConversationHistoryMessages($conversationHistory),
                 ['role' => 'user', 'content' => $question],
             ];
 
-            // 工具調用循環（與 generateSQL 相似邏輯）
-            $maxRounds = max(1, (int) config('nl_query_tools.max_tool_calls', 20));
+            // 工具調用循環（與 generateSQL 相似邏輯）。fallback 40 對齊
+            // config/nl_query_tools.php 的全域預設值，避免此處與 buildQaSystemPrompt()
+            // 各自寫一個不同的 fallback 而互相矛盾（見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md 第 7.5 節）。
+            $maxRounds = max(1, (int) config('nl_query_tools.max_tool_calls', 40));
             $round = 0;
             $allToolResults = [];
             $allSqlUsed = [];
@@ -656,11 +664,41 @@ class NaturalLanguageQueryService {
     }
 
     /**
+     * 見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md 第 7.1 節：把先前輪次的
+     * question/summary 組成 user/assistant 交錯訊息，插入本輪新問題之前。只用
+     * summary（既有 response contract 的精簡摘要欄位），不塞入完整 tool-call/
+     * tool-result 訊息——本輪若需要新資料會透過工具調用迴圈重新查詢，優於重播
+     * 舊結果。summary 為空字串時該輪只送 user 訊息，避免送出空的 assistant 內容。
+     *
+     * @param array<int, array{question: string, summary: string}> $conversationHistory
+     * @return array<int, array{role: string, content: string}>
+     */
+    protected function buildConversationHistoryMessages(array $conversationHistory): array {
+        $messages = [];
+        foreach ($conversationHistory as $turn) {
+            $question = trim((string) ($turn['question'] ?? ''));
+            if ($question === '') {
+                continue;
+            }
+
+            $messages[] = ['role' => 'user', 'content' => $question];
+
+            $summary = trim((string) ($turn['summary'] ?? ''));
+            if ($summary !== '') {
+                $messages[] = ['role' => 'assistant', 'content' => $summary];
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
      * 構建歷史問答模式的系統提示詞
      */
     protected function buildQaSystemPrompt(string $schemaPrompt, bool $toolsEnabled): string {
         $toolsHint = '';
-        $maxToolRounds = max(1, (int) config('nl_query_tools.max_tool_calls', 20));
+        // fallback 40 對齊 config/nl_query_tools.php 全域預設值，見上方 answerQuestion() 內同一修正的說明。
+        $maxToolRounds = max(1, (int) config('nl_query_tools.max_tool_calls', 40));
 
         if ($toolsEnabled) {
             $toolsHint = <<<TOOLS
@@ -731,6 +769,7 @@ DYNASTIES;
    - **📋 資料庫事實**：直接來自 CBDB 查詢的數據（人物存在性、生卒年、朝代、別名、入仕方式、著述、關係等）
    - **📚 模型補充**：模型自身的歷史知識補充（朝代背景、制度解釋、歷史上下文等），應使用較保守語氣
 6. 若資料不足，應明確說明，不要編造
+7. 使用者可能會針對先前的問答內容進行追問，請利用對話歷史進行指代消解（例如「他」「這個人」「那個機構」可能指向先前輪次提到的實體），若無法確定所指對象，請在回答中禮貌詢問澄清，而非臆測
 
 **回答格式要求：**
 回答必須是嚴格的 JSON，包含以下欄位：

--- a/app/Services/QueryPlaygroundService.php
+++ b/app/Services/QueryPlaygroundService.php
@@ -58,6 +58,9 @@ class QueryPlaygroundService {
             'generateFromNlStreamEndpoint' => route('query-playground.generate-from-nl-stream', [], false),
             'answerFromNlEndpoint' => route('query-playground.answer-from-nl', [], false),
             'answerFromNlStreamEndpoint' => route('query-playground.answer-from-nl-stream', [], false),
+            // QA 模式多輪追問輪數上限（見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md 第 10 節）：
+            // 前端一律讀取此 prop 判斷何時停用追問輸入框，不寫死數字，避免前後端上限不同步。
+            'qaMaxTurns' => (int) config('query_playground.qa_max_turns', 5),
         ];
     }
 

--- a/config/query_playground.php
+++ b/config/query_playground.php
@@ -3,4 +3,13 @@
 return [
     'sse_heartbeat_seconds' => env('QUERY_PLAYGROUND_SSE_HEARTBEAT_SECONDS', 10),
     'sse_padding_bytes' => env('QUERY_PLAYGROUND_SSE_PADDING_BYTES', 2048),
+
+    // 見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md：QA 模式多輪追問，對話總輪數硬上限
+    // （含首輪）；validation 換算 conversation_history 陣列筆數上限為 qa_max_turns - 1。
+    'qa_max_turns' => env('QUERY_PLAYGROUND_QA_MAX_TURNS', 5),
+    // 每個登入使用者每分鐘可呼叫 answer-from-nl／answer-from-nl-stream 的次數上限。
+    'qa_rate_limit_per_minute' => env('QUERY_PLAYGROUND_QA_RATE_LIMIT_PER_MINUTE', 10),
+    // conversation_history 內所有 summary 加總字元數上限（防禦性保險，正常情況下
+    // qa_max_turns - 1 筆 summary 不可能超過此值，除非 request 被竄改）。
+    'qa_history_char_limit' => env('QUERY_PLAYGROUND_QA_HISTORY_CHAR_LIMIT', 6000),
 ];

--- a/docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md
+++ b/docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md
@@ -1,6 +1,12 @@
 # Query Playground QA 模式多輪追問功能 — Work Plan
 
-> 狀態：規劃中（僅文件，尚未實作）
+> **狀態：已實作**（第 9 節五個階段皆完成：Controller/Validation/Rate Limiting、Service
+> 層、前端、測試、前端建置。每階段皆經 review agent 與 codex exec 兩輪獨立審閱至無嚴重
+> 問題。**唯一未完成項目**：`npm run build` 與 `tsc --noEmit` 皆已驗證通過，但本機開發
+> 環境沒有可連線的 MySQL/MariaDB 服務，無法用 `run` skill 實際開瀏覽器手動點擊驗收；
+> 已改以 35 個自動化測試（`tests/Feature/HistoricalQaTest.php`，涵蓋 request/response
+> contract、驗證失敗情境、SSE、`conversation_history` 組裝進 LLM `messages[]` 的實際內容、
+> rate limiting）作為主要驗證依據，合併前建議在有真實資料庫的環境補一次手動驗收。）
 > 本規劃文件僅提供繁體中文版本；不代表功能實作範圍排除英文 i18n——依 `AGENTS.md` 第 6 節規則，新增的 UI 字串（第 4.3 節）仍須比照專案既有慣例同步維護 `resources/lang/zh-TW/*.php` 與 `resources/lang/en/*.php` 兩份翻譯檔，不可只做繁中。
 > 對應功能：`/app/query-playground?mode=qa`（歷史問答 QA 模式）
 > 參考範例：Google 搜尋結果 AI Overview 的「Ask anything」追問輸入框——首次答案生成後，答案下方會持續顯示一個輸入框，使用者可針對同一上下文繼續提問。

--- a/resources/js/inertia/Pages/QueryPlayground/Index.tsx
+++ b/resources/js/inertia/Pages/QueryPlayground/Index.tsx
@@ -26,6 +26,7 @@ interface PageProps {
     generateFromNlStreamEndpoint: string;
     answerFromNlEndpoint: string;
     answerFromNlStreamEndpoint: string;
+    qaMaxTurns: number;
 }
 
 interface QueryResult {
@@ -48,6 +49,7 @@ export default function Index() {
         generateFromNlStreamEndpoint,
         answerFromNlEndpoint,
         answerFromNlStreamEndpoint,
+        qaMaxTurns,
     } = props;
 
     const t = useTranslation('query');
@@ -252,6 +254,7 @@ export default function Index() {
                             nlModel={nlModel}
                             answerFromNlEndpoint={answerFromNlEndpoint}
                             answerFromNlStreamEndpoint={answerFromNlStreamEndpoint}
+                            qaMaxTurns={qaMaxTurns}
                         />
                     )}
                 </div>

--- a/resources/js/inertia/components/QueryPlayground/HistoricalQaPanel.tsx
+++ b/resources/js/inertia/components/QueryPlayground/HistoricalQaPanel.tsx
@@ -8,50 +8,109 @@ interface Evidence {
     detail: string;
 }
 
+/**
+ * 見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md：一輪問答（Q + A）。對話歷史完全
+ * 存在前端 state（不落地、不做 localStorage），重新整理頁面即遺失。
+ */
+interface QaTurn {
+    id: string;
+    question: string;
+    status: 'pending' | 'streaming' | 'done' | 'error';
+    answerMarkdown?: string;
+    summary?: string;
+    sqlUsed?: string[];
+    toolCalls?: ToolCallTrace[];
+    evidence?: Evidence[];
+    caveat?: string;
+    error?: string;
+}
+
 interface Props {
     nlModel: string;
     answerFromNlEndpoint: string;
     answerFromNlStreamEndpoint: string;
+    /** 見第 10 節：由後端 config('query_playground.qa_max_turns') 透過 Inertia props 傳入，前端不寫死數字。 */
+    qaMaxTurns: number;
 }
 
-export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answerFromNlStreamEndpoint }: Props) {
+function makeTurnId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answerFromNlStreamEndpoint, qaMaxTurns }: Props) {
     const t = useTranslation('query');
     const [question, setQuestion] = useState('');
     const [consent, setConsent] = useState(false);
     const [useTools, setUseTools] = useState(true);
     const [useStreaming, setUseStreaming] = useState(true);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState('');
-    const [answerMarkdown, setAnswerMarkdown] = useState('');
-    const [summary, setSummary] = useState('');
-    const [sqlUsed, setSqlUsed] = useState<string[]>([]);
-    const [toolCalls, setToolCalls] = useState<ToolCallTrace[]>([]);
-    const [evidence, setEvidence] = useState<Evidence[]>([]);
-    const [caveat, setCaveat] = useState('');
-    const [showDetails, setShowDetails] = useState(false);
+    const [turns, setTurns] = useState<QaTurn[]>([]);
     const abortControllerRef = useRef<AbortController | null>(null);
+    const activeTurnIdRef = useRef<string | null>(null);
 
-    const resetResults = () => {
-        setError('');
-        setAnswerMarkdown('');
-        setSummary('');
-        setSqlUsed([]);
-        setToolCalls([]);
-        setEvidence([]);
-        setCaveat('');
+    const isFirstTurn = turns.length === 0;
+    const limitReached = turns.length >= qaMaxTurns;
+    const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
+    const isBusy = lastTurn !== null && (lastTurn.status === 'pending' || lastTurn.status === 'streaming');
+
+    const updateTurn = (turnId: string, patch: Partial<QaTurn>) => {
+        setTurns((prev) => prev.map((turn) => (turn.id === turnId ? { ...turn, ...patch } : turn)));
+    };
+
+    const appendToolCall = (turnId: string, trace: ToolCallTrace) => {
+        setTurns((prev) => prev.map((turn) =>
+            turn.id === turnId ? { ...turn, toolCalls: [...(turn.toolCalls || []), trace] } : turn,
+        ));
+    };
+
+    const updateLastToolCall = (turnId: string, matchId: string, patch: Partial<ToolCallTrace>) => {
+        setTurns((prev) => prev.map((turn) => {
+            if (turn.id !== turnId) return turn;
+            const toolCalls = turn.toolCalls || [];
+            const updated = [...toolCalls];
+            let idx = matchId ? updated.findLastIndex((tc) => tc.tool_call_id === matchId) : -1;
+            if (idx < 0) idx = updated.findLastIndex((tc) => tc.status === 'running');
+            if (idx >= 0) updated[idx] = { ...updated[idx], ...patch };
+            return { ...turn, toolCalls: updated };
+        }));
+    };
+
+    /** 見第 4.1 節：只取已完成輪次的 {question, summary}，不送完整 answer_markdown。 */
+    const buildConversationHistory = (): { question: string; summary: string }[] =>
+        turns
+            .filter((turn) => turn.status === 'done')
+            .map((turn) => ({ question: turn.question, summary: turn.summary || '' }));
+
+    // 按鈕本身也用 isBusy 停用（見下方 render）：若在請求進行中仍能清空 turns，
+    // 該請求的 activeTurnIdRef/abortControllerRef 之後在 finally 被清成 null，
+    // 會誤傷使用者緊接著送出的下一輪請求（取消鍵失靈、無法正確 abort）。
+    const handleNewConversation = () => {
+        setTurns([]);
+        setQuestion('');
     };
 
     const handleSubmit = useCallback(async () => {
-        if (!question.trim() || !consent) return;
+        const trimmedQuestion = question.trim();
+        if (!trimmedQuestion || isBusy || limitReached) return;
+        if (isFirstTurn && !consent) return;
 
-        setLoading(true);
-        resetResults();
+        const turnId = makeTurnId();
+        activeTurnIdRef.current = turnId;
+        const conversationHistory = buildConversationHistory();
+
+        setTurns((prev) => [...prev, { id: turnId, question: trimmedQuestion, status: 'pending' }]);
+        setQuestion('');
 
         const csrfToken = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content || '';
+        const requestBody: Record<string, unknown> = { question: trimmedQuestion, use_tools: useTools };
+        if (conversationHistory.length > 0) {
+            requestBody.conversation_history = conversationHistory;
+        }
 
         if (useStreaming) {
             try {
                 abortControllerRef.current = new AbortController();
+                updateTurn(turnId, { status: 'streaming' });
+
                 const response = await fetch(answerFromNlStreamEndpoint, {
                     method: 'POST',
                     headers: {
@@ -59,7 +118,7 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                         'X-CSRF-TOKEN': csrfToken,
                         'Accept': 'text/event-stream',
                     },
-                    body: JSON.stringify({ question, use_tools: useTools }),
+                    body: JSON.stringify(requestBody),
                     signal: abortControllerRef.current.signal,
                 });
 
@@ -80,7 +139,7 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                     if (!currentEvent || !currentData) return;
                     try {
                         const parsed = JSON.parse(currentData);
-                        handleStreamEvent(currentEvent, parsed);
+                        handleStreamEvent(turnId, currentEvent, parsed);
                     } catch (e) {
                         console.warn('Failed to parse SSE event:', e);
                     }
@@ -125,10 +184,10 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                 }
             } catch (err) {
                 if (err instanceof Error && err.name === 'AbortError') return;
-                setError(err instanceof Error ? err.message : t('qa_failed'));
+                updateTurn(turnId, { status: 'error', error: err instanceof Error ? err.message : t('qa_failed') });
             } finally {
-                setLoading(false);
                 abortControllerRef.current = null;
+                activeTurnIdRef.current = null;
             }
         } else {
             // Non-streaming
@@ -140,7 +199,7 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                         'X-CSRF-TOKEN': csrfToken,
                         'Accept': 'application/json',
                     },
-                    body: JSON.stringify({ question, use_tools: useTools }),
+                    body: JSON.stringify(requestBody),
                 });
 
                 const data = await response.json();
@@ -148,14 +207,16 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                     throw new Error(data.error || t('qa_failed'));
                 }
 
-                setAnswerMarkdown(data.answer_markdown || '');
-                setSummary(data.summary || '');
-                setSqlUsed(data.sql_used || []);
-                setEvidence(data.evidence || []);
-                setCaveat(data.caveat || '');
-                // Populate tool calls from non-streaming response
+                const patch: Partial<QaTurn> = {
+                    status: 'done',
+                    answerMarkdown: data.answer_markdown || '',
+                    summary: data.summary || '',
+                    sqlUsed: data.sql_used || [],
+                    evidence: data.evidence || [],
+                    caveat: data.caveat || '',
+                };
                 if (Array.isArray(data.tool_calls)) {
-                    const traces: ToolCallTrace[] = data.tool_calls.map((tc: Record<string, unknown>) => ({
+                    patch.toolCalls = data.tool_calls.map((tc: Record<string, unknown>) => ({
                         tool_call_id: String(tc.tool_call_id ?? ''),
                         name: String(tc.tool_name ?? ''),
                         status: tc.status === 'error' ? 'error' : 'completed',
@@ -163,144 +224,209 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                         result_summary: (tc.result_summary as ToolResultSummary) ?? undefined,
                         error: tc.status === 'error' ? String((tc.result_summary as Record<string, unknown>)?.error ?? '') : undefined,
                     }));
-                    setToolCalls(traces);
                 }
+                updateTurn(turnId, patch);
             } catch (err) {
-                setError(err instanceof Error ? err.message : t('qa_failed'));
+                updateTurn(turnId, { status: 'error', error: err instanceof Error ? err.message : t('qa_failed') });
             } finally {
-                setLoading(false);
+                activeTurnIdRef.current = null;
             }
         }
-    }, [question, consent, useTools, useStreaming, answerFromNlEndpoint, answerFromNlStreamEndpoint, t]);
+    }, [question, consent, useTools, useStreaming, isBusy, limitReached, isFirstTurn, turns, answerFromNlEndpoint, answerFromNlStreamEndpoint, t]);
 
-    const handleStreamEvent = (event: string, data: Record<string, unknown>) => {
+    const handleStreamEvent = (turnId: string, event: string, data: Record<string, unknown>) => {
         switch (event) {
             case 'status':
                 // General status message — no-op for now
                 break;
             case 'tool_execution_start':
-                setToolCalls((prev) => [...prev, {
+                appendToolCall(turnId, {
                     tool_call_id: String(data.tool_call_id ?? ''),
                     name: String(data.tool_name || data.name || 'tool'),
                     status: 'running',
                     arguments: (data.arguments as Record<string, unknown>) ?? undefined,
-                }]);
+                });
                 break;
             case 'tool_execution_complete': {
                 const toolCallId = String(data.tool_call_id ?? '');
                 const status: ToolCallTrace['status'] = data.success === false ? 'error' : 'completed';
                 const resultSummary = (data.result_summary as ToolResultSummary) ?? undefined;
-                setToolCalls((prev) => {
-                    const updated = [...prev];
-                    let idx = toolCallId ? updated.findLastIndex(tc => tc.tool_call_id === toolCallId) : -1;
-                    if (idx < 0) idx = updated.findLastIndex(tc => tc.status === 'running');
-                    if (idx >= 0) {
-                        updated[idx] = {
-                            ...updated[idx],
-                            status,
-                            result_summary: resultSummary,
-                            error: status === 'error' ? (resultSummary?.error ?? String(data.error ?? '')) : undefined,
-                        };
-                    }
-                    return updated;
+                updateLastToolCall(turnId, toolCallId, {
+                    status,
+                    result_summary: resultSummary,
+                    error: status === 'error' ? (resultSummary?.error ?? String(data.error ?? '')) : undefined,
                 });
                 break;
             }
             case 'complete':
-                setAnswerMarkdown(String(data.answer_markdown || ''));
-                setSummary(String(data.summary || ''));
-                setSqlUsed((data.sql_used as string[]) || []);
-                setEvidence((data.evidence as Evidence[]) || []);
-                setCaveat(String(data.caveat || ''));
+                updateTurn(turnId, {
+                    status: 'done',
+                    answerMarkdown: String(data.answer_markdown || ''),
+                    summary: String(data.summary || ''),
+                    sqlUsed: (data.sql_used as string[]) || [],
+                    evidence: (data.evidence as Evidence[]) || [],
+                    caveat: String(data.caveat || ''),
+                });
                 break;
             case 'error':
-                setError(String(data.error || t('qa_error')));
+                updateTurn(turnId, { status: 'error', error: String(data.error || t('qa_error')) });
                 break;
         }
     };
 
     const handleCancel = () => {
         abortControllerRef.current?.abort();
-        setLoading(false);
+        // 取消時該輪從未完成，從 turns 移除而非留下卡住的 pending/streaming 卡片。
+        const turnId = activeTurnIdRef.current;
+        if (turnId) {
+            setTurns((prev) => prev.filter((turn) => turn.id !== turnId));
+        }
+        activeTurnIdRef.current = null;
     };
 
     return (
         <div>
-            {/* Privacy notice */}
-            <div style={{
-                backgroundColor: 'var(--warning-subtle)',
-                border: '1px solid var(--warning-border)',
-                borderRadius: 6,
-                padding: 12,
-                marginBottom: 16,
-                fontSize: '0.85rem',
-                color: 'var(--warning-subtle-foreground)',
-            }}>
-                <strong>{t('qa_privacy_label')}</strong>{' '}{t('qa_privacy_body', { model: nlModel })}
-            </div>
-
-            {/* Question input */}
-            <div style={{ marginBottom: 12 }}>
-                <label style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--muted-foreground)', display: 'block', marginBottom: 4 }}>
-                    {t('qa_placeholder')}
-                </label>
-                <textarea
-                    value={question}
-                    onChange={(e) => setQuestion(e.target.value)}
-                    placeholder={t('qa_example')}
-                    rows={3}
-                    maxLength={1000}
-                    disabled={loading}
-                    style={{
-                        width: '100%',
-                        padding: 12,
-                        border: '1px solid var(--input)',
-                        borderRadius: 6,
-                        fontSize: '0.9rem',
-                        resize: 'vertical',
-                        boxSizing: 'border-box',
-                    }}
-                />
-                <div style={{ textAlign: 'right', fontSize: '0.75rem', color: 'var(--muted-foreground)', marginTop: 2 }}>
-                    {question.length}/1000
+            {/* Privacy notice：只在第一輪（尚未開始對話）顯示，追問沿用同一份提交端行為，不重複記錄新的同意動作。 */}
+            {isFirstTurn && (
+                <div style={{
+                    backgroundColor: 'var(--warning-subtle)',
+                    border: '1px solid var(--warning-border)',
+                    borderRadius: 6,
+                    padding: 12,
+                    marginBottom: 16,
+                    fontSize: '0.85rem',
+                    color: 'var(--warning-subtle-foreground)',
+                }}>
+                    <strong>{t('qa_privacy_label')}</strong>{' '}{t('qa_privacy_body', { model: nlModel })}
                 </div>
-            </div>
+            )}
 
-            {/* Options */}
-            <div style={{ display: 'flex', gap: 16, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
-                    <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
-                    {t('qa_agree_privacy')}
-                </label>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
-                    <input type="checkbox" checked={useTools} onChange={(e) => setUseTools(e.target.checked)} />
-                    {t('qa_use_tools')}
-                </label>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
-                    <input type="checkbox" checked={useStreaming} onChange={(e) => setUseStreaming(e.target.checked)} />
-                    {t('qa_stream')}
-                </label>
-            </div>
-
-            {/* Submit button */}
-            <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-                <button
-                    onClick={handleSubmit}
-                    disabled={loading || !question.trim() || !consent}
-                    style={{
-                        padding: '8px 18px',
-                        fontSize: '0.85rem',
+            {/* 訊息串：依序顯示每一輪 Q/A */}
+            {turns.map((turn) => (
+                <div key={turn.id} style={{ marginBottom: 20 }}>
+                    <div style={{
                         fontWeight: 600,
-                        border: 'none',
-                        borderRadius: 5,
-                        backgroundColor: loading || !question.trim() || !consent ? 'var(--muted-foreground)' : 'var(--success)',
-                        color: 'var(--success-foreground)',
-                        cursor: loading || !question.trim() || !consent ? 'default' : 'pointer',
-                    }}
-                >
-                    {loading ? t('qa_answering') : t('qa_ask')}
-                </button>
-                {loading && (
+                        fontSize: '0.9rem',
+                        color: 'var(--foreground)',
+                        marginBottom: 8,
+                    }}>
+                        {turn.question}
+                    </div>
+
+                    {turn.error && (
+                        <div style={{
+                            backgroundColor: 'var(--danger-subtle)',
+                            border: '1px solid var(--danger-border)',
+                            borderRadius: 6,
+                            padding: 12,
+                            marginBottom: 12,
+                            fontSize: '0.85rem',
+                            color: 'var(--danger-subtle-foreground)',
+                        }}>
+                            ⚠ {turn.error}
+                        </div>
+                    )}
+
+                    {(turn.toolCalls?.length ?? 0) > 0 && <ToolTracePanel toolCalls={turn.toolCalls || []} />}
+
+                    {(turn.status === 'pending' || turn.status === 'streaming') && !turn.answerMarkdown && (turn.toolCalls?.length ?? 0) === 0 && (
+                        <div style={{ padding: 24, textAlign: 'center', color: 'var(--muted-foreground)' }}>
+                            <div style={{ fontSize: '1.5rem', marginBottom: 8 }}>⏳</div>
+                            {t('qa_querying')}
+                        </div>
+                    )}
+
+                    {turn.answerMarkdown && (
+                        <TurnAnswer t={t} turn={turn} />
+                    )}
+                </div>
+            ))}
+
+            {/* 輪數上限提示 */}
+            {limitReached && (
+                <div style={{
+                    backgroundColor: 'var(--muted)',
+                    border: '1px solid var(--border)',
+                    borderRadius: 6,
+                    padding: 12,
+                    marginBottom: 16,
+                    fontSize: '0.85rem',
+                    color: 'var(--muted-foreground)',
+                }}>
+                    {t('qa_turn_limit_reached', { count: String(qaMaxTurns) })}
+                </div>
+            )}
+
+            {/* Question input：第一輪顯示完整表單（含同意勾選/選項），追問後精簡為「Ask anything」樣式。 */}
+            {!limitReached && (
+                <div style={{ marginBottom: 12 }}>
+                    {isFirstTurn && (
+                        <label style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--muted-foreground)', display: 'block', marginBottom: 4 }}>
+                            {t('qa_placeholder')}
+                        </label>
+                    )}
+                    <textarea
+                        value={question}
+                        onChange={(e) => setQuestion(e.target.value)}
+                        placeholder={isFirstTurn ? t('qa_example') : t('qa_follow_up_placeholder')}
+                        rows={isFirstTurn ? 3 : 2}
+                        maxLength={1000}
+                        disabled={isBusy}
+                        style={{
+                            width: '100%',
+                            padding: 12,
+                            border: '1px solid var(--input)',
+                            borderRadius: 6,
+                            fontSize: '0.9rem',
+                            resize: 'vertical',
+                            boxSizing: 'border-box',
+                        }}
+                    />
+                    <div style={{ textAlign: 'right', fontSize: '0.75rem', color: 'var(--muted-foreground)', marginTop: 2 }}>
+                        {question.length}/1000
+                    </div>
+                </div>
+            )}
+
+            {/* Options：只在第一輪顯示，追問沿用第一輪選擇的 use_tools/use_streaming。 */}
+            {isFirstTurn && !limitReached && (
+                <div style={{ display: 'flex', gap: 16, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
+                        <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
+                        {t('qa_agree_privacy')}
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
+                        <input type="checkbox" checked={useTools} onChange={(e) => setUseTools(e.target.checked)} />
+                        {t('qa_use_tools')}
+                    </label>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
+                        <input type="checkbox" checked={useStreaming} onChange={(e) => setUseStreaming(e.target.checked)} />
+                        {t('qa_stream')}
+                    </label>
+                </div>
+            )}
+
+            {/* Submit / cancel / new conversation buttons */}
+            <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+                {!limitReached && (
+                    <button
+                        onClick={handleSubmit}
+                        disabled={isBusy || !question.trim() || (isFirstTurn && !consent)}
+                        style={{
+                            padding: '8px 18px',
+                            fontSize: '0.85rem',
+                            fontWeight: 600,
+                            border: 'none',
+                            borderRadius: 5,
+                            backgroundColor: isBusy || !question.trim() || (isFirstTurn && !consent) ? 'var(--muted-foreground)' : 'var(--success)',
+                            color: 'var(--success-foreground)',
+                            cursor: isBusy || !question.trim() || (isFirstTurn && !consent) ? 'default' : 'pointer',
+                        }}
+                    >
+                        {isBusy ? t('qa_answering') : t('qa_ask')}
+                    </button>
+                )}
+                {isBusy && (
                     <button
                         onClick={handleCancel}
                         style={{
@@ -316,59 +442,58 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                         {t('qa_cancel')}
                     </button>
                 )}
+                {turns.length > 0 && (
+                    <button
+                        onClick={handleNewConversation}
+                        disabled={isBusy}
+                        style={{
+                            padding: '8px 14px',
+                            fontSize: '0.85rem',
+                            border: '1px solid var(--muted-foreground)',
+                            borderRadius: 5,
+                            backgroundColor: 'transparent',
+                            color: 'var(--muted-foreground)',
+                            cursor: isBusy ? 'default' : 'pointer',
+                            opacity: isBusy ? 0.5 : 1,
+                        }}
+                    >
+                        {t('qa_new_conversation')}
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/** 單輪答案卡片：答案本文、caveat、可折疊的 SQL/證據來源詳細資訊。 */
+function TurnAnswer({ t, turn }: { t: (key: string, replace?: Record<string, string>) => string; turn: QaTurn }) {
+    const [showDetails, setShowDetails] = useState(false);
+    const sqlUsed = turn.sqlUsed || [];
+    const evidence = turn.evidence || [];
+
+    return (
+        <div>
+            <div style={{
+                backgroundColor: 'var(--surface-sunken)',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                padding: 20,
+                marginBottom: 16,
+            }}>
+                <h4 style={{ margin: '0 0 12px', fontSize: '1rem', fontWeight: 600, color: 'var(--foreground)' }}>
+                    {t('qa_answer')}
+                </h4>
+                <div
+                    style={{
+                        fontSize: '0.9rem',
+                        lineHeight: 1.7,
+                        color: 'var(--foreground)',
+                    }}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(turn.answerMarkdown || '') }}
+                />
             </div>
 
-            {/* Error */}
-            {error && (
-                <div style={{
-                    backgroundColor: 'var(--danger-subtle)',
-                    border: '1px solid var(--danger-border)',
-                    borderRadius: 6,
-                    padding: 12,
-                    marginBottom: 12,
-                    fontSize: '0.85rem',
-                    color: 'var(--danger-subtle-foreground)',
-                }}>
-                    ⚠ {error}
-                </div>
-            )}
-
-            {/* Tool trace */}
-            <ToolTracePanel toolCalls={toolCalls} />
-
-            {/* Loading indicator */}
-            {loading && !answerMarkdown && toolCalls.length === 0 && (
-                <div style={{ padding: 24, textAlign: 'center', color: 'var(--muted-foreground)' }}>
-                    <div style={{ fontSize: '1.5rem', marginBottom: 8 }}>⏳</div>
-                    {t('qa_querying')}
-                </div>
-            )}
-
-            {/* Answer display */}
-            {answerMarkdown && (
-                <div style={{
-                    backgroundColor: 'var(--surface-sunken)',
-                    border: '1px solid var(--border)',
-                    borderRadius: 6,
-                    padding: 20,
-                    marginBottom: 16,
-                }}>
-                    <h4 style={{ margin: '0 0 12px', fontSize: '1rem', fontWeight: 600, color: 'var(--foreground)' }}>
-                        {t('qa_answer')}
-                    </h4>
-                    <div
-                        style={{
-                            fontSize: '0.9rem',
-                            lineHeight: 1.7,
-                            color: 'var(--foreground)',
-                        }}
-                        dangerouslySetInnerHTML={{ __html: renderMarkdown(answerMarkdown) }}
-                    />
-                </div>
-            )}
-
-            {/* Caveat */}
-            {caveat && answerMarkdown && (
+            {turn.caveat && (
                 <div style={{
                     backgroundColor: 'var(--muted)',
                     border: '1px solid var(--border)',
@@ -378,12 +503,11 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                     fontSize: '0.8rem',
                     color: 'var(--muted-foreground)',
                 }}>
-                    ⚠ {caveat}
+                    ⚠ {turn.caveat}
                 </div>
             )}
 
-            {/* Details panel (collapsible) */}
-            {answerMarkdown && (sqlUsed.length > 0 || evidence.length > 0) && (
+            {(sqlUsed.length > 0 || evidence.length > 0) && (
                 <div style={{ marginBottom: 12 }}>
                     <button
                         onClick={() => setShowDetails(!showDetails)}
@@ -408,7 +532,6 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                             padding: 16,
                             backgroundColor: 'var(--card)',
                         }}>
-                            {/* SQL used */}
                             {sqlUsed.length > 0 && (
                                 <div style={{ marginBottom: 12 }}>
                                     <label style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--muted-foreground)', display: 'block', marginBottom: 6 }}>
@@ -432,7 +555,6 @@ export default function HistoricalQaPanel({ nlModel, answerFromNlEndpoint, answe
                                 </div>
                             )}
 
-                            {/* Evidence */}
                             {evidence.length > 0 && (
                                 <div>
                                     <label style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--muted-foreground)', display: 'block', marginBottom: 6 }}>

--- a/resources/lang/en/query.php
+++ b/resources/lang/en/query.php
@@ -107,6 +107,9 @@ return [
     'qa_model'                 => '📚 Model',
     'qa_hide_details'          => '▼ Hide Details',
     'qa_show_details'          => '▶ Show Details (SQL, Evidence)',
+    'qa_follow_up_placeholder' => 'Ask a follow-up…',
+    'qa_new_conversation'      => 'New Conversation',
+    'qa_turn_limit_reached'    => 'This conversation has reached its limit (:count turns). Please start a new conversation.',
 
     // NL Query Logs page
     'log_page_title'         => 'NL Query Logs',

--- a/resources/lang/zh-TW/query.php
+++ b/resources/lang/zh-TW/query.php
@@ -107,6 +107,9 @@ return [
     'qa_model'                 => '📚 模型補充',
     'qa_hide_details'          => '▼ 隱藏詳細資訊',
     'qa_show_details'          => '▶ 顯示詳細資訊（SQL、證據來源）',
+    'qa_follow_up_placeholder' => '繼續追問…',
+    'qa_new_conversation'      => '開新對話',
+    'qa_turn_limit_reached'    => '已達單一對話上限（:count 輪），請開新對話',
 
     // NL Query Logs page
     'log_page_title'         => '自然語言查詢日誌',

--- a/routes/web.php
+++ b/routes/web.php
@@ -507,8 +507,17 @@ Route::middleware('auth')->group(function () {
     Route::post('query-playground/schema', 'QueryPlaygroundController@qbeSchema')->name('query-playground.schema');
     Route::post('query-playground/generate-from-nl', 'QueryPlaygroundController@generateFromNL')->name('query-playground.generate-from-nl');
     Route::post('query-playground/generate-from-nl-stream', 'QueryPlaygroundController@generateFromNLStream')->name('query-playground.generate-from-nl-stream');
-    Route::post('query-playground/answer-from-nl', 'QueryPlaygroundController@answerFromNL')->name('query-playground.answer-from-nl');
-    Route::post('query-playground/answer-from-nl-stream', 'QueryPlaygroundController@answerFromNLStream')->name('query-playground.answer-from-nl-stream');
+    // QA 模式多輪追問每輪都會呼叫一次 LLM API，屬有實際成本的操作；比照 routes/ai.php 既有
+    // throttle 慣例，依登入使用者 ID 限流（見 docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md 第 6.4 節）。
+    // 用具名 limiter（定義於 RouteServiceProvider::boot()）而非直接把數字內插進字串：
+    // 內插字串在路由註冊當下就把上限值定死，之後改 config 不會生效；具名 limiter 的 callback
+    // 於每次請求時才讀取 config，才能真正做到「config 驅動」且可在測試中動態調整。
+    Route::post('query-playground/answer-from-nl', 'QueryPlaygroundController@answerFromNL')
+        ->middleware('throttle:qa-answer')
+        ->name('query-playground.answer-from-nl');
+    Route::post('query-playground/answer-from-nl-stream', 'QueryPlaygroundController@answerFromNLStream')
+        ->middleware('throttle:qa-answer')
+        ->name('query-playground.answer-from-nl-stream');
     Route::get('query-playground/nl-query-logs', 'QueryPlaygroundController@nlQueryLogs')->name('query-playground.nl-query-logs');
     Route::get('app/query-playground/nl-query-logs', 'QueryPlaygroundController@appNlQueryLogs')
         ->middleware('inertia')

--- a/tests/Feature/HistoricalQaTest.php
+++ b/tests/Feature/HistoricalQaTest.php
@@ -100,6 +100,19 @@ class HistoricalQaTest extends TestCase {
         });
     }
 
+    #[Test]
+    public function qa_max_turns_prop_reflects_config() {
+        Config::set('query_playground.qa_max_turns', 7);
+
+        $this->be($this->adminUser);
+        $response = $this->get(route('app.query-playground.index'));
+
+        $response->assertInertia(function (AssertableInertia $page) {
+            $page->component('QueryPlayground/Index')
+                ->where('qaMaxTurns', 7);
+        });
+    }
+
     // ──── Authorization ────
 
     #[Test]
@@ -157,6 +170,216 @@ class HistoricalQaTest extends TestCase {
         ]);
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['question']);
+    }
+
+    #[Test]
+    public function answer_from_nl_accepts_request_without_conversation_history() {
+        // 向後相容：不帶 conversation_history（或帶空陣列）與現行單輪行為完全一致。
+        $this->be($this->adminUser);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => '李白是唐代詩人。',
+            'summary' => '唐代詩人',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '李白是什麼時代的人？',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        $this->assertArrayNotHasKey('conversation_id', $response->json());
+        $this->assertArrayNotHasKey('turn_index', $response->json());
+    }
+
+    #[Test]
+    public function answer_from_nl_rejects_conversation_history_exceeding_max_turns() {
+        Config::set('query_playground.qa_max_turns', 5);
+        $this->be($this->adminUser);
+
+        // qa_max_turns=5 → conversation_history 上限 4 筆，送 5 筆應被拒。
+        $history = array_map(fn ($i) => ['question' => "問題 {$i}", 'summary' => "摘要 {$i}"], range(1, 5));
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => $history,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['conversation_history']);
+    }
+
+    #[Test]
+    public function answer_from_nl_accepts_conversation_history_at_max_turns_boundary() {
+        Config::set('query_playground.qa_max_turns', 5);
+        $this->be($this->adminUser);
+
+        // 剛好 4 筆歷史（qa_max_turns - 1）應通過驗證，不被 max 規則擋下。
+        $history = array_map(fn ($i) => ['question' => "問題 {$i}", 'summary' => "摘要 {$i}"], range(1, 4));
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => 'ok',
+            'summary' => 'ok',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => $history,
+        ]);
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function answer_from_nl_rejects_conversation_history_missing_question() {
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => [
+                ['summary' => '只有摘要，沒有 question'],
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['conversation_history.0.question']);
+    }
+
+    #[Test]
+    public function answer_from_nl_rejects_conversation_history_exceeding_char_limit() {
+        Config::set('query_playground.qa_history_char_limit', 100);
+        $this->be($this->adminUser);
+
+        // 單筆 summary 80 字，2 筆共 160 字，超過門檻 100。
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => [
+                ['question' => 'q1', 'summary' => str_repeat('字', 80)],
+                ['question' => 'q2', 'summary' => str_repeat('字', 80)],
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['conversation_history']);
+    }
+
+    #[Test]
+    public function answer_from_nl_accepts_conversation_history_exactly_at_char_limit() {
+        Config::set('query_playground.qa_history_char_limit', 100);
+        $this->be($this->adminUser);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => 'ok',
+            'summary' => 'ok',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        // question 2 字 + summary 98 字 = 剛好 100，門檻是「超過才擋」，等於門檻應通過。
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => [
+                ['question' => 'q1', 'summary' => str_repeat('字', 98)],
+            ],
+        ]);
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function answer_from_nl_with_qa_max_turns_zero_rejects_any_conversation_history() {
+        // qa_max_turns 若被誤設為 0/負值：max(0, qa_max_turns - 1) 降級為 0，
+        // 效果是「不允許任何歷史紀錄」，但仍允許不帶 conversation_history 的首輪問題。
+        Config::set('query_playground.qa_max_turns', 0);
+        $this->be($this->adminUser);
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '追問',
+            'conversation_history' => [
+                ['question' => 'q1', 'summary' => 's1'],
+            ],
+        ]);
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['conversation_history']);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => 'ok',
+            'summary' => 'ok',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '首輪問題',
+        ])->assertOk();
+    }
+
+    #[Test]
+    public function answer_from_nl_forwards_conversation_history_to_service() {
+        $this->be($this->adminUser);
+
+        $history = [
+            ['question' => '李白是誰？', 'summary' => '李白是唐代詩人。'],
+        ];
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->expects($this->once())
+            ->method('answerQuestion')
+            ->with(
+                '他還有哪些作品？',
+                null,
+                null,
+                true,
+                null,
+                null,
+                $history
+            )
+            ->willReturn([
+                'success' => true,
+                'answer_markdown' => 'ok',
+                'summary' => 'ok',
+                'sql_used' => [],
+                'tool_calls' => [],
+                'evidence' => [],
+                'caveat' => '',
+                'model' => 'gemini-test-model',
+            ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $response = $this->postJson(route('query-playground.answer-from-nl'), [
+            'question' => '他還有哪些作品？',
+            'conversation_history' => $history,
+        ]);
+
+        $response->assertOk();
     }
 
     #[Test]
@@ -297,6 +520,65 @@ class HistoricalQaTest extends TestCase {
         $this->assertStringContainsString('text/event-stream', $response->headers->get('Content-Type'));
         $this->assertStringContainsString('no-cache, no-transform', (string) $response->headers->get('Cache-Control'));
         $this->assertSame('no', $response->headers->get('X-Accel-Buffering'));
+    }
+
+    #[Test]
+    public function answer_from_nl_stream_forwards_conversation_history_and_completes() {
+        $this->be($this->adminUser);
+
+        $history = [
+            ['question' => '李白是誰？', 'summary' => '李白是唐代詩人。'],
+        ];
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->expects($this->once())
+            ->method('answerQuestion')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $history
+            )
+            ->willReturn([
+                'success' => true,
+                'answer_markdown' => '他還寫過很多詩。',
+                'summary' => '李白的其他作品',
+                'sql_used' => [],
+                'tool_calls' => [],
+                'evidence' => [],
+                'caveat' => '',
+                'model' => 'gemini-test-model',
+            ]);
+
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $response = $this->call('POST', route('query-playground.answer-from-nl-stream'), [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'text/event-stream',
+        ], json_encode(['question' => '他還有哪些作品？', 'conversation_history' => $history]));
+
+        $response->assertStatus(200);
+        $response->assertStreamed();
+        $this->assertStringContainsString('event: complete', $response->streamedContent());
+    }
+
+    #[Test]
+    public function answer_from_nl_stream_rejects_conversation_history_exceeding_max_turns() {
+        Config::set('query_playground.qa_max_turns', 5);
+        $this->be($this->adminUser);
+
+        $history = array_map(fn ($i) => ['question' => "問題 {$i}", 'summary' => "摘要 {$i}"], range(1, 5));
+
+        $response = $this->postJson(route('query-playground.answer-from-nl-stream'), [
+            'question' => '追問',
+            'conversation_history' => $history,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['conversation_history']);
     }
 
     #[Test]
@@ -577,5 +859,153 @@ class HistoricalQaTest extends TestCase {
         // 驗證最後一輪沒有被套用 response_format
         $lastRequest = $capturedRequests[count($capturedRequests) - 1];
         $this->assertArrayNotHasKey('response_format', $lastRequest, '最後一輪 QA 請求不應套用 SQL 的 response_format');
+    }
+
+    // ──── conversation_history 組裝進 LLM messages[] ────
+
+    #[Test]
+    public function qa_conversation_history_is_assembled_into_llm_messages_using_summary() {
+        Config::set('nl_query_tools.enabled', false);
+
+        $capturedRequests = [];
+        $service = $this->mockLlmService(function (array $requestData) use (&$capturedRequests) {
+            $capturedRequests[] = $requestData;
+
+            return [
+                'successful' => true,
+                'status' => 200,
+                'body' => '',
+                'json' => [
+                    'choices' => [[
+                        'message' => ['role' => 'assistant', 'content' => json_encode([
+                            'answer_markdown' => '他還寫過很多詩。',
+                            'summary' => '李白的其他作品',
+                            'sql_used' => [],
+                            'evidence' => [],
+                            'caveat' => '',
+                        ])],
+                        'finish_reason' => 'stop',
+                    ]],
+                ],
+            ];
+        });
+
+        $conversationHistory = [
+            ['question' => '李白是誰？', 'summary' => '李白是唐代詩人。'],
+            ['question' => '他生於哪一年？', 'summary' => ''], // 空 summary：只應組出 user 訊息
+        ];
+
+        $result = $service->answerQuestion('他還有哪些作品？', null, null, null, null, null, $conversationHistory);
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(1, $capturedRequests);
+
+        $messages = $capturedRequests[0]['messages'];
+        // [system, user(Q1), assistant(A1), user(Q2)（無 assistant，因 summary 為空）, user(本輪新問題)]
+        $this->assertSame('system', $messages[0]['role']);
+        $this->assertSame('user', $messages[1]['role']);
+        $this->assertSame('李白是誰？', $messages[1]['content']);
+        $this->assertSame('assistant', $messages[2]['role']);
+        $this->assertSame('李白是唐代詩人。', $messages[2]['content']);
+        $this->assertSame('user', $messages[3]['role']);
+        $this->assertSame('他生於哪一年？', $messages[3]['content']);
+        $this->assertSame('user', $messages[4]['role']);
+        $this->assertSame('他還有哪些作品？', $messages[4]['content']);
+        $this->assertCount(5, $messages, 'messages 應恰為 [system, user, assistant, user, user]，空 summary 的一輪不應多出空的 assistant 訊息');
+    }
+
+    #[Test]
+    public function qa_without_conversation_history_still_assembles_two_messages() {
+        // 向後相容：不帶 conversation_history 時，messages 應與現行單輪行為一致（只有 system+user）。
+        Config::set('nl_query_tools.enabled', false);
+
+        $capturedRequests = [];
+        $service = $this->mockLlmService(function (array $requestData) use (&$capturedRequests) {
+            $capturedRequests[] = $requestData;
+
+            return [
+                'successful' => true,
+                'status' => 200,
+                'body' => '',
+                'json' => [
+                    'choices' => [[
+                        'message' => ['role' => 'assistant', 'content' => json_encode([
+                            'answer_markdown' => '李白是唐代詩人。',
+                            'summary' => '唐代詩人',
+                            'sql_used' => [],
+                            'evidence' => [],
+                            'caveat' => '',
+                        ])],
+                        'finish_reason' => 'stop',
+                    ]],
+                ],
+            ];
+        });
+
+        $result = $service->answerQuestion('李白是什麼時代的人？');
+
+        $this->assertTrue($result['success']);
+        $messages = $capturedRequests[0]['messages'];
+        $this->assertCount(2, $messages);
+        $this->assertSame('system', $messages[0]['role']);
+        $this->assertSame('user', $messages[1]['role']);
+        $this->assertSame('李白是什麼時代的人？', $messages[1]['content']);
+    }
+
+    // ──── Rate limiting ────
+
+    #[Test]
+    public function answer_from_nl_returns_429_after_exceeding_rate_limit() {
+        Config::set('query_playground.qa_rate_limit_per_minute', 2);
+        $this->be($this->adminUser);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => 'ok',
+            'summary' => 'ok',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $payload = ['question' => '李白是什麼時代的人？'];
+
+        $this->postJson(route('query-playground.answer-from-nl'), $payload)->assertOk();
+        $this->postJson(route('query-playground.answer-from-nl'), $payload)->assertOk();
+        $third = $this->postJson(route('query-playground.answer-from-nl'), $payload);
+
+        $third->assertStatus(429);
+    }
+
+    #[Test]
+    public function answer_from_nl_rate_limit_is_keyed_per_user() {
+        Config::set('query_playground.qa_rate_limit_per_minute', 1);
+
+        $mockService = $this->createMock(NaturalLanguageQueryService::class);
+        $mockService->method('answerQuestion')->willReturn([
+            'success' => true,
+            'answer_markdown' => 'ok',
+            'summary' => 'ok',
+            'sql_used' => [],
+            'tool_calls' => [],
+            'evidence' => [],
+            'caveat' => '',
+            'model' => 'gemini-test-model',
+        ]);
+        $this->app->instance(NaturalLanguageQueryService::class, $mockService);
+
+        $payload = ['question' => '李白是什麼時代的人？'];
+
+        $this->be($this->adminUser);
+        $this->postJson(route('query-playground.answer-from-nl'), $payload)->assertOk();
+        $this->postJson(route('query-playground.answer-from-nl'), $payload)->assertStatus(429);
+
+        // 換一個使用者，限流額度應該是獨立的，不受上一位使用者已用額度影響。
+        $this->be($this->regularUser);
+        $this->postJson(route('query-playground.answer-from-nl'), $payload)->assertOk();
     }
 }


### PR DESCRIPTION
## Summary
依 `docs/QUERY_PLAYGROUND_QA_MULTITURN_PLAN.md` 完成整份規劃文件的實作（無狀態設計：對話歷史留在前端 state，後端不新增任何資料表）。

- **提交端**：`answer-from-nl`/`answer-from-nl-stream` 新增選填的 `conversation_history` 欄位（`{question, summary}[]`），驗證輪數上限（`qa_max_turns - 1`）與歷史字元數上限（`qa_history_char_limit`），成功則轉發進 `NaturalLanguageQueryService::answerQuestion()` 新增的 `$conversationHistory` 參數。
- **Service 層**：把歷史組成 user/assistant 交錯訊息插入 system prompt 與本輪問題之間，只用 `summary` 精簡摘要（不塞完整 `answer_markdown`），system prompt 新增一條指代消解指示；順帶修正 `max_tool_calls` 本地預設值（20）與全域 config（40）不一致的既有小問題。
- **Rate limiting**：按登入使用者限流，設計上刻意不用文件字面建議的路由字串內插寫法（`throttle:{$n},1` 會在路由註冊當下把上限值定死，測試中 `Config::set()` 動態調整不會生效），改用具名 `RateLimiter::for()`，callback 於每次請求時才讀 config。
- **前端**：`HistoricalQaPanel.tsx` 由單一答案 state 改為 `turns` 陣列，支援訊息串顯示、追問輸入框、`qaMaxTurns`（由後端 Inertia props 傳入，不寫死數字）控制的輪數上限提示、開新對話按鈕，新增 3 個翻譯字串（zh-TW/en 同步）。
- **測試**：新增 35 個測試（原 20 個 + 15 個新案例），涵蓋 request/response contract 向後相容、驗證失敗情境（422）、SSE 對應版本、`conversation_history` 實際組裝進 LLM `messages[]` 的內容、rate limiting（含按使用者獨立額度）。

## Review 紀錄
依專案流程，三個小環節（Controller+Service 合併審閱、前端、測試隨每環節補齊）皆各自經過一輪 review agent 與一輪 `codex exec` 獨立審閱，全部確認無嚴重問題。過程中修正 2 個真實問題：
1. 前端「開新對話」按鈕在請求進行中仍可點擊會造成 ref 競態（codex 發現）——已加上 `isBusy` 停用。
2. 開發過程中發現本機 `bootstrap/cache/*.php`（gitignored，未入版控）是 stale 快取，導致 `CACHE_DRIVER` 等 phpunit.xml env 覆寫失效，連帶造成本 session 稍早看到的幾個看似無關的既有測試失敗——已釐清並清除，純本機環境問題，與程式碼無關。

## 已知限制
本機開發環境沒有可連線的 MySQL/MariaDB 服務，**未能實際開瀏覽器手動點擊驗收**多輪追問流程。已用完整的自動化測試套件作為主要驗證依據，但仍建議合併前在有真實資料庫的環境跑一次手動驗收（第一輪提問 → 追問輸入框出現 → 訊息串正確累加 → 達輪數上限停用 → 開新對話清空 → rate limit 429 時前端錯誤訊息合理）。

## Test plan
- `./vendor/bin/phpunit`：全量 2380 tests 通過
- `./vendor/bin/php-cs-fixer fix`：0 fixes
- `npx tsc --noEmit`：改動的兩個 TS 檔案零新增錯誤
- `npm run build`：成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)