### PR TITLE
補回 TEXT_CODES 編輯頁的作者清單並可直接跳轉到作者

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## 2026-08
 
+### 補回 TEXT_CODES 編輯頁的作者清單（React 遷移時漏移植）
+- 使用者回報 `/app/codes/TEXT_CODES/{id}/edit` 不再顯示作者。查證：該區塊只存在於舊版 `codes/edit.blade.php`（2022-01 #186 引入、2025-12 #655 改善多作者顯示），**2026-06-26 React/Inertia 上線（3f131d6）時漏移植**，而同一個 commit 把 `codes` flag 翻成 `new`，功能自此在正式站消失。旁證三項：後端端點 `/api/select/search/textauthor` 完好（12497 回 1 筆、35232 回 98 筆）、翻譯鍵 `author_label`／`no_author_data` 等留在原地無人使用、React 端零引用。
+- 補回方式改為**伺服器端隨頁面一次 JOIN 取回**（`CodesController::textCodesAuthors()` → `text_authors` prop），順手修掉舊版三個缺陷：舊版走 AJAX 且每列再各查一次 `BIOG_MAIN` 與 `TEXT_ROLE_CODES`（N+1）、`paginate(100)` 會靜默截斷、連 `c_personid=0`（未詳哨兵）也給連結。現行回報真實 `total` 與顯示上限（200；全庫單書最多 98 位），超過時前端明示「共 N 位，僅顯示前 M 位」。
+- **可直接跳轉到作者**：每位作者連到 `/app/basicinformation/{id}?tab=texts`（該作者的著述分頁，對齊舊版語義；此路徑正是 `LegacyBladeFormGate` 把舊 URL 導向的目標），另開新分頁以免弄丟表單上未儲存的輸入；`c_personid=0` 不給連結。`BIOG_TEXT_DATA` 主鍵為 `(c_personid, c_role_id, c_textid)`、含 `c_role_id`，同一人可在同一本書掛多個角色，故逐（人物, 角色）成對列出、React key 用此複合鍵；`c_textid` 固定時 `ORDER BY c_personid, c_role_id` 即全序，截斷取的永遠是同一批前 N 筆。
+- 這一區是唯讀參考，不可拖垮編輯本身：`appEdit` 的 `try/catch` 在呼叫點之前就結束，故 `textCodesAuthors()` 自行接住例外並降級為 `failed` 態（前端顯示既有的 `codes.load_failed`），對齊舊版「AJAX 失敗只顯示紅字、表單照樣可編輯可儲存」的爆炸半徑。未加此保護時，缺表會讓整頁 500（已用測試反向驗證）。
+- `c_textid=0` 不特別排除：它是真實可編輯的「未知」書目列，其下 37 筆關係人是「著作不明」的真實資料（角色含撰著者／編纂者），編目者編輯該列時需要看得到才能重新歸屬；改以 `isset($rowArray['c_textid'])` 區分「真的是 0」與「取不到欄位」。
+- 回歸測試 `CodesTextAuthorsTest`（8 tests：單作者含連結／同一人多角色不去重／未詳哨兵無連結／未知書目列仍列出自己的關係人／不跨書洩漏／無作者空清單／非 TEXT_CODES 無此 prop／上限截斷回報真實總數）。另以 headless Chrome 對真實庫驗證 12 項（含 98 位多作者全列與滾動、實際點擊跳轉後落在該作者的著述分頁）。
+
 ### 人物編輯中樞切分頁一律重抓資料（修「別人改了、切分頁看不到」）
 - 現象（使用者回報 `/app/basicinformation/{id}/edit`）：某條記錄被別人或自己在另一個瀏覽器分頁新增／刪除／修改後，在本頁切分頁（例如別名→親屬→別名）時，分頁徽章計數與列表內容都不變，必須整頁重載才看得到。
 - 根因一：`TabContentLoader` 的分頁資料是「一載入就永久快取」（同一 personId 不重複請求），切走再切回沿用首次載入的快照。此前兩個 commit 只修了**自己在本頁的修改**（409fd9e 徽章、7f8d7a8 基本資料切分頁顯示舊值），別人的修改仍看不到。

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -21,6 +21,14 @@ use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 
 class CodesController extends Controller {
+    /**
+     * TEXT_CODES 編輯頁作者清單的顯示上限。
+     *
+     * 目前全庫單書最多 98 位（2026-08 實測），200 留足餘裕；超過時前端會明示「顯示前 N 筆／共 M 筆」，
+     * 不像舊版 /api/select/search/textauthor 的 paginate(100) 那樣靜默截斷。
+     */
+    protected const TEXT_AUTHOR_DISPLAY_LIMIT = 200;
+
     protected $codesrepostory;
     protected $operationRepository;
 
@@ -937,6 +945,12 @@ class CodesController extends Controller {
             'required_columns' => $this->codeColumnFormMeta($table)['required'],
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
+            // TEXT_CODES：附上該書的作者／編者等關係人（唯讀錄入參考）。其餘碼表為 null，前端不渲染。
+            // 用 isset 而非 ?? 0：c_textid=0 是真實可編輯的「未知」書目列（其下掛著 37 筆關係人），
+            // 不能與「取不到 c_textid」混為一談而一律查 0。
+            'text_authors' => $table === 'TEXT_CODES' && isset($rowArray['c_textid'])
+                ? $this->textCodesAuthors((int) $rowArray['c_textid'])
+                : null,
             'urls' => [
                 'update' => route('app.codes.update', ['table_name' => $table, 'id' => $compositeId], false),
                 'propose' => route('app.codes.propose.update', ['table_name' => $table, 'id' => $compositeId], false),
@@ -947,6 +961,92 @@ class CodesController extends Controller {
                 'codes' => is_array($t = trans('codes')) ? $t : [],
             ],
         ]);
+    }
+
+    /**
+     * TEXT_CODES 編輯頁用：該書的作者／編者等關係人（唯讀，作為錄入參考）。
+     *
+     * 對齊舊版 codes/edit.blade.php 的作者區塊（2022-01 #186、2025-12 #655），但改為伺服器端一次 JOIN
+     * 隨頁面取回，修掉舊版三個問題：舊版走 /api/select/search/textauthor，每列再各查一次 BIOG_MAIN 與
+     * TEXT_ROLE_CODES（N+1）、paginate(100) 會靜默截斷、且連 c_personid=0（未詳哨兵）也給連結。
+     *
+     * BIOG_TEXT_DATA 主鍵為 (c_personid, c_role_id, c_textid)——含 c_role_id，故同一人可在同一本書
+     * 掛多個角色，須以 personid + role_id 成對回傳（前端 key 亦用此組合，不可只用 personid）。
+     * c_textid 固定時，ORDER BY c_personid, c_role_id 即為全序，截斷取的永遠是同一批前 N 筆。
+     *
+     * @return array{total: int, limit: int, items: array<int, array<string, mixed>>, failed: bool}
+     */
+    protected function textCodesAuthors(int $textId): array {
+        try {
+            // 不特別排除 c_textid=0：它是真實可編輯的「未知」書目列，其下 37 筆關係人是「著作不明」的
+            // 真實資料（角色含撰著者／編纂者），舊版也照列。編目者編輯該列時看得到才能重新歸屬。
+            // 這個 count 只餵截斷提示裡的數字（是否截斷由下方多取一筆決定，不靠它）。
+            // 目前全庫單書最多 98 筆、上限 200，提示實際上還用不到；仍保留是因為 c_textid 有索引、
+            // 單書 count 幾乎零成本，資料成長後才不必回頭補。
+            $total = (int) DB::table('BIOG_TEXT_DATA')->where('c_textid', $textId)->count();
+
+            $rows = DB::table('BIOG_TEXT_DATA as btd')
+                ->leftJoin('BIOG_MAIN as bm', 'bm.c_personid', '=', 'btd.c_personid')
+                ->leftJoin('TEXT_ROLE_CODES as trc', 'trc.c_role_id', '=', 'btd.c_role_id')
+                ->where('btd.c_textid', $textId)
+                ->orderBy('btd.c_personid')
+                ->orderBy('btd.c_role_id')
+                // 多取一筆用來判斷「是否還有更多」。若改用 total > count(items) 判斷，count 與 select
+                // 是兩次獨立查詢／快照，兩者之間插入一列就可能讓兩數相等而**靜默**吞掉截斷提示。
+                ->limit(self::TEXT_AUTHOR_DISPLAY_LIMIT + 1)
+                ->get([
+                    'btd.c_personid',
+                    'btd.c_role_id',
+                    'bm.c_name_chn',
+                    'bm.c_name',
+                    'trc.c_role_desc_chn',
+                    'trc.c_role_desc',
+                ]);
+        } catch (\Throwable $e) {
+            // 這一區只是唯讀的錄入參考，不該讓它把整個編輯頁打成 500——appEdit 的 try/catch 到本方法
+            // 呼叫點之前就結束了。舊版 AJAX 失敗時僅顯示紅字「載入失敗」、表單照樣可編輯可儲存，
+            // 這裡沿用同一語義：記錄例外後降級為失敗態，前端以同一個 codes.load_failed 提示。
+            report($e);
+
+            return [
+                'total' => 0,
+                'limit' => self::TEXT_AUTHOR_DISPLAY_LIMIT,
+                'items' => [],
+                'truncated' => false,
+                'failed' => true,
+            ];
+        }
+
+        $truncated = $rows->count() > self::TEXT_AUTHOR_DISPLAY_LIMIT;
+        $rows = $rows->take(self::TEXT_AUTHOR_DISPLAY_LIMIT);
+
+        $items = [];
+        foreach ($rows as $row) {
+            $personId = (int) $row->c_personid;
+
+            $items[] = [
+                'c_personid' => $personId,
+                'c_role_id' => (int) $row->c_role_id,
+                'name_chn' => $row->c_name_chn,
+                'name' => $row->c_name,
+                'role_chn' => $row->c_role_desc_chn,
+                'role' => $row->c_role_desc,
+                // c_personid=0 是「未詳」哨兵（BIOG_MAIN 確實有這一列），跳過去沒有意義，故不給連結。
+                // 其餘指向 React 人物中樞的著述分頁（對齊舊版連到該人物 texts 的語義）。
+                'url' => $personId > 0
+                    ? route('app.basicinformation.show', ['id' => $personId, 'tab' => 'texts'], false)
+                    : null,
+            ];
+        }
+
+        return [
+            // total 是「關係列」數而非人數——同一人的多個角色是多列（見上方主鍵說明），前端字串用「筆」。
+            'total' => $total,
+            'limit' => self::TEXT_AUTHOR_DISPLAY_LIMIT,
+            'items' => $items,
+            'truncated' => $truncated,
+            'failed' => false,
+        ];
     }
 
     public function update(Request $request, $table_name, $id) {

--- a/resources/js/inertia/Pages/Codes/Edit.tsx
+++ b/resources/js/inertia/Pages/Codes/Edit.tsx
@@ -8,6 +8,7 @@ import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
 import { ProposalModeDialog } from '../../components/ui/ProposalModeDialog';
 import { PinyinUmlautConfirmDialog } from '../../components/PinyinUmlautConfirmDialog';
 import { collectUmlautConversions, type Tier2UmlautHit } from '../../utils/pinyinUmlaut';
+import { TextCodesAuthorList, type TextAuthors } from '../../components/TextCodesAuthorList';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { SharedProps } from '../../types/page';
 
@@ -25,12 +26,14 @@ interface CodesEditPageProps extends SharedProps {
     required_columns?: string[];
     can_propose: boolean;
     tier2_fields?: string[];
+    /** 僅 TEXT_CODES 有值（該書的作者／編者等關係人）；其餘碼表為 null。 */
+    text_authors?: TextAuthors | null;
     urls: { update: string; propose: string; destroy: string; show: string };
 }
 
 export default function CodesEdit() {
     const props = usePage<CodesEditPageProps>().props;
-    const { table, columns, values, key_columns, required_columns, can_propose, tier2_fields, urls } = props;
+    const { table, columns, values, key_columns, required_columns, can_propose, tier2_fields, text_authors, urls } = props;
     const requiredSet = new Set(required_columns ?? []);
     const t = useTranslation('codes');
     const tc = useTranslation('common');
@@ -80,6 +83,16 @@ export default function CodesEdit() {
             breadcrumbs={[{ label: 'Codes', url: '/app/codes' }, { label: table, url: urls.show }, { label: tc('edit') }]}
         >
             <form onSubmit={submit} className="max-w-3xl space-y-3 rounded-lg border border-border bg-card p-4">
+                {/* TEXT_CODES：作者／編者等關係人（唯讀錄入參考），置於欄位之上、對齊舊版版位。
+                    不用 FormField：它會把 id 注入單一子節點並讓 <label for> 指過去，而這一區沒有
+                    表單控制項，label 指向 <div> 是無效關聯；改用純標題文字。 */}
+                {text_authors && (
+                    <div className="space-y-1">
+                        <p className="text-sm font-medium">{t('author_label')}</p>
+                        <TextCodesAuthorList authors={text_authors} t={t} />
+                    </div>
+                )}
+
                 {columns.map((col) => (
                     <FormField
                         key={col}

--- a/resources/js/inertia/components/TextCodesAuthorList.tsx
+++ b/resources/js/inertia/components/TextCodesAuthorList.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { formatBilingualLabel } from './PersonBrowser/shared/formatters';
+
+/**
+ * TEXT_CODES 編輯頁的作者／編者等關係人清單（唯讀，作為錄入參考）。
+ *
+ * 對齊舊版 codes/edit.blade.php 的作者區塊（2022-01 #186、2025-12 #655）——該區塊在 2026-06-26
+ * React/Inertia 上線（3f131d6）時漏移植，正式站上就此消失；此元件補回。
+ *
+ * 資料由後端 CodesController::textCodesAuthors() 隨頁面一次取回（非 AJAX），故無載入態；
+ * 但保留失敗態：後端查詢失敗時降級成提示，讓表單本身仍可編輯可儲存（對齊舊版 AJAX 失敗行為）。
+ */
+
+export interface TextAuthor {
+    c_personid: number;
+    c_role_id: number;
+    name_chn: string | null;
+    name: string | null;
+    role_chn: string | null;
+    role: string | null;
+    /** 該作者的著述分頁；c_personid=0（未詳哨兵）為 null，不給連結。 */
+    url: string | null;
+}
+
+export interface TextAuthors {
+    /** 關係列總數（非人數：同一人的多個角色分列計算）。 */
+    total: number;
+    /** 後端的顯示上限。 */
+    limit: number;
+    items: TextAuthor[];
+    /**
+     * 後端判定「還有更多未顯示」。刻意由後端多取一筆判斷，而非在前端比較 total 與 items.length——
+     * total 來自另一次 count 查詢，兩者之間若有寫入就會相等而漏掉提示。
+     */
+    truncated: boolean;
+    /** 後端查詢失敗（降級態）；此時 items 為空但不代表這本書沒有作者。 */
+    failed: boolean;
+}
+
+/** 超過此筆數改為可滾動清單（對齊舊版的 5 筆門檻）。 */
+const SCROLL_THRESHOLD = 5;
+
+interface Props {
+    authors: TextAuthors;
+    t: (key: string, replace?: Record<string, string>) => string;
+}
+
+export function TextCodesAuthorList({ authors, t }: Props) {
+    const { total, items, failed, truncated } = authors;
+
+    // 失敗態與空態都不顯示操作提示（提示在講「點人名可跳轉」，此時無人名可點）。
+    if (failed) {
+        return <p className="text-sm text-destructive">{t('load_failed')}</p>;
+    }
+
+    if (items.length === 0) {
+        return <p className="text-sm text-muted-foreground">{t('no_author_data')}</p>;
+    }
+
+    const scrolling = items.length > SCROLL_THRESHOLD;
+    // 截斷時 total 至少是「已顯示 + 1」：count 與 select 之間若有寫入，count 可能落後，
+    // 但提示本身已由後端的 truncated 決定，不會消失。
+    const reportedTotal = Math.max(total, items.length + 1);
+
+    return (
+        <div className="space-y-1">
+            <ul
+                className={
+                    'm-0 list-none space-y-1 p-0 text-sm'
+                    // 可滾動時給邊框與底色（對齊舊版 .author-list-scroll）：細/覆蓋式滾動條在
+                    // Windows/macOS 預設看不見，沒有這個框使用者不會知道下面還有列。
+                    + (scrolling ? ' max-h-40 overflow-y-auto rounded-md border border-border bg-muted/30 p-2 pr-2' : '')
+                }
+            >
+                {items.map((a) => {
+                    const person = formatBilingualLabel(a.name_chn, a.name) ?? t('author_unknown_person');
+                    const role = formatBilingualLabel(a.role_chn, a.role);
+
+                    return (
+                        // 同一人可在同一本書掛多個角色（BIOG_TEXT_DATA 主鍵
+                        // (c_personid, c_role_id, c_textid) 含 c_role_id），
+                        // 故 key 必須是 personid + role_id 這組複合鍵，不可只用 personid。
+                        <li key={`${a.c_personid}-${a.c_role_id}`}>
+                            {a.url ? (
+                                <a
+                                    href={a.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary hover:underline"
+                                >
+                                    [{a.c_personid}] {person}
+                                </a>
+                            ) : (
+                                // c_personid=0（未詳）：跳過去沒有意義，顯示為純文字。
+                                <span className="text-muted-foreground">[{a.c_personid}] {person}</span>
+                            )}
+                            {role && <span className="text-muted-foreground"> — {role}</span>}
+                        </li>
+                    );
+                })}
+            </ul>
+            {truncated && (
+                <p className="text-xs text-muted-foreground">
+                    {t('author_truncated', { total: String(reportedTotal), shown: String(items.length) })}
+                </p>
+            )}
+            <p className="text-xs text-muted-foreground">{t('author_hint')}</p>
+        </div>
+    );
+}

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -127,6 +127,11 @@ return [
     'proposal_ignore_hint' => 'If you save directly, this field will be ignored.',
     'no_textid_msg' => 'No c_textid, cannot load author.',
     'no_author_data' => 'No author data',
+    // TEXT_CODES edit page author block (React version)
+    'author_hint' => 'Read-only reference; click a linked name to open that author\'s texts page in a new tab (unknown persons are not linked).',
+    'author_unknown_person' => 'Unknown (no matching person record)',
+    // "entries" not "people": one person holding several roles counts as several entries.
+    'author_truncated' => ':total entries in total (each role counted separately), showing the first :shown',
     'load_failed' => 'Load failed',
     'load_no_data_alert' => 'Load Data: No results found',
     'load_success_alert' => 'Load Data: Updated c_instance_title_chn and c_instance_title',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -125,6 +125,11 @@ return [
     'proposal_ignore_hint' => '如果直接儲存，此欄位會被忽略。',
     'no_textid_msg' => '無 c_textid，無法載入作者',
     'no_author_data' => '無作者資料',
+    // TEXT_CODES 編輯頁作者區塊（React 版）
+    'author_hint' => '唯讀，作為錄入參考；點有連結的人名可另開該作者的著述頁（未詳者無連結）',
+    'author_unknown_person' => '未詳（無對應人物記錄）',
+    // 「筆」而非「位」：同一人可掛多個角色，一人可能佔多筆，這裡數的是關係列。
+    'author_truncated' => '共 :total 筆（同一人的多個角色分列計算），僅顯示前 :shown 筆',
     'load_failed' => '載入失敗',
     'load_no_data_alert' => 'Load Data：無查詢結果',
     'load_success_alert' => 'Load Data：已更新 c_instance_title_chn 與 c_instance_title',

--- a/tests/Feature/CodesTextAuthorsTest.php
+++ b/tests/Feature/CodesTextAuthorsTest.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * TEXT_CODES 編輯頁的作者清單（app.codes.edit → text_authors prop）。
+ *
+ * 這個區塊原本存在於舊版 codes/edit.blade.php（2022-01 #186、2025-12 #655），
+ * 2026-06-26 React/Inertia 上線（3f131d6）時漏移植而消失；此測試鎖住補回後的行為，
+ * 包含舊版三個缺陷的修正：N+1、paginate(100) 靜默截斷、未詳哨兵也給連結。
+ */
+class CodesTextAuthorsTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-codes-text-authors';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['codes.tables' => ['TEXT_CODES' => '書名代碼', 'TEST_PLAIN_CODES' => '無作者的表']]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('TEXT_CODES', function ($table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title_chn')->nullable();
+            $table->string('c_title')->nullable();
+        });
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 12497, 'c_title_chn' => '雪篷夜話', 'c_title' => 'xue peng ye hua'],
+            ['c_textid' => 777, 'c_title_chn' => '無作者書', 'c_title' => 'wu zuo zhe shu'],
+            ['c_textid' => 888, 'c_title_chn' => '多角色書', 'c_title' => 'duo jue se shu'],
+            // c_textid=0 是真實可編輯的「未知」書目列（正式庫確實存在，title=未知）
+            ['c_textid' => 0, 'c_title_chn' => '未知', 'c_title' => 'Weizhi'],
+        ]);
+
+        Schema::create('TEST_PLAIN_CODES', function ($table) {
+            $table->integer('code_id')->primary();
+            $table->string('description')->nullable();
+        });
+        DB::table('TEST_PLAIN_CODES')->insert(['code_id' => 1, 'description' => 'x']);
+
+        Schema::create('BIOG_MAIN', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+        });
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 0, 'c_name_chn' => '未詳', 'c_name' => 'Weixiang'],
+            ['c_personid' => 47509, 'c_name_chn' => '陳善', 'c_name' => 'Chen Shan'],
+            ['c_personid' => 68294, 'c_name_chn' => '胡纘宗', 'c_name' => 'Hu Zuanzong'],
+        ]);
+
+        Schema::create('TEXT_ROLE_CODES', function ($table) {
+            $table->integer('c_role_id')->primary();
+            $table->string('c_role_desc')->nullable();
+            $table->string('c_role_desc_chn')->nullable();
+        });
+        DB::table('TEXT_ROLE_CODES')->insert([
+            ['c_role_id' => 0, 'c_role_desc' => 'unknown', 'c_role_desc_chn' => '未詳'],
+            ['c_role_id' => 1, 'c_role_desc' => 'author', 'c_role_desc_chn' => '撰著者'],
+            ['c_role_id' => 3, 'c_role_desc' => 'compiler', 'c_role_desc_chn' => '編纂者'],
+        ]);
+
+        Schema::create('BIOG_TEXT_DATA', function ($table) {
+            $table->integer('c_textid');
+            $table->integer('c_personid');
+            $table->integer('c_role_id');
+            $table->primary(['c_textid', 'c_personid', 'c_role_id']);
+        });
+        DB::table('BIOG_TEXT_DATA')->insert([
+            // 使用者回報的那本書：單一作者
+            ['c_textid' => 12497, 'c_personid' => 47509, 'c_role_id' => 0],
+            // 同一人在同一本書掛兩個角色（真實資料存在，如 textid 14790 / personid 68294）
+            ['c_textid' => 888, 'c_personid' => 68294, 'c_role_id' => 0],
+            ['c_textid' => 888, 'c_personid' => 68294, 'c_role_id' => 3],
+            // 未詳哨兵作者（c_personid=0），真實資料有 2569 筆
+            ['c_textid' => 888, 'c_personid' => 0, 'c_role_id' => 1],
+            // c_textid=0（「未知」書目）下掛的關係人：不得洩漏到其他書，但編輯該列時要看得到
+            ['c_textid' => 0, 'c_personid' => 47509, 'c_role_id' => 1],
+        ]);
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->string('resource')->nullable();
+            $table->text('resource_id')->nullable();
+            $table->string('op_type')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /** 同一個測試可能發多次請求（如 displayLimit()），故取用既有帳號而非每次新建。 */
+    private function activeUser(): User {
+        return User::firstOrCreate(
+            ['email' => 'u@example.com'],
+            [
+                'name' => 'U', 'password' => bcrypt('x'),
+                'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+            ]
+        );
+    }
+
+    private function editTextCode(int $textId) {
+        return $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEXT_CODES', 'id' => $textId]));
+    }
+
+    /** 顯示上限取自受測程式自己回報的值，避免測試把 200 這個數字寫死。 */
+    private function displayLimit(): int {
+        $limit = null;
+        $this->editTextCode(12497)->assertInertia(function (Assert $page) use (&$limit) {
+            $limit = $page->toArray()['props']['text_authors']['limit'];
+        });
+
+        return (int) $limit;
+    }
+
+    #[Test]
+    public function text_codes_edit_lists_the_author_with_a_link_to_that_person(): void {
+        $this->editTextCode(12497)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Edit')
+                ->where('text_authors.total', 1)
+                ->has('text_authors.items', 1)
+                ->where('text_authors.items.0.c_personid', 47509)
+                ->where('text_authors.items.0.name_chn', '陳善')
+                ->where('text_authors.items.0.name', 'Chen Shan')
+                ->where('text_authors.items.0.role_chn', '未詳')
+                ->where('text_authors.items.0.role', 'unknown')
+                // 「直接跳轉到那個作者」：連到該作者的著述分頁
+                ->where('text_authors.items.0.url', '/app/basicinformation/47509?tab=texts'));
+    }
+
+    #[Test]
+    public function author_list_keeps_one_row_per_role_for_the_same_person(): void {
+        // BIOG_TEXT_DATA 主鍵含 c_role_id：同一人的多個角色是不同列，不可被去重掉。
+        $this->editTextCode(888)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', 3)
+                ->has('text_authors.items', 3)
+                // 排序：c_personid 再 c_role_id
+                ->where('text_authors.items.0.c_personid', 0)
+                ->where('text_authors.items.1.c_personid', 68294)
+                ->where('text_authors.items.1.c_role_id', 0)
+                ->where('text_authors.items.2.c_personid', 68294)
+                ->where('text_authors.items.2.c_role_id', 3)
+                ->where('text_authors.items.2.role_chn', '編纂者'));
+    }
+
+    #[Test]
+    public function unknown_person_sentinel_gets_no_link(): void {
+        // c_personid=0 是「未詳」哨兵，跳過去沒有意義；舊版對它也給連結，這裡刻意不給。
+        $this->editTextCode(888)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.items.0.c_personid', 0)
+                ->where('text_authors.items.0.url', null)
+                ->where('text_authors.items.1.url', '/app/basicinformation/68294?tab=texts'));
+    }
+
+    #[Test]
+    public function unknown_book_row_still_lists_its_own_relations(): void {
+        // c_textid=0（「未知」書目）是真實可編輯的列，其下的關係人是「著作不明」的真實資料，
+        // 編目者要看得到才能重新歸屬——不可因為它是哨兵值就整區清空。
+        $this->editTextCode(0)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', 1)
+                ->has('text_authors.items', 1)
+                ->where('text_authors.items.0.c_personid', 47509));
+    }
+
+    #[Test]
+    public function authors_do_not_leak_between_books(): void {
+        // 12497 只有它自己的那一筆，不會撈到掛在 c_textid=0 底下的同一個人。
+        $this->editTextCode(12497)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', 1)
+                ->where('text_authors.items.0.c_role_id', 0));
+    }
+
+    #[Test]
+    public function book_without_authors_returns_empty_list(): void {
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', 0)
+                ->has('text_authors.items', 0));
+    }
+
+    #[Test]
+    public function author_query_failure_degrades_instead_of_breaking_the_edit_page(): void {
+        // appEdit 的 try/catch 在呼叫 textCodesAuthors() 之前就結束了，若不自行接住例外，
+        // 這個唯讀參考區塊的 DB 失敗會把整個編輯頁打成 500、連編輯都做不了。
+        // 舊版 AJAX 失敗時只是顯示紅字「載入失敗」、表單照樣可用，這裡必須維持同樣的爆炸半徑。
+        Schema::drop('BIOG_TEXT_DATA');
+
+        $this->editTextCode(12497)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Edit')
+                ->where('text_authors.failed', true)
+                ->has('text_authors.items', 0)
+                // 表單本身仍完整可編輯
+                ->where('values.c_textid', 12497)
+                ->has('urls.update'));
+    }
+
+    #[Test]
+    public function successful_author_query_is_not_marked_failed(): void {
+        $this->editTextCode(12497)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.failed', false)
+                ->where('text_authors.truncated', false));
+    }
+
+    #[Test]
+    public function list_exactly_at_the_limit_is_not_marked_truncated(): void {
+        // 邊界：剛好等於上限不算截斷（多取一筆的判斷法不可 off-by-one）。
+        $limit = $this->displayLimit();
+        $rows = [];
+        for ($i = 1; $i <= $limit - 1; $i++) { // 777 已有 0 筆；補到剛好 $limit
+            $pid = 200000 + $i;
+            DB::table('BIOG_MAIN')->insert(['c_personid' => $pid, 'c_name_chn' => 'Q' . $i, 'c_name' => 'Q' . $i]);
+            $rows[] = ['c_textid' => 777, 'c_personid' => $pid, 'c_role_id' => 1];
+        }
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 200000, 'c_name_chn' => 'Q0', 'c_name' => 'Q0']);
+        $rows[] = ['c_textid' => 777, 'c_personid' => 200000, 'c_role_id' => 1];
+        DB::table('BIOG_TEXT_DATA')->insert($rows);
+
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', $limit)
+                ->has('text_authors.items', $limit)
+                ->where('text_authors.truncated', false));
+    }
+
+    #[Test]
+    public function other_code_tables_get_no_author_prop(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEST_PLAIN_CODES', 'id' => 1]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Codes/Edit')
+                ->where('text_authors', null));
+    }
+
+    #[Test]
+    public function author_list_is_capped_and_reports_the_true_total(): void {
+        // 舊版端點 paginate(100) 會靜默截斷；改為回報真實總數 + 上限，讓前端能明示。
+        // 上限值由 prop 自己回報（不硬寫 200），改常數時此測試會跟著走而非莫名轉紅。
+        $limit = $this->displayLimit();
+        $overflow = 5;
+
+        // 刻意以「c_personid 遞減」的順序插入，讓「有排序」與「照插入順序」在結果上可區分：
+        // 若少了 ORDER BY，SQLite 會回插入順序（大的 personid 在前），下面的邊界斷言就會失敗。
+        $rows = [];
+        for ($i = $limit + $overflow; $i >= 1; $i--) {
+            $pid = 100000 + $i;
+            DB::table('BIOG_MAIN')->insert(['c_personid' => $pid, 'c_name_chn' => 'P' . $i, 'c_name' => 'P' . $i]);
+            $rows[] = ['c_textid' => 777, 'c_personid' => $pid, 'c_role_id' => 1];
+        }
+        DB::table('BIOG_TEXT_DATA')->insert($rows);
+
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', $limit + $overflow)
+                ->where('text_authors.limit', $limit)
+                ->has('text_authors.items', $limit)
+                // truncated 由後端多取一筆判斷，不是前端比較 total 與 items 長度（見 CodesController）
+                ->where('text_authors.truncated', true)
+                // 截斷取的必須是「排序後的前 N 筆」而非任意 N 筆：
+                // 最小的 personid 在首、被切掉的是最大的那幾個。
+                ->where('text_authors.items.0.c_personid', 100001)
+                ->where('text_authors.items.' . ($limit - 1) . '.c_personid', 100000 + $limit));
+    }
+
+    #[Test]
+    public function author_list_is_ordered_by_person_then_role(): void {
+        // 排序是截斷可預測的前提，且不可依賴資料庫的插入順序。以亂序插入後斷言完整順序。
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 500, 'c_name_chn' => 'A', 'c_name' => 'A'],
+            ['c_personid' => 100, 'c_name_chn' => 'B', 'c_name' => 'B'],
+        ]);
+        DB::table('BIOG_TEXT_DATA')->insert([
+            ['c_textid' => 777, 'c_personid' => 500, 'c_role_id' => 1],
+            ['c_textid' => 777, 'c_personid' => 100, 'c_role_id' => 3],
+            ['c_textid' => 777, 'c_personid' => 500, 'c_role_id' => 0],
+            ['c_textid' => 777, 'c_personid' => 100, 'c_role_id' => 1],
+        ]);
+
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('text_authors.items', 4)
+                ->where('text_authors.items.0.c_personid', 100)
+                ->where('text_authors.items.0.c_role_id', 1)
+                ->where('text_authors.items.1.c_personid', 100)
+                ->where('text_authors.items.1.c_role_id', 3)
+                ->where('text_authors.items.2.c_personid', 500)
+                ->where('text_authors.items.2.c_role_id', 0)
+                ->where('text_authors.items.3.c_personid', 500)
+                ->where('text_authors.items.3.c_role_id', 1));
+    }
+
+    #[Test]
+    public function person_missing_from_biog_main_still_renders_a_row(): void {
+        // LEFT JOIN 落空（BIOG_MAIN 無此人）時不可整列消失——舊版會把 null 當物件用而印出殘缺文字。
+        // 姓名回傳 null，由前端以 author_unknown_person 顯示。
+        DB::table('BIOG_TEXT_DATA')->insert(['c_textid' => 777, 'c_personid' => 999111, 'c_role_id' => 1]);
+
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('text_authors.total', 1)
+                ->has('text_authors.items', 1)
+                ->where('text_authors.items.0.c_personid', 999111)
+                ->where('text_authors.items.0.name_chn', null)
+                ->where('text_authors.items.0.name', null)
+                // 仍給連結：這是資料缺漏，人物頁本身可能存在（或讓使用者看到 404 也比整列消失好）
+                ->where('text_authors.items.0.url', '/app/basicinformation/999111?tab=texts'));
+    }
+
+    #[Test]
+    public function role_missing_from_role_codes_still_renders_a_row(): void {
+        DB::table('BIOG_TEXT_DATA')->insert(['c_textid' => 777, 'c_personid' => 47509, 'c_role_id' => 4242]);
+
+        $this->editTextCode(777)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('text_authors.items', 1)
+                ->where('text_authors.items.0.c_role_id', 4242)
+                ->where('text_authors.items.0.role_chn', null)
+                ->where('text_authors.items.0.role', null));
+    }
+}


### PR DESCRIPTION
## 問題

使用者回報 `/app/codes/TEXT_CODES/12497/edit` 不再顯示作者。查證後確認**不是誤記，也不是刻意移除，是 React 遷移時漏移植**：

- 作者區塊只存在於舊版 `resources/views/codes/edit.blade.php`（2022-01 #186 引入、2025-12 #655 改善多作者顯示）。
- **2026-06-26 React/Inertia 上線（3f131d6）時沒有跟著搬**，而同一個 commit 把 `codes` flag 翻成 `new`，功能自此在正式站消失。
- 三項旁證：後端端點 `/api/select/search/textauthor` 完好（12497 回 1 筆、35232 回 98 筆）；翻譯鍵 `author_label`／`no_author_data` 留在原地無人使用；React 端零引用。

本機以真實瀏覽器對照兩個版本（同一台、同一個資料庫）：舊版 Blade 頁完整列出作者（35232 有 98 個 `<li>`、98 個人物連結），React 頁**連請求都沒發**。

## 修法

改為**伺服器端隨 Inertia 頁面一次 JOIN 取回**（`CodesController::textCodesAuthors()` → `text_authors` prop），而非重建舊版的 AJAX。順手修掉舊版三個缺陷：

| 舊版問題 | 現行 |
|---|---|
| 每列再各查一次 `BIOG_MAIN` 與 `TEXT_ROLE_CODES`（N+1） | 一次三表 LEFT JOIN |
| `paginate(100)` 靜默截斷 | 明示「共 N 筆，僅顯示前 M 筆」（上限 200；全庫單書最多 98） |
| `c_personid=0`（未詳哨兵）也給連結 | 不給連結，顯示為灰字 |
| 人物或角色查不到時印出殘缺字串 | 姓名回傳 null，前端顯示「未詳（無對應人物記錄）」；角色缺失則省略 |

**可直接跳轉到作者**：每位作者連到 `/app/basicinformation/{id}?tab=texts`（該作者的著述分頁，對齊舊版語義；此路徑正是 `LegacyBladeFormGate` 把舊 URL 導向的目標，直連只是省一次 302）。另開新分頁——本頁沒有 dirty 守衛，同分頁跳轉會靜默丟掉表單上已輸入的內容，而這一區就在欄位正上方、最容易誤點。

`BIOG_TEXT_DATA` 主鍵為 `(c_personid, c_role_id, c_textid)`、含 `c_role_id`，同一人可在同一本書掛多個角色（真實案例：text 14790／person 68294），故逐（人物, 角色）成對列出，React key 用此複合鍵；`c_textid` 固定時 `ORDER BY c_personid, c_role_id` 即全序，截斷取的永遠是同一批前 N 筆。

## 審查發現並修掉的問題

- **唯讀參考區塊原本會把整頁打成 500**（本 PR 中途引入）：`appEdit` 的 `try/catch` 在呼叫點之前就結束，缺表時 `QueryException` 直接冒出去——比舊版更糟（舊版 AJAX 失敗只顯示紅字「載入失敗」、表單照樣可編輯可儲存）。改為本方法自行接住 `\Throwable`、`report()` 後降級為 `failed` 態，前端顯示既有的 `codes.load_failed`。已用暫時移除 `catch` 的方式反向驗證新測試會轉紅（500 ≠ 200）。
- **`c_textid=0` 原本被我特別排除**，理由還寫錯了：它是**真實可編輯的「未知」書目列**，其下 37 筆關係人是「著作不明」的真實資料（角色含撰著者／編纂者），舊版也照列，編目者編輯該列時需要看得到才能重新歸屬。改以 `isset($rowArray['c_textid'])` 區分「真的是 0」與「取不到欄位」。
- **count／select 競態會靜默吞掉截斷提示**：改由後端多取一筆判斷 `truncated`，不再用 `total` 與 `items.length` 相比（兩者是獨立查詢，中間有寫入就會相等）。
- **量詞錯誤**：截斷提示原寫「共 N 位」，但同一人的多個角色是多筆，改為「筆」／"entries"。
- **主鍵欄位順序寫錯**：docblock 原寫 `(c_textid, c_personid, c_role_id)`，實際是 `(c_personid, c_role_id, c_textid)`（已對 `SHOW CREATE TABLE` 核對）。
- 可滾動時補回邊框與底色（對齊舊版 `.author-list-scroll`）：細／覆蓋式滾動條在 Windows 與 macOS 預設看不見，沒有這個框使用者不會知道下面還有列。
- 連結色改用 `text-primary`（與 `Pages/Codes/Create.tsx`、`Index.tsx` 一致），標題改純文字而非 `FormField` 的 `label`（這一區沒有表單控制項，`label for` 指向 `div` 是無效關聯）。
- `author_hint` 原本承諾「點人名可跳轉」，但未詳哨兵不可點（正式庫有 2569 筆），已改為「點有連結的人名…（未詳者無連結）」。

## 測試

- `CodesTextAuthorsTest`（14 tests）：單作者含連結／同一人多角色不去重／排序為人物再角色／未詳哨兵無連結／「未知」書目列仍列出自己的關係人／不跨書洩漏／LEFT JOIN 落空仍成列（人物與角色兩種）／查詢失敗降級不 500／上限截斷回報真實總數／剛好等於上限不算截斷／非 TEXT_CODES 無此 prop。上限值取自 prop 自己回報的數字，不硬寫 200。
- headless Chrome 對真實 MariaDB 驗證 13 項：作者名／ID／角色／連結與 `target=_blank`；98 位多作者全數列出並套用滾動樣式；`c_personid=0` 不可點而同書其他作者可點；**實際點擊後落在 `47509 · 陳善 (Chen Shan) · 宋` 的著述分頁**；其他碼表不出現此區塊。
- `./vendor/bin/phpunit` 2443 tests 綠；`php-cs-fixer`（清 cache）零改動；`npm run build` 通過；`tsc` 錯誤行數與修改前相同（51，皆為既有問題）。

## 範圍與後續

- 作者區塊在舊版**只存在於編輯頁**（`create.blade.php`／`show.blade.php` 從來沒有），故 `Pages/Codes/Create.tsx`／`Show.tsx` 不加是對的。`Pages/Codes/ProposalEdit.tsx` 是 React 時代才有的介面、無舊版對應，未加屬一致性缺口而非回歸。
- `/api/select/search/textauthor` 與 `loading_author`／`no_textid_msg` 等鍵**不可現在刪**：舊版 Blade 仍在用，且 codes 系列的 legacy 路由沒有 flag gate，`/codes/TEXT_CODES/{id}/edit` 目前仍可直接開。建議列入 Phase 7 AdminLTE 下架清單一併移除。
- 現在同時存在兩份「某書作者」實作（上限 100 vs 200、哨兵處理與角色語言不同），這是 flag-gated 遷移的固有狀態，Phase 7 收斂。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
