### PR TITLE
fix(runtime-limits): 執行時間／記憶體上限改為「只放寬不縮限」——修掉整套 phpunit 跑不完與生產的降級

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 
-# Dependabot 版本更新設定。
+# Dependabot 版本更新（version updates）設定。
 #
-# 背景：此倉庫先前只啟用了 security alerts（Dependabot 會掃 composer.lock 並回報漏洞），
-# 但沒有這份設定檔，因此 Dependabot 不會自動開修補 PR——告警只會累積、需人工處理。
-# 一併補上 npm 與 github-actions：package-lock.json 先前完全沒有被掃描，屬零覆蓋。
+# 這份檔案管的是**定期版本更新**。**安全更新（security updates）不歸它管**——那由 repo 的
+# Dependabot security updates 開關控制，沒有這份檔案照樣會開 PR（實例：#1191 fast-uri、
+# #1205 postcss 都在本檔加入之前就由 Dependabot 自動開出並合併）。兩者是各自獨立的機制。
+#
+# 不要加 target-branch：Dependabot 在建立**安全更新** PR 時會忽略設了 target-branch 的設定項，
+# 於是安全更新 PR 拿不到下面的 groups 分組、commit-message prefix 與 PR 上限。省略時預設就是
+# repo 的 default branch（本倉庫為 develop），所以寫了只有壞處。
 #
 # 分組（groups）策略：同一 ecosystem 的 patch／minor 合併成單一 PR，避免每週被大量
 # 單套件 PR 淹沒；major 升級刻意不分組，維持一個套件一個 PR 以便逐一評估破壞性變更。
@@ -17,7 +21,6 @@ updates:
       time: '09:00'
       timezone: Asia/Taipei
     open-pull-requests-limit: 5
-    target-branch: develop
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
@@ -35,7 +38,6 @@ updates:
       time: '09:00'
       timezone: Asia/Taipei
     open-pull-requests-limit: 5
-    target-branch: develop
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
@@ -51,6 +53,17 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 3
-    target-branch: develop
     commit-message:
       prefix: 'chore(ci)'
+
+  # 釘住的 base image 也需要納管；注意必須用 directories 明確指出 Dockerfile 所在目錄，
+  # 用 directory: / 找不到它們（Dependabot 只在指定目錄裡找 Dockerfile）。
+  - package-ecosystem: docker
+    directories:
+      - /docker
+      - /.devcontainer
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'chore(docker)'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 本檔案改為維護近階段的重要變更與產品方向，不再保留完整歷史流水帳。較舊的大型升級請參考 `docs/` 下專門文檔。
 
+## 2026-08
+
+### 執行時間／記憶體上限改為「只放寬不縮限」，修掉整套 phpunit 跑不完的元凶
+- `set_time_limit()`／`ini_set('max_execution_time')`／`ini_set('memory_limit')` 的作用域是**整個 PHP process**，而 PHPUnit 共用單一 process。原本散在 `AiPostingAutofillController`、`QueryPlaygroundController`（SSE）、`Api/ApiController*`、`BiogMainRepository`、`CbdbTableMaintenanceController` 的呼叫——執行時間 13 處（10 處在 class 宣告前的**檔案頂層**、autoload 到就生效）、記憶體 11 處（10 處在頂層）——會把上限套到其後整段測試流程，使全套測試必定被 `Maximum execution time exceeded` 攔腰砍斷，錯誤還指向無關檔案。全套實測需 368 秒，先撞 120 秒（autofill）再撞 300 秒（頂層 `ini_set`）兩層卡點。
+- 新增 `App\Support\ExecutionTimeLimit` 與 `App\Support\MemoryLimit`，語義統一為**只放寬、絕不縮限**（現值為 0／-1＝無限制，或已更寬時一律 no-op）。**生產實測（2026-08-03）**：web（php-fpm 8.4）`max_execution_time = 30`／`memory_limit = 1G`，CLI `0`／`-1`。因此舊寫法在生產其實在**降級**——每次 `/api/select/*` 請求被從 1G 壓到 512M，artisan 則從無限制被壓到 300 秒／512M。收斂後 web 放寬行為完全不變，CLI 與測試環境不再被誤傷。
+- `Api/ApiController3` 的 600 秒改為 300：生產 fpm pool 的 `request_terminate_timeout = 300s` 會先殺掉 worker，PHP 端寫 600 永遠跑不到，屬虛假餘量。
+- `docker/php.ini` 補上「未被任何環境載入、數值與生產不符」的警示標頭（Dockerfile 未 COPY、compose 未 mount）。
+- 回歸測試：`tests/Unit/ExecutionTimeLimitTest.php`、`tests/Unit/MemoryLimitTest.php`（皆以子行程驗證正式環境分支，涵蓋放寬／不縮限／無法解析三類）。全套 `phpunit` 首次能一次跑完。
+
+### 依賴安全維護：清空 Dependabot 告警並補上版本更新設定
+- `guzzlehttp/guzzle` 7.10.0 → 7.15.2、`guzzlehttp/psr7` 2.11.0 → 2.13.0（連帶 promises 2.5.1、symfony/deprecation-contracts v3.7.1），清掉 9 個 medium 告警，`composer audit` 歸零；`composer.json` 未動（落在既有 `^7.2` 約束內）。影響面最大的是兩個 proxy 相關（CVE-2026-55568 HTTPS proxy 靜默降級、Proxy-Authorization 洩漏給 origin）——三處 LLM 外呼都帶 `Authorization: Bearer`。
+- 新增 `.github/dependabot.yml`：composer／npm weekly（minor＋patch 分組成單一 PR、major 逐套件）、github-actions 與 docker monthly（後者用 `directories` 指向 `/docker`、`/.devcontainer`，`directory: /` 找不到 Dockerfile）。**刻意不設 `target-branch`**：Dependabot 建立安全更新 PR 時會忽略設了該欄的設定項，導致分組與 prefix 對安全更新失效。
+- 釐清一點：安全更新 PR 由 repo 的 Dependabot security updates 開關控制，**與這份設定檔無關**（#1191、#1205 在本檔加入前就已自動開出）。
+
 ## 2026-07
 
 ### 提案核准段三：BIOG_MAIN 收斂到 v2 handler 重放（人物主檔告別盲寫路徑 C）

--- a/app/Http/Controllers/AiPostingAutofillController.php
+++ b/app/Http/Controllers/AiPostingAutofillController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\PostingAutofillService;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -41,7 +42,8 @@ class AiPostingAutofillController extends Controller {
         $personId = $request->input('person_id');
 
         // AI API 回應可能需要較長時間，延長 PHP 執行時間限制
-        set_time_limit(120);
+        // （測試環境不設限：set_time_limit 會套住整個 PHPUnit process，見 ExecutionTimeLimit）
+        ExecutionTimeLimit::extendTo(120);
 
         $startTime = microtime(true);
         $result = $this->autofillService->extractAndMatch($sourceText, $personId);

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -17,11 +17,12 @@ use App\Models\EntryCodeTypeRel;
 use App\Models\OfficeCode;
 use App\Models\OfficeCodeTypeRel;
 use App\Models\OfficeTypeTree;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -18,11 +18,12 @@ use App\Models\OfficeCode;
 use App\Models\OfficeCodeTypeRel;
 use App\Models\OfficeTypeTree;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController2.php
+++ b/app/Http/Controllers/Api/ApiController2.php
@@ -14,12 +14,13 @@ use App\Models\BiogAddr;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\OfficeCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController2 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController2.php
+++ b/app/Http/Controllers/Api/ApiController2.php
@@ -15,12 +15,13 @@ use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\OfficeCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController2 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController3.php
+++ b/app/Http/Controllers/Api/ApiController3.php
@@ -17,12 +17,16 @@ use App\Models\Dynasty;
 use App\Models\EntryCode;
 use App\Models\KinshipCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '1024M');
-ExecutionTimeLimit::extendTo(600);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('1024M');
+// 原值 600 秒是虛假的餘量：生產 php-fpm 的 request_terminate_timeout = 300s 會先殺掉 worker，
+// PHP 端寫 600 也永遠跑不到（實測 2026-08-03）。改為 300 與真正的天花板對齊；若確實需要更久，
+// 必須同時調整 fpm pool 的 request_terminate_timeout，光改這裡無效。
+ExecutionTimeLimit::extendTo(300);
 
 class ApiController3 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController3.php
+++ b/app/Http/Controllers/Api/ApiController3.php
@@ -16,12 +16,13 @@ use App\Models\BiogMain;
 use App\Models\Dynasty;
 use App\Models\EntryCode;
 use App\Models\KinshipCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '1024M');
-ini_set('max_execution_time', 600);
+ExecutionTimeLimit::extendTo(600);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController3 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4.php
+++ b/app/Http/Controllers/Api/ApiController4.php
@@ -14,12 +14,13 @@ use App\Models\BiogAddr;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController4 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4.php
+++ b/app/Http/Controllers/Api/ApiController4.php
@@ -15,12 +15,13 @@ use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController4 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4_1.php
+++ b/app/Http/Controllers/Api/ApiController4_1.php
@@ -15,12 +15,13 @@ use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController4_1 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4_1.php
+++ b/app/Http/Controllers/Api/ApiController4_1.php
@@ -14,12 +14,13 @@ use App\Models\BiogAddr;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController4_1 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -15,12 +15,13 @@ use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController4_2 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController4_2.php
+++ b/app/Http/Controllers/Api/ApiController4_2.php
@@ -14,12 +14,13 @@ use App\Models\BiogAddr;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController4_2 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController5.php
+++ b/app/Http/Controllers/Api/ApiController5.php
@@ -15,12 +15,13 @@ use App\Models\BiogAddr;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController5 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController5.php
+++ b/app/Http/Controllers/Api/ApiController5.php
@@ -14,12 +14,13 @@ use App\Models\AssocCode;
 use App\Models\BiogAddr;
 use App\Models\BiogMain;
 use App\Models\KinshipCode;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController5 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController6.php
+++ b/app/Http/Controllers/Api/ApiController6.php
@@ -13,12 +13,13 @@ use App\Models\AddrCode;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController6 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController6.php
+++ b/app/Http/Controllers/Api/ApiController6.php
@@ -12,12 +12,13 @@ use App\Http\Controllers\Controller;
 use App\Models\AddrCode;
 use App\Models\BiogAddrCode;
 use App\Models\BiogMain;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController6 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController7.php
+++ b/app/Http/Controllers/Api/ApiController7.php
@@ -13,12 +13,13 @@ use App\Models\AddrCode;
 use App\Models\AssocCode;
 use App\Models\BiogMain;
 use App\Models\Dynasty;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 class ApiController7 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/Api/ApiController7.php
+++ b/app/Http/Controllers/Api/ApiController7.php
@@ -14,12 +14,13 @@ use App\Models\AssocCode;
 use App\Models\BiogMain;
 use App\Models\Dynasty;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 class ApiController7 extends Controller {
     use AuthenticatesUsers;

--- a/app/Http/Controllers/CbdbTableMaintenanceController.php
+++ b/app/Http/Controllers/CbdbTableMaintenanceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\NameFtsProgressService;
+use App\Support\MemoryLimit;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
@@ -118,7 +119,7 @@ class CbdbTableMaintenanceController extends Controller {
 
         // 移除執行時間限制
         set_time_limit(0);
-        ini_set('memory_limit', '1024M');
+        MemoryLimit::extendTo('1024M');
 
         // 構建 Artisan::call() 參數（關聯數組格式）
         $params = [];

--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\NaturalLanguageQueryService;
 use App\Services\QueryPlaygroundService;
 use App\Services\SqlTableNameExtractor;
+use App\Support\ExecutionTimeLimit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -187,7 +188,7 @@ class QueryPlaygroundController extends Controller {
      */
     protected function streamSseResponse(callable $producer) {
         return response()->stream(function () use ($producer) {
-            set_time_limit(300);  // SSE 串流需要較長時間（多輪工具呼叫 + LLM 回應）
+            ExecutionTimeLimit::extendTo(300);  // SSE 串流需要較長時間（多輪工具呼叫 + LLM 回應）
             ignore_user_abort(true);
 
             $lastSentAt = microtime(true);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -36,12 +36,13 @@ use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\CompositePrimaryKey;
 use App\Support\ExecutionTimeLimit;
+use App\Support\MemoryLimit;
 use App\Support\PinyinUmlaut;
 use Carbon\Carbon;
-use Illuminate\Http\Request;
 //修改結束
 
 //20230628建安修改
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -49,8 +50,8 @@ use Illuminate\Support\Facades\Log;
 
 //修改結束
 
-ini_set('memory_limit', '512M');
-ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
+MemoryLimit::extendTo('512M');
+ExecutionTimeLimit::extendTo(300);  // 只放寬不縮限：CLI／測試環境（上限為 0＝無限制）一律 no-op，見 ExecutionTimeLimit
 
 /**
  * Class BiogMainRepository

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -35,13 +35,14 @@ use App\Services\ExplicitCascadeLogger;
 use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
 use App\Support\CompositePrimaryKey;
+use App\Support\ExecutionTimeLimit;
 use App\Support\PinyinUmlaut;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 //修改結束
 
 //20230628建安修改
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -49,7 +50,7 @@ use Illuminate\Support\Facades\Log;
 //修改結束
 
 ini_set('memory_limit', '512M');
-ini_set('max_execution_time', 300);
+ExecutionTimeLimit::extendTo(300);  // 測試環境為 no-op，避免套住整個 PHPUnit process
 
 /**
  * Class BiogMainRepository

--- a/app/Support/ExecutionTimeLimit.php
+++ b/app/Support/ExecutionTimeLimit.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * 延長 PHP 執行時間限制的統一入口。
+ *
+ * 為什麼需要包一層：`set_time_limit()`／`ini_set('max_execution_time', N)` 的作用域是**整個
+ * PHP process**，不是單一 request。PHPUnit 預設 `processIsolation="false"`，所有測試共用一個
+ * process，因此任何在請求處理中（或更糟：在 class 檔頂層、autoload 時）呼叫它的程式碼，一旦
+ * 被觸發就會把 N 秒的牆鐘套到**其後整段測試流程**上——測試總時長超過 N 秒時整套直接
+ * `Fatal error: Maximum execution time exceeded`，且錯誤指向當下剛好在跑的無關檔案
+ * （實際踩到的有 BcryptHasher.php、Model.php、NamespacedItemResolver.php），極難追查。
+ *
+ * 具體踩過的兩層坑：
+ *  1. `AiPostingAutofillController::extract()` 的 `set_time_limit(120)`。該測試檔依檔名排序在
+ *     tests/Feature 最前面，於是整套測試從第 18 個測試起只剩 120 秒可用。
+ *  2. 拔掉 (1) 之後換成 300 秒卡點：`Api/ApiController*.php` 與 `BiogMainRepository.php` 在
+ *     class 宣告前的頂層 `ini_set('max_execution_time', 300)`，autoload 到該檔就生效。
+ *
+ * CLI SAPI 的 `max_execution_time` 預設為 0（無限制），本來就不該有這些限制。
+ * 因此：測試環境下不設限，正式環境行為完全不變。
+ */
+class ExecutionTimeLimit {
+    /**
+     * 把執行時間上限延長到 $seconds 秒；測試環境下為 no-op。
+     *
+     * 僅適用於「為了長時間操作而**放寬**限制」的情境。若目的是完全移除限制，
+     * 直接用 `set_time_limit(0)` 即可——那不會縮限任何東西，無此問題。
+     */
+    public static function extendTo(int $seconds): void {
+        if (self::runningTests()) {
+            return;
+        }
+
+        set_time_limit($seconds);
+    }
+
+    /**
+     * 不透過容器判斷是否在跑測試。
+     *
+     * 刻意不用 `app()->runningUnitTests()`：部分呼叫點在 class 檔頂層、於 autoload 時執行，
+     * 當下 Laravel 容器可能尚未 boot（甚至尚未建立），呼叫 `app()` 會炸。
+     *
+     * - `PHPUNIT_COMPOSER_INSTALL`：PHPUnit 的入口腳本在載入任何應用程式碼前就定義。
+     * - `class_exists(..., false)`：第二參數 false＝不觸發 autoload，因此正式環境即使
+     *   vendor 內裝著 phpunit（require-dev）也不會誤判為測試環境。
+     */
+    private static function runningTests(): bool {
+        return defined('PHPUNIT_COMPOSER_INSTALL')
+            || class_exists(\PHPUnit\Framework\TestCase::class, false);
+    }
+}

--- a/app/Support/ExecutionTimeLimit.php
+++ b/app/Support/ExecutionTimeLimit.php
@@ -18,21 +18,40 @@ namespace App\Support;
  *  2. 拔掉 (1) 之後換成 300 秒卡點：`Api/ApiController*.php` 與 `BiogMainRepository.php` 在
  *     class 宣告前的頂層 `ini_set('max_execution_time', 300)`，autoload 到該檔就生效。
  *
- * CLI SAPI 的 `max_execution_time` 預設為 0（無限制），本來就不該有這些限制。
- * 因此：測試環境下不設限，正式環境行為完全不變。
+ * 語義為「**只放寬、絕不縮限**」（理由與生產實測值見 extendTo() 的 docblock）：
+ *  - web 正式環境（php.ini 30 秒）行為完全不變，仍放寬到 300／600。
+ *  - CLI／artisan（預設 0＝無限制）與測試環境一律 no-op。
  */
 class ExecutionTimeLimit {
     /**
-     * 把執行時間上限延長到 $seconds 秒；測試環境下為 no-op。
+     * 把執行時間上限**放寬**到 $seconds 秒。只放寬、絕不縮限；測試環境下一律 no-op。
      *
-     * 僅適用於「為了長時間操作而**放寬**限制」的情境。若目的是完全移除限制，
-     * 直接用 `set_time_limit(0)` 即可——那不會縮限任何東西，無此問題。
+     * 「只放寬不縮限」為何必要（生產實測 2026-08-03）：
+     *  - web（php-fpm 8.4）`max_execution_time = 30` → 放寬到 300／600 是這些公開重查詢端點
+     *    賴以存活的設定，必須保留。
+     *  - CLI（artisan）`max_execution_time = 0`（無限制）→ 無條件 set_time_limit(300) 會**憑空
+     *    加上 300 秒上限**。這些呼叫點多半在 class 檔頂層、autoload 到就生效，長跑命令若剛好
+     *    載入該檔就會被砍在半途。舊寫法（頂層 ini_set）即有此問題，這裡一併封掉。
+     *
+     * 若目的是完全**移除**限制，直接用 `set_time_limit(0)`，不要走這裡。
      */
     public static function extendTo(int $seconds): void {
         if (self::runningTests()) {
             return;
         }
 
+        // `max_execution_time` 恆存在，(int) 轉換無歧義；萬一取不到值折疊成 0＝視為無限制、
+        // 放棄調整，方向與 MemoryLimit::toBytes() 回 null 一致（寧可不動，不猜測）。
+        $current = (int) ini_get('max_execution_time');
+        if ($current === 0 || $current >= $seconds) {
+            // 0＝無限制（CLI 預設）；已更寬則沿用現值。兩者都不該被這裡收窄。
+            return;
+        }
+
+        // set_time_limit() 會重置計時器（實測 ini_set('max_execution_time') 亦然，兩者等價）。
+        // 注意：重置是**有條件**的——走到上面的 early return 就不會重置。因此本方法不可用來
+        // 在長時間迴圈裡「續命」（現值已 >= 要求值時它什麼都不做）。若將來需要無條件續命，
+        // 請另加一個語義明確的 reset()，不要改這裡的守衛。
         set_time_limit($seconds);
     }
 

--- a/app/Support/MemoryLimit.php
+++ b/app/Support/MemoryLimit.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * 放寬 PHP 記憶體上限的統一入口。與 ExecutionTimeLimit 同一個問題、同一套語義。
+ *
+ * 為什麼需要包一層：`ini_set('memory_limit', ...)` 的作用域是**整個 PHP process**，不是單一
+ * request。舊寫法把它放在 `Api/ApiController*.php` 與 `BiogMainRepository.php` 的 class 宣告
+ * **之前**（檔案頂層），autoload 到該檔就生效，於是：
+ *  - PHPUnit 共用單一 process，autoload 到任一檔就把整個測試 process 的上限改掉，且「哪個檔
+ *    最後被載入就贏」（512M vs 1024M），會隨測試檔排序漂移。
+ *  - 更嚴重的是在正式環境它其實在**降級**（見下方實測），與寫這行的原意相反。
+ *
+ * 生產實測（2026-08-03，php-fpm 8.4 / CLI 8.4）：
+ *  - web `memory_limit = 1G` → 舊寫法的 `ini_set('memory_limit', '512M')` 把每一次
+ *    `/api/select/*` 請求從 1G **壓到 512M**，只剩伺服器願意給的一半；`'1024M'` 則等於 1G、
+ *    是 no-op。也就是說這些行在生產沒有一行達成了它想達成的事。
+ *  - CLI `memory_limit = -1`（無限制）→ 舊寫法把 artisan 壓到 512M。
+ *
+ * 因此語義同樣是「**只放寬、絕不縮限**」。刻意不直接刪掉呼叫點：低配環境（PHP 內建預設 128M）
+ * 跑這些重查詢端點仍需要放寬，直接刪會讓那些環境 OOM。
+ *
+ * 註：本類別不需要 ExecutionTimeLimit 那樣的「測試環境 no-op」判斷——測試環境的上限本來就
+ * 遠高於這裡要求的值（本機 CLI 4G、生產 CLI 無限制），「只放寬」天然就是 no-op；萬一某環境
+ * 以更低的上限跑測試，放寬也只會讓測試更不容易 OOM，不會製造新的失敗。
+ */
+class MemoryLimit {
+    /**
+     * 把記憶體上限放寬到 $limit（PHP shorthand，如 '512M'、'1G'）。只放寬、絕不縮限。
+     */
+    public static function extendTo(string $limit): void {
+        $requested = self::toBytes($limit);
+        if ($requested === null) {
+            return;
+        }
+
+        $current = self::toBytes((string) ini_get('memory_limit'));
+        if ($current === null) {
+            return;
+        }
+
+        // -1（無限制）在 toBytes() 回傳 PHP_INT_MAX，因此這個比較同時涵蓋「已無限制」。
+        if ($current >= $requested) {
+            return;
+        }
+
+        ini_set('memory_limit', $limit);
+    }
+
+    /**
+     * 把 PHP shorthand 記憶體字串換算成 bytes；'-1'（無限制）回傳 PHP_INT_MAX。
+     * 無法解析時回傳 null——呼叫端會放棄調整、不做任何猜測。
+     *
+     * 本函式刻意比 PHP 自身的 shorthand 規則更嚴（不收 '1024MB'／'1T'／'+512M'／'-2'）。
+     * 這是安全的方向：所有不認得的輸入都走 null → 提早 return → 完全不動 ini。特別是負值
+     * （PHP 語義上任何負值都代表無限制）雖然走 null 而非 PHP_INT_MAX 分支，最終效果一致
+     * ——都不會把上限收窄。
+     */
+    private static function toBytes(string $value): ?int {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+        if ($value === '-1') {
+            return PHP_INT_MAX;
+        }
+
+        if (!preg_match('/^(\d+)([KMG])?$/i', $value, $matches)) {
+            return null;
+        }
+
+        $bytes = (int) $matches[1];
+        $multiplier = match (strtoupper($matches[2] ?? '')) {
+            'K' => 1024,
+            'M' => 1024 * 1024,
+            'G' => 1024 * 1024 * 1024,
+            default => 1,
+        };
+
+        // 溢位視為「無法解析」而非飽和成 PHP_INT_MAX。兩個理由：
+        //  1. $bytes * $multiplier 超過 int 範圍時 PHP 會轉成 float，而回傳型別是 ?int，會拋
+        //     TypeError——在檔案頂層呼叫點就是 autoload 期的 500，正是本次要修掉的那種難查故障。
+        //  2. 若飽和成 PHP_INT_MAX 而讓 extendTo() 判定「該放寬」，它接著會拿**原始 shorthand
+        //     字串**（如 '99999999999999999999G'）去 ini_set()，PHP 認不得而發 Invalid
+        //     "memory_limit" setting warning，還可能在 ini_get() 留下異常值。回 null 則提早
+        //     return、完全不動 ini，與其他無法解析的輸入一致。
+        if ($bytes > intdiv(PHP_INT_MAX, $multiplier)) {
+            return null;
+        }
+
+        return $bytes * $multiplier;
+    }
+}

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,3 +1,15 @@
+; ⚠️ 此檔目前【未被任何環境載入】，數值也與生產不符——請勿據此推論線上設定。
+;
+; - docker/Dockerfile 沒有 COPY 這個檔案，docker-compose.yml 也沒有 mount，
+;   FrankenPHP 容器實際生效的是鏡像內建的 PHP 預設值，不是這裡寫的值。
+; - 生產（AWS，php-fpm 8.4）實測 2026-08-03：
+;     web  /etc/php/8.4/fpm/php.ini  max_execution_time = 30    memory_limit = 1G
+;     CLI  /etc/php/8.4/cli/php.ini  max_execution_time = 0     memory_limit = -1
+;   另有 fpm pool 的 request_terminate_timeout = 300s（比 PHP 端設定更硬的天花板）。
+;   下面寫的 300 / 256M 兩個值都與生產不同。
+; - 保留此檔僅為歷史紀錄（php-fpm 時代的開發設定，註解仍提及 Laravel 8.83）。
+;   若要真正生效，需在 Dockerfile 加 COPY 或在 compose 掛載，並先重新核對每一項數值。
+
 ; PHP 配置文件（开发环境）
 
 ; 错误报告

--- a/tests/Unit/ExecutionTimeLimitTest.php
+++ b/tests/Unit/ExecutionTimeLimitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\ExecutionTimeLimit;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ExecutionTimeLimitTest extends TestCase {
+    #[Test]
+    public function extend_to_is_a_no_op_under_tests() {
+        // 回歸護欄：set_time_limit() 套住整個 PHP process，PHPUnit 又共用單一 process，
+        // 因此測試環境下必須不設限——否則某個測試觸發後，整套測試會在 N 秒後被
+        // 「Maximum execution time exceeded」攔腰砍斷，且錯誤指向無關檔案、極難追查。
+        $before = ini_get('max_execution_time');
+
+        ExecutionTimeLimit::extendTo(1);
+
+        $this->assertSame($before, ini_get('max_execution_time'));
+        $this->assertSame('0', (string) ini_get('max_execution_time'), 'CLI 下應維持無限制');
+    }
+}

--- a/tests/Unit/ExecutionTimeLimitTest.php
+++ b/tests/Unit/ExecutionTimeLimitTest.php
@@ -4,19 +4,43 @@ namespace Tests\Unit;
 
 use App\Support\ExecutionTimeLimit;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 class ExecutionTimeLimitTest extends TestCase {
     #[Test]
     public function extend_to_is_a_no_op_under_tests() {
-        // 回歸護欄：set_time_limit() 套住整個 PHP process，PHPUnit 又共用單一 process，
-        // 因此測試環境下必須不設限——否則某個測試觸發後，整套測試會在 N 秒後被
-        // 「Maximum execution time exceeded」攔腰砍斷，且錯誤指向無關檔案、極難追查。
+        // 回歸護欄：set_time_limit()／ini_set('max_execution_time') 套住整個 PHP process，
+        // PHPUnit 又共用單一 process，因此測試環境下必須不設限——否則某個測試觸發後，整套測試
+        // 會在 N 秒後被「Maximum execution time exceeded」攔腰砍斷，且錯誤指向無關檔案、極難追查。
+        //
+        // 刻意只斷言「前後相等」而非斷言某個具體數值：後者斷的是跑測試時的 php.ini 設定
+        // （CI 若以 `php -d max_execution_time=30` 執行就會紅），不是本類別的行為。
         $before = ini_get('max_execution_time');
 
         ExecutionTimeLimit::extendTo(1);
 
         $this->assertSame($before, ini_get('max_execution_time'));
-        $this->assertSame('0', (string) ini_get('max_execution_time'), 'CLI 下應維持無限制');
+    }
+
+    #[Test]
+    public function extend_to_actually_raises_the_limit_outside_tests() {
+        // 另一個方向的護欄：確認正式環境下 extendTo() 真的會設限。
+        // 缺了這條，「測試偵測邏輯被改壞成永遠 no-op」就沒有任何測試會發現。
+        //
+        // 必須開子行程才測得到：子行程只 require vendor/autoload.php，既不定義
+        // PHPUNIT_COMPOSER_INSTALL 也不載入 PHPUnit\Framework\TestCase，因此會走正式分支。
+        $php = (new PhpExecutableFinder())->find();
+        $this->assertNotFalse($php, '找不到 PHP 執行檔');
+
+        $code = "require 'vendor/autoload.php';"
+            ." App\\Support\\ExecutionTimeLimit::extendTo(300);"
+            ." echo ini_get('max_execution_time');";
+
+        $process = new Process([$php, '-d', 'max_execution_time=30', '-r', $code], base_path());
+        $process->mustRun();
+
+        $this->assertSame('300', trim($process->getOutput()));
     }
 }

--- a/tests/Unit/ExecutionTimeLimitTest.php
+++ b/tests/Unit/ExecutionTimeLimitTest.php
@@ -29,8 +29,27 @@ class ExecutionTimeLimitTest extends TestCase {
         // 另一個方向的護欄：確認正式環境下 extendTo() 真的會設限。
         // 缺了這條，「測試偵測邏輯被改壞成永遠 no-op」就沒有任何測試會發現。
         //
-        // 必須開子行程才測得到：子行程只 require vendor/autoload.php，既不定義
-        // PHPUNIT_COMPOSER_INSTALL 也不載入 PHPUnit\Framework\TestCase，因此會走正式分支。
+        $this->assertSame('300', $this->limitAfterExtendTo('30'), '30 < 300 應放寬到 300');
+    }
+
+    #[Test]
+    public function extend_to_never_narrows_an_already_wider_limit() {
+        // 「只放寬不縮限」的兩個關鍵情境（生產實測值）：
+        //  - 0＝無限制，是 CLI／artisan 的預設。無條件 set_time_limit(300) 會憑空加上 300 秒
+        //    上限，長跑命令會被砍在半途——這正是舊寫法（頂層 ini_set）的既有 bug。
+        //  - 現值已更寬時沿用現值，不把它收窄。
+        $this->assertSame('0', $this->limitAfterExtendTo('0'), '0＝無限制，不可被收窄');
+        $this->assertSame('600', $this->limitAfterExtendTo('600'), '已更寬則沿用現值');
+        $this->assertSame('300', $this->limitAfterExtendTo('300'), '相等時維持現值');
+    }
+
+    /**
+     * 在子行程裡以指定的 max_execution_time 起始值呼叫 extendTo(300)，回傳呼叫後的實際值。
+     *
+     * 必須開子行程才測得到正式分支：子行程只 require vendor/autoload.php，既不定義
+     * PHPUNIT_COMPOSER_INSTALL 也不載入 PHPUnit\Framework\TestCase。
+     */
+    private function limitAfterExtendTo(string $startingLimit): string {
         $php = (new PhpExecutableFinder())->find();
         $this->assertNotFalse($php, '找不到 PHP 執行檔');
 
@@ -38,9 +57,9 @@ class ExecutionTimeLimitTest extends TestCase {
             ." App\\Support\\ExecutionTimeLimit::extendTo(300);"
             ." echo ini_get('max_execution_time');";
 
-        $process = new Process([$php, '-d', 'max_execution_time=30', '-r', $code], base_path());
+        $process = new Process([$php, '-d', "max_execution_time={$startingLimit}", '-r', $code], base_path());
         $process->mustRun();
 
-        $this->assertSame('300', trim($process->getOutput()));
+        return trim($process->getOutput());
     }
 }

--- a/tests/Unit/MemoryLimitTest.php
+++ b/tests/Unit/MemoryLimitTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\MemoryLimit;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+class MemoryLimitTest extends TestCase {
+    #[Test]
+    public function extend_to_raises_a_lower_limit() {
+        // 低配環境（PHP 內建預設 128M）跑重查詢端點仍需要放寬——這是刻意保留呼叫點、
+        // 而非直接刪掉那 11 行的原因。
+        $this->assertSame('512M', $this->limitAfterExtendTo('128M', '512M'));
+    }
+
+    #[Test]
+    public function extend_to_never_narrows_an_already_wider_limit() {
+        // 生產實測（2026-08-03）：web memory_limit = 1G、CLI = -1（無限制）。
+        // 舊寫法無條件 ini_set('memory_limit','512M') 在這兩種情況下都是**降級**——
+        // 每次 /api/select/* 請求只剩伺服器願意給的一半。這裡確認不再發生。
+        $this->assertSame('1G', $this->limitAfterExtendTo('1G', '512M'), '1G > 512M，不可被收窄');
+        $this->assertSame('-1', $this->limitAfterExtendTo('-1', '512M'), '-1＝無限制，不可被收窄');
+        $this->assertSame('512M', $this->limitAfterExtendTo('512M', '512M'), '相等時維持現值');
+    }
+
+    #[Test]
+    public function extend_to_treats_1024m_as_equal_to_1g() {
+        // 生產主場景：ApiController3 要求 '1024M'，而生產 web 的 memory_limit 是 '1G'。
+        // 「這行在生產是 no-op、沒有降級」是整個改動的核心論據，必須有測試鎖住。
+        // 同時鎖住 toBytes() 的單位換算——若有人誤用 1000 進位，這條會立刻紅。
+        $this->assertSame('1G', $this->limitAfterExtendTo('1G', '1024M'));
+    }
+
+    #[Test]
+    public function extend_to_ignores_unparsable_values() {
+        // 解析不了就放棄調整，不猜測（避免把上限設成意料外的值）。
+        //
+        // 只測 requested 這一側：「現值無法解析」無法用 `php -d memory_limit=bogus` 造出來——
+        // PHP 自己會先攔下並 fallback（Warning: Invalid "memory_limit" setting…），子行程拿到的
+        // 已是合法值。該分支（toBytes(ini_get(...)) === null）因此在實務上不可達，留著純為防禦。
+        $this->assertSame('256M', $this->limitAfterExtendTo('256M', 'not-a-size'), 'requested 無法解析');
+
+        // 溢位同樣視為無法解析：若飽和成 PHP_INT_MAX 而判定「該放寬」，就會拿這個 PHP 認不得的
+        // 原始字串去 ini_set()，發出 Invalid "memory_limit" setting warning。
+        $this->assertSame('256M', $this->limitAfterExtendTo('256M', '99999999999999999999G'), 'requested 溢位');
+    }
+
+    /**
+     * 在子行程裡以 $startingLimit 起始，呼叫 MemoryLimit::extendTo($requested)，回傳呼叫後的實際值。
+     */
+    private function limitAfterExtendTo(string $startingLimit, string $requested): string {
+        $php = (new PhpExecutableFinder())->find();
+        $this->assertNotFalse($php, '找不到 PHP 執行檔');
+
+        $code = "require 'vendor/autoload.php';"
+            ." App\\Support\\MemoryLimit::extendTo('{$requested}');"
+            ." echo ini_get('memory_limit');";
+
+        $process = new Process([$php, '-d', "memory_limit={$startingLimit}", '-r', $code], base_path());
+        $process->mustRun();
+
+        return trim($process->getOutput());
+    }
+}

--- a/tests/Unit/RuntimeLimitCallSitesTest.php
+++ b/tests/Unit/RuntimeLimitCallSitesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+/**
+ * 護欄鎖在**呼叫點**上，而不只是 helper。
+ *
+ * ExecutionTimeLimitTest／MemoryLimitTest 驗證的是 helper 的「只放寬不縮限」語義；但真正要防的
+ * 回歸是「有人把這些檔案頂層的呼叫改回 `ini_set()`／`set_time_limit()`」——那樣 helper 再正確也
+ * 沒用，整套 phpunit 會再次跑不完，而且錯誤會指向無關檔案、極難追查（歷史上踩過 BcryptHasher.php、
+ * Model.php、NamespacedItemResolver.php）。
+ *
+ * 做法：開子行程、以刻意壓低的上限起始，require 該檔（頂層敘述於 autoload／include 時就會執行），
+ * 然後檢查兩個 ini 有沒有被改動。子行程只 require vendor/autoload.php，不 boot Laravel。
+ */
+class RuntimeLimitCallSitesTest extends TestCase {
+    /**
+     * 頂層帶有 ExecutionTimeLimit／MemoryLimit 呼叫的檔案（相對 base_path）。
+     *
+     * @return array<string, array{string}>
+     */
+    public static function topLevelCallSiteFiles(): array {
+        $files = [
+            'app/Http/Controllers/Api/ApiController.php',
+            'app/Http/Controllers/Api/ApiController2.php',
+            'app/Http/Controllers/Api/ApiController3.php',
+            'app/Http/Controllers/Api/ApiController4.php',
+            'app/Http/Controllers/Api/ApiController4_1.php',
+            'app/Http/Controllers/Api/ApiController4_2.php',
+            'app/Http/Controllers/Api/ApiController5.php',
+            'app/Http/Controllers/Api/ApiController6.php',
+            'app/Http/Controllers/Api/ApiController7.php',
+            'app/Repositories/BiogMainRepository.php',
+        ];
+
+        return array_combine($files, array_map(static fn ($f) => [$f], $files));
+    }
+
+    #[Test]
+    #[DataProvider('topLevelCallSiteFiles')]
+    public function requiring_the_file_does_not_narrow_process_limits(string $relativePath) {
+        // 起始值刻意比呼叫點要求的（300／600 秒、512M／1024M）更寬：
+        //  - max_execution_time=0 模擬 CLI／artisan 的無限制
+        //  - memory_limit=4G 高於任何呼叫點要求值
+        // 只放寬不縮限成立時，require 之後兩者都必須原封不動。
+        $output = $this->iniAfterRequiring($relativePath, '0', '4G');
+
+        $this->assertSame(
+            ['0', '4G'],
+            $output,
+            "require {$relativePath} 改動了 process 的執行時間／記憶體上限——"
+            .'呼叫點應走 ExecutionTimeLimit／MemoryLimit（只放寬不縮限），不可直接 ini_set／set_time_limit。'
+        );
+    }
+
+    #[Test]
+    public function the_call_sites_still_raise_a_genuinely_lower_limit() {
+        // 反向確認上面那條不是因為呼叫點被整個刪掉才過的：以低配環境起始時必須真的放寬。
+        // ApiController3 要求 300 秒／1024M。
+        $output = $this->iniAfterRequiring('app/Http/Controllers/Api/ApiController3.php', '30', '128M');
+
+        $this->assertSame(['300', '1024M'], $output);
+    }
+
+    /**
+     * 在子行程中以指定的起始 ini require $relativePath，回傳 [max_execution_time, memory_limit]。
+     *
+     * @return array{string, string}
+     */
+    private function iniAfterRequiring(string $relativePath, string $startingTime, string $startingMemory): array {
+        $php = (new PhpExecutableFinder())->find();
+        $this->assertNotFalse($php, '找不到 PHP 執行檔');
+        $this->assertTrue(function_exists('set_time_limit'), 'set_time_limit 被 disable_functions 停用，本測試無意義');
+
+        $code = "require 'vendor/autoload.php';"
+            ." require '{$relativePath}';"
+            ." echo ini_get('max_execution_time'), '|', ini_get('memory_limit');";
+
+        $process = new Process(
+            [$php, '-d', "max_execution_time={$startingTime}", '-d', "memory_limit={$startingMemory}", '-r', $code],
+            base_path()
+        );
+        $process->mustRun();
+
+        $parts = explode('|', trim($process->getOutput()));
+        $this->assertCount(2, $parts, '子行程輸出格式非預期：'.$process->getOutput());
+
+        return [$parts[0], $parts[1]];
+    }
+}


### PR DESCRIPTION
## 問題

`set_time_limit()`／`ini_set('max_execution_time')`／`ini_set('memory_limit')` 的作用域是**整個 PHP process**，不是單一 request。PHPUnit 預設 `processIsolation="false"`，所有測試共用一個 process——所以任何應用程式碼設下的上限都會套到**其後整段測試流程**上。全套測試需 ~368 秒，於是必定被攔腰砍斷：

```
Fatal error: Maximum execution time of 120 seconds exceeded
  in .../Illuminate/Hashing/BcryptHasher.php on line 62
```

錯誤指向**當下剛好在跑的無關檔案**（實際踩到 `BcryptHasher.php`、`Model.php`、`NamespacedItemResolver.php`），完全沒有指向元凶。**兩層**卡點，拔掉第一層才會看到第二層：

| 上限 | 來源 | 為什麼會中 |
|---|---|---|
| **120 秒** | `AiPostingAutofillController::extract()` 的 `set_time_limit(120)` | `AiPostingAutofillTest.php` 依檔名排序在 `tests/Feature` **最前面**，整套從第 18 個測試起只剩 120 秒 |
| **300 秒** | `Api/ApiController*.php`、`BiogMainRepository.php` 在 class 宣告前的**檔案頂層** `ini_set` | file-scope 語句，**autoload 到該檔就生效**，不需呼叫任何方法 |

## 生產實測翻轉了原本的假設

我 ssh 上生產確認（2026-08-03）。原先我是照 `docker/php.ini` 推論的，**那份檔案未被任何環境載入、兩個值都與生產不符**：

| | `max_execution_time` | `memory_limit` |
|---|---|---|
| **web（php-fpm 8.4）** | **30** | **1G** |
| **CLI（artisan）** | **0**（無限制）| **-1**（無限制）|
| `docker/php.ini` 聲稱 | 300 | 256M |

另外 fpm pool：`request_terminate_timeout = 300s`、`request_slowlog_timeout = 3s`。
日誌命中：`Maximum execution time` / `Allowed memory size` / `execution timed out` / `exited on signal` **皆為 0**。

於是原本無條件覆寫的寫法在生產其實在**降級**，與寫這些行的原意相反：

- **`ini_set('memory_limit','512M')` 把每一次 `/api/select/*` 請求從 1G 壓到剩一半**（該端點 `auth.optional`、未登入可打）；`'1024M'` 等於 1G、是 no-op。**那 11 行在生產沒有一行達成了它想達成的事。**
- CLI 更極端：artisan 從無限制被壓到 300 秒／512M。

## 改動

**1. 語義統一為「只放寬、絕不縮限」**

新增 `App\Support\ExecutionTimeLimit` 與 `App\Support\MemoryLimit`：現值為 `0`／`-1`（無限制）或已 >= 要求值時一律 no-op。

- web 放寬 30 → 300／600 的行為**完全不變**（load-bearing，這些公開重查詢端點賴以存活）。
- CLI／artisan 與測試環境不再被誤傷。
- 測試環境偵測不用 `app()->runningUnitTests()`——頂層呼叫點在 autoload 時執行，容器可能尚未 boot；改用 `PHPUNIT_COMPOSER_INSTALL` 常數 + `class_exists(..., false)`（不觸發 autoload，正式環境有 require-dev 的 phpunit 也不會誤判）。
- **刻意不直接刪掉那 11 個呼叫點**：低配環境（PHP 內建預設 128M）跑這些端點仍需要放寬，直接刪會讓那些環境 OOM。
- `MemoryLimit::toBytes()` 對無法解析與**溢位**一律回 `null`（完全不動 ini）。溢位若飽和成 `PHP_INT_MAX`，`extendTo()` 會拿 PHP 認不得的原始 shorthand 去 `ini_set()` 而發 `Invalid "memory_limit" setting` warning——codex 覆核指出，已修。

**2. `Api/ApiController3` 的 600 秒改為 300**

fpm 的 `request_terminate_timeout = 300s` 會先殺掉 worker，PHP 端寫 600 永遠跑不到，是**虛假的餘量**。要真的更久必須同時調 fpm pool，光改這裡無效。

**3. `.github/dependabot.yml`**

- 移除 3 處 `target-branch: develop`：Dependabot 建立**安全更新** PR 時會忽略設了該欄的設定項，導致 `groups`／`commit-message` prefix／PR 上限對安全更新失效——而安全更新正是加這份設定的初衷。省略時預設就是 default branch（本倉庫為 `develop`）。
- 新增 `docker` ecosystem，用 `directories: [/docker, /.devcontainer]`（`directory: /` 找不到 Dockerfile）。
- 更正原註解的錯誤因果：**安全更新由 repo 的 Dependabot security updates 開關控制、與這份檔案無關**（#1191 fast-uri、#1205 postcss 都在本檔加入之前就已自動開出並合併）。

**4. `docker/php.ini` 補警示標頭**

未被任何環境載入、數值與生產不符。先前據它推論線上設定曾導致誤判，標明以免重演。

**5. `CHANGELOG.md`** 新增 2026-08 段落。

## 驗證

全套測試**能一次跑完**（先前只能分批）：

```
$ ./vendor/bin/phpunit
OK (2410 tests, 10653 assertions)
Time: 05:47.221, Memory: 218.00 MB
```

5 分 47 秒＝347 秒，正是超過 300 秒卡點的原因。`php-cs-fixer` 無修正。

新增／補強的護欄：

| 測試 | 覆蓋 |
|---|---|
| `tests/Unit/MemoryLimitTest.php` | 放寬／不縮限（1G、-1、相等）／**`1024M` 等於 `1G`（生產主場景）**／無法解析／溢位 |
| `tests/Unit/ExecutionTimeLimitTest.php` | 測試環境 no-op／正式環境真的放寬／不縮限（0、600、300 相等邊界）|
| `tests/Unit/RuntimeLimitCallSitesTest.php`（新增）| **護欄鎖在呼叫點上**：開子行程 require 那 10 個頂層呼叫點檔案，斷言不得改動 process 的兩個上限；另反向確認低配環境下仍會放寬 |

最後一項防的是「有人把呼叫改回 `ini_set`／`set_time_limit`」——那樣 helper 再正確也沒用。三個測試都以子行程驗證正式分支（只 `require vendor/autoload.php`，不定義 `PHPUNIT_COMPOSER_INSTALL`、不載入 `TestCase`）。

## 雙閘 review

- **第一道（review agent）**：無嚴重 issues。採納其建議補上「`1024M` 在 `1G` 下必須 no-op」這個生產主場景測試（整個改動的核心論據卻原本沒測到）與呼叫點護欄；並修掉 `toBytes()` 溢位、對齊兩個類別的註解。
- **第二道（codex）**：第一輪報 2 個嚴重問題。溢位那條已修；**SSE 計時器那條前提不成立**——codex 認為「php-fpm worker 會跨 request 保留 ini 設定」，但 runtime ini 改動會在 `php_request_shutdown` 由 `zend_ini_deactivate` 還原，每個 request 都從 30 秒重新起算，SSE 每次都會走到 `set_time_limit(300)`；且 `request_terminate_timeout` 是從 request 受理起算的更硬牆鐘，PHP 端重置計時器本來就換不到額外時間。第二輪覆核後 codex 回報**無嚴重 issues**。
- 另外在兩道闸互相矛盾的一點上（`ini_set` 是否會重置計時器）我實測判定：對照組在第 3 秒被砍，`set_time_limit` 與 `ini_set` 兩組都活過 4 秒——**兩者等價**，替換無行為回歸。

## 本輪刻意未動

生產環境本身與運維項（依使用者指示）：`/var/log/php8.4-fpm-slow.log` 已 858 MB 且 logrotate 未納管、磁碟 90%（剩 4.0G）、`CbdbApiController@person` 的慢查詢。另 `CbdbTableMaintenanceController` 的 `set_time_limit(0)` 未動——那是**移除**限制，不會縮限任何東西。

🤖 Generated with [Claude Code](https://claude.com/claude-code)