### PR TITLE
修正人物編輯中樞切分頁不會反映他人／另一分頁的修改

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## 2026-08
 
+### 人物編輯中樞切分頁一律重抓資料（修「別人改了、切分頁看不到」）
+- 現象（使用者回報 `/app/basicinformation/{id}/edit`）：某條記錄被別人或自己在另一個瀏覽器分頁新增／刪除／修改後，在本頁切分頁（例如別名→親屬→別名）時，分頁徽章計數與列表內容都不變，必須整頁重載才看得到。
+- 根因一：`TabContentLoader` 的分頁資料是「一載入就永久快取」（同一 personId 不重複請求），切走再切回沿用首次載入的快照。此前兩個 commit 只修了**自己在本頁的修改**（409fd9e 徽章、7f8d7a8 基本資料切分頁顯示舊值），別人的修改仍看不到。
+- 根因二：判斷「已快取」的旗標設在 `setCache` 的 updater 裡、下一行讀取——而 React 只在 eager state 快路徑才會同步呼叫 updater，因此該旗標並不可靠。實測（headless Chrome 對真實庫）13 個分頁裡 7～8 個沿用舊快取、5～6 個湊巧重抓，行為不確定。
+- 根因三：提供徽章計數與人物標題的 summary 端點只在掛載時抓一次（依賴不含 `activeTab`），切分頁完全不會重抓。兩個宿主頁（`PersonEditor` 中樞、`PersonBrowser/Index` 主從檢視）都是同一寫法。
+- 修法：新增純函式模組 `tabCachePolicy.ts`——**每次「分頁啟用」（personId／activeTab／重載序號任一改變）都重新向後端取資料**。已有資料的分頁在重新驗證期間先繼續顯示舊資料（不閃載入佔位；子資源端點約 13ms 伺服器工作、12 個計數皆為覆蓋索引查詢）；`basic_info` 例外一律等新資料才渲染，因為其內容 `BasicInfoEditor` 在掛載時把欄位值快照進自己的 state、之後不跟 props 同步，先用舊資料掛載會永遠停在舊值、按下儲存還會把舊值寫回覆蓋他人修改。啟用起始狀態在 render 期間標記（React 允許的「隨 props 調整 state」用法）而非 effect 裡，避免編輯器先以舊資料掛載一次再被替換。
+- 兩個宿主頁的 summary 依賴加入 `activeTab`：同一人物已有摘要時走靜默更新（不進 loading、失敗沿用舊摘要），並補 `AbortController` 讓慢的舊回應不會蓋掉新回應。每輪一律把 loading 設成「本輪的意圖」而非只在非靜默時設 true——否則「非靜默請求被中止→下一輪是靜默」會讓 `summaryLoading` 永遠卡住，而 `PersonSummaryPanel` 的 loading 分支在 summary 之前短路，整塊摘要面板會空掉（人物 A→B→A、或請求在途中 `person_id` 被移除即可重現）。連帶移除已無作用的 `refreshTabCache`（其職責由「每次啟用都重抓」結構性取代）與 `PersonEditor` 中從未被讀取的 `summaryLoading`／`summaryError`。
+- 每筆分頁快取帶一個 activation 戳記，回應落庫前比對：快取只以分頁為鍵，而 abort 發生在 effect cleanup（commit 之後），若回應落在「新一輪已 commit、cleanup 未跑」的空隙，就會把上一個人物／上一輪的資料寫進當前分頁。比對放在 `setCache` 的 updater 內、對 committed state 進行，不在 render 期間寫 ref（那會被丟棄的並行 render 汙染）。`activationKeyOf` 的組成必須與抓取 effect 的依賴**完全一致**（personId／分頁／重載序號／資料端點）——少涵蓋任一項就會出現「effect 重跑卻沿用同一戳記」，兩個請求共用戳記、舊回應可蓋掉新回應，且不重新標記啟用（`basic_info` 會在編輯器仍掛載時被塞進新資料、畫面仍停在舊快照）。此條由測試鎖住。
+- 順手補 i18n：`TabContentLoader` 的「載入中…／載入失敗／重新載入／未支援的分頁」原為硬編碼中文。改為一律重抓後這些提示的出現頻率大增（`basic_info` 每次回訪都會短暫顯示），英文語境不應再落回中文，故改走 `person` 翻譯（新增 `reload`／`unsupported_tab` 兩個鍵，zh-TW／en 同步）。
+- 回歸測試：`tabCachePolicy.test.ts`（vitest，鎖住「切分頁必須重抓」與 `basic_info` 不可先用舊資料渲染）。另以 headless Chrome 對真實 MariaDB 做端到端驗證：修復前後同一組 23 項檢查（外部新增／刪除／改親屬關係類型／改基本資料欄位在兩個宿主頁切分頁後即時反映；每次切分頁只發 1＋1 個請求、停在同頁不輪詢；快速連點與離線／重試路徑；不回歸 409fd9e／7f8d7a8 的自身修改情境）由 6 項失敗轉為全綠。
+
 ### 修改提案改為「同一編輯器＋同一管線重發」（resubmit），廢除通用全欄表單改提案
 - 根因追認（op 351725）：「修改提案」原復用 codes 通用編輯頁——按 `Schema::getColumnListing` **全欄**渲染（含四個稽核欄的空輸入框）、儲存時整包回寫 `resource_data` 且無白名單——提案被編輯一次，payload 就被灌入稽核欄 null 鍵，核准重放即撞 handler 白名單 422。「發提案」與「改提案」走不同介面與流程，正是髒 payload 的製造機。
 - 新流程：**修改提案＝單一交易內撤回舊提案＋以完全相同的提交流程重發**。新端點 `POST api/v2/proposals/{operation}/resubmit`（`MutationController::resubmit`）：驗擁有權／狀態 → 交易內先把舊提案標 `cancelled`（讓「同主鍵已有待審提案」護欄天然放行）→ 與 `store()` 相同 dispatch 重放 registry handler（mode 強制 proposal）→ 失敗整筆回滾（舊提案回到 pending、handler 欄位級錯誤原樣回給編輯器）→ 成功則舊 meta 記 `superseded_by`、新 meta 記 `resubmit_of`。「編輯後的 payload」與「新提交的 payload」由構造保證一致。

--- a/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
+++ b/resources/js/inertia/Pages/BasicInformation/PersonEditor.tsx
@@ -78,9 +78,9 @@ export default function PersonEditor() {
 
     const tPerson = useTranslation('person');
 
+    // 本頁不渲染摘要的 loading／error 態（標題與徽章在摘要到齊前分別退回 person_label／person_banner.counts），
+    // 故不保留對應 state——先前那兩個 state 從未被讀取。
     const [summary, setSummary] = useState<PersonSummary | null>(null);
-    const [summaryLoading, setSummaryLoading] = useState(false);
-    const [summaryError, setSummaryError] = useState<string | null>(null);
     const [activeTab, setActiveTab] = useState(initialTab || 'basic_info');
     const [summaryRefreshKey, setSummaryRefreshKey] = useState(0);
     const [basicInfoEditorState, setBasicInfoEditorState] = useState({ editing: false, dirty: false });
@@ -96,22 +96,30 @@ export default function PersonEditor() {
     useEffect(() => registerDirtyChecker(() => dirtyRef.current), []);
 
     // ── 載入摘要（header + tab_counts）──
+    // 依賴含 activeTab：**每次切分頁都重新抓摘要**，否則分頁徽章計數會停在頁面初載的數字——
+    // 其他人（或自己在另一個瀏覽器分頁）新增／刪除記錄後，切分頁時計數不會變（須整頁重載才更新）。
+    // 已有「同一個人物」的摘要時，失敗就沿用舊摘要（計數暫時偏舊勝過把標題與徽章清空）。
+    const summaryPersonRef = useRef<number | null>(null);
+    summaryPersonRef.current = summary?.c_personid ?? null;
     useEffect(() => {
-        setSummaryLoading(true);
-        setSummaryError(null);
+        const hasSamePerson = summaryPersonRef.current === personId;
+        // 快速連續切分頁會疊發多個請求；abort 舊請求，避免慢的舊回應蓋掉新回應。
+        const controller = new AbortController();
         const url = summaryEndpoint.replace('__PERSON_ID__', String(personId));
-        fetch(url)
+        fetch(url, { signal: controller.signal })
             .then((r) => {
                 if (!r.ok) throw new Error(`HTTP ${r.status}`);
                 return r.json();
             })
             .then((data) => setSummary(data))
             .catch((err) => {
-                setSummaryError(err instanceof Error ? err.message : tPerson('load_failed'));
+                if (err instanceof DOMException && err.name === 'AbortError') return;
+                if (hasSamePerson) return;
                 setSummary(null);
-            })
-            .finally(() => setSummaryLoading(false));
-    }, [personId, summaryEndpoint, summaryRefreshKey, tPerson]);
+            });
+
+        return () => controller.abort();
+    }, [personId, summaryEndpoint, summaryRefreshKey, activeTab]);
 
     // ── 離頁守衛（編輯中有未儲存變更時）──
     useEffect(() => {

--- a/resources/js/inertia/Pages/PersonBrowser/Index.tsx
+++ b/resources/js/inertia/Pages/PersonBrowser/Index.tsx
@@ -341,28 +341,54 @@ export default function PersonBrowserIndex() {
     }, []);
 
     // ── Load summary when selectedId changes ──
+    // 依賴含 activeTab：**每次切分頁都重新抓摘要**，否則分頁徽章計數會停在選取人物時的數字——
+    // 其他人（或自己在另一個瀏覽器分頁）新增／刪除記錄後，切分頁時計數不會變（須整頁重載才更新）。
+    // 已有摘要時為靜默更新：不進 loading、失敗也保留舊摘要，避免每次切分頁都閃一下摘要面板。
+    // 只有「同一個人物、已有摘要」才靜默更新；換人物時仍走 loading，避免面板短暫顯示上一個人的摘要。
+    const summaryPersonRef = useRef<number | null>(null);
+    summaryPersonRef.current = summary?.c_personid ?? null;
     useEffect(() => {
         if (selectedId == null) {
             setSummary(null);
+            setSummaryLoading(false);
+            setSummaryError(null);
             return;
         }
-        setSummaryLoading(true);
-        setSummaryError(null);
+        const silent = summaryPersonRef.current === selectedId;
+        // 每次執行都把 loading 設成「本次的意圖」，不是只在非靜默時設 true：
+        // 否則「非靜默請求被中止 → 下一輪是靜默」會讓 loading 永遠卡在 true
+        // （PersonSummaryPanel 的 loading 分支在 summary 之前短路，面板會整塊空掉）。
+        setSummaryLoading(!silent);
+        if (!silent) {
+            setSummaryError(null);
+        }
+        // 快速連續切分頁會疊發多個請求；abort 舊請求，避免慢的舊回應蓋掉新回應。
+        const controller = new AbortController();
         const url = summaryEndpoint.replace('__PERSON_ID__', String(selectedId));
-        fetch(url)
+        fetch(url, { signal: controller.signal })
             .then((r) => {
                 if (!r.ok) throw new Error(`HTTP ${r.status}`);
                 return r.json();
             })
             .then((data) => {
                 setSummary(data);
+                setSummaryError(null);
             })
             .catch((err) => {
+                if (err instanceof DOMException && err.name === 'AbortError') return;
+                // 靜默更新失敗就沿用既有摘要（計數暫時偏舊勝過把摘要面板清空）。
+                if (silent) return;
                 setSummaryError(err.message || tPerson('load_failed'));
                 setSummary(null);
             })
-            .finally(() => setSummaryLoading(false));
-    }, [selectedId, summaryEndpoint, summaryRefreshKey]);
+            .finally(() => {
+                // 已被中止＝已有新的一輪接手（cleanup 先於新 effect 執行，而本回呼在其後才跑），
+                // 此時不可再覆寫新一輪剛設好的 loading。
+                if (!controller.signal.aborted) setSummaryLoading(false);
+            });
+
+        return () => controller.abort();
+    }, [selectedId, summaryEndpoint, summaryRefreshKey, activeTab]);
 
     // ── Tab change ──
     const handleTabChange = useCallback(

--- a/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
+++ b/resources/js/inertia/components/PersonBrowser/TabContentLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import BasicInfoView from './BasicInfoView';
 import BasicInfoEditor from '../BasicInfoEditor';
 import { useTranslation } from '../../hooks/useTranslation';
@@ -14,6 +14,14 @@ import TextsTab from './tabs/TextsTab';
 import PostingsTab from './tabs/PostingsTab';
 import InstitutionsTab from './tabs/InstitutionsTab';
 import KinshipTab from './tabs/KinshipTab';
+import {
+    activationKeyOf,
+    applyError,
+    applySuccess,
+    beginActivation,
+    dropTab,
+    type TabCache,
+} from './tabCachePolicy';
 
 interface Props {
     personId: number | null;
@@ -50,12 +58,6 @@ interface Props {
     onRegisterBasicInfoSaveHandler?: (handler: (() => Promise<boolean>) | null) => void;
 }
 
-interface TabState {
-    loading: boolean;
-    error: string | null;
-    data: unknown;
-}
-
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 type TypedTabComponent = React.ComponentType<{ data: any; canEdit: boolean; postCE?: boolean; onSelectPerson?: (personId: number) => void }>;
 
@@ -65,8 +67,12 @@ const TAB_COMPONENTS: Record<string, TypedTabComponent> = {
 };
 
 /**
- * 根據 activeTab 和 personId lazy load 對應 tab 資料。
- * 已載入的 tab 資料會快取（同一 personId 不重複請求）。
+ * 根據 activeTab 和 personId 載入對應 tab 資料。
+ *
+ * **每次切分頁都會重新向後端取資料**（見 tabCachePolicy）：分頁資料不再永久沿用首次載入的快照，
+ * 否則其他人、或自己在另一個瀏覽器分頁的新增／刪除／修改，在不整頁重載的情況下永遠看不到。
+ * 已有舊資料的分頁在重新驗證期間先繼續顯示舊資料，不閃載入佔位；`basic_info` 例外（其編輯器
+ * 在掛載時快照欄位值，必須等新資料才渲染）。
  */
 export default function TabContentLoader({
     personId,
@@ -108,36 +114,46 @@ export default function TabContentLoader({
         const v2 = tPerson(k); if (v2 && v2 !== k) return v2;
         const v3 = tCommon(k); return v3 && v3 !== k ? v3 : k;
     };
-    const [cache, setCache] = useState<Record<string, TabState>>({});
+    const [cache, setCache] = useState<TabCache>({});
     const [fetchSeq, setFetchSeq] = useState(0);
-    const cachePersonRef = useRef<number | null>(personId);
+    const [cachePerson, setCachePerson] = useState<number | null>(personId);
+    const [activation, setActivation] = useState<string | null>(null);
 
-    // 人物切換時同步清快取，本次渲染直接使用空值
-    const personChanged = cachePersonRef.current !== personId;
-    if (personChanged) {
-        cachePersonRef.current = personId;
+    // 一次「分頁啟用」＝抓取 effect 的任一依賴改變。每次啟用都會重新抓資料（見下方 effect）。
+    // key 的組成必須與 effect 依賴完全一致，否則會出現「effect 重跑但沿用同一戳記」的漏洞。
+    const activationKey = activationKeyOf(personId, activeTab, fetchSeq, tabEndpoint);
+
+    // 標記啟用起始狀態刻意放在 render 期間、而非 effect 裡：effect 晚一拍會讓 basic_info 先以舊資料
+    // 掛載一次 BasicInfoEditor（閃動 + 多跑一輪 onRegisterSaveHandler／onEditorStateChange）再被替換。
+    // render 期間 setState 是 React 允許的「隨 props 調整 state」用法；條件下一輪即為 false，不會無限迴圈。
+    // 同時以區域變數 effectiveCache 讓本次渲染直接反映，不必等下一輪。
+    let effectiveCache = cache;
+
+    // 人物切換：整批丟棄舊人物的快取（其他分頁的資料也不再屬於這個人）。
+    if (cachePerson !== personId) {
+        setCachePerson(personId);
         if (Object.keys(cache).length > 0) {
             setCache({});
         }
+        effectiveCache = {};
     }
 
-    const effectiveCache = personChanged ? {} : cache;
+    if (activation !== activationKey) {
+        setActivation(activationKey);
+        setCache((prev) => beginActivation(prev, activeTab, activationKey));
+        effectiveCache = beginActivation(effectiveCache, activeTab, activationKey);
+    }
 
-    // lazy load — 由 personId / activeTab / fetchSeq 驅動
+    // 每次啟用都重新抓資料——不再有「已快取就跳過」的短路。
+    // （舊版的短路旗標是在 setCache 的 updater 裡設定的，而 React 只在 eager state 快路徑才會同步呼叫
+    //  updater，於是 13 個分頁裡有 7～8 個沿用舊快取、5～6 個湊巧重抓，行為並不確定。）
     useEffect(() => {
         if (personId == null || !activeTab) return;
 
-        // 透過 updater 讀取最新 cache，避免把 cache 引用放進依賴
-        let alreadyCached = false;
-        setCache((prev) => {
-            if (prev[activeTab]) {
-                alreadyCached = true;
-                return prev;
-            }
-            return { ...prev, [activeTab]: { loading: true, error: null, data: null } };
-        });
-        if (alreadyCached) return;
-
+        // 本輪的啟用識別碼。落庫由 applySuccess／applyError 比對快取裡的 activation 戳記——
+        // 已被新啟用取代的回應原封不動丟掉（abort 在 cleanup 才發生，仍有「新一輪已 commit、
+        // cleanup 未跑」的空隙）。比對在 updater 內對 committed state 進行，不靠 render 期間的 ref。
+        const myActivation = activationKeyOf(personId, activeTab, fetchSeq, tabEndpoint);
         const url = tabEndpoint
             .replace('__PERSON_ID__', String(personId))
             .replace('__TAB_KEY__', activeTab);
@@ -150,19 +166,18 @@ export default function TabContentLoader({
                 return res.json();
             })
             .then((data) => {
-                setCache((prev) => ({ ...prev, [activeTab]: { loading: false, error: null, data } }));
+                setCache((prev) => applySuccess(prev, activeTab, myActivation, data));
             })
             .catch((err: unknown) => {
                 if (err instanceof DOMException && err.name === 'AbortError') {
                     return;
                 }
 
-                const message = err instanceof Error ? err.message : '載入失敗';
+                // 只存技術細節（HTTP 狀態等）；使用者看到的「載入失敗」字樣由 render 端翻譯後加上，
+                // 這樣 effect 不必依賴 tPerson——依賴多一項而 activationKey 少一項就會產生共用戳記的漏洞。
+                const message = err instanceof Error ? err.message : '';
 
-                setCache((prev) => ({
-                    ...prev,
-                    [activeTab]: { loading: false, error: message, data: null },
-                }));
+                setCache((prev) => applyError(prev, activeTab, myActivation, message));
             });
 
         return () => {
@@ -171,11 +186,7 @@ export default function TabContentLoader({
     }, [personId, activeTab, tabEndpoint, fetchSeq]);
 
     const retryActiveTab = () => {
-        setCache((prev) => {
-            const next = { ...prev };
-            delete next[activeTab];
-            return next;
-        });
+        setCache((prev) => dropTab(prev, activeTab));
         setFetchSeq((s) => s + 1);
     };
 
@@ -186,44 +197,24 @@ export default function TabContentLoader({
         onSubresourceChanged?.();
     };
 
-    // 靜默刷新指定分頁的快取資料：於背景重新抓取並就地更新 cache[tabKey].data，
-    // 不觸發 loading 態、不卸載當前掛載的元件（其 state 為當前真相），
-    // 以便使用者切換分頁後再回來時「重新掛載」讀到最新資料，而非最初載入的舊快照。
-    // 失敗時保留既有快取，避免把已顯示的資料清成錯誤態。
-    const refreshTabCache = (tabKey: string) => {
-        if (personId == null || !tabKey) return;
-        const url = tabEndpoint
-            .replace('__PERSON_ID__', String(personId))
-            .replace('__TAB_KEY__', tabKey);
-        fetch(url)
-            .then((res) => {
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
-                return res.json();
-            })
-            .then((data) => {
-                setCache((prev) => ({ ...prev, [tabKey]: { loading: false, error: null, data } }));
-            })
-            .catch(() => {
-                /* 保留既有快取 */
-            });
-    };
-
     if (personId == null) {
         return null;
     }
 
     const state = effectiveCache[activeTab];
 
+    // 這幾個提示原為硬編碼中文。切分頁改為一律重抓後，載入佔位與失敗提示的出現頻率大增
+    // （尤其 basic_info 每次回訪都會短暫顯示），英文語境不能再落回中文，故改走 person 翻譯。
     if (!state || state.loading) {
-        return <div style={msgStyle}>載入中…</div>;
+        return <div style={msgStyle}>{tPerson('loading')}</div>;
     }
 
-    if (state.error) {
+    if (state.error != null) {
         return (
             <div style={{ ...msgStyle, color: 'var(--destructive)' }}>
-                <div>載入失敗：{state.error}</div>
+                <div>{tPerson('load_failed')}{state.error ? `：${state.error}` : ''}</div>
                 <button type="button" style={retryButtonStyle} onClick={retryActiveTab}>
-                    重新載入
+                    {tPerson('reload')}
                 </button>
             </div>
         );
@@ -271,12 +262,9 @@ export default function TabContentLoader({
                     t={tEditor}
                     onEditorStateChange={onBasicInfoEditorStateChange}
                     onRegisterSaveHandler={onRegisterBasicInfoSaveHandler}
-                    onSaved={() => {
-                        // 儲存成功後靜默刷新 basic_info 快取（修：切分頁再切回顯示舊值），
-                        // 並通知上層刷新摘要計數。
-                        refreshTabCache('basic_info');
-                        onBasicInfoSaved?.();
-                    }}
+                    // 儲存成功後只通知上層刷新摘要計數／標題；不必另外刷 basic_info 快取——
+                    // 編輯器保有剛存下的值，而下一次切回本分頁本來就會重新抓資料。
+                    onSaved={onBasicInfoSaved}
                 />
             );
         }
@@ -519,7 +507,7 @@ export default function TabContentLoader({
     }
 
     // Fallback（不應出現，但作為安全後備）
-    return <div style={msgStyle}>未支援的分頁：{activeTab}</div>;
+    return <div style={msgStyle}>{tPerson('unsupported_tab')}：{activeTab}</div>;
 }
 
 const msgStyle: React.CSSProperties = {

--- a/resources/js/inertia/components/PersonBrowser/tabCachePolicy.test.ts
+++ b/resources/js/inertia/components/PersonBrowser/tabCachePolicy.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+    activationKeyOf,
+    applyError,
+    applySuccess,
+    beginActivation,
+    dropTab,
+    TABS_REQUIRING_FRESH_DATA,
+    type TabCache,
+} from './tabCachePolicy';
+
+/**
+ * 回歸鎖：切分頁必須重新向後端取資料。
+ *
+ * 原本的錯誤行為是「分頁資料一載入就永久快取」——切走再切回沿用首次載入的快照，
+ * 於是他人（或自己在另一個瀏覽器分頁）的新增／刪除／修改在切分頁時完全看不到。
+ * 這組測試鎖住修復後的語義，避免日後有人為了「少發幾個請求」把快取短路加回來。
+ */
+describe('tabCachePolicy', () => {
+    const EP = '/app/basicinformation/__PERSON_ID__/tabs/__TAB_KEY__';
+    const A = activationKeyOf(11, 'alt_names', 0, EP);
+    const A2 = activationKeyOf(11, 'alt_names', 1, EP);
+    const cacheWith = (entries: TabCache): TabCache => ({ ...entries });
+    const entry = (data: unknown, activation: string, over: Partial<TabCache[string]> = {}) => ({
+        loading: false, error: null, data, activation, ...over,
+    });
+
+    describe('activationKeyOf', () => {
+        it('分頁改變即為新啟用（→ 必須重新抓資料）', () => {
+            expect(activationKeyOf(11, 'alt_names', 0, EP)).not.toBe(activationKeyOf(11, 'kinship', 0, EP));
+        });
+
+        it('切走再切回同一分頁也是新啟用：key 由當前分頁決定，重新啟用就會重新抓', () => {
+            const first = activationKeyOf(11, 'alt_names', 0, EP);
+            const away = activationKeyOf(11, 'kinship', 0, EP);
+            const back = activationKeyOf(11, 'alt_names', 0, EP);
+            expect(away).not.toBe(first);
+            // 切回時 key 由 kinship 變回 alt_names，對 effect 而言依賴已改變 → 重跑 → 重新抓。
+            expect(back).not.toBe(away);
+        });
+
+        it('人物改變即為新啟用', () => {
+            expect(activationKeyOf(11, 'alt_names', 0, EP)).not.toBe(activationKeyOf(12, 'alt_names', 0, EP));
+        });
+
+        it('重載序號改變即為新啟用（重試／新增刪除後）', () => {
+            expect(activationKeyOf(11, 'alt_names', 0, EP)).not.toBe(activationKeyOf(11, 'alt_names', 1, EP));
+        });
+
+        it('personId 為 null 時不會與 personId 為 0 的人物撞 key', () => {
+            expect(activationKeyOf(null, 'alt_names', 0, EP)).not.toBe(activationKeyOf(0, 'alt_names', 0, EP));
+        });
+
+        // 抓取 effect 的依賴是 [personId, activeTab, tabEndpoint, fetchSeq]——key 必須涵蓋全部四項。
+        // 少涵蓋任一項，effect 會重跑卻沿用同一戳記：兩個請求共用戳記、舊回應可蓋掉新回應，
+        // 且不重新標記啟用（basic_info 會在編輯器仍掛載時被塞新資料、畫面停在舊快照）。
+        it('資料端點改變即為新啟用（key 必須涵蓋抓取 effect 的每一項依賴）', () => {
+            expect(activationKeyOf(11, 'alt_names', 0, EP)).not.toBe(activationKeyOf(11, 'alt_names', 0, `${EP}?v=2`));
+        });
+    });
+
+    describe('beginActivation', () => {
+        it('首次啟用（無快取）→ 顯示載入佔位', () => {
+            const next = beginActivation({}, 'alt_names', A);
+            expect(next.alt_names).toEqual({ loading: true, error: null, data: null, activation: A });
+        });
+
+        it('已有資料的列表分頁 → 先顯示舊資料、背景重新驗證（不閃載入佔位）', () => {
+            const prev = cacheWith({ alt_names: entry({ items: [1] }, A) });
+            const next = beginActivation(prev, 'alt_names', A2);
+            expect(next.alt_names.loading).toBe(false);
+            expect(next.alt_names.data).toEqual({ items: [1] });
+        });
+
+        it('重新蓋上本輪的 activation 戳記（舊戳記的回應之後會被丟棄）', () => {
+            const prev = cacheWith({ alt_names: entry({ items: [1] }, A) });
+            expect(beginActivation(prev, 'alt_names', A2).alt_names.activation).toBe(A2);
+        });
+
+        it('basic_info 即使已有資料也一律等新資料才渲染（編輯器在掛載時快照 initialFields）', () => {
+            const prev = cacheWith({ basic_info: entry({ form: { fields: {} } }, A) });
+            const next = beginActivation(prev, 'basic_info', A2);
+            expect(next.basic_info).toEqual({ loading: true, error: null, data: null, activation: A2 });
+        });
+
+        it('TABS_REQUIRING_FRESH_DATA 就是 basic_info（改動需連帶檢查編輯器掛載語義）', () => {
+            expect([...TABS_REQUIRING_FRESH_DATA]).toEqual(['basic_info']);
+        });
+
+        it('上一輪失敗（data 為 null）→ 重新顯示載入佔位', () => {
+            const prev = cacheWith({ alt_names: entry(null, A, { error: 'HTTP 500' }) });
+            const next = beginActivation(prev, 'alt_names', A2);
+            expect(next.alt_names).toEqual({ loading: true, error: null, data: null, activation: A2 });
+        });
+
+        it('清掉上一輪的錯誤：這次啟用會重新抓，成敗由這次結果決定', () => {
+            const prev = cacheWith({ alt_names: entry({ items: [] }, A, { error: 'HTTP 500' }) });
+            expect(beginActivation(prev, 'alt_names', A2).alt_names.error).toBeNull();
+        });
+
+        it('不動其他分頁的快取', () => {
+            const prev = cacheWith({
+                alt_names: entry({ items: [1] }, A),
+                kinship: entry({ items: [2] }, A),
+            });
+            expect(beginActivation(prev, 'alt_names', A2).kinship).toBe(prev.kinship);
+        });
+
+        it('不就地修改傳入的快取', () => {
+            const prev = cacheWith({ alt_names: entry({ items: [1] }, A) });
+            const snapshot = JSON.stringify(prev);
+            beginActivation(prev, 'alt_names', A2);
+            expect(JSON.stringify(prev)).toBe(snapshot);
+        });
+    });
+
+    describe('applySuccess', () => {
+        it('以新資料取代先前顯示的舊資料', () => {
+            const prev = cacheWith({ alt_names: entry({ items: ['舊'] }, A) });
+            const next = applySuccess(prev, 'alt_names', A, { items: ['新'] });
+            expect(next.alt_names).toEqual({ loading: false, error: null, data: { items: ['新'] }, activation: A });
+        });
+
+        it('activation 已被新啟用換掉 → 丟棄這個回應（原封不動回傳）', () => {
+            const prev = cacheWith({ alt_names: entry({ items: ['新一輪'] }, A2) });
+            expect(applySuccess(prev, 'alt_names', A, { items: ['遲到的舊回應'] })).toBe(prev);
+        });
+
+        it('分頁已被移除（換人物／重載）→ 丟棄這個回應', () => {
+            expect(applySuccess({}, 'alt_names', A, { items: [1] })).toEqual({});
+        });
+    });
+
+    describe('applyError', () => {
+        it('顯示錯誤且不留舊資料——不讓使用者在不知情下對著舊資料編輯', () => {
+            const prev = cacheWith({ alt_names: entry({ items: ['舊'] }, A, { loading: true }) });
+            const next = applyError(prev, 'alt_names', A, 'HTTP 500');
+            expect(next.alt_names).toEqual({ loading: false, error: 'HTTP 500', data: null, activation: A });
+        });
+
+        it('activation 已被新啟用換掉 → 不可把新一輪的畫面打成錯誤態', () => {
+            const prev = cacheWith({ alt_names: entry({ items: ['新一輪'] }, A2) });
+            expect(applyError(prev, 'alt_names', A, 'HTTP 500')).toBe(prev);
+        });
+    });
+
+    describe('dropTab', () => {
+        it('只移除指定分頁', () => {
+            const prev = cacheWith({
+                alt_names: entry({ items: [1] }, A),
+                kinship: entry({ items: [2] }, A),
+            });
+            const next = dropTab(prev, 'alt_names');
+            expect('alt_names' in next).toBe(false);
+            expect(next.kinship).toBe(prev.kinship);
+        });
+
+        it('分頁不存在時回傳同一個物件（避免無謂的 re-render）', () => {
+            const prev = cacheWith({ kinship: entry(null, A) });
+            expect(dropTab(prev, 'alt_names')).toBe(prev);
+        });
+
+        it('移除後，該分頁在途中的回應會被丟棄（戳記不再存在）', () => {
+            const prev = cacheWith({ alt_names: entry({ items: [1] }, A) });
+            const dropped = dropTab(prev, 'alt_names');
+            expect(applySuccess(dropped, 'alt_names', A, { items: ['遲到'] })).toBe(dropped);
+        });
+    });
+});

--- a/resources/js/inertia/components/PersonBrowser/tabCachePolicy.ts
+++ b/resources/js/inertia/components/PersonBrowser/tabCachePolicy.ts
@@ -1,0 +1,109 @@
+/**
+ * 分頁資料快取策略（TabContentLoader 用）。
+ *
+ * 背景：原本 13 個子資源分頁的資料「一載入就永久快取」——切走再切回不再向後端要資料。
+ * 結果是其他人（或自己在另一個瀏覽器分頁）的新增／刪除／修改，在不整頁重載的情況下永遠看不到；
+ * 分頁徽章計數同樣停在頁面初載的數字。
+ *
+ * 現行策略：每次「分頁啟用」（personId／activeTab／重載序號任一改變）都重新向後端取資料。
+ * 已有舊資料的分頁在重新驗證期間先繼續顯示舊資料（stale-while-revalidate），避免高頻切分頁時
+ * 每次都閃一下載入佔位（子資源端點約 200ms）；`basic_info` 例外，見 TABS_REQUIRING_FRESH_DATA。
+ *
+ * 這裡刻意寫成純函式：切分頁是否重新抓資料、哪些分頁不可先用舊資料渲染、哪些回應該被丟棄，
+ * 是這次修復的核心語義，由 tabCachePolicy.test.ts 直接鎖住。
+ */
+
+export interface TabState {
+    /** 目前沒有可顯示的資料、正在抓取 → 顯示載入佔位。 */
+    loading: boolean;
+    error: string | null;
+    data: unknown;
+    /**
+     * 產生這筆狀態的啟用識別碼（見 activationKeyOf）。
+     * 回應落庫前比對此欄，把「已被新啟用取代」的回應丟掉——快取只以分頁為鍵，而 abort 發生在
+     * effect cleanup（commit 之後），若回應剛好落在「新一輪已 commit、cleanup 尚未跑」的空隙，
+     * 就會把上一個人物／上一輪的資料寫進當前分頁。比對放在 updater 內、對committed state 進行，
+     * 因此不需要在 render 期間寫 ref（那會被丟棄的並行 render 汙染）。
+     */
+    activation: string;
+}
+
+export type TabCache = Record<string, TabState>;
+
+/**
+ * 重新驗證期間「不可先用舊資料渲染」的分頁。
+ *
+ * `basic_info` 的內容是 BasicInfoEditor——它在掛載時把 initialFields 快照進自己的 state，
+ * 之後不再跟著 props 同步。若先用舊資料掛載、稍後才把新資料寫進快取，編輯器會永遠停在舊值，
+ * 而且按下「直接保存」會把舊值整包寫回、覆蓋他人剛才的修改。故此分頁一律等新資料到齊才渲染。
+ */
+export const TABS_REQUIRING_FRESH_DATA: ReadonlySet<string> = new Set(['basic_info']);
+
+/**
+ * 一次分頁啟用的起始狀態。
+ * 可沿用舊資料者不進 loading（先顯示舊資料，等新資料覆蓋）；否則顯示載入佔位。
+ * 一律清掉上一輪的錯誤——這次啟用會重新抓一次，成敗由這次的結果決定。
+ */
+export function beginActivation(prev: TabCache, tabKey: string, activation: string): TabCache {
+    const existing = prev[tabKey];
+    const showStaleWhileRevalidating = existing?.data != null && !TABS_REQUIRING_FRESH_DATA.has(tabKey);
+
+    return {
+        ...prev,
+        [tabKey]: {
+            loading: !showStaleWhileRevalidating,
+            error: null,
+            data: showStaleWhileRevalidating ? existing.data : null,
+            activation,
+        },
+    };
+}
+
+/** 抓取成功：以新資料取代（含先前顯示的舊資料）。已被新啟用取代則原封不動。 */
+export function applySuccess(prev: TabCache, tabKey: string, activation: string, data: unknown): TabCache {
+    if (prev[tabKey]?.activation !== activation) {
+        return prev;
+    }
+
+    return { ...prev, [tabKey]: { loading: false, error: null, data, activation } };
+}
+
+/**
+ * 抓取失敗：顯示錯誤 + 重新載入按鈕，不留舊資料。已被新啟用取代則原封不動。
+ * 寧可讓使用者看到「載入失敗」，也不要讓他在不知情的狀況下對著舊資料編輯。
+ */
+export function applyError(prev: TabCache, tabKey: string, activation: string, message: string): TabCache {
+    if (prev[tabKey]?.activation !== activation) {
+        return prev;
+    }
+
+    return { ...prev, [tabKey]: { loading: false, error: message, data: null, activation } };
+}
+
+/** 明確重載（重試、或列表內新增／刪除成功後）：丟掉該分頁舊資料，下一次啟用會顯示載入佔位。 */
+export function dropTab(prev: TabCache, tabKey: string): TabCache {
+    if (!(tabKey in prev)) {
+        return prev;
+    }
+    const next = { ...prev };
+    delete next[tabKey];
+
+    return next;
+}
+
+/**
+ * 分頁啟用識別碼：personId／分頁／重載序號／資料端點任一改變即為一次新啟用，必須重新抓資料。
+ * 「切分頁要重新抓資料」這條語義就落在這個 key 上。
+ *
+ * 這四個參數必須與 TabContentLoader 抓取 effect 的依賴**完全一致**。少放一個（例如 tabEndpoint）
+ * 會讓 effect 重跑卻沿用同一個 activation 戳記：兩個請求共用戳記，先發後到的舊回應就會蓋掉新回應，
+ * 而且不會重新標記啟用（basic_info 因此可能在編輯器仍掛載時被塞進新資料，顯示的仍是舊快照）。
+ */
+export function activationKeyOf(
+    personId: number | null,
+    activeTab: string,
+    fetchSeq: number,
+    tabEndpoint: string,
+): string {
+    return `${personId ?? ''}|${activeTab}|${fetchSeq}|${tabEndpoint}`;
+}

--- a/resources/lang/en/person.php
+++ b/resources/lang/en/person.php
@@ -190,6 +190,8 @@ return [
     'text_type_explanatory' => 'Explanatory Texts',
 
     'load_failed' => 'Load failed',
+    'reload' => 'Reload',
+    'unsupported_tab' => 'Unsupported tab',
     'query_failed' => 'Query failed',
     'results_record_summary' => 'Records: :record_count / Persons: :person_count',
     'results_empty_hint' => 'Set filters above; click any tile to open the filter dialog, then run the query.',

--- a/resources/lang/zh-TW/person.php
+++ b/resources/lang/zh-TW/person.php
@@ -190,6 +190,8 @@ return [
     'text_type_explanatory' => '論說',
 
     'load_failed' => '載入失敗',
+    'reload' => '重新載入',
+    'unsupported_tab' => '未支援的分頁',
     'query_failed' => '查詢失敗',
     'results_record_summary' => '記錄 :record_count 筆 / 人物 :person_count 位',
     'results_empty_hint' => '先在上方設定條件；每一格都可以直接點開 modal 編輯，再執行查詢。',


### PR DESCRIPTION
## 問題

使用者回報 `/app/basicinformation/{id}/edit`：某條記錄被**別人**、或自己在**另一個瀏覽器分頁**新增／刪除／修改後，在本頁切分頁（例如別名→親屬→別名）時，分頁徽章計數與列表內容都不變，必須整頁重載才看得到。

已在本機以 headless Chrome 對真實 MariaDB 復現。修復前 23 項端到端檢查有 6 項失敗。

## 三個根因（不是一個）

1. **`TabContentLoader` 的分頁資料「一載入就永久快取」**（同一 personId 不重複請求），切走再切回沿用首次載入的快照。此前兩個 commit 只修了「自己在本頁的修改」——409fd9e（徽章）、7f8d7a8（基本資料切分頁顯示舊值）——別人的修改仍看不到。
2. **判斷「已快取」的旗標並不可靠**：`alreadyCached` 設在 `setCache` 的 updater 裡、下一行讀取，而 React 只在 eager state 快路徑才會同步呼叫 updater。實測 13 個分頁裡 **7～8 個沿用舊快取、5～6 個湊巧重抓**——所以「親屬會更新、別名不會」不是設計，是不確定行為。
3. **提供徽章計數與人物標題的 summary 端點只在掛載時抓一次**（依賴不含 `activeTab`），切分頁完全不會重抓。兩個宿主頁（`PersonEditor` 中樞、`PersonBrowser/Index` 主從檢視）都是同一寫法。

## 修法

新增純函式模組 `tabCachePolicy.ts`：**每次「分頁啟用」都重新向後端取資料**。

- 已有資料的分頁在重新驗證期間**先繼續顯示舊資料**（stale-while-revalidate），不閃載入佔位——實測分頁回訪的感知延遲仍是 5～9ms。
- **`basic_info` 例外**，一律等新資料才渲染：其內容 `BasicInfoEditor` 在掛載時把欄位值快照進自己的 state 且不跟 props 同步，先用舊資料掛載會永遠停在舊值，而且按下「直接保存」會把舊值整包寫回、**覆蓋他人剛才的修改**。代價是每次回訪多約 320ms 的載入佔位（artisan serve 最壞情況）。
- 啟用起始狀態在 **render 期間**標記（React 允許的「隨 props 調整 state」用法）而非 effect 裡，避免編輯器先以舊資料掛載一次再被替換。
- 每筆快取帶 `activation` 戳記，回應落庫前在 `setCache` 的 updater 內比對 committed state，丟掉已被新啟用取代的回應（`abort` 在 cleanup 才發生，仍有「新一輪已 commit、cleanup 未跑」的空隙）。`activationKeyOf` 的組成**必須與抓取 effect 的依賴完全一致**，否則會出現「effect 重跑卻沿用同一戳記」——此條由測試鎖住。

兩個宿主頁的 summary 依賴加入 `activeTab`，同一人物已有摘要時靜默更新（不進 loading、失敗沿用舊摘要）並補 `AbortController`。連帶移除已無作用的 `refreshTabCache`。

## 成本評估（實測，非估算）

- `summary()` 約 13ms 伺服器工作；12 個計數全部是 `c_personid` 覆蓋索引查詢（`Extra=Using index`）。
- 兩個請求**會重疊**（987ms 視窗內重疊 791ms）：Laravel 的 `FileSessionHandler` 用 `sharedGet`（共享鎖、讀完即放），並非 PHP 原生 `session_start()` 那種整個請求持有獨占 flock，故不會被 session 鎖串行化。
- 分頁回訪感知延遲 5～9ms（stale-while-revalidate 立即上畫面）；只有 `basic_info` 會等新資料。

## 審查發現並修掉的問題

- **`summaryLoading` 可能永久卡住**（本 PR 中途引入）：`PersonSummaryPanel` 的 loading 分支在 `summary` 之前短路，整塊摘要面板會空掉。兩條可達路徑——人物 A→B→A 且 B 的請求在途中被中止；以及請求在途中 `person_id` 被移除。改為每輪一律把 loading 設成本輪的意圖，並只在未被中止時於 `finally` 清除。已補瀏覽器檢查復現這兩條路徑。
- **render 期間寫 ref 會被丟棄的並行 render 汙染**：原本用 `latestActivationRef` 擋過期回應，改為把戳記存進快取項、在 updater 內比對 committed state。
- **`tabEndpoint`／`tPerson` 是 effect 依賴卻不在 activation key 裡**：會讓 effect 重跑卻沿用同一戳記。已把 `tabEndpoint` 納入 key，並把 `tPerson` 從 effect 移除（effect 只存技術細節，翻譯字樣由 render 端組出）。
- **i18n**：`載入中…`／`載入失敗`／`重新載入`／`未支援的分頁` 原為硬編碼中文，改為一律重抓後出現頻率大增（`basic_info` 每次回訪都會短暫顯示），已改走 `person` 翻譯（新增 `reload`／`unsupported_tab`，zh-TW／en 同步）。

## 測試

- `tabCachePolicy.test.ts`（vitest 23 tests）：鎖住「切分頁必須重抓」、`basic_info` 不可先用舊資料渲染、過期回應須丟棄、key 須涵蓋每項 effect 依賴。
- headless Chrome 對真實 MariaDB 端到端 23 項：兩個宿主頁的外部新增／刪除／改親屬關係類型／改基本資料欄位；每次切分頁只發 1+1 個請求、停在同頁不輪詢；快速連點（+1500ms 延遲下連點 5 個分頁）與離線／重試路徑；摘要面板不卡 loading；不回歸 409fd9e／7f8d7a8 的自身修改情境。**修復前 6 項失敗 → 修復後全綠。**
- `./vendor/bin/phpunit` 2429 tests 綠；`npx vitest run` 51 tests 綠；`php-cs-fixer`（清 cache + dist config dry-run）零改動；`npm run build` 通過；`tsc` 錯誤行數與修改前相同（51，皆為既有 `unknown` → typed props 問題）。

## 已知取捨與未處理項（另案）

- `basic_info` 每次回訪都會短暫顯示載入佔位（必要代價，換取不會覆寫他人修改）。
- 重新驗證失敗時 `applyError` 不留舊資料、顯示「載入失敗＋重新載入」——刻意如此，寧可讓使用者看到失敗，也不要讓他在不知情下對著舊資料編輯。
- `app/basicinformation/{id}/summary`／`tabs/{tabKey}` 無登入門檻（訪客可檢視為既有設計）亦**無 throttle**；本 PR 使其被呼叫頻率提高，建議另案評估限流。
- 審查另外指出數處**同類但不同面**的問題（皆非本 PR 範圍）：`InstitutionForm`／`OfficeForm`／`Codes/Edit`／`OfficeEditor` 以掛載時快照整包回寫、無 baseline diff 與並發權杖，可能靜默還原他人欄位或刪除他人剛新增的副表列——這是「stale write」而非本 PR 的「stale read」，影響更大，值得另開議題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
