### PR TITLE
chore(ci): 新增 Dependabot 版本更新設定（composer／npm／github-actions）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+# Dependabot 版本更新設定。
+#
+# 背景：此倉庫先前只啟用了 security alerts（Dependabot 會掃 composer.lock 並回報漏洞），
+# 但沒有這份設定檔，因此 Dependabot 不會自動開修補 PR——告警只會累積、需人工處理。
+# 一併補上 npm 與 github-actions：package-lock.json 先前完全沒有被掃描，屬零覆蓋。
+#
+# 分組（groups）策略：同一 ecosystem 的 patch／minor 合併成單一 PR，避免每週被大量
+# 單套件 PR 淹沒；major 升級刻意不分組，維持一個套件一個 PR 以便逐一評估破壞性變更。
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Taipei
+    open-pull-requests-limit: 5
+    target-branch: develop
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+    groups:
+      composer-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Taipei
+    open-pull-requests-limit: 5
+    target-branch: develop
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # CI workflow 用的 action（actions/checkout 等）也會有安全更新，一併納管。
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    target-branch: develop
+    commit-message:
+      prefix: 'chore(ci)'


### PR DESCRIPTION
## 摘要

補上 `.github/dependabot.yml`。倉庫先前**只啟用 security alerts、沒有這份設定檔**，所以 Dependabot 只會回報漏洞、不會自動開修補 PR——告警因此一路累積等人工處理（#1206 一次清掉的 9 個 guzzle／psr7 medium 告警就是這樣攢起來的）。

## 設定內容

| ecosystem | 頻率 | 分組 | PR 上限 |
|---|---|---|---|
| `composer` | weekly（週一 09:00 Asia/Taipei）| minor＋patch 合併成單一 PR | 5 |
| `npm` | weekly（同上）| minor＋patch 合併成單一 PR | 5 |
| `github-actions` | monthly | 不分組 | 3 |

- **`npm` 是新增覆蓋**：Dependabot 的 alert 先前只掃 `composer.lock`，`package-lock.json` 屬**零覆蓋**、完全沒有訊號。補了才會開始有。
- **分組策略**：patch／minor 合併成一個 PR，避免每週被大量單套件 PR 淹沒；**major 刻意不分組**，維持一個套件一個 PR，方便逐一評估破壞性變更。
- **全部 `target-branch: develop`**，對齊本專案的主要開發分支（否則 Dependabot 會朝 GitHub 的 default branch 開 PR）。
- `github-actions` 一併納管：`actions/checkout` 等也會有安全更新，現有 3 個 workflow（`codeql.yml`／`php-cs-fixer.yml`／`phpunit.yml`）都吃得到。

## 影響

純 CI 設定，不動任何應用程式碼，無需跑測試。合併後 Dependabot 會在下一個週一開始按上表產生 PR。

## 相關

- #1206（本次手動清掉的 9 個 guzzle／psr7 告警——有了這份設定，同類告警之後會自動來 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)