### PR TITLE
chore(deps): 升級 guzzle 7.15.2／psr7 2.13.0——修補 9 個 Dependabot 安全告警

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -687,25 +687,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -713,9 +714,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -793,7 +795,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -809,28 +811,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -876,7 +879,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -892,20 +895,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -914,7 +917,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -995,7 +998,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1011,7 +1014,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -4074,16 +4077,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -4121,7 +4124,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4141,7 +4144,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -10337,5 +10340,5 @@
         "ext-curl": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## 摘要

清空 Dependabot 的全部 9 個 open alert（全 medium、全 composer）。這 9 個告警其實只是 2 個套件的版本落後：

| 套件 | 現況 | 升到 | 涉及 alert |
|---|---|---|---|
| `guzzlehttp/guzzle` | 7.10.0 | **7.15.2** | #392 #394 #400 #401 #402 #403 #404 |
| `guzzlehttp/psr7` | 2.11.0 | **2.13.0** | #393 #405 |

連帶升級 `guzzlehttp/promises` 2.3.0 → 2.5.1、`symfony/deprecation-contracts` v3.7.0 → v3.7.1。

**只動 `composer.lock`**：目標版本完全落在 `composer.json` 既有的 `"guzzlehttp/guzzle": "^7.2"` 約束內，不需改 `composer.json`。

## 對本專案的實際暴露面

Guzzle 是 Laravel `Http` facade 的底層，本專案有 5 處外呼：

| 位置 | 對象 |
|---|---|
| `NaturalLanguageQueryService.php:1574` | LLM API（帶 `Authorization: Bearer`）|
| `PostingAutofillService.php:166` | LLM API（帶 Bearer）|
| `CodeLookupService.php:314` | LLM API（帶 Bearer）|
| `ChgisMapManager.php:46,137` | CHGIS 底圖 HEAD／GET（追蹤最多 10 次 redirect）|

按此排優先序：

**影響最大（有對應的呼叫形狀）**
- **GHSA-wpwq-4j6v-78m3（CVE-2026-55568）HTTPS proxy 靜默降級為明文** 與 **GHSA-94pj-82f3-465w（Proxy-Authorization 洩漏給 origin）**：三處 LLM 呼叫都把 API key 放在 header。部署環境若設了 `HTTPS_PROXY`／`HTTP_PROXY`（容器環境常見），這兩個就是明文外洩 API key 的路徑。
- **GHSA-h95v-h523-3mw8（URI fragment 洩漏進 redirect 的 Referer）**：`ChgisMapManager` 是唯一跟 redirect 的呼叫，它已明寫 `'referer' => false`，**目前已被緩解**；升級才是根治，不再依賴呼叫端自律。

**目前不可達，但屬技術債**
- `psr7` 的 **GHSA-c2w2-prh8-qm98（CVE-2026-59882）host confusion** 與 **GHSA-vm85-hxw5-5432（CVE-2026-55766）start-line CRLF injection**：需要使用者可控的 URL／method 才可觸發，現行 5 處 URL 全來自 config。但 psr7 是全站共用的 PSR-7 實作，未來任何新外呼都會踩。
- 4 個 cookie 相關（#394 #401 #402 #403）：Laravel `Http` 預設不啟用 cookie jar，這 5 處也都沒開。升級順帶清掉。

## 驗證

```
$ composer audit
No security vulnerability advisories found.     ← 9 → 0
```

測試 **2389 tests 全綠**（本機分批執行，合計覆蓋 100%）：

| 批次 | 結果 |
|---|---|
| Unit | ✅ 433 tests / 1089 assertions |
| Feature 1–45 | ✅ 569 tests / 2394 |
| Feature 46–90 | ✅ 578 tests / 2477 |
| Feature 91–130 | ✅ 379 tests / 2137 |
| Feature 131–169 | ✅ 412 tests / 2410 |
| AiPostingAutofillTest | ✅ 18 tests / 64 |

未跑 `php-cs-fixer`（無 PHP 檔變更）。

## 過程中發現的既有問題（不在本 PR）

1. **`AiPostingAutofillController.php:44` 的 `set_time_limit(120)` 會炸掉整套測試**：PHPUnit 未開 process isolation，跑到 `AiPostingAutofillTest`（檔名排序最前）之後整個 process 被套上 120 秒牆鐘，全套必定 `Fatal error: Maximum execution time exceeded`。這也是本 PR 只能分批跑測試的原因。另開 PR 修。
2. **缺 `.github/dependabot.yml`**：倉庫只開了 security alerts、沒開 version updates，所以 Dependabot 不會自動開修補 PR——這正是 9 個告警累積至今的原因；且 `package-lock.json` 完全沒被掃描。另開 PR 補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)