### PR TITLE
修正親屬編輯頁人物自動完成偶爾誤帶不相干候選的問題

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -26,6 +26,7 @@ use App\Repositories\NianHaoRepository;
 use App\Repositories\YearRangeRepository;
 use App\Services\PinyinDictionary;
 use App\Services\VariantCharNormalizer;
+use App\Support\ExactCodeMatchGuard;
 use App\Support\PinyinUmlaut;
 use App\v1;
 use Illuminate\Http\Request;
@@ -168,7 +169,7 @@ class ApiController extends Controller {
 
     public function searchText(Request $request) {
         //20190708依據需求修改輸出內容
-        $data = TextCode::where('c_title_chn', 'like', '%'.$request->q.'%')->orWhere('c_title', 'like', '%'.$request->q.'%')->orWhere('c_textid', $request->q)->paginate(20);
+        $data = TextCode::where('c_title_chn', 'like', '%'.$request->q.'%')->orWhere('c_title', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_textid', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_textid;
@@ -241,7 +242,7 @@ class ApiController extends Controller {
         $baseQuery = OfficeCode::where(function ($q) use ($request) {
             $q->where('c_office_chn', 'like', '%'.$request->q.'%')
                 ->orWhere('c_office_pinyin', 'like', '%'.$request->q.'%')
-                ->orWhere('c_office_id', $request->q);
+                ->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q2) => $q2->orWhere('c_office_id', $request->q));
         });
 
         if ((int) $request->c_dy > 0) {
@@ -272,7 +273,7 @@ class ApiController extends Controller {
     }
 
     public function socialinst(Request $request) {
-        $data = SocialInst::where('c_inst_name_hz', 'like', '%'.$request->q.'%')->orWhere('c_inst_name_py', 'like', '%'.$request->q.'%')->orWhere('c_inst_name_code', $request->q)->paginate(20);
+        $data = SocialInst::where('c_inst_name_hz', 'like', '%'.$request->q.'%')->orWhere('c_inst_name_py', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_inst_name_code', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_inst_name_code;
@@ -422,7 +423,7 @@ class ApiController extends Controller {
     }
 
     public function searchEntry(Request $request) {
-        $data = EntryCode::where('c_entry_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_entry_desc', 'like', '%'.$request->q.'%')->orWhere('c_entry_code', $request->q)->paginate(20);
+        $data = EntryCode::where('c_entry_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_entry_desc', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_entry_code', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_entry_code;
@@ -436,7 +437,7 @@ class ApiController extends Controller {
     }
 
     public function searchKincode(Request $request) {
-        $data = KinshipCode::where('c_kinrel_chn', 'like', '%'.$request->q.'%')->orWhere('c_kinrel', 'like', '%'.$request->q.'%')->orWhere('c_kincode', $request->q)->paginate(20);
+        $data = KinshipCode::where('c_kinrel_chn', 'like', '%'.$request->q.'%')->orWhere('c_kinrel', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_kincode', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_kincode;
@@ -450,7 +451,7 @@ class ApiController extends Controller {
     }
 
     public function searchAssoccode(Request $request) {
-        $data = AssocCode::where('c_assoc_desc', 'like', '%'.$request->q.'%')->orWhere('c_assoc_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_assoc_code', $request->q)->paginate(20);
+        $data = AssocCode::where('c_assoc_desc', 'like', '%'.$request->q.'%')->orWhere('c_assoc_desc_chn', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_assoc_code', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_assoc_code;
@@ -464,7 +465,7 @@ class ApiController extends Controller {
     }
 
     public function searchStatuscode(Request $request) {
-        $data = StatusCode::where('c_status_desc', 'like', '%'.$request->q.'%')->orWhere('c_status_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_status_code', $request->q)->paginate(20);
+        $data = StatusCode::where('c_status_desc', 'like', '%'.$request->q.'%')->orWhere('c_status_desc_chn', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_status_code', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_status_code;
@@ -522,10 +523,12 @@ class ApiController extends Controller {
 
                 $data = $query->paginate($num);
             } else {
-                // 回退方案：FTS 未找到結果時，使用原有的 LIKE 查詢（§D-8：c_name 以展開集 OR 同查 v／ü 形）
+                // 回退方案：FTS 未找到結果時，使用原有的 LIKE 查詢（§D-8：c_name 以展開集 OR 同查 v／ü 形）。
+                // 註：走到這個 else 分支時 $request->q 必為非純數字（純數字已在上方 ctype_digit 分支處理），
+                // 不再加 orWhere('c_personid', $request->q)——否則 MySQL/MariaDB 會把非數字字串寬鬆轉型成 0，
+                // 誤中 c_personid=0（「未詳」占位列）。
                 $data = BiogMain::where(function ($sub) use ($request, $qForms) {
-                    $sub->where('c_name_chn', 'like', '%'.$request->q.'%')
-                        ->orWhere('c_personid', $request->q);
+                    $sub->where('c_name_chn', 'like', '%'.$request->q.'%');
                     foreach ($qForms as $form) {
                         $sub->orWhere('c_name', 'like', '%'.$form.'%');
                     }
@@ -547,7 +550,7 @@ class ApiController extends Controller {
     }
 
     public function searchEvent(Request $request) {
-        $data = EventCode::where('c_event_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_event_name', 'like', '%'.$request->q.'%')->orWhere('c_event_code', $request->q)->paginate(20);
+        $data = EventCode::where('c_event_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_event_name', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_event_code', $request->q))->paginate(20);
         $data->appends(['q' => $request->q])->links();
         foreach ($data as $item) {
             $item['id'] = $item->c_event_code;
@@ -562,7 +565,7 @@ class ApiController extends Controller {
 
     public function codeAddr(Request $request) {
         $num = is_null($request->num) ? 20 : $request->num;
-        $data = AddressCode::where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_addr_id', $request->q)->paginate($num);
+        $data = AddressCode::where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_addr_id', $request->q))->paginate($num);
         $data->appends(['q' => $request->q])->links();
 
         return $data;

--- a/app/Repositories/AddrCodeRepository.php
+++ b/app/Repositories/AddrCodeRepository.php
@@ -12,6 +12,7 @@ namespace App\Repositories;
 use App\Models\AddrBelong;
 use App\Models\AddrCode;
 use App\Models\AddressCode;
+use App\Support\ExactCodeMatchGuard;
 use Illuminate\Http\Request;
 
 /**
@@ -38,7 +39,7 @@ class AddrCodeRepository {
         if (!$request->q) {
             return AddressCode::select(['c_addr_id', 'c_name_chn', 'c_name'])->paginate($num);
         }
-        $names = AddressCode::select(['c_addr_id', 'c_name_chn', 'c_name'])->where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->orWhere('c_addr_id', $request->q)->paginate($num);
+        $names = AddressCode::select(['c_addr_id', 'c_name_chn', 'c_name'])->where('c_name_chn', 'like', '%'.$request->q.'%')->orWhere('c_name', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_addr_id', $request->q))->paginate($num);
         $names->appends(['q' => $request->q])->links();
 
         return $names;
@@ -84,7 +85,7 @@ class AddrCodeRepository {
         $query = AddrCode::where(function ($q) use ($request) {
             $q->where('c_name_chn', 'like', '%'.$request->q.'%')
                 ->orWhere('c_name', 'like', '%'.$request->q.'%')
-                ->orWhere('c_addr_id', $request->q);
+                ->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q2) => $q2->orWhere('c_addr_id', $request->q));
         });
 
         // 根據朝代起止年過濾地址：地址的 c_firstyear~c_lastyear 必須與朝代起止年有交集

--- a/app/Repositories/AltCodeRepository.php
+++ b/app/Repositories/AltCodeRepository.php
@@ -10,6 +10,7 @@
 namespace App\Repositories;
 
 use App\Models\AltnameCode;
+use App\Support\ExactCodeMatchGuard;
 use Illuminate\Http\Request;
 
 class AltCodeRepository {
@@ -20,7 +21,7 @@ class AltCodeRepository {
         if (!$request->q) {
             return AltnameCode::paginate($num);
         }
-        $names = AltnameCode::where('c_name_type_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_name_type_desc', 'like', '%'.$request->q.'%')->orWhere('c_name_type_code', $request->q)->paginate($num);
+        $names = AltnameCode::where('c_name_type_desc_chn', 'like', '%'.$request->q.'%')->orWhere('c_name_type_desc', 'like', '%'.$request->q.'%')->when(ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_name_type_code', $request->q))->paginate($num);
         $names->appends(['q' => $request->q])->links();
 
         return $names;

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -585,9 +585,11 @@ class BiogMainRepository {
                   ->where('A2.c_alt_name_type_code', '=', 5);
         });
 
+        // 註：走到這裡時 $request->q 必為非純數字（純數字已在上方 ctype_digit 分支處理），
+        // 不再加 orWhere('BIOG_MAIN.c_personid', $request->q)——否則 MySQL/MariaDB 會把非數字字串
+        // 寬鬆轉型成 0，誤中 c_personid=0（「未詳」占位列）。
         $names = $names->where(function ($query) use ($request, $qForms) {
-            $query->where('BIOG_MAIN.c_name_chn', 'like', '%'.$request->q.'%')
-                ->orWhere('BIOG_MAIN.c_personid', $request->q);
+            $query->where('BIOG_MAIN.c_name_chn', 'like', '%'.$request->q.'%');
             // §D-8：拼音／羅馬字欄位以展開集 OR 同查 v／ü 形（單一形輸入時 $qForms 僅一元、行為不變）。
             #20230626增加[外文全名]與[外文羅馬字轉寫姓名]可查得
             $pinyinCols = [
@@ -682,12 +684,12 @@ class BiogMainRepository {
             return self::appendUnknownDynastyFacet($validDynasties, $unknownCount);
         }
 
-        // 回退 LIKE 路徑
+        // 回退 LIKE 路徑（走到這裡時 $q 必為非純數字，見上方 ctype_digit 分支，
+        // 故不加 orWhere('BIOG_MAIN.c_personid', $q)，避免 MySQL/MariaDB 寬鬆轉型誤中 c_personid=0）。
         $fallbackBaseQuery = DB::table('BIOG_MAIN')
             ->leftJoin('DYNASTIES', 'DYNASTIES.c_dy', '=', 'BIOG_MAIN.c_dy')
             ->where(function ($query) use ($q, $qForms) {
-                $query->where('BIOG_MAIN.c_name_chn', 'like', '%' . $q . '%')
-                    ->orWhere('BIOG_MAIN.c_personid', $q);
+                $query->where('BIOG_MAIN.c_name_chn', 'like', '%' . $q . '%');
                 // §D-8：與 namesByQuery 一致，拼音／羅馬字欄位以展開集 OR 同查 v／ü 形。
                 $pinyinCols = [
                     'c_name', 'c_surname', 'c_mingzi',

--- a/app/Support/ExactCodeMatchGuard.php
+++ b/app/Support/ExactCodeMatchGuard.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * 各 search/* 端點常見寫法：LIKE 模糊比對 OR 代碼欄位精確比對（讓使用者可直接輸入代碼查詢）。
+ * 但代碼欄位多為整數型別，MySQL/MariaDB 在非嚴格模式下比對「整數欄位 = 非數字字串」時，
+ * 字串會被寬鬆轉型成 0，導致誤中代碼 0（多為「未詳」占位列）——使用者輸入人名／關鍵字搜尋時，
+ * 偶爾會在下拉候選中看到一筆不相干的「0 未詳」。
+ *
+ * 用法：只在 $q 為純數字時才附加代碼相等的 orWhere 分支，否則完全略過該分支
+ * （不使用任何「保證不存在」的哨兵值——代碼欄位多為有號 int 且無 UNSIGNED／CHECK 限制，
+ * 無法保證未來或既有資料不會出現負值代碼）。
+ *
+ *     $query->where('c_name_chn', 'like', '%'.$q.'%')
+ *         ->when(ExactCodeMatchGuard::isNumeric($q), fn ($q2) => $q2->orWhere('c_personid', $q));
+ */
+class ExactCodeMatchGuard {
+    public static function isNumeric(mixed $q): bool {
+        return ctype_digit((string) $q);
+    }
+}

--- a/app/v1.php
+++ b/app/v1.php
@@ -37,7 +37,7 @@ class v1 extends Model {
         $qForms = \App\Support\PinyinSearchNormalizer::expand($rawQ);
         $data = BiogMain::where(function ($sub) use ($request, $qForms) {
             $sub->where('c_name_chn', 'like', $request->q)
-                ->orWhere('c_personid', $request->q);
+                ->when(\App\Support\ExactCodeMatchGuard::isNumeric($request->q), fn ($q) => $q->orWhere('c_personid', $request->q));
             foreach ($qForms as $form) {
                 $sub->orWhere('c_name', 'like', $form);
             }

--- a/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
+++ b/resources/js/inertia/components/PersonBrowser/shared/CodeAutocomplete.tsx
@@ -134,6 +134,9 @@ export default function CodeAutocomplete(props: Props) {
     const [selectedLabel, setSelectedLabel] = useState<string>(initialLabel ?? '');
     const containerRef = useRef<HTMLDivElement>(null);
     const debounceRef = useRef<number | null>(null);
+    // search 模式用：避免舊查詢（如常見姓氏字首，結果多、後端較慢）晚於新查詢（字數更多、結果少）
+    // 回應，導致 setOptions 被過期回應覆蓋、下拉顯示與目前輸入不符的候選（如誤留一筆不相干的舊結果）。
+    const searchSeqRef = useRef(0);
 
     // 同步 initialLabel（編輯既有資料時）。
     useEffect(() => {
@@ -168,7 +171,18 @@ export default function CodeAutocomplete(props: Props) {
 
     // search 模式：依輸入 debounce 查詢。
     useEffect(() => {
-        if (props.mode !== 'search' || !open) {
+        if (props.mode !== 'search') {
+            return;
+        }
+        // 一進 effect（即使用者按鍵、開關下拉的當下）就立刻認領新序號，而非等 250ms debounce
+        // 觸發才認領：這樣任何仍在飛行中的舊查詢回應，只要使用者已再次按鍵／關閉下拉，
+        // 就立刻失效（seq 落後），不需等到下一次 debounce 真正送出新請求才失效——
+        // 否則舊回應可能剛好在「使用者已打字但新請求尚未送出」的空窗期回來，覆蓋畫面。
+        const seq = ++searchSeqRef.current;
+        if (!open) {
+            // 認領新 seq 已讓任何仍在飛行中的舊請求的 finally 失效（guard 擋下），
+            // 這裡改由本次 effect 負責重置 loading，避免卡在「載入中」。
+            setLoading(false);
             return;
         }
         if (debounceRef.current) {
@@ -177,20 +191,24 @@ export default function CodeAutocomplete(props: Props) {
         const q = query.trim();
         if (q === '') {
             setOptions([]);
+            setLoading(false);
             return;
         }
         debounceRef.current = window.setTimeout(() => {
             setLoading(true);
             setError(null);
             fetchSearch((props as SearchProps).endpoint, q, (props as SearchProps).extraQuery)
-                .then(setOptions)
-                .catch((e) => setError(e instanceof Error ? e.message : '查詢失敗'))
-                .finally(() => setLoading(false));
+                .then((opts) => { if (seq === searchSeqRef.current) setOptions(opts); })
+                .catch((e) => { if (seq === searchSeqRef.current) setError(e instanceof Error ? e.message : '查詢失敗'); })
+                .finally(() => { if (seq === searchSeqRef.current) setLoading(false); });
         }, 250);
         return () => {
             if (debounceRef.current) {
                 window.clearTimeout(debounceRef.current);
             }
+            // 防禦性處理：若 mode 從 'search' 切換離開（目前無呼叫端會動態切換，但避免未來新增
+            // 用法時遺漏），讓本次仍在飛行中的 search 請求跟著失效，不讓其回應影響切換後的狀態。
+            ++searchSeqRef.current;
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [query, open, props.mode]);

--- a/tests/Unit/ExactCodeMatchGuardTest.php
+++ b/tests/Unit/ExactCodeMatchGuardTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\ExactCodeMatchGuard;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 回歸測試：search/* 端點的「代碼相等」OR 分支必須只在輸入為純數字時生效。
+ * 背景：MySQL/MariaDB 非嚴格模式比對「整數欄位 = 非數字字串」時會把字串寬鬆轉型成 0，
+ * 導致使用者輸入人名（如「趙匡胤」）搜尋親屬姓名時，下拉候選誤中 c_personid=0（「未詳」占位列）。
+ */
+class ExactCodeMatchGuardTest extends TestCase {
+    #[Test]
+    public function purely_numeric_query_is_treated_as_a_code_lookup(): void {
+        $this->assertTrue(ExactCodeMatchGuard::isNumeric('123'));
+        $this->assertTrue(ExactCodeMatchGuard::isNumeric('0'));
+        $this->assertTrue(ExactCodeMatchGuard::isNumeric(0));
+    }
+
+    #[Test]
+    public function non_numeric_query_is_not_treated_as_a_code_lookup(): void {
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric('趙匡胤'));
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric('12a'));
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric('-1'));
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric(''));
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric(null));
+        $this->assertFalse(ExactCodeMatchGuard::isNumeric(' 123 '));
+    }
+}


### PR DESCRIPTION
## Summary
- 修正使用者回報：在親屬編輯頁 (`/app/basicinformation/{id}/kinship/edit-v2`) 的「親屬姓名（c_kin_id）」自動完成輸入人名後、選擇前稍等，下拉候選偶爾變成不相干結果（如「0 未詳」）的問題。
- 根因分兩個獨立部分，皆已修復：
  1. **後端**：多個 `search/*` 端點（含供此頁使用的 `/api/select/search/biog`，以及主要人物搜尋 `/api/name` 等其餘同類端點）在 LIKE 模糊比對之外，另用 `orWhere('id_col', $request->q)` 讓使用者可直接輸入代碼查詢；MySQL/MariaDB 非嚴格模式下整數欄位與非數字字串比較會把字串寬鬆轉型成 0，導致人名搜尋時偶爾誤中 `id=0`（「未詳」占位列）。新增 `App\Support\ExactCodeMatchGuard::isNumeric()`，僅在輸入為純數字時才附加代碼相等分支。
  2. **前端**：全站共用的自動完成元件 `CodeAutocomplete`（search 模式）debounce 僅用 `setTimeout` 延後查詢，未對底層 fetch 做序號/取消保護，導致先打出常見姓氏字首（結果多、較慢）又打出更精確字（結果少、較快）時，舊查詢回應可能晚於新查詢回應才 resolve、覆蓋畫面。新增序號守衛（`searchSeqRef`），確保只有最新一次查詢的回應才會套用到畫面。
- 已檢查全站其他自動完成輸入框：確認同一元件與同類後端端點皆已一併修復（含先前疑似 dead code 但實際仍可達的兩個 repository 方法）。

## Test plan
- [x] `./vendor/bin/phpunit`：全專案 2445 tests / 11008 assertions 全過
- [x] `./vendor/bin/php-cs-fixer fix --dry-run`：0 files need fixing
- [x] `npx tsc --noEmit` / `npm run build`：無新增錯誤、建置成功
- [x] 新增單元測試 `tests/Unit/ExactCodeMatchGuardTest.php` 驗證後端守衛邏輯
- [x] 兩個修復各經過 code-review agent 與 `codex exec` 多輪把關（含發現並修正 loading 卡住、mode 切換等邊界情況）後才提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)