### PR TITLE
提案核准段三：BIOG_MAIN 收斂到 v2 handler 重放

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 2026-07
 
+### 提案核准段三：BIOG_MAIN 收斂到 v2 handler 重放（人物主檔告別盲寫路徑 C）
+- `BIOG_MAIN` 加入 `OperationsProposalController::HANDLER_ROUTED_RESOURCES`，三種操作各按 direct 語義重放：update → `BiogMainMutationHandler`（delta 套用當下資料列＋`BasicInformationRequest` 驗證，「名（中）／拼音名不可清空」護欄改由 handler 統一提供）；delete → `BiogMainDeleteHandler`（軟刪除）；create → `BiogMainCreateHandler`（c_personid 驗證＋欄位白名單）。
+- **封掉物理 DELETE 洞**：收斂前若出現 BIOG_MAIN 的刪除提案，通用 `applyDeleteProposal()` 會直接 `DELETE FROM BIOG_MAIN`——與 direct 的軟刪除語義相反，且在入邊 FK 尚為 CASCADE 的觀察期會靜默連鎖刪除 25 張子表資料。現行雖無提交端會產生此類提案，屬防禦性封洞。
+- 隨收斂移除不可達死碼：`tableModelMap`、`NO_CLEAR_COLUMNS_ON_APPLY`／`assertNoClearColumns`、applyCreate/UpdateProposal 的 Eloquent 分支。核准失敗訊息攤平 handler 欄位級錯誤（如「名不能為空」）保留審核指向性。
+- 詳見 `docs/PERSON_PROPOSAL_PATHS.md` §4.6；回歸測試 `tests/Feature/BiogMainProposalTest.php`（13 tests）。
+
 ### 外部資料庫引用瀏覽器改版：/external-db-link、開放活躍帳號、Blade 版下架
 - 原 admin/wiki-maintenance 頁面全面翻新：改用共用 DataTable（TanStack）元件，新增搜尋（人名／頁碼標題模糊、純數字比對人物 ID）、白名單欄位伺服器端排序，列表補朝代／指數年／指數地址欄；換頁／排序／搜尋／來源全同步進 URL query，連結可分享復現。
 - 權限自「活躍管理員」降為「活躍帳號」（唯讀瀏覽頁；排序／搜尋門檻與 codes 對齊），側欄項目自「管理工具」移入「專家工具」。

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -23,31 +23,7 @@ class OperationsProposalController extends Controller {
     protected array $tableColumnCache = [];
 
     /**
-     * 表名到模型類的映射
-     * 用於將審批應用到資料表時使用 Eloquent 模型，以觸發觀察者
-     *
-     * @var array
-     */
-    protected $tableModelMap = [
-        'BIOG_MAIN' => \App\Models\BiogMain::class,
-        // 未來可以添加更多表的映射
-        // 注意：ALTNAME_DATA 使用復合主鍵，不使用 Eloquent，改為手動調用索引服務
-    ];
-
-    /**
-     * 核准套用時的「不可清空」欄位守衛（per-table）：payload 將該欄寫成空、而資料列當下有值時，
-     * 擋下核准。兜住「提交端驗證修復前的存量 pending 提案」與 legacy 提交路徑（所有提案核准必經此處）。
-     * 以「當下 DB 現值」而非提案存檔時的 original 比對：提案送出後若他人已補值，清空它的舊提案照樣被擋。
-     */
-    protected const NO_CLEAR_COLUMNS_ON_APPLY = [
-        'BIOG_MAIN' => [
-            'c_mingzi_chn' => '名（中）',
-            'c_mingzi' => '拼音名',
-        ],
-    ];
-
-    /**
-     * 段一／段二：以 v2 mutation handler 重放核准的人物子資源提案（表名 → API resource）。
+     * 段一／段二／段三：以 v2 mutation handler 重放核准的人物提案（表名 → API resource）。
      *
      * 這些表的提案原本落到通用行覆寫（applyCreate/Update/DeleteProposal）或 legacy repository
      * 委派（applyOffice/PossessionCreate/PossessionUpdate/EventProposal），繞過聚合的
@@ -61,12 +37,25 @@ class OperationsProposalController extends Controller {
      * （對齊 PostingMutationHandler／PossessionMutationHandler／EventMutationHandler／
      * *CreateHandler 既有的 direct 地址副表同步邏輯）。
      *
+     * 段三（BIOG_MAIN，人物主檔）三種操作各按 direct 語義重放，不照抄子資源形狀：
+     *  - update → BiogMainMutationHandler：核准時把提案 delta 套用到「當下」資料列並重跑
+     *    BasicInformationRequest 驗證（含「名（中）／拼音名原值非空即不可清空」護欄，取代先前
+     *    控制器層的 NO_CLEAR_COLUMNS_ON_APPLY——語義等價且 direct／proposal 同一份）。
+     *  - delete → BiogMainDeleteHandler：人物「刪除」是軟刪除（c_name_chn='<待删除>' 的 UPDATE）。
+     *    先前通用 applyDeleteProposal() 會對 BIOG_MAIN 做**物理 DELETE**——與 direct 語義相反，
+     *    且在入邊 FK 尚為 CASCADE 期間會靜默連鎖刪除 25 張子表資料（見
+     *    docs/CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §11.1）。現行無任何提交端會產生
+     *    BIOG_MAIN 的 TYPE_PROPOSAL_DELETE，此路由是防禦性封洞。
+     *  - create → BiogMainCreateHandler：帶 c_personid 驗證（非 0、不得已存在、不得過大）與
+     *    欄位白名單，取代先前的盲 Eloquent create（僅 legacy 提交路由理論可達）。
+     *
      * 不含：委派檔 KIN_DATA／ASSOC_DATA（兩人互為鏡像的親屬／社會關係，核准時的鏡像衝突語義
      * 仍在 legacy 那側、需先裁定域邏輯才能收斂，見 docs/PERSON_PROPOSAL_PATHS.md §5.1）；
      * code 表提案走 CodesController 自己的核准路徑、不經此。
      * auth 無礙：canReviewProposals() 與 canWriteDirectly() 為同一謂詞，能到核准端點者必過 authorizeDirect()。
      */
     protected const HANDLER_ROUTED_RESOURCES = [
+        'BIOG_MAIN' => 'basicinformation',
         'ALTNAME_DATA' => 'altnames',
         'BIOG_ADDR_DATA' => 'addresses',
         'ENTRY_DATA' => 'entries',
@@ -505,6 +494,16 @@ class OperationsProposalController extends Controller {
         $body = json_decode($response->getContent(), true);
         if ($status < 200 || $status >= 300) {
             $message = is_array($body) ? (string) ($body['message'] ?? '提案套用失敗') : '提案套用失敗';
+            // handler 的欄位級錯誤（如 BIOG_MAIN 的「名不能為空」）對審核者有指向性，攤平附在訊息後。
+            $fieldErrors = is_array($body['errors'] ?? null)
+                ? implode('；', array_map(
+                    static fn ($messages) => implode('；', array_map('strval', (array) $messages)),
+                    $body['errors']
+                ))
+                : '';
+            if ($fieldErrors !== '') {
+                $message .= '：'.$fieldErrors;
+            }
 
             // 交回外層交易回滾；訊息不外洩底層細節（approve() 已有 ValidationException/QueryException 友善提示）。
             throw new \RuntimeException("提案套用失敗（{$resource}/{$handlerOperation}）：{$message}");
@@ -707,15 +706,6 @@ class OperationsProposalController extends Controller {
             throw new \RuntimeException('資料已存在，無法再次新增。');
         }
 
-        // 檢查是否有對應的模型類，如果有則使用 Eloquent 模型以觸發觀察者
-        if (isset($this->tableModelMap[$table])) {
-            $modelClass = $this->tableModelMap[$table];
-            $model = $modelClass::create($data);
-
-            return $this->convertRowToArray($model);
-        }
-
-        // 如果沒有對應的模型，則使用原有的 DB::table() 方法
         DB::table($table)->insert($data);
 
         $row = DB::table($table)->where($this->buildKeyConditions($keyColumns, $data))->first();
@@ -731,23 +721,6 @@ class OperationsProposalController extends Controller {
         return $this->convertRowToArray($row);
     }
 
-    /**
-     * 「不可清空」守衛：提案 payload 把 NO_CLEAR_COLUMNS_ON_APPLY 所列欄位寫成空白、
-     * 而該列當下（$currentRow）有值時，拒絕核准。原本即為空的欄位不受影響（可維持空）。
-     */
-    protected function assertNoClearColumns(string $table, array $data, array $currentRow): void {
-        foreach (self::NO_CLEAR_COLUMNS_ON_APPLY[$table] ?? [] as $column => $label) {
-            if (!array_key_exists($column, $data)) {
-                continue;
-            }
-            $proposed = trim((string) ($data[$column] ?? ''));
-            $current = trim((string) ($currentRow[$column] ?? ''));
-            if ($proposed === '' && $current !== '') {
-                throw new \RuntimeException("此提案會清空既有的「{$label}」，無法核准。");
-            }
-        }
-    }
-
     protected function applyUpdateProposal(string $table, array $data, array $keyColumns, array $original): array {
         if (empty($original)) {
             throw new \RuntimeException('缺少原始資料，無法更新。');
@@ -756,43 +729,10 @@ class OperationsProposalController extends Controller {
         $data = $this->enforceAuditFieldsForUpdate($table, $data, $original);
         $conditions = $this->buildKeyConditions($keyColumns, $original);
 
-        // 檢查是否有對應的模型類，如果有則使用 Eloquent 模型以觸發觀察者
-        if (isset($this->tableModelMap[$table])) {
-            $modelClass = $this->tableModelMap[$table];
-            $model = $modelClass::where($conditions)->first();
-            if (!$model) {
-                throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
-            }
-
-            $this->assertNoClearColumns($table, $data, $model->toArray());
-
-            foreach ($keyColumns as $column) {
-                if (!array_key_exists($column, $original)) {
-                    continue;
-                }
-                if (array_key_exists($column, $data) && !$this->keyValuesMatch($data[$column], $original[$column])) {
-                    throw new \RuntimeException('提案不可修改主鍵欄位。');
-                }
-            }
-
-            $updatePayload = array_diff_key($data, array_flip($keyColumns));
-            if (!empty($updatePayload)) {
-                // 使用 update() 方法，這會觸發 Observer 並強制更新
-                $model->update($updatePayload);
-                // 重新讀取以確保獲取最新數據
-                $model->refresh();
-            }
-
-            return $this->convertRowToArray($model);
-        }
-
-        // 如果沒有對應的模型，則使用原有的 DB::table() 方法
         $current = DB::table($table)->where($conditions)->first();
         if (!$current) {
             throw new \RuntimeException('資料不存在或已被刪除，無法更新。');
         }
-
-        $this->assertNoClearColumns($table, $data, (array) $current);
 
         $updatePayload = $this->buildUpdatePayload($data, $keyColumns, $original);
 

--- a/docs/PERSON_PROPOSAL_PATHS.md
+++ b/docs/PERSON_PROPOSAL_PATHS.md
@@ -53,7 +53,7 @@ direct 與 proposal 因此天然對等，不需要兩邊各自維護。
 | events | `EVENTS_DATA` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A** |
 | kinship | `KIN_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 鏡像同步 |
 | associations | `ASSOC_DATA` | v2 handler | ⚠ B | ⚠ B | ❌ **C** ＋ 鏡像同步 |
-| **biogmain** | `BIOG_MAIN` | v2 handler | ❌ **C** | ❌ **C**（Eloquent＋不可清空守衛） | ❌ **C** |
+| **biogmain** | `BIOG_MAIN` | v2 handler | ✅ **A** | ✅ **A** | ✅ **A**（軟刪除） |
 
 **注意分派順序**：`applyProposal()` 先判 A，再判 DELETE→C，才輪到 B（kinship／associations）的
 兩個分支。委派檔（B）的 DELETE 因此其實不走 B、而是掉進 C，只是 `approve()` 另外替 ASSOC／KIN
@@ -134,6 +134,20 @@ eventStoreById/eventUpdateById` **未刪除**：Blade 版 `BasicInformationOffic
 `BasicInformationPossessionController`／`BasicInformationEventsController` 仍在用（AGENTS.md
 所述 flag-gated 回退頁面），這幾個 repository 方法繼續服務直接編輯，只是核准不再另外呼叫它們。
 
+### 4.6 段三：`BIOG_MAIN`（人物主檔）收斂到路徑 A——三種操作各按 direct 語義路由
+
+依 §6 建議先查清三種操作的實際語義後收斂（不照抄 update 的形狀硬套）：
+
+| 操作 | 重放對象 | 語義決定 |
+|---|---|---|
+| UPDATE | `BiogMainMutationHandler`（direct） | 唯一有活提交端的操作（v2 `mode=proposal` 與 legacy Blade `action=proposal` 兩條）。核准＝把提案 delta（`diff(original, data)`，BLOCKED_FIELDS 由 handler 濾除）套用到**當下**資料列並重跑 `BasicInformationRequest` 驗證。「名（中）／拼音名不可清空」護欄由 handler 的 `validationRules($original)` 提供（原值非空才掛 required，§5.2 確認之等價護欄），控制器層的 `NO_CLEAR_COLUMNS_ON_APPLY`／`assertNoClearColumns`／`tableModelMap` Eloquent 分支隨之移除（收斂後不可達） |
+| DELETE | `BiogMainDeleteHandler`（direct） | **現行沒有任何提交端會產生 `BIOG_MAIN` 的 TYPE_PROPOSAL_DELETE**（眾包刪除走 op_type=4＋crowdsourcing_status=2，另一條審核流）；此路由是防禦性封洞——收斂前通用 `applyDeleteProposal()` 會對 BIOG_MAIN 做**物理 DELETE**，與 direct 的軟刪除（`c_name_chn='<待删除>'` 的 UPDATE）語義相反，且在入邊 FK 尚為 CASCADE 期間會靜默連鎖刪除 25 張子表資料（見 CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §11.1） |
+| CREATE | `BiogMainCreateHandler`（direct） | 僅 legacy 提交路由理論可達（UI 不產生；人物新增另有流程）。重放帶 `c_personid` 驗證（非 0、不得已存在、不得過大）與欄位白名單，取代先前的盲 Eloquent create |
+
+回歸測試：`tests/Feature/BiogMainProposalTest.php`（含軟刪除取代物理 DELETE、create 撞既有
+personid fail-closed、清空名（中）被 handler 驗證擋下）。核准失敗訊息現會攤平 handler 的
+欄位級錯誤（如「參數校驗失敗：名不能為空」），對審核者保留指向性。
+
 ---
 
 ## 5. 還沒做什麼
@@ -154,17 +168,10 @@ eventStoreById/eventUpdateById` **未刪除**：Blade 版 `BasicInformationOffic
 頁面獨立提案／編輯同一組關係，核准時要怎麼判定衝突、要不要覆寫對面、由誰的版本為準，
 是尚未理清的領域決策，遷到路徑 A 前需要先裁定清楚，不只是接線。**本輪刻意不動**。
 
-### 5.2 `BIOG_MAIN`（路徑 C）——人物主記錄的核准仍是盲寫
+### 5.2 `BIOG_MAIN`——✅ 已收斂（見 §4.6）
 
-`BIOG_MAIN` 的 update 提案核准走通用 Eloquent 更新（`tableModelMap` → `BiogMain::update()`），
-直接編輯卻走 `BiogMainMutationHandler`。要收斂需先確認 handler 側具備等價於
-`NO_CLEAR_COLUMNS_ON_APPLY`（`c_mingzi_chn`／`c_mingzi` 不可被清空）的護欄，否則會失去這道保護。
-
-**現況更新**：查證 `BiogMainMutationHandler::validationRules()`（自 2026-07-15 起）已存在等價
-護欄（原值非空才掛 required，註解明寫「direct 與 proposal 一致」），§5.2 原本要求的前置確認
-**已滿足**——收斂到路徑 A 目前僅剩「路由＋驗證」，是下一個可做的項目（BIOG_MAIN 無鏡像、
-無地址副表，形狀比 §4.5 更簡單；但 CREATE／DELETE 語義需另外確認：人物「刪除」是軟刪除
-而非物理 DELETE，「新增」是否有對應的 create 提案流程需先查證再收斂，不能照抄 update 的做法）。
+原記載的前置確認（handler 側「不可清空」護欄）與 CREATE／DELETE 語義查證均已完成並落地，
+三種操作全部路由到對應 direct handler 重放。
 
 ### 5.3 提交端的第二條路徑（legacy）
 
@@ -178,15 +185,15 @@ Blade 時代的提案提交入口，涵蓋全部 13 個資源，**直接 `record
 
 ## 6. 建議順序
 
-1. **`BIOG_MAIN` update 收斂到 A**：guard 已確認存在（§5.2），先查清 CREATE／DELETE 的實際語義
-   （軟刪除、是否有 create 提案）再決定三種操作各自怎麼路由，不要照抄 update 的形狀硬套。
+1. ~~**`BIOG_MAIN` 收斂到 A**~~ ✅ 已完成（§4.6，三種操作各按 direct 語義路由）。
 2. **kinship／associations 收斂到 A**（需先裁定鏡像語義）：建議單獨開分支、單獨 review，
    因為它改的是核准時的鏡像衝突行為——這是唯一還需要「重新裁定域邏輯」而非單純接線的項目。
 3. **下架 legacy 提交路徑**：確認 Blade 頁全數不再使用後移除路由，消滅繞過提交端驗證的入口。
 
-完成 1–2 後，`OperationsProposalController` 的路徑 B／C 可整段移除
-（含 `applyKinship/AssocProposal`、`applyCreate/Update/DeleteProposal`、`tableModelMap` 等
-重複實作），控制器塌成「decode → resolve → handle → updateStatus」。
+完成 2 後，`OperationsProposalController` 的路徑 B／C 可整段移除
+（含 `applyKinship/AssocProposal`、`applyCreate/Update/DeleteProposal` 等重複實作；
+`tableModelMap` 與 `NO_CLEAR_COLUMNS_ON_APPLY` 已隨 §4.6 移除），
+控制器塌成「decode → resolve → handle → updateStatus」。
 
 ---
 

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -419,7 +419,8 @@ class BiogMainProposalTest extends TestCase {
 
     #[Test]
     public function testApproveRejectsProposalThatWouldClearExistingMingzi() {
-        // 核准端「不可清空」守衛：payload 把名（中）寫成空、而該列當下有值 → 拒絕核准、資料不變、提案維持 pending。
+        // 「不可清空」語義（核准＝重放 BiogMainMutationHandler direct）：payload 把名（中）寫成空、
+        // 而該列當下有值 → handler 驗證擋下（名不能為空）、資料不變、提案維持 pending。
         // 模擬「提交端驗證修復前的存量 pending 提案」與 legacy 路徑提交的提案。
         $admin = $this->makeAdmin();
         $this->actingAs($admin);
@@ -463,7 +464,7 @@ class BiogMainProposalTest extends TestCase {
 
         $response->assertRedirect();
         $flash = session('flash_notification', collect())->toArray();
-        $this->assertStringContainsString('清空既有的「名（中）」', $flash[0]['message'] ?? '');
+        $this->assertStringContainsString('名不能為空', $flash[0]['message'] ?? '');
 
         // 資料未變、提案未被標記 approved（交易整筆回滾）。
         $this->assertDatabaseHas('BIOG_MAIN', [
@@ -526,6 +527,168 @@ class BiogMainProposalTest extends TestCase {
         $operation->refresh();
         $payload = json_decode($operation->resource_data, true);
         $this->assertSame('approved', $payload['__review_status']);
+    }
+
+    #[Test]
+    public function testApproveBiogMainDeleteProposalSoftDeletesInsteadOfPhysicalDelete() {
+        // BIOG_MAIN 刪除提案核准＝重放 BiogMainDeleteHandler（軟刪除：c_name_chn='<待删除>' 的 UPDATE）。
+        // 收斂前通用 applyDeleteProposal() 會對 BIOG_MAIN 做物理 DELETE——與 direct 語義相反，
+        // 且在入邊 FK 尚為 CASCADE 期間會靜默連鎖刪除子表資料。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        $personId = 6;
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => $personId,
+            'c_name_chn' => '孫六',
+            'c_notes' => 'Some notes',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_PROPOSAL_DELETE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => (string) $personId,
+            'resource_data' => json_encode([
+                'c_personid' => $personId,
+                'c_name_chn' => '孫六',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+            ]),
+            'resource_original' => json_encode([
+                'c_personid' => $personId,
+                'c_name_chn' => '孫六',
+                'c_notes' => 'Some notes',
+            ]),
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'ok to delete',
+        ])->assertRedirect();
+
+        // 原列仍在（軟刪除），僅改名為刪除標記；notes 等其他欄位不動。
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => $personId,
+            'c_name_chn' => '<待删除>',
+            'c_notes' => 'Some notes',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+
+        // handler 自寫 op_type=4（TYPE_DELETE）final operation 與 audit（operation='UPDATE'，軟刪除語義）。
+        $this->assertDatabaseHas('operations', [
+            'c_personid' => $personId,
+            'op_type' => Operation::TYPE_DELETE,
+            'resource' => 'BIOG_MAIN',
+        ]);
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'BIOG_MAIN',
+            'operation' => 'UPDATE',
+        ]);
+    }
+
+    #[Test]
+    public function testApproveBiogMainCreateProposalRejectedWhenPersonIdExists() {
+        // BIOG_MAIN create 提案核准＝重放 BiogMainCreateHandler：c_personid 已存在 → fail-closed，
+        // 不再走收斂前的盲 Eloquent create。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 7,
+            'c_name_chn' => '既有人物',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => 7,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => '7',
+            'resource_data' => json_encode([
+                'c_personid' => 7,
+                'c_surname_chn' => '錢',
+                'c_mingzi_chn' => '七',
+                'c_mingzi' => 'Qi',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+            ]),
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'try approve',
+        ])->assertRedirect();
+
+        $flash = session('flash_notification', collect())->toArray();
+        $this->assertStringContainsString('審核失敗', $flash[0]['message'] ?? '');
+
+        // 既有列未被覆寫；提案維持 pending。
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 7,
+            'c_name_chn' => '既有人物',
+        ]);
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('pending', $payload['__review_status']);
+    }
+
+    #[Test]
+    public function testApproveBiogMainCreateProposalCreatesViaHandler() {
+        // create 提案核准成功路徑：經 BiogMainCreateHandler 白名單＋c_personid 驗證後由
+        // repository store 落庫（事務＋operation＋audit）。
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 1,
+            'c_name_chn' => '既有人物',
+        ]);
+
+        $operation = Operation::create([
+            'user_id' => 100,
+            'c_personid' => 8,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => '8',
+            'resource_data' => json_encode([
+                'c_personid' => 8,
+                'c_surname_chn' => '錢',
+                'c_mingzi_chn' => '八',
+                'c_surname' => 'Qian',
+                'c_mingzi' => 'Ba',
+                'c_notes' => 'Created via proposal',
+                '__key_columns' => ['c_personid'],
+                '__review_status' => 'pending',
+            ]),
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation), [
+            'review_comment' => 'ok to create',
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 8,
+            'c_name_chn' => '錢八',
+            'c_notes' => 'Created via proposal',
+        ]);
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status']);
+
+        // handler 自寫 op_type=1（TYPE_CREATE）final operation 與 INSERT audit。
+        $this->assertDatabaseHas('operations', [
+            'c_personid' => 8,
+            'op_type' => Operation::TYPE_CREATE,
+            'resource' => 'BIOG_MAIN',
+        ]);
+        $this->assertDatabaseHas('audit_log', [
+            'table_name' => 'BIOG_MAIN',
+            'operation' => 'INSERT',
+        ]);
     }
 
     #[Test]


### PR DESCRIPTION
## 摘要

依 `docs/PERSON_PROPOSAL_PATHS.md` §6 建議順序的第 1 項（段三）：把 `BIOG_MAIN`（人物主檔）的提案核准從「盲寫路徑 C」收斂到 v2 handler 重放（路徑 A），核准與直接編輯自此逐位一致。三種操作各按 direct 語義路由、不照抄子資源形狀：

| 操作 | 重放對象 | 說明 |
|---|---|---|
| UPDATE | `BiogMainMutationHandler` | 唯一有活提交端的操作（v2 `mode=proposal`＋legacy Blade `action=proposal`）。核准＝把提案 delta 套用到**當下**資料列並重跑 `BasicInformationRequest` 驗證；「名（中）／拼音名不可清空」護欄改由 handler 的 `validationRules($original)` 統一提供（語義等價、direct 與核准同一份程式） |
| DELETE | `BiogMainDeleteHandler` | **防禦性封洞**：收斂前通用 `applyDeleteProposal()` 會對 BIOG_MAIN 做物理 `DELETE`——與 direct 的軟刪除（`c_name_chn='<待删除>'`）語義相反，且在入邊 FK 尚為 CASCADE 的觀察期會靜默連鎖刪除 25 張子表資料（見 CASCADE_TO_RESTRICT_MIGRATION_NOTES.md §11.1）。現行無提交端會產生此類提案 |
| CREATE | `BiogMainCreateHandler` | 僅 legacy 提交路由理論可達。重放帶 `c_personid` 驗證（非 0、不得已存在、不得過大）與欄位白名單，取代盲 Eloquent create |

## 隨收斂移除的死碼

- `tableModelMap`（BIOG_MAIN 是唯一條目）與 `applyCreateProposal`／`applyUpdateProposal` 的 Eloquent 分支
- `NO_CLEAR_COLUMNS_ON_APPLY`／`assertNoClearColumns`（護欄移交 handler）

另：核准失敗訊息現會攤平 handler 的欄位級錯誤（如「參數校驗失敗：名不能為空」），對審核者保留指向性——此改進對全部已收斂資源生效。

## 測試

- `BiogMainProposalTest` 13 tests（新增：delete 提案核准＝軟刪除非物理 DELETE、create 撞既有 personid fail-closed、create 成功路徑；改寫：清空名（中）改斷言 handler 驗證訊息）
- 全套 `./vendor/bin/phpunit`：**2392 tests / 10586 assertions 全綠**
- `php-cs-fixer` 無修正

## 文件

- `PERSON_PROPOSAL_PATHS.md`：新增 §4.6（三種操作的語義決定）、§5.2／§6 標記完成
- `CHANGELOG.md` 同步

## 後續（不在本 PR）

- kinship／associations 收斂（§5.1，需先裁定鏡像衝突語義）
- 下架 legacy 提案提交路由（§5.3）