### PR TITLE
補回 codes 表單的逐欄行為：稽核欄不可編輯、欄位提示、依 c_textid 帶入書名

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 2026-08
 
+### 補回 codes 表單的逐欄行為：稽核欄不可編輯、欄位提示、依 c_textid 帶入書名
+- 起因：上一則作者清單的缺口不是孤例。以「Blade 有用、React 端完全找不到的翻譯鍵」為橋樑掃過全站（961 個鍵→275 個孤兒；扣掉 `cbdbapi/person`、`maps`、`home` 三個本來就沒有 React 版也沒有 flag 的頁面共 81 個），確認**真缺口集中在 `Codes/Edit.tsx`**——React 版把新增／編輯頁寫成泛用表單（`columns` → 純 `Input`），舊版 `codes/edit.blade.php` 的逐欄特殊處理因此整批漏移植。掃描方法的侷限一併記下：先前想用「Blade 呼叫但 React 沒呼叫的端點」當主訊號會誤報，因為 React 的端點多由 server props 傳入（`Welcome.tsx` 的姓名搜尋即為例）。
+- 新增 `CodesController::codeColumnBehaviour()` 作為逐欄行為的單一落點，Create／Edit 兩頁共用，避免各自再長出一套硬編碼：
+  - **稽核欄（`c_created_by/date`、`c_modified_by/date`）一律灰底唯讀**。先前 React 可自由輸入卻毫無提示，而後端 `enforceAuditFieldsForUpdate` 本來就會覆蓋（`c_created_*` 還原原值、`c_modified_*` 蓋當下），等於讓使用者對著會被丟棄的輸入框打字。新增與編輯採同一條規則；用 `readOnly` 而非 `disabled`——這四欄的用途就是被讀，`disabled` 會讓文字無法選取複製，而舊版用的也是 `readonly`。**送出內容與改動前逐位元相同**（欄位仍在 `columns` 與 `form.data` 裡，只改 UI），另補測試鎖住「偽造稽核值送出也不生效」。
+  - `c_modified_*` 補回「提交後會被替換為 X」預覽，且改走 `AuditActor::currentName()`——與實際落庫的署名同源，舊版用 `Auth::user()->name`，在核准情境下與實際寫入的雙人名不一致。
+  - 欄位提示（TEXT_CODES／ADDR_CODES 複製提示）改由後端供給：`Edit.tsx` 先前完全沒有，`Create.tsx` 則是**硬編碼中文**（英文語境漏字、且與既有 `codes.*` 鍵重複）。新增無 HTML 的 `hint_*` 鍵，連結以結構化資料另傳（前端不需要 `dangerouslySetInnerHTML`），並用 flag-aware 的 `codesShowUrl()` 指向 React 版碼表頁。
+- **TEXT_INSTANCE_DATA 依 `c_textid` 帶入書名**（舊版的「Load Data」鈕）。修掉舊版兩個缺陷：舊版打 `/api/select/search/text`（`c_title_chn LIKE %q% OR c_textid = q`）再取 `data[0]`，用 ID 查時可能撈到「標題剛好含這串數字」的別本書——改為新端點 `app/codes/text-title/{textId}` 主鍵精確查詢；舊版無條件覆寫兩個書名欄——改為**只填空欄**（使用者指定），不蓋掉人工修訂過的書名，並沿用舊版填入後標黃底的提示。
+- 附帶修掉 `Create.tsx` 的結構缺陷：兩顆送出按鈕原本被包在 `{can_propose && ...}` 內，而 `app.codes.create` 沒有 auth middleware，訪客／非活躍帳號會看到一個完整表單卻一顆按鈕都沒有；改為與 `Edit.tsx` 對齊（「直接保存」永在、「提交建議」看 `can_propose`）。
+- 新欄位元件刻意**不套用 `ui/FormField`**：它會把 id 與 aria 注入「單一子節點」，而這裡的子節點是包住輸入框＋動作鈕＋提示的 `<div>`——會讓 `<div>` 與 `<input>` 拿到相同 id（每頁重複十餘個），且 `<label for>` 指到不可標記的 `<div>` 而失效（點欄位標籤不再聚焦輸入框），`aria-invalid`／`aria-describedby` 也會落在 div 上而使 `Input` 的紅框與螢幕報讀關聯失效。改為自行組出 label／aria 關聯。
+- 新端點補 `throttle:60,1`（與 `codes.export` 同理由：直連 live 生產庫且無登入門檻）。帶入結果訊息就近顯示在 `c_textid` 下方並帶 `role="status"`（原本放表單底部，`TEXT_INSTANCE_DATA` 欄位多時會離按鈕太遠），使用者一動表單即清除訊息與黃底。請求期間若使用者改了 `c_textid` 或手動填了書名欄，回應會被丟棄或跳過該欄，不覆蓋剛輸入的內容。
+- 帶入結果的訊息**逐欄判定**而非看「整次請求有沒有書名」：書目常只有中文書名而無拼音書名（實測 21 筆 TEXT_CODES 如此、7 筆 instance 正好是這形狀），用單一旗標會把「拼音欄還空著、來源也沒有拼音書名」誤報成「兩欄皆已有值」。現在會如實列出哪些欄被帶入、哪些欄因來源沒有書名而仍為空。
+- 欄位提示的連結改以 `:link` 佔位就地嵌回句中（保留舊版 inline `<a>` 的讀法，字串本身仍無 HTML）；「提交後會被替換為 X」加 `tone=warn` 以粗體主色呈現——舊版是 `text-info` + `<strong>`，不該與一般說明同重量。
+- 提案調整頁（`Codes/ProposalEdit.tsx`）一併套用同一份逐欄行為：稽核欄同樣唯讀，但**不給替換預覽**（替換發生在核准當下、由審核人蓋章，此刻預告的署名與時間都會不同）。核准端本來就會剔除並重蓋，此處只是不再邀請使用者對著會被丟棄的輸入框打字。`Edit.tsx` 也補上舊版兩頁都有、React 只有 Create 有的「直接儲存會忽略此欄」提示。
+- 回歸測試 `CodesColumnBehaviourTest`（18 tests：四個稽核欄唯讀／提案調整頁同樣唯讀但無替換預覽／替換預覽只給 `c_modified_*`／未登入無預覽但仍唯讀／新增頁同規則且欄位清單不變／偽造稽核值不生效／`c_textid` 提示與動作且提示不含 HTML／提示連結 flag-aware 指向 `/app/codes/TEXT_CODES`／新增頁也有提示／en 語境真的拿到英文／ADDR_BELONGS_DATA 兩欄提示／無特殊行為的表為空／端點精確查詢且不退回標題模糊命中／可查 `c_textid=0` 的「未知」書目／回報無書名的書目／非數字 ID 被拒）。另以 headless Chrome 對真實庫驗證 16 項（含實際按下帶入書名取得「愛日齋叢鈔」、第二次按不覆蓋、每欄僅一個 DOM id 且 label 正確關聯）。
+
 ### 補回 TEXT_CODES 編輯頁的作者清單（React 遷移時漏移植）
 - 使用者回報 `/app/codes/TEXT_CODES/{id}/edit` 不再顯示作者。查證：該區塊只存在於舊版 `codes/edit.blade.php`（2022-01 #186 引入、2025-12 #655 改善多作者顯示），**2026-06-26 React/Inertia 上線（3f131d6）時漏移植**，而同一個 commit 把 `codes` flag 翻成 `new`，功能自此在正式站消失。旁證三項：後端端點 `/api/select/search/textauthor` 完好（12497 回 1 筆、35232 回 98 筆）、翻譯鍵 `author_label`／`no_author_data` 等留在原地無人使用、React 端零引用。
 - 補回方式改為**伺服器端隨頁面一次 JOIN 取回**（`CodesController::textCodesAuthors()` → `text_authors` prop），順手修掉舊版三個缺陷：舊版走 AJAX 且每列再各查一次 `BIOG_MAIN` 與 `TEXT_ROLE_CODES`（N+1）、`paginate(100)` 會靜默截斷、連 `c_personid=0`（未詳哨兵）也給連結。現行回報真實 `total` 與顯示上限（200；全庫單書最多 98 位），超過時前端明示「共 N 位，僅顯示前 M 位」。

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -29,6 +29,12 @@ class CodesController extends Controller {
      */
     protected const TEXT_AUTHOR_DISPLAY_LIMIT = 200;
 
+    /**
+     * 稽核欄：一律由系統蓋章（見 AGENTS.md §1.2、enforceAuditFieldsForCreate/Update），
+     * 因此在泛用 codes 表單上為唯讀——使用者輸入不會生效，開放編輯只會誤導。
+     */
+    protected const AUDIT_COLUMNS = ['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'];
+
     protected $codesrepostory;
     protected $operationRepository;
 
@@ -945,6 +951,9 @@ class CodesController extends Controller {
             'required_columns' => $this->codeColumnFormMeta($table)['required'],
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
+            // 逐欄特殊行為（稽核欄唯讀＋替換預覽、欄位提示、Load Data 動作）。
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_keys($rowArray), 'edit'),
+            'text_title_endpoint' => route('app.codes.text-title', ['textId' => '__TEXT_ID__'], false),
             // TEXT_CODES：附上該書的作者／編者等關係人（唯讀錄入參考）。其餘碼表為 null，前端不渲染。
             // 用 isset 而非 ?? 0：c_textid=0 是真實可編輯的「未知」書目列（其下掛著 37 筆關係人），
             // 不能與「取不到 c_textid」混為一談而一律查 0。
@@ -1047,6 +1056,111 @@ class CodesController extends Controller {
             'truncated' => $truncated,
             'failed' => false,
         ];
+    }
+
+    /**
+     * 泛用 codes 表單的「按表／按欄位」特殊行為。
+     *
+     * React 版把 codes 新增／編輯頁寫成泛用表單（columns → input），舊版 codes/edit.blade.php 的
+     * 逐欄特殊處理因此全部漏移植：稽核欄唯讀與「提交後會被替換為 X」提示、TEXT_CODES／ADDR_CODES
+     * 的複製提示、TEXT_INSTANCE_DATA 的「Load Data」按鈕。這裡把那些知識集中成一份資料，
+     * 由 Create／Edit 兩頁共用，避免各自再長出一套硬編碼。
+     *
+     * 提示文字刻意在後端翻譯：`field_will_be_replaced` 要串當下的署名與時間戳（與實際落庫的
+     * AuditActor::currentName() 一致）。連結另以結構化資料傳出，前端不需要 dangerouslySetInnerHTML。
+     *
+     * @param  array<int, string> $columns
+     * @param  string             $mode edit|create|proposal。稽核欄唯讀三者皆同；「提交後會被替換為 X」
+     *                                  只在 edit 有意義——proposal 的替換發生在核准當下、由審核人蓋章，
+     *                                  現在預告一個署名與時間都會不同的值只會誤導。
+     * @return array<string, array<string, mixed>>
+     */
+    protected function codeColumnBehaviour(string $table, array $columns, string $mode): array {
+        $behaviour = [];
+
+        // 稽核欄一律由系統蓋章，任何模式都不開放使用者編輯 → 灰底唯讀（可看、可複製、不可改）。
+        // 新增與編輯採同一條規則，不做「新增時隱藏」的第二套行為。
+        // 用 readonly 而非 disabled：這四欄的用途就是被讀，disabled 會讓文字無法選取；
+        // 舊版 codes/edit.blade.php 用的也是 readonly。
+        foreach (self::AUDIT_COLUMNS as $column) {
+            if (!in_array($column, $columns, true)) {
+                continue;
+            }
+            $behaviour[$column] = ['readonly' => true];
+        }
+
+        // 「提交後會被替換為 X」：只有 c_modified_* 會被改寫成當下值，故只有這兩欄給預覽。
+        if ($mode === 'edit' && Auth::check() && Auth::user()->isActive()) {
+            $preview = [
+                'c_modified_by' => \App\Support\AuditActor::currentName(),
+                'c_modified_date' => Carbon::now(config('app.timezone'))->format('Y-m-d H:i:s'),
+            ];
+            foreach ($preview as $column => $value) {
+                if (isset($behaviour[$column]) && $value !== null && $value !== '') {
+                    // tone=warn：這不是一般說明，是「你看到的值會被覆蓋」的警示（舊版是 text-info + <strong>）。
+                    $behaviour[$column]['hint'] = [
+                        'text' => __('codes.field_will_be_replaced').$value,
+                        'tone' => 'warn',
+                    ];
+                }
+            }
+        }
+
+        // 逐表欄位提示（文案無 HTML，連結另傳）＋額外互動。
+        $hints = [
+            'TEXT_INSTANCE_DATA' => [
+                'c_textid' => [
+                    'hint' => [
+                        'text' => __('codes.hint_text_codes_copy'),
+                        'link' => ['href' => $this->codesShowUrl('TEXT_CODES'), 'label' => 'TEXT_CODES'],
+                    ],
+                    // 依 c_textid 從 TEXT_CODES 帶入書名（對齊舊版「Load Data」鈕）。
+                    'action' => 'load_text_title',
+                ],
+            ],
+            'ADDR_BELONGS_DATA' => [
+                'c_addr_id' => ['hint' => [
+                    'text' => __('codes.hint_addr_copy'),
+                    'link' => ['href' => $this->codesShowUrl('ADDR_CODES'), 'label' => 'ADDR_CODES'],
+                ]],
+                'c_belongs_to' => ['hint' => [
+                    'text' => __('codes.hint_addr_copy'),
+                    'link' => ['href' => $this->codesShowUrl('ADDR_CODES'), 'label' => 'ADDR_CODES'],
+                ]],
+            ],
+        ];
+
+        foreach ($hints[$table] ?? [] as $column => $extra) {
+            if (!in_array($column, $columns, true)) {
+                continue;
+            }
+            $behaviour[$column] = array_merge($behaviour[$column] ?? [], $extra);
+        }
+
+        return $behaviour;
+    }
+
+    /**
+     * TEXT_INSTANCE_DATA 的「Load Data」用：依 c_textid 精確取回書名。
+     *
+     * 舊版按鈕打的是 /api/select/search/text（`c_title_chn LIKE %q% OR c_textid = q` 再取 data[0]），
+     * 用 ID 查時可能撈到「標題剛好含這串數字」的別本書。這裡改為主鍵精確查詢，不重現該缺陷。
+     */
+    public function textTitle($textId) {
+        $row = DB::table('TEXT_CODES')
+            ->where('c_textid', (int) $textId)
+            ->first(['c_textid', 'c_title_chn', 'c_title']);
+
+        if (!$row) {
+            return response()->json(['found' => false], 404);
+        }
+
+        return response()->json([
+            'found' => true,
+            'c_textid' => (int) $row->c_textid,
+            'c_title_chn' => $row->c_title_chn,
+            'c_title' => $row->c_title,
+        ]);
     }
 
     public function update(Request $request, $table_name, $id) {
@@ -1183,6 +1297,8 @@ class CodesController extends Controller {
         $columns = $this->getTableColumns($table);
         $keyColumns = $this->getKeyColumns($table);
         $columns = $this->orderColumnsForCreate($columns, $keyColumns);
+        // 稽核欄仍留在欄位清單內（送出內容與先前完全相同，不改寫入行為）；
+        // 只在 UI 上停用——見 codeColumnBehaviour()。
 
         $defaults = [];
         $firstKey = $keyColumns[0] ?? null;
@@ -1209,6 +1325,9 @@ class CodesController extends Controller {
             'required_columns' => $formMeta['required'],
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
+            // 與 edit 共用同一份逐欄行為（此頁的欄位提示原為前端硬編碼中文，改由此處統一供給）。
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'create'),
+            'text_title_endpoint' => route('app.codes.text-title', ['textId' => '__TEXT_ID__'], false),
             'urls' => [
                 'store' => route('app.codes.store', ['table_name' => $table], false),
                 'propose' => route('app.codes.propose.store', ['table_name' => $table], false),
@@ -1336,6 +1455,9 @@ class CodesController extends Controller {
             'review_status' => $payload['__review_status'] ?? 'pending',
             'review_comment' => $payload['__review_comment'] ?? null,
             'is_create_proposal' => (int) $operation['op_type'] === Operation::TYPE_PROPOSAL_CREATE,
+            // 提案調整頁同樣不開放編輯稽核欄（三個碼表表單一致）。核准端本來就會剔除並重蓋，
+            // 但讓使用者對著一個會被丟棄的輸入框打字沒有意義。mode=proposal → 唯讀但不給替換預覽。
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'proposal'),
             'urls' => [
                 'update' => route('app.codes.proposals.update', ['table_name' => $table, 'operation' => $operation['id']], false),
                 'return' => route('operations.index', ['proposals_only' => 1], false),

--- a/resources/js/inertia/Pages/Codes/Create.tsx
+++ b/resources/js/inertia/Pages/Codes/Create.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../Layouts/DashboardLayout';
 import { Button } from '../../components/ui/Button';
-import { Input } from '../../components/ui/Input';
 import { FormField } from '../../components/ui/FormField';
+import { CodesColumnField, type ColumnBehaviour } from '../../components/Codes/CodesColumnField';
+import { useLoadTextTitle } from '../../components/Codes/useLoadTextTitle';
 import { PinyinUmlautConfirmDialog } from '../../components/PinyinUmlautConfirmDialog';
 import { ProposalModeDialog } from '../../components/ui/ProposalModeDialog';
 import { collectUmlautConversions, type Tier2UmlautHit } from '../../utils/pinyinUmlaut';
@@ -17,23 +18,22 @@ interface CodesCreatePageProps extends SharedProps {
     required_columns?: string[];
     can_propose: boolean;
     tier2_fields?: string[];
+    /**
+     * 逐欄特殊行為（稽核欄唯讀、欄位提示、Load Data 動作），由後端 codeColumnBehaviour() 供給。
+     * 先前此頁的欄位提示是前端硬編碼中文（英文語境會漏字，且與 codes.* 既有鍵重複），已移除。
+     */
+    column_behaviour?: Record<string, ColumnBehaviour>;
+    text_title_endpoint?: string;
     urls: { store: string; propose: string; show: string };
 }
 
-// 特定表的欄位輔助說明（沿用舊頁 help-block 文案）。
-const COLUMN_HINTS: Record<string, Record<string, { text: string; link?: { href: string; label: string } }>> = {
-    ADDR_BELONGS_DATA: {
-        c_addr_id: { text: '請從 ADDR_CODES 表中複製 c_addr_id 填入', link: { href: '/codes/ADDR_CODES', label: 'ADDR_CODES' } },
-        c_belongs_to: { text: '請從 ADDR_CODES 表中複製 c_addr_id 填入', link: { href: '/codes/ADDR_CODES', label: 'ADDR_CODES' } },
-    },
-    TEXT_INSTANCE_DATA: {
-        c_textid: { text: '請確保 TEXT_CODES 表中存在這本書的 c_textid，再複製 ID 填入', link: { href: '/codes/TEXT_CODES', label: 'TEXT_CODES' } },
-    },
-};
-
 export default function CodesCreate() {
     const props = usePage<CodesCreatePageProps>().props;
-    const { table, columns, defaults, required_columns, can_propose, tier2_fields, urls } = props;
+    const {
+        table, columns, defaults, required_columns, can_propose, tier2_fields,
+        column_behaviour, text_title_endpoint, urls,
+    } = props;
+    const behaviourOf = column_behaviour ?? {};
     const requiredSet = new Set(required_columns ?? []);
     const t = useTranslation('codes');
     const tc = useTranslation('common');
@@ -68,9 +68,16 @@ export default function CodesCreate() {
         }
         run();
     };
-    const tableHints = COLUMN_HINTS[table] ?? {};
     const saveDirect = () => gate((ov) => submitPost(urls.store, ov));
     const propose = () => gate((ov) => submitPost(urls.propose, ov));
+
+    // TEXT_INSTANCE_DATA：依 c_textid 帶入書名（只填空欄）。
+    const loadTitle = useLoadTextTitle({
+        endpoint: text_title_endpoint ?? '',
+        getField: (c) => form.data[c] ?? '',
+        setField: (c, v) => form.setData(c, v),
+        t,
+    });
 
     return (
         <DashboardLayout
@@ -84,54 +91,53 @@ export default function CodesCreate() {
                 }}
                 className="max-w-3xl space-y-3 rounded-lg border border-border bg-card p-4"
             >
-                {columns.map((col) => {
-                    const hint = tableHints[col];
-                    return (
-                        <FormField key={col} label={col} htmlFor={col} required={requiredSet.has(col)} error={form.errors[col]}>
-                            <Input
-                                id={col}
-                                value={form.data[col] ?? ''}
-                                onChange={(e) => form.setData(col, e.target.value)}
-                            />
-                            {hint && (
-                                <p className="text-xs text-muted-foreground">
-                                    {hint.text}
-                                    {hint.link && (
-                                        <>
-                                            {' '}
-                                            <a href={hint.link.href} target="_blank" rel="noreferrer" className="text-primary hover:underline">
-                                                {hint.link.label}
-                                            </a>
-                                        </>
-                                    )}
-                                </p>
-                            )}
-                        </FormField>
-                    );
-                })}
+                {columns.map((col) => (
+                    <CodesColumnField
+                        key={col}
+                        column={col}
+                        value={form.data[col] ?? ''}
+                        // 動一下表單就清掉上次帶入的訊息與黃底（那是對上一次動作的描述）。
+                        onChange={(v) => { form.setData(col, v); loadTitle.reset(); }}
+                        error={form.errors[col]}
+                        required={requiredSet.has(col)}
+                        behaviour={behaviourOf[col]}
+                        actionLabel={t('load_text_title_btn')}
+                        onAction={() => void loadTitle.run()}
+                        actionPending={loadTitle.pending}
+                        actionMessage={behaviourOf[col]?.action ? loadTitle.message : null}
+                        actionFailed={loadTitle.failed}
+                        highlighted={loadTitle.filled.includes(col)}
+                    />
+                ))}
 
                 {can_propose && (
-                    <>
-                        <FormField label={t('proposal_desc')} htmlFor="__proposal_comment" hint={t('proposal_desc_hint')}>
-                            <textarea
-                                id="__proposal_comment"
-                                rows={3}
-                                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                placeholder={t('proposal_desc_hint')}
-                                value={form.data.__proposal_comment ?? ''}
-                                onChange={(e) => form.setData('__proposal_comment', e.target.value)}
-                            />
-                            <p className="text-xs text-muted-foreground">如果直接儲存，此欄位會被忽略。</p>
-                        </FormField>
-
-                        <div className="flex gap-2">
-                            <Button type="submit" disabled={form.processing}>{t('save_direct')}</Button>
-                            <Button type="button" variant="secondary" disabled={form.processing} onClick={() => (canWriteDirectly ? setConfirmProposalMode(true) : propose())}>
-                                {t('submit_proposal')}
-                            </Button>
-                        </div>
-                    </>
+                    <FormField label={t('proposal_desc')} htmlFor="__proposal_comment" hint={t('proposal_desc_hint')}>
+                        <textarea
+                            id="__proposal_comment"
+                            rows={3}
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            placeholder={t('proposal_desc_hint')}
+                            value={form.data.__proposal_comment ?? ''}
+                            onChange={(e) => form.setData('__proposal_comment', e.target.value)}
+                        />
+                        <p className="text-xs text-muted-foreground">{t('proposal_ignore_hint')}</p>
+                    </FormField>
                 )}
+
+                {/* 送出按鈕移出 can_propose：先前兩顆鈕被包在該條件裡，非活躍帳號／訪客會看到
+                    一個完整表單卻一顆按鈕都沒有（app.codes.create 無 auth middleware）。
+                    與 Edit.tsx 的結構對齊——「直接保存」永遠在，「提交建議」才看 can_propose。 */}
+                <div className="flex flex-wrap gap-2">
+                    <Button type="submit" disabled={form.processing}>{t('save_direct')}</Button>
+                    {can_propose && (
+                        <Button type="button" variant="secondary" disabled={form.processing} onClick={() => (canWriteDirectly ? setConfirmProposalMode(true) : propose())}>
+                            {t('submit_proposal')}
+                        </Button>
+                    )}
+                    <a href={urls.show} className="inline-flex items-center rounded-md border border-input px-4 py-2 text-sm hover:bg-muted">
+                        {tc('cancel')}
+                    </a>
+                </div>
             </form>
 
             <PinyinUmlautConfirmDialog

--- a/resources/js/inertia/Pages/Codes/Edit.tsx
+++ b/resources/js/inertia/Pages/Codes/Edit.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { router, useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../Layouts/DashboardLayout';
 import { Button } from '../../components/ui/Button';
-import { Input } from '../../components/ui/Input';
 import { FormField } from '../../components/ui/FormField';
+import { CodesColumnField, type ColumnBehaviour } from '../../components/Codes/CodesColumnField';
+import { useLoadTextTitle } from '../../components/Codes/useLoadTextTitle';
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
 import { ProposalModeDialog } from '../../components/ui/ProposalModeDialog';
 import { PinyinUmlautConfirmDialog } from '../../components/PinyinUmlautConfirmDialog';
@@ -28,12 +29,19 @@ interface CodesEditPageProps extends SharedProps {
     tier2_fields?: string[];
     /** 僅 TEXT_CODES 有值（該書的作者／編者等關係人）；其餘碼表為 null。 */
     text_authors?: TextAuthors | null;
+    /** 逐欄特殊行為（稽核欄唯讀＋替換預覽、欄位提示、Load Data 動作），由後端供給。 */
+    column_behaviour?: Record<string, ColumnBehaviour>;
+    text_title_endpoint?: string;
     urls: { update: string; propose: string; destroy: string; show: string };
 }
 
 export default function CodesEdit() {
     const props = usePage<CodesEditPageProps>().props;
-    const { table, columns, values, key_columns, required_columns, can_propose, tier2_fields, text_authors, urls } = props;
+    const {
+        table, columns, values, key_columns, required_columns, can_propose, tier2_fields,
+        text_authors, column_behaviour, text_title_endpoint, urls,
+    } = props;
+    const behaviourOf = column_behaviour ?? {};
     const requiredSet = new Set(required_columns ?? []);
     const t = useTranslation('codes');
     const tc = useTranslation('common');
@@ -77,6 +85,14 @@ export default function CodesEdit() {
     };
     const propose = () => gate((ov) => submitVia('post', urls.propose, ov));
 
+    // TEXT_INSTANCE_DATA：依 c_textid 帶入書名（只填空欄）。
+    const loadTitle = useLoadTextTitle({
+        endpoint: text_title_endpoint ?? '',
+        getField: (c) => form.data[c] ?? '',
+        setField: (c, v) => form.setData(c, v),
+        t,
+    });
+
     return (
         <DashboardLayout
             title={`${tc('edit')} — ${table}`}
@@ -94,22 +110,24 @@ export default function CodesEdit() {
                 )}
 
                 {columns.map((col) => (
-                    <FormField
+                    <CodesColumnField
                         key={col}
-                        label={col}
-                        htmlFor={col}
-                        required={requiredSet.has(col)}
+                        column={col}
+                        value={form.data[col] ?? ''}
+                        // 動一下表單就清掉上次帶入的訊息與黃底（那是對上一次動作的描述）。
+                        onChange={(v) => { form.setData(col, v); loadTitle.reset(); }}
                         error={form.errors[col]}
-                    >
-                        <Input
-                            id={col}
-                            value={form.data[col] ?? ''}
-                            onChange={(e) => form.setData(col, e.target.value)}
-                        />
-                        {key_columns.includes(col) && (
-                            <span className="text-xs text-blue-700">PK</span>
-                        )}
-                    </FormField>
+                        required={requiredSet.has(col)}
+                        isKey={key_columns.includes(col)}
+                        behaviour={behaviourOf[col]}
+                        actionLabel={t('load_text_title_btn')}
+                        onAction={() => void loadTitle.run()}
+                        actionPending={loadTitle.pending}
+                        // 訊息就近顯示在觸發它的欄位下方（TEXT_INSTANCE_DATA 欄位多，放表單底部會離按鈕太遠）。
+                        actionMessage={behaviourOf[col]?.action ? loadTitle.message : null}
+                        actionFailed={loadTitle.failed}
+                        highlighted={loadTitle.filled.includes(col)}
+                    />
                 ))}
 
                 {can_propose && (
@@ -122,6 +140,8 @@ export default function CodesEdit() {
                             value={form.data.__proposal_comment ?? ''}
                             onChange={(e) => form.setData('__proposal_comment', e.target.value)}
                         />
+                        {/* 舊版 codes/edit.blade.php 與 create.blade.php 兩頁都有這句，React 只有 Create 有。 */}
+                        <p className="text-xs text-muted-foreground">{t('proposal_ignore_hint')}</p>
                     </FormField>
                 )}
 

--- a/resources/js/inertia/Pages/Codes/ProposalEdit.tsx
+++ b/resources/js/inertia/Pages/Codes/ProposalEdit.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../Layouts/DashboardLayout';
 import { Button } from '../../components/ui/Button';
-import { Input } from '../../components/ui/Input';
 import { FormField } from '../../components/ui/FormField';
+import { CodesColumnField, type ColumnBehaviour } from '../../components/Codes/CodesColumnField';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { SharedProps } from '../../types/page';
 
@@ -23,12 +23,15 @@ interface CodesProposalEditPageProps extends SharedProps {
     review_status: string;
     review_comment: string | null;
     is_create_proposal: boolean;
+    /** 逐欄行為（此頁只用到稽核欄唯讀；替換預覽不給——核准當下才由審核人蓋章）。 */
+    column_behaviour?: Record<string, ColumnBehaviour>;
     urls: { update: string; return: string };
 }
 
 export default function CodesProposalEdit() {
     const props = usePage<CodesProposalEditPageProps>().props;
-    const { table, columns, values, key_columns, proposal_meta, review_status, review_comment, urls } = props;
+    const { table, columns, values, key_columns, proposal_meta, review_status, review_comment, column_behaviour, urls } = props;
+    const behaviourOf = column_behaviour ?? {};
     const t = useTranslation('codes');
 
     const initial: Record<string, string> = { __proposal_comment: proposal_meta.comment ?? '' };
@@ -58,10 +61,15 @@ export default function CodesProposalEdit() {
 
             <form onSubmit={submit} className="max-w-3xl space-y-3 rounded-lg border border-border bg-card p-4">
                 {columns.map((col) => (
-                    <FormField key={col} label={col} htmlFor={col} error={form.errors[col]}>
-                        <Input id={col} value={form.data[col] ?? ''} onChange={(e) => form.setData(col, e.target.value)} />
-                        {key_columns.includes(col) && <span className="text-xs text-blue-700">PK</span>}
-                    </FormField>
+                    <CodesColumnField
+                        key={col}
+                        column={col}
+                        value={form.data[col] ?? ''}
+                        onChange={(v) => form.setData(col, v)}
+                        error={form.errors[col]}
+                        isKey={key_columns.includes(col)}
+                        behaviour={behaviourOf[col]}
+                    />
                 ))}
 
                 <FormField label={t('proposal_desc')} htmlFor="__proposal_comment" hint={t('resubmit_notice')}>

--- a/resources/js/inertia/components/Codes/CodesColumnField.tsx
+++ b/resources/js/inertia/components/Codes/CodesColumnField.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { Input } from '../ui/Input';
+import { Button } from '../ui/Button';
+
+/**
+ * 泛用 codes 表單的單一欄位。
+ *
+ * React 版原本把新增／編輯頁寫成「columns → 純 Input」，舊版 codes/edit.blade.php 的逐欄特殊處理
+ * （稽核欄不可編輯＋替換預覽、欄位提示、TEXT_INSTANCE_DATA 的 Load Data 鈕）因此全部漏移植。
+ * 這個元件是那些行為的單一落點；行為資料由後端 CodesController::codeColumnBehaviour() 供給，
+ * 前端不再各自硬編碼（Create.tsx 先前的 COLUMN_HINTS 就是硬編碼中文、英文語境會漏字）。
+ *
+ * 刻意**不**使用 ui/FormField：它會把 id 與 aria 注入「單一子節點」，而這裡的子節點是一個包住
+ * 輸入框＋動作鈕＋提示的 <div>——那會讓 <div> 和 <input> 拿到相同 id（重複 id），且 <label for>
+ * 指到不可標記的 <div> 而失效（點欄位標籤不再聚焦輸入框）。故在此自行組出 label／aria 關聯。
+ */
+
+export interface ColumnBehaviour {
+    /**
+     * 系統蓋章的欄位（稽核欄）→ 灰底唯讀。
+     * 用 readOnly 而非 disabled：這四欄的用途就是「被讀」，readOnly 仍可聚焦、可選取複製，
+     * 且與舊版 codes/edit.blade.php 的 readonly 屬性一致；disabled 會讓文字無法選取。
+     * 兩者都達成「使用者不能改」。送出內容不受影響：Inertia useForm 送的是 form.data（JS 物件），
+     * 不是 DOM 表單；後端一律以 enforceAuditFieldsForCreate/Update 覆蓋。
+     */
+    readonly?: boolean;
+    /**
+     * 欄位提示。text 已由後端翻譯；link 另以資料傳出，故不需要 dangerouslySetInnerHTML。
+     * text 內若含 `:link` 佔位，連結會就地嵌在句中（保留舊版讀法）；沒有佔位則附在句末。
+     * tone='warn' 用於「提交後會被替換為 X」——舊版是 text-info + <strong>，不該與一般提示同重量。
+     */
+    hint?: { text: string; link?: { href: string; label: string }; tone?: 'info' | 'warn' };
+    /** 額外互動。目前僅 'load_text_title'（依 c_textid 帶入書名）。 */
+    action?: string;
+}
+
+interface Props {
+    column: string;
+    value: string;
+    onChange: (value: string) => void;
+    error?: string | string[] | null;
+    required?: boolean;
+    isKey?: boolean;
+    behaviour?: ColumnBehaviour;
+    /** 動作按鈕文案；有 behaviour.action 時必須提供。 */
+    actionLabel?: string;
+    onAction?: () => void;
+    actionPending?: boolean;
+    /** 動作結果訊息，就近顯示在觸發它的欄位下方（而非表單底部）。 */
+    actionMessage?: string | null;
+    actionFailed?: boolean;
+    /** 剛被動作填入 → 標黃底（對齊舊版 Load Data 後的 #FFFFBB 提示）。 */
+    highlighted?: boolean;
+}
+
+/**
+ * 把提示文字裡的 `:link` 佔位換成真正的 <a>，讓連結留在句中（舊版是 HTML 字串裡的 inline <a>）。
+ * 沒有佔位（或沒有 link）時退回「句末附連結」。React 會轉義文字，故無 XSS 風險。
+ */
+function renderHintText(hint: NonNullable<ColumnBehaviour['hint']>): React.ReactNode {
+    const { link } = hint;
+    if (!link) {
+        return hint.text;
+    }
+
+    const anchor = (key: string) => (
+        <a
+            key={key}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+        >
+            {link.label}
+        </a>
+    );
+
+    if (!hint.text.includes(':link')) {
+        return <>{hint.text}{' '}{anchor('link')}</>;
+    }
+
+    // 替換**所有** :link 佔位（不只第一個），否則多佔位的譯文會把後面的 :link 當純文字印出來。
+    const segments = hint.text.split(':link');
+
+    return (
+        <>
+            {segments.map((segment, index) => (
+                <React.Fragment key={index}>
+                    {segment}
+                    {index < segments.length - 1 && anchor(`link-${index}`)}
+                </React.Fragment>
+            ))}
+        </>
+    );
+}
+
+export function CodesColumnField({
+    column, value, onChange, error, required, isKey,
+    behaviour, actionLabel, onAction, actionPending, actionMessage, actionFailed, highlighted,
+}: Props) {
+    const readOnly = behaviour?.readonly === true;
+    const hint = behaviour?.hint;
+    const messages = Array.isArray(error) ? error : error ? [error] : [];
+    const hasError = messages.length > 0;
+    const describedById = `${column}-desc`;
+
+    return (
+        <div className="space-y-1">
+            <LabelPrimitive.Root htmlFor={column} className="text-sm font-medium">
+                {column}
+                {/* 稽核欄由系統蓋章，不是使用者的責任，故不標必填星號。 */}
+                {required && !readOnly && <span className="ml-0.5 text-destructive">*</span>}
+            </LabelPrimitive.Root>
+
+            <div className="flex items-start gap-2">
+                <Input
+                    id={column}
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    readOnly={readOnly}
+                    aria-readonly={readOnly || undefined}
+                    aria-invalid={hasError ? true : undefined}
+                    aria-describedby={hasError || hint || actionMessage ? describedById : undefined}
+                    // 唯讀欄位灰底表示「系統維護」；剛被帶入的欄位黃底表示「這是剛填上的」。
+                    className={
+                        (readOnly ? 'bg-muted text-muted-foreground ' : '')
+                        + (highlighted ? 'bg-yellow-100 dark:bg-yellow-900/40' : '')
+                    }
+                />
+                {behaviour?.action && onAction && (
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        className="shrink-0"
+                        disabled={actionPending}
+                        onClick={onAction}
+                    >
+                        {actionLabel}
+                    </Button>
+                )}
+            </div>
+
+            {isKey && <span className="text-xs text-blue-700 dark:text-blue-400">PK</span>}
+
+            <div id={describedById}>
+                {hint && (
+                    <p className={hint.tone === 'warn' ? 'text-xs font-semibold text-primary' : 'text-xs text-muted-foreground'}>
+                        {renderHintText(hint)}
+                    </p>
+                )}
+                {actionMessage && (
+                    <p
+                        className={actionFailed ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}
+                        role="status"
+                        aria-live="polite"
+                    >
+                        {actionMessage}
+                    </p>
+                )}
+                {messages.map((m, i) => (
+                    <p key={i} className="text-xs text-destructive" role="alert">
+                        {m}
+                    </p>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/inertia/components/Codes/useLoadTextTitle.ts
+++ b/resources/js/inertia/components/Codes/useLoadTextTitle.ts
@@ -1,0 +1,157 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * TEXT_INSTANCE_DATA 的「Load Data」：依 c_textid 從 TEXT_CODES 帶入 c_instance_title_chn／c_instance_title。
+ *
+ * 對齊舊版 codes/edit.blade.php 的按鈕，但修掉舊版兩件事：
+ *   1. 舊版打 /api/select/search/text（`c_title_chn LIKE %q% OR c_textid = q`）再取 data[0]，
+ *      用 ID 查時可能撈到「標題剛好含這串數字」的別本書。改打主鍵精確查詢端點。
+ *   2. 舊版無條件覆寫兩個書名欄。改為**只填空欄**（使用者決定），不蓋掉人工修訂過的書名。
+ */
+
+/** 目標欄位：值為空字串／空白時視為「空欄」。 */
+const TARGET_FIELDS = ['c_instance_title_chn', 'c_instance_title'] as const;
+
+/** 書名來源欄 → 表單目標欄。 */
+const SOURCE_OF: Record<string, 'c_title_chn' | 'c_title'> = {
+    c_instance_title_chn: 'c_title_chn',
+    c_instance_title: 'c_title',
+};
+
+interface Options {
+    /** 後端提供的端點模板，含 __TEXT_ID__ 佔位。 */
+    endpoint: string;
+    /** 讀取當前表單值。 */
+    getField: (column: string) => string;
+    /** 寫入表單值。 */
+    setField: (column: string, value: string) => void;
+    /** 訊息文案（已翻譯）。 */
+    t: (key: string, replace?: Record<string, string>) => string;
+}
+
+export interface LoadTextTitleState {
+    pending: boolean;
+    /** 提示訊息（成功或失敗皆用此欄；failed 決定顏色）。 */
+    message: string | null;
+    failed: boolean;
+    /** 剛被帶入的欄位，供 UI 標黃底。 */
+    filled: string[];
+}
+
+const EMPTY: LoadTextTitleState = { pending: false, message: null, failed: false, filled: [] };
+
+export function useLoadTextTitle({ endpoint, getField, setField, t }: Options) {
+    const [state, setState] = useState<LoadTextTitleState>(EMPTY);
+    // 只有「最後一次啟動的請求」可以寫狀態。涵蓋成功／404／例外三條出口——
+    // 只在成功路徑檢查是不夠的：舊請求的 404 會蓋掉新畫面（顯示「找不到 A」而欄位已是 B）。
+    const runSeqRef = useRef(0);
+
+    /**
+     * 使用者一動表單就把上次的結果訊息與黃底清掉（那是對「上一次動作」的描述）。
+     * 刻意保留 pending：否則請求進行中改欄位會把按鈕重新啟用，讓兩個請求交錯。
+     */
+    const reset = useCallback(() => {
+        setState((prev) => (prev.message === null && prev.filled.length === 0
+            ? prev
+            : { ...EMPTY, pending: prev.pending }));
+    }, []);
+
+    const run = useCallback(async () => {
+        const textId = (getField('c_textid') ?? '').trim();
+        if (!/^\d+$/.test(textId)) {
+            setState({ ...EMPTY, message: t('load_text_title_need_textid'), failed: true });
+
+            return;
+        }
+
+        if (TARGET_FIELDS.every((f) => (getField(f) ?? '').trim() !== '')) {
+            setState({ ...EMPTY, message: t('load_text_title_all_present') });
+
+            return;
+        }
+
+        const seq = ++runSeqRef.current;
+        // 這份回應是否還該影響畫面：必須是最後一次啟動的請求，且 c_textid 未被改掉。
+        // 三條出口（成功／404／例外）都要過這道閘——只擋成功路徑的話，舊請求的 404
+        // 會蓋掉新畫面（顯示「找不到 A」而欄位已經是 B）。
+        const isCurrent = () => runSeqRef.current === seq && (getField('c_textid') ?? '').trim() === textId;
+
+        setState({ ...EMPTY, pending: true });
+        try {
+            const res = await fetch(endpoint.replace('__TEXT_ID__', textId), {
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+            });
+            if (res.status === 404) {
+                if (isCurrent()) {
+                    setState({ ...EMPTY, message: t('load_text_title_not_found', { id: textId }), failed: true });
+                }
+
+                return;
+            }
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+
+            if (!isCurrent()) {
+                // 已被新的一輪取代或 c_textid 已改：只有仍是自己那一輪時才收掉 pending，
+                // 否則會把接手那一輪的 pending 清掉、讓按鈕提早啟用。
+                if (runSeqRef.current === seq) {
+                    setState(EMPTY);
+                }
+
+                return;
+            }
+
+            // 逐欄判定，不用「整次請求有沒有書名」的單一旗標——書目常只有中文書名而沒有拼音書名
+            // （實測 TEXT_CODES 有 21 筆如此），那時若只看整體旗標，會把「拼音欄還空著、來源也沒有
+            // 拼音書名」誤報成「兩欄皆已有值」。
+            const filled: string[] = [];
+            const noSource: string[] = [];
+            for (const field of TARGET_FIELDS) {
+                // 空欄判定在 await 之後重做：請求期間使用者可能剛手動填了其中一欄，不可蓋掉。
+                if ((getField(field) ?? '').trim() !== '') {
+                    continue;
+                }
+                const incoming = data[SOURCE_OF[field]];
+                if (incoming == null || String(incoming) === '') {
+                    noSource.push(field);
+
+                    continue;
+                }
+                setField(field, String(incoming));
+                filled.push(field);
+            }
+
+            const parts: string[] = [];
+            if (filled.length > 0) {
+                parts.push(t('load_text_title_filled', { fields: filled.join(', ') }));
+            }
+            if (noSource.length > 0) {
+                // 這些欄還空著，但來源書目也沒有對應書名——如實說明，別讓使用者以為按了沒反應。
+                parts.push(t('load_text_title_source_empty', { fields: noSource.join(', ') }));
+            }
+            if (parts.length === 0) {
+                // 兩個目標欄本來就都有值 → 依「只填空欄」的規則不動任何東西。
+                parts.push(t('load_text_title_all_present'));
+            }
+
+            setState({ ...EMPTY, filled, message: parts.join(' ') });
+        } catch (err) {
+            if (!isCurrent()) {
+                if (runSeqRef.current === seq) {
+                    setState(EMPTY);
+                }
+
+                return;
+            }
+            setState({
+                ...EMPTY,
+                failed: true,
+                // 用括號夾技術細節，避免在 en 語境出現全角冒號。
+                message: `${t('load_text_title_failed')}${err instanceof Error ? ` (${err.message})` : ''}`,
+            });
+        }
+    }, [endpoint, getField, setField, t]);
+
+    return { ...state, run, reset };
+}

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -127,6 +127,19 @@ return [
     'proposal_ignore_hint' => 'If you save directly, this field will be ignored.',
     'no_textid_msg' => 'No c_textid, cannot load author.',
     'no_author_data' => 'No author data',
+    // Column hints for the React generic form (no HTML; the link is passed separately as data).
+    // These coexist with the *_copy_hint keys above, which still carry <a> tags for the legacy Blade page.
+    // :link is replaced by a real <a> in the frontend (keeps the legacy in-sentence link without HTML in the string)
+    'hint_text_codes_copy' => 'Make sure the book\'s c_textid exists in the :link table, then copy the ID here.',
+    'hint_addr_copy' => 'Copy c_addr_id from the :link table.',
+    // TEXT_INSTANCE_DATA "Load Data" (fill the titles from c_textid)
+    'load_text_title_btn' => 'Load title',
+    'load_text_title_filled' => 'Filled: :fields',
+    'load_text_title_all_present' => 'Both title fields already have values; nothing changed (empty fields only).',
+    'load_text_title_source_empty' => 'The book has no matching title in TEXT_CODES, so these stay empty: :fields',
+    'load_text_title_not_found' => 'No book found with c_textid = :id',
+    'load_text_title_need_textid' => 'Please fill in c_textid first.',
+    'load_text_title_failed' => 'Load failed',
     // TEXT_CODES edit page author block (React version)
     'author_hint' => 'Read-only reference; click a linked name to open that author\'s texts page in a new tab (unknown persons are not linked).',
     'author_unknown_person' => 'Unknown (no matching person record)',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -125,6 +125,19 @@ return [
     'proposal_ignore_hint' => '如果直接儲存，此欄位會被忽略。',
     'no_textid_msg' => '無 c_textid，無法載入作者',
     'no_author_data' => '無作者資料',
+    // React 版泛用表單的欄位提示（無 HTML；連結由後端另以結構化資料傳出）。
+    // 與上方帶 <a> 的 *_copy_hint 並存：那兩個仍由舊版 Blade 使用。
+    // :link 由前端替換成真正的 <a>（保留舊版「連結在句中」的讀法，又不必回到 HTML 字串）
+    'hint_text_codes_copy' => '請確保 :link 表中存在這本書的 c_textid，再複製 ID 填入',
+    'hint_addr_copy' => '請從 :link 表中複製 c_addr_id 填入',
+    // TEXT_INSTANCE_DATA 的「Load Data」（依 c_textid 帶入書名）
+    'load_text_title_btn' => '帶入書名',
+    'load_text_title_filled' => '已帶入：:fields',
+    'load_text_title_all_present' => '兩個書名欄皆已有值，未變更（只填空欄）',
+    'load_text_title_source_empty' => '該書目在 TEXT_CODES 沒有對應書名，這些欄位仍為空：:fields',
+    'load_text_title_not_found' => '找不到 c_textid = :id 的書目',
+    'load_text_title_need_textid' => '請先填入 c_textid',
+    'load_text_title_failed' => '帶入失敗',
     // TEXT_CODES 編輯頁作者區塊（React 版）
     'author_hint' => '唯讀，作為錄入參考；點有連結的人名可另開該作者的著述頁（未詳者無連結）',
     'author_unknown_person' => '未詳（無對應人物記錄）',

--- a/routes/web.php
+++ b/routes/web.php
@@ -290,6 +290,13 @@ Route::get('app/codes', 'CodesController@appIndex')
 // 直連 live 生產庫，故加 throttle 防爬蟲爆量。設計見 docs/OFFICE_CODES_EXPORT_SYNC.md。
 Route::get('codes/{table_name}/export', 'CodesController@export')->name('codes.export')->middleware('throttle:6,1');
 Route::get('codes/{table_name}', 'CodesController@show')->name('codes.show');
+// TEXT_INSTANCE_DATA 的「Load Data」用：依 c_textid 精確取回書名（JSON，不掛 inertia）。
+// 額外路徑段，置於下方 {table_name} 泛用路由之前，避免被攔截。
+// 直連 live 生產庫、且與 codes 讀取面一樣無登入門檻，故加 throttle（同 codes.export 的理由）。
+Route::get('app/codes/text-title/{textId}', 'CodesController@textTitle')
+    ->where('textId', '[0-9]+')
+    ->middleware('throttle:60,1')
+    ->name('app.codes.text-title');
 // Inertia + React 版（單表資料檢視 + 新增流程）
 Route::get('app/codes/{table_name}/create', 'CodesController@appCreate')
     ->middleware('inertia')

--- a/tests/Feature/CodesColumnBehaviourTest.php
+++ b/tests/Feature/CodesColumnBehaviourTest.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 泛用 codes 表單的逐欄行為（column_behaviour prop）與 Load Data 端點。
+ *
+ * 這些是舊版 codes/edit.blade.php 有、React 遷移（3f131d6）漏移植的行為：稽核欄不可編輯、
+ * 欄位提示、TEXT_INSTANCE_DATA 依 c_textid 帶入書名。
+ */
+class CodesColumnBehaviourTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-codes-column-behaviour';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['codes.tables' => [
+            'TEXT_INSTANCE_DATA' => '書目版本',
+            'ADDR_BELONGS_DATA' => '地址歸屬',
+            'TEST_PLAIN_CODES' => '無特殊行為的表',
+        ]]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('TEXT_CODES', function ($table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title_chn')->nullable();
+            $table->string('c_title')->nullable();
+        });
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 500, 'c_title_chn' => '雪篷夜話', 'c_title' => 'xue peng ye hua'],
+            // 標題裡剛好含「500」：舊版用 LIKE 查 c_textid 時可能撈到這一本（本次刻意不重現）
+            ['c_textid' => 900, 'c_title_chn' => '雜記五百篇 500 卷', 'c_title' => 'za ji 500'],
+            // c_textid=0（「未知」書目）：真實庫存在此列。非數字 textId 若沒被路由擋下，
+            // (int)'abc' === 0 會撈到它——下面的測試靠這個可辨識的書名才驗得出守衛有效。
+            ['c_textid' => 0, 'c_title_chn' => '未知書目哨兵', 'c_title' => 'unknown sentinel'],
+            // 兩個書名欄皆空的書目：驗「書目存在但沒有書名可帶入」要如實說明，不可誤報成「已有值」
+            ['c_textid' => 700, 'c_title_chn' => null, 'c_title' => null],
+        ]);
+
+        Schema::create('TEXT_INSTANCE_DATA', function ($table) {
+            $table->integer('c_textid');
+            $table->integer('c_instance_id')->default(0);
+            $table->string('c_instance_title_chn')->nullable();
+            $table->string('c_instance_title')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->primary(['c_textid', 'c_instance_id']);
+        });
+        DB::table('TEXT_INSTANCE_DATA')->insert([
+            'c_textid' => 500, 'c_instance_id' => 1,
+            'c_instance_title_chn' => null, 'c_instance_title' => null,
+            'c_created_by' => '原始建立者', 'c_created_date' => '2019-01-01 00:00:00',
+        ]);
+
+        Schema::create('ADDR_BELONGS_DATA', function ($table) {
+            $table->integer('c_addr_id');
+            $table->integer('c_belongs_to')->default(0);
+            $table->primary(['c_addr_id', 'c_belongs_to']);
+        });
+        DB::table('ADDR_BELONGS_DATA')->insert(['c_addr_id' => 7, 'c_belongs_to' => 8]);
+
+        Schema::create('TEST_PLAIN_CODES', function ($table) {
+            $table->integer('code_id')->primary();
+            $table->string('description')->nullable();
+        });
+        DB::table('TEST_PLAIN_CODES')->insert(['code_id' => 1, 'description' => 'x']);
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->string('resource')->nullable();
+            $table->text('resource_id')->nullable();
+            $table->string('op_type')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    private function activeUser(): User {
+        return User::firstOrCreate(
+            ['email' => 'u@example.com'],
+            [
+                'name' => '張三', 'password' => bcrypt('x'),
+                'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+            ]
+        );
+    }
+
+    // ───────── 稽核欄：任何模式都灰底唯讀（不開放編輯） ─────────
+
+    #[Test]
+    public function edit_marks_audit_columns_readonly(): void {
+        // 用 readonly 而非 disabled：這四欄的用途就是被讀，readOnly 仍可選取複製（舊版也是 readonly）。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('column_behaviour.c_created_by.readonly', true)
+                ->where('column_behaviour.c_created_date.readonly', true)
+                ->where('column_behaviour.c_modified_by.readonly', true)
+                ->where('column_behaviour.c_modified_date.readonly', true));
+    }
+
+    #[Test]
+    public function edit_previews_only_the_modified_audit_values(): void {
+        // c_modified_* 會被改寫成當下值 → 給「提交後會被替換為 X」預覽；
+        // c_created_* 是沿用原值、不會被改寫 → 不該給這個預覽。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertArrayNotHasKey('hint', $b['c_created_by'], 'c_created_* 不應有替換預覽');
+                $this->assertArrayNotHasKey('hint', $b['c_created_date']);
+                $this->assertStringContainsString('張三', $b['c_modified_by']['hint']['text']);
+                $this->assertMatchesRegularExpression(
+                    '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/',
+                    $b['c_modified_date']['hint']['text']
+                );
+            });
+    }
+
+    #[Test]
+    public function guest_gets_readonly_audit_columns_without_the_preview(): void {
+        // 未登入者看不到「會被替換為誰」（沒有署名可預覽），但欄位一樣不可編輯。
+        $this->get(route('app.codes.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertTrue($b['c_modified_by']['readonly']);
+                $this->assertArrayNotHasKey('hint', $b['c_modified_by']);
+            });
+    }
+
+    #[Test]
+    public function create_marks_audit_columns_readonly_and_keeps_them_in_the_columns_prop(): void {
+        // 新增與編輯同一條規則：稽核欄不開放編輯（灰底唯讀）。
+        // 斷言的是 columns prop 而非實際 HTTP payload——兩頁的 form.data 都是由 columns 建出來的
+        // （Create.tsx／Edit.tsx 的 `columns.forEach` 初始化），所以這是「送出內容不變」在伺服器端
+        // 能拿到的最貼近代理。曾有一版把稽核欄從 columns 移除、因而改動 payload，已撤回；此斷言即防它復發。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'TEXT_INSTANCE_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $props = $page->toArray()['props'];
+                foreach (['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'] as $col) {
+                    $this->assertContains($col, $props['columns'], "{$col} 仍應在欄位清單（送出內容不變）");
+                    $this->assertTrue($props['column_behaviour'][$col]['readonly'], "{$col} 應唯讀");
+                }
+            });
+    }
+
+    #[Test]
+    public function create_does_not_show_the_replacement_preview(): void {
+        // 「提交後會被替換為 X」只在編輯有意義：新增時這些欄位還沒有值可談替換。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'TEXT_INSTANCE_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach (['c_created_by', 'c_modified_by', 'c_modified_date'] as $col) {
+                    $this->assertArrayNotHasKey('hint', $b[$col]);
+                }
+            });
+    }
+
+    #[Test]
+    public function create_still_stamps_audit_fields(): void {
+        // performStore → enforceAuditFieldsForCreate 蓋上建立者與時間（行為與先前相同）。
+        $this->actingAs($this->activeUser())
+            ->post(route('app.codes.store', ['table_name' => 'TEXT_INSTANCE_DATA']), [
+                'c_textid' => 500, 'c_instance_id' => 2, 'c_instance_title_chn' => '新版本',
+                // 停用欄位的值仍在 Inertia payload 裡（送的是 form.data 不是 DOM 表單）
+                'c_created_by' => '冒名者', 'c_created_date' => '1999-01-01 00:00:00',
+            ])
+            ->assertRedirect();
+
+        $row = DB::table('TEXT_INSTANCE_DATA')->where('c_textid', 500)->where('c_instance_id', 2)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('張三', $row->c_created_by, '建立者必須是實際操作者，不能被送出的值左右');
+        $this->assertStringStartsWith(date('Y'), (string) $row->c_created_date);
+    }
+
+    #[Test]
+    public function edit_cannot_overwrite_audit_columns_even_if_submitted(): void {
+        // 欄位停用只是 UI；真正的保證在後端。直接送出偽造的稽核值也不得生效。
+        $this->actingAs($this->activeUser())
+            ->patch(route('app.codes.update', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']), [
+                'c_textid' => 500, 'c_instance_id' => 1, 'c_instance_title_chn' => '改過',
+                'c_created_by' => '冒名者', 'c_created_date' => '1999-01-01 00:00:00',
+                'c_modified_by' => '冒名者',
+            ])
+            ->assertRedirect();
+
+        $row = DB::table('TEXT_INSTANCE_DATA')->where('c_textid', 500)->where('c_instance_id', 1)->first();
+        $this->assertSame('原始建立者', $row->c_created_by, 'c_created_by 必須沿用原值');
+        $this->assertStringStartsWith('2019-01-01', (string) $row->c_created_date);
+        $this->assertSame('張三', $row->c_modified_by, 'c_modified_by 必須是當下操作者');
+    }
+
+    // ───────── 欄位提示與動作 ─────────
+
+    #[Test]
+    public function text_instance_textid_gets_hint_and_load_action(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour']['c_textid'];
+                $this->assertSame('load_text_title', $b['action']);
+                // 提示文字帶 :link 佔位，前端就地換成真正的 <a>（保留舊版「連結在句中」的讀法）。
+                $this->assertStringContainsString(':link', $b['hint']['text']);
+                // 提示文字不得含 HTML：連結另以結構化資料傳出，前端不用 dangerouslySetInnerHTML。
+                $this->assertStringNotContainsString('<a', $b['hint']['text']);
+                $this->assertSame('TEXT_CODES', $b['hint']['link']['label']);
+                // flag-aware：codes flag=new 時必須指向 React 版（先前 Create.tsx 硬寫 /codes/TEXT_CODES）
+                $this->assertSame('/app/codes/TEXT_CODES', $b['hint']['link']['href']);
+            });
+    }
+
+    #[Test]
+    public function addr_belongs_columns_get_the_copy_hint(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'ADDR_BELONGS_DATA', 'id' => '7_._8']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach (['c_addr_id', 'c_belongs_to'] as $col) {
+                    $this->assertStringContainsString(':link', $b[$col]['hint']['text']);
+                    $this->assertStringNotContainsString('<a', $b[$col]['hint']['text']);
+                    $this->assertSame('ADDR_CODES', $b[$col]['hint']['link']['label']);
+                    $this->assertSame('/app/codes/ADDR_CODES', $b[$col]['hint']['link']['href']);
+                    $this->assertArrayNotHasKey('action', $b[$col]);
+                }
+            });
+    }
+
+    #[Test]
+    public function plain_table_has_no_special_behaviour(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEST_PLAIN_CODES', 'id' => 1]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('column_behaviour', []));
+    }
+
+    // ───────── Load Data 端點 ─────────
+
+    #[Test]
+    public function text_title_endpoint_returns_the_exact_book(): void {
+        $this->getJson(route('app.codes.text-title', ['textId' => 500]))
+            ->assertOk()
+            ->assertJson(['found' => true, 'c_textid' => 500, 'c_title_chn' => '雪篷夜話', 'c_title' => 'xue peng ye hua']);
+    }
+
+    #[Test]
+    public function text_title_endpoint_does_not_fall_back_to_a_title_match(): void {
+        // 舊版按鈕打 /api/select/search/text（c_title_chn LIKE %q% OR c_textid = q）再取 data[0]，
+        // 查 c_textid=500 時可能回傳「雜記五百篇 500 卷」。此端點必須是主鍵精確查詢。
+        $this->getJson(route('app.codes.text-title', ['textId' => 500]))
+            ->assertOk()
+            ->assertJsonPath('c_title_chn', '雪篷夜話');
+
+        // 不存在的 ID 不得因為標題含該數字就命中
+        $this->getJson(route('app.codes.text-title', ['textId' => 5001]))
+            ->assertStatus(404)
+            ->assertJson(['found' => false]);
+    }
+
+    #[Test]
+    public function text_title_endpoint_rejects_non_numeric_ids(): void {
+        // 非數字必須被路由的 where('[0-9]+') 擋掉：否則會落到控制器做 (int)'abc' === 0，
+        // 撈到 c_textid=0 的「未知」書目（fixture 裡刻意放了可辨識的書名）。
+        // 狀態碼釘 405 而非 404：該路徑同時符合泛用的 PATCH/PUT/DELETE app/codes/{table_name}/{id}，
+        // Laravel 對「路徑存在但方法不符」固定回 405——若守衛被移除，這裡會變成 200。
+        $response = $this->getJson('/app/codes/text-title/abc');
+        $response->assertStatus(405);
+        // 關鍵斷言：不得回傳 c_textid=0 那一列的內容。移除路由守衛時此行會失敗。
+        $this->assertStringNotContainsString('未知書目哨兵', $response->getContent());
+    }
+
+    #[Test]
+    public function text_title_endpoint_can_still_look_up_the_unknown_book_row(): void {
+        // c_textid=0 是真實可編輯的列，明確用 0 查詢時應該查得到（不是被當成無效輸入）。
+        $this->getJson(route('app.codes.text-title', ['textId' => 0]))
+            ->assertOk()
+            ->assertJson(['found' => true, 'c_textid' => 0, 'c_title_chn' => '未知書目哨兵']);
+    }
+
+    #[Test]
+    public function text_title_endpoint_reports_a_book_with_no_titles(): void {
+        // 前端據此顯示「該書沒有書名可帶入」，而不是誤報成「兩欄皆已有值」。
+        $this->getJson(route('app.codes.text-title', ['textId' => 700]))
+            ->assertOk()
+            ->assertJson(['found' => true, 'c_textid' => 700])
+            ->assertJsonPath('c_title_chn', null)
+            ->assertJsonPath('c_title', null);
+    }
+
+    #[Test]
+    public function proposal_edit_also_marks_audit_columns_readonly_without_the_preview(): void {
+        // 三個碼表表單一致：提案調整頁也不開放編輯稽核欄。
+        // 但不給「提交後會被替換為 X」——替換發生在核准當下、由審核人蓋章，現在預告會誤導。
+        $opId = DB::table('operations')->insertGetId([
+            'user_id' => $this->activeUser()->id,
+            'c_personid' => 0,
+            'resource' => 'TEXT_INSTANCE_DATA',
+            'resource_id' => '500_._1',
+            'op_type' => \App\Models\Operation::TYPE_PROPOSAL_UPDATE,
+            'resource_data' => json_encode([
+                'c_textid' => 500, 'c_instance_id' => 1, 'c_instance_title_chn' => '提案改名',
+                '__key_columns' => ['c_textid', 'c_instance_id'],
+                '__proposal_meta' => ['action' => 'update', 'table' => 'TEXT_INSTANCE_DATA'],
+                '__review_status' => 'pending',
+            ]),
+            'resource_original' => json_encode(['c_textid' => 500, 'c_instance_id' => 1]),
+            'crowdsourcing_status' => 0,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.proposals.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'operation' => $opId]))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach (['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'] as $col) {
+                    $this->assertTrue($b[$col]['readonly'], "{$col} 應唯讀");
+                    $this->assertArrayNotHasKey('hint', $b[$col], "{$col} 不應有替換預覽");
+                }
+            });
+    }
+
+    #[Test]
+    public function create_page_also_gets_the_column_hints(): void {
+        // 這些提示原本是 Create.tsx 的硬編碼中文（英文語境漏字），現由後端供給；不可只有 edit 有。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'TEXT_INSTANCE_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour']['c_textid'];
+                $this->assertStringContainsString(':link', $b['hint']['text']);
+                $this->assertStringNotContainsString('<a', $b['hint']['text']);
+                $this->assertSame('TEXT_CODES', $b['hint']['link']['label']);
+                $this->assertSame('load_text_title', $b['action']);
+            });
+    }
+
+    #[Test]
+    public function column_hints_are_translated_in_the_en_locale(): void {
+        // 修復動機之一就是「英文語境漏字」——鎖住 en 真的拿到英文而非中文。
+        $this->actingAs($this->activeUser())
+            ->withSession(['locale' => 'en'])
+            ->get(route('app.codes.edit', ['table_name' => 'TEXT_INSTANCE_DATA', 'id' => '500_._1']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertStringContainsString('Make sure', $b['c_textid']['hint']['text']);
+                $this->assertStringContainsString('replaced', $b['c_modified_by']['hint']['text']);
+            });
+    }
+}


### PR DESCRIPTION
## 起因：作者清單的缺口不是孤例

上一個 PR（#1224）補回 TEXT_CODES 編輯頁的作者清單後，做了一次全站掃描找同類缺口。方法是以**翻譯鍵**當橋樑（Blade 用 `__('group.key')`、React 用 `t('key')`，共用同一份 lang 檔）：Blade 使用 961 個鍵，其中 275 個在 React 端完全找不到。扣掉 `cbdbapi/person`、`maps`、`home` 三個**本來就沒有 React 版也沒有 flag**的頁面（共 81 個鍵），確認**真缺口集中在 `Codes/Edit.tsx`**。

原因很清楚：React 把新增／編輯頁寫成泛用表單（`columns` → 純 `<Input>`），而舊版 `codes/edit.blade.php` 是「按表／按欄位」特殊處理，那些分支整批沒跟過來。

> 方法論註記：原本想用「Blade 呼叫但 React 沒呼叫的端點」當主訊號（就是抓到作者清單的線索），但那會誤報——React 的端點多由 server props 傳入，`Welcome.tsx` 的姓名搜尋就是例子。翻譯鍵可靠得多。

## 修法

新增 `CodesController::codeColumnBehaviour()` 作為逐欄行為的**單一落點**，三個碼表表單（Create／Edit／ProposalEdit）共用，避免各自再長出一套硬編碼。

| 舊版行為 | 修復前的 React | 現行 |
|---|---|---|
| 四個稽核欄 `readonly` | 可自由輸入、無任何提示 | 灰底 `readOnly`（三個表單一致） |
| `c_modified_*` 標「提交後會被替換為 X」 | 無 | 補回，且改走 `AuditActor::currentName()`（與實際落庫署名同源）；`tone=warn` 粗體主色 |
| TEXT_CODES／ADDR_CODES 複製提示 | `Edit` 無；`Create` 硬編碼中文 | 後端供給、`:link` 佔位就地嵌回句中、連結 flag-aware |
| TEXT_INSTANCE_DATA「Load Data」鈕 | 完全沒有 | 補回，只填空欄 |

**稽核欄用 `readOnly` 而非 `disabled`**：這四欄的用途就是被讀，`disabled` 在 Chrome／Firefox 會讓文字無法選取複製，而舊版用的也是 `readonly`。兩者都達成「使用者不能改」。**送出內容與改動前逐位元相同**——欄位仍在 `columns` 與 `form.data` 裡，只改 UI；另有測試鎖住「偽造稽核值送出也不生效」（`c_created_by` 沿用原值、`c_modified_by` 蓋成當下操作者）。

**Load Data 修掉舊版兩個缺陷**：舊版打 `/api/select/search/text`（`c_title_chn LIKE %q% OR c_textid = q`）再取 `data[0]`，用 ID 查時可能撈到「標題剛好含這串數字」的別本書——改為新端點 `app/codes/text-title/{textId}` 主鍵精確查詢（帶 `throttle:60,1`，理由同 `codes.export`）；舊版無條件覆寫兩個書名欄——改為**只填空欄**，不蓋掉人工修訂過的書名，並沿用舊版填入後標黃底的提示。

## 審查發現並修掉的問題

- **`FormField` 包 `<div>` 造成重複 DOM id 與 label 失效**（本 PR 中途引入，而且我在 `Edit.tsx` 別處寫過警告這個陷阱的註解）：`FormField` 會把 id 與 aria 注入「單一子節點」，而這裡的子節點是包住輸入框＋動作鈕＋提示的 `<div>`——`<div>` 與 `<input>` 拿到相同 id（每頁重複十餘個）、`<label for>` 指到不可標記的 `<div>` 而失效（點欄位標籤不再聚焦輸入框）、`aria-invalid`／`aria-describedby` 也落在 div 上。改為不套 `FormField`、自行組出 label／aria 關聯。
- **訊息會說謊**：`sourceHadTitle` 原本是「整次請求」一個旗標，於是「中文欄已填、拼音欄空、書目只有中文書名」——一個**真實存在的形狀**（21 筆 TEXT_CODES 無拼音書名、7 筆 instance 正好如此）——會誤報成「兩個書名欄皆已有值」。改為逐欄判定，如實列出哪些欄被帶入、哪些欄因來源沒有書名而仍為空。
- **併發**：以單調遞增的 run token 加 `c_textid` 比對，成功／404／例外三條出口都只允許「最後一次啟動且 `c_textid` 未變」的請求寫狀態（原本只擋成功路徑，舊請求的 404 會蓋掉新畫面）；`reset()` 保留 `pending`，避免請求進行中改欄位讓按鈕重新啟用而交錯。
- **無效的測試**：`text_title_endpoint_rejects_non_numeric_ids` 原本移除路由守衛也照樣綠——fixture 缺 `c_textid=0` 那一列，`(int)'abc' === 0` 沒東西可撈。補上可辨識的哨兵書名並釘住狀態碼；實際移除守衛驗證過會轉紅（200 ≠ 405）。
- 其他：`:link` 只替換第一個佔位（多佔位譯文會漏）、CJK 全角標點漏進英文語境、新端點無 throttle、訊息離按鈕太遠且未加 `role="status"`、三個測試名稱與斷言不符、`Edit.tsx` 漏了舊版兩頁都有的「直接儲存會忽略此欄」提示。
- **一致性補完**：提案調整頁（`ProposalEdit.tsx`）同樣套用逐欄行為（稽核欄唯讀，但**不給替換預覽**——替換發生在核准當下、由審核人蓋章）。核准端 `OperationsProposalController::enforceAuditFieldsForCreate/Update` 本來就會無條件剔除並重蓋，所以這不是資料漏洞，只是不再邀請使用者對著會被丟棄的輸入框打字。
- 附帶修掉 `Create.tsx` 的結構缺陷：兩顆送出按鈕原本被包在 `{can_propose && ...}` 內，而 `app.codes.create` 沒有 auth middleware，訪客／非活躍帳號會看到完整表單卻一顆按鈕都沒有。

## 測試

- `CodesColumnBehaviourTest`（18 tests）：稽核欄三個表單皆唯讀／替換預覽只給 `c_modified_*`／未登入無預覽但仍唯讀／提案調整頁唯讀但無預覽／新增頁欄位清單不變／偽造稽核值不生效／提示帶 `:link` 且不含 HTML／連結 flag-aware 指向 `/app/codes/TEXT_CODES`／新增頁也有提示／en 語境真的拿到英文／端點精確查詢且不退回標題模糊命中／可查 `c_textid=0` 的「未知」書目／回報無書名的書目／非數字 ID 被拒。
- headless Chrome 對真實 MariaDB 驗證 **22 項**：稽核欄唯讀灰底且每欄僅一個 DOM id、label 正確關聯、替換預覽含操作者名與時間戳、帶入「愛日齋叢鈔」並標黃底、第二次按不覆蓋、訊息就近顯示且動表單即清除、其他碼表無此按鈕；另針對只有中文書名的 `c_textid=7626` 驗三種訊息情境（兩欄空／中文欄已填／兩欄皆有值）。
- `./vendor/bin/phpunit` 2461 tests 綠；`php-cs-fixer`（清 cache）零改動；`npm run build` 通過；`tsc` 錯誤行數與改動前相同（51，皆為既有問題）。

## 範圍與後續

- **人物選擇器（`c_personid`／`c_kin_id` 等欄改為可搜尋人物）不在本 PR**，另開處理。已定調用**外鍵指向 `BIOG_MAIN`** 為唯一權威（schema 說了算，`information_schema` 自動推導、不需人工白名單）。影響 17 張碼表。
- 舊版 `codes/edit.blade.php` 除人物選擇器外已無其他未移植行為（本次逐行對照確認）。
- `/api/select/search/textauthor` 與 `codes.person_search_placeholder`、`loading_author`、`no_textid_msg` 等鍵**不可現在刪**：舊版 Blade 仍在用，且 codes 系列 legacy 路由沒有 flag gate。列入 Phase 7 AdminLTE 下架清單。
- 已知並存的小事：`c_modified_date` 的預覽時間戳在頁面久置後會與實際寫入時間有落差（舊版同行為，屬 parity）；新增頁的 `c_textid` 預填是 `max+1`（不存在的書），第一次按帶入會回「找不到」（舊版同行為）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
