### PR TITLE
codes 表單的人物欄改為可搜尋的人物選擇器（判準改用外鍵）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## 2026-08
 
+### codes 表單的人物欄改為可搜尋的人物選擇器（判準改用外鍵）
+- 承上一則：泛用 codes 表單漏移植的最後一項。舊版 `codes/edit.blade.php` 把人物欄渲染成 select2（姓名或 ID 皆可查），React 版是純數字輸入框——使用者必須先知道人物 ID 才能填。
+- **判準改為「外鍵實際指向 `BIOG_MAIN`」，以 schema 宣告為唯一權威**（`CodesController::personFkColumns()`）。舊版是按欄名硬編碼 `c_personid`／`c_kin_id`，會漏掉 `ASSOC_DATA` 的 `c_assoc_id`（社會關係「對方是誰」）、`c_assoc_kin_id`、`c_assoc_claimer_id`、`c_tertiary_personid` 與 `ENTRY_DATA.c_assoc_id` 共 5 個真人物欄——恰恰是最需要用姓名搜尋的地方。改用外鍵後涵蓋 **17 張碼表、25 個欄位**，且隨 schema 自動跟上，不需維護人工白名單。
+- 兩項刻意的取捨（已與使用者確認「錯判和漏都符合設計」）：`BIOG_MAIN.c_index_year_source_id` 會被納入（欄名像出處，但 schema 確實宣告外鍵指向 `BIOG_MAIN`）；`MERGED_PERSON_DATA.c_personid` 不納入（無外鍵——被合併的人可能已不存在）。兩者都由測試明文鎖住。
+- 外鍵反射用 `Schema::getForeignKeys()` 而非 `information_schema`：後者在 SQLite 不存在，前者由 driver 各自實作（SQLite 走 `PRAGMA foreign_key_list`），符合雙資料庫相容要求；反射失敗只讓該欄退回純輸入框並記錄例外，不讓整頁掛掉。
+- 選擇器沿用既有的 `CodeAutocomplete`（`mode="search"`，端點 `/api/select/search/biog`，與親屬編輯頁的「親屬姓名」同一支），因此自動獲得同一份 debounce 與過期回應守衛。後端另附上目前值的顯示名稱（`picker.label`，如「晁公武 / Chao Gongwu」），否則畫面上只看到一個數字；姓名兩欄皆空的人物退回顯示 ID，不讓欄位看起來像沒選。
+- **「未詳」哨兵**：人物搜尋端點 `ApiController::searchBiog` 刻意把 person 0（未詳）的 option value 編成 `-999`，那是前端「未設定」哨兵、不是人物 ID。`BIOG_MAIN` 沒有 `-999` 這一列，直接落庫會撞外鍵 1452（錯誤訊息還指向「必填未填」），而提案路徑不碰資料表、會把 `-999` 原樣存進 `resource_data`，讓審核人看到 `-999` 並在核准時才爆掉——而「未詳」在 CBDB 極常見。改為在 `extractFormData()` 這個單一收口把人物欄的 `-999` 還原成 `0`（五條 codes 寫入／記錄路徑全部經過它；先前兩處 inline `Arr::except` 的控制鍵清單與它完全等價）。**只在「`-999` 確定不是真實人物」時才還原**：`c_personid` 是有號 int、無 UNSIGNED／CHECK 限制，schema 允許負值（現行資料 min=0、無負值），若真有 person `-999`，無條件改寫會把關係靜默改指到別人身上；查不到 `BIOG_MAIN` 時亦不改寫。同一份顧慮見 `ExactCodeMatchGuard`。
+- **人物主鍵欄不再預填猜測值**：`appCreate` 原本把第一個主鍵欄預填成 `max+1`，而 `BIOG_ADDR_DATA`、`STATUS_DATA` 的第一個主鍵欄就是 `c_personid`；CBDB 人物 ID 很密集，那個猜測值往往真的存在，於是選擇器會把它解析成一位**真實人物姓名**，看起來像「已選好某人」——使用者填完其他欄一存，資料就被歸到隨機的人身上。先前是純數字輸入框，數字看起來就是佔位符，風險較低；改成選擇器後必須擋掉。留空反而能得到正確的「請確認主鍵欄位已填寫完整」提示。
+- 有值就一定有可顯示文字：查不到人物時 `picker.label` 退回顯示 ID。否則 `CodeAutocomplete` 顯示空白而 `form.data` 仍藏著那個值，使用者以為沒填、送出後撞外鍵（提案調整頁尤其會遇到——`resource_data` 裡的人物可能在送審後被合併掉）。
+- 外鍵表名比對改為大小寫不敏感：MySQL 在 `lower_case_table_names=1`（Windows 預設）會回報 `biog_main`，硬比大寫會讓**所有選擇器無聲消失**。控制器其他處（`guardTable`／`getKeyColumns`／`isReadOnlyTable`）也都先 `strtoupper`。
+- 送出內容不變：選擇器回寫的仍是代碼字串，清空得到空字串——與先前純文字輸入框可被清空的行為一致。人物欄若同時是主鍵（如 `KIN_DATA.c_personid`），透過選擇器改值與先前用文字框改值走同一條 `performUpdate` 路徑（依 URL 主鍵定位、`update()` 就地換鍵，重複鍵與完整性違規各有友善訊息），**不是本次新增的能力**。
+- 選擇器的顯示文字帶人物 ID（如「11 晁公武 / Chao Gongwu」）：改成選擇器後欄位本身不再顯示數字，而編目者是以 ID 工作的；搜尋候選同樣以 ID 開頭，選前選後讀法一致。
+- 回歸測試 `CodesPersonPickerTest`（15 tests：六個有外鍵的欄位都有選擇器／涵蓋舊版按欄名會漏掉的 4 欄／非人物欄不給／帶 ID 的顯示名稱／無值與查不到時的退回行為／欄名像人物但無外鍵者不給／無人物欄的表為空／新增頁不預填人物主鍵／選未詳落庫為 0／`-999` 是真實人物時不改寫／非人物欄的 `-999` 原樣保留／提案不留 `-999`／人物選擇器與稽核欄唯讀互不覆寫）。另以 headless Chrome 對真實庫驗證 7 項（含姓名搜尋、ID 搜尋、`MERGED_PERSON_DATA` 維持純輸入）。
+
 ### 補回 codes 表單的逐欄行為：稽核欄不可編輯、欄位提示、依 c_textid 帶入書名
 - 起因：上一則作者清單的缺口不是孤例。以「Blade 有用、React 端完全找不到的翻譯鍵」為橋樑掃過全站（961 個鍵→275 個孤兒；扣掉 `cbdbapi/person`、`maps`、`home` 三個本來就沒有 React 版也沒有 flag 的頁面共 81 個），確認**真缺口集中在 `Codes/Edit.tsx`**——React 版把新增／編輯頁寫成泛用表單（`columns` → 純 `Input`），舊版 `codes/edit.blade.php` 的逐欄特殊處理因此整批漏移植。掃描方法的侷限一併記下：先前想用「Blade 呼叫但 React 沒呼叫的端點」當主訊號會誤報，因為 React 的端點多由 server props 傳入（`Welcome.tsx` 的姓名搜尋即為例）。
 - 新增 `CodesController::codeColumnBehaviour()` 作為逐欄行為的單一落點，Create／Edit 兩頁共用，避免各自再長出一套硬編碼：

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -35,6 +35,15 @@ class CodesController extends Controller {
      */
     protected const AUDIT_COLUMNS = ['c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date'];
 
+    /** 人物搜尋端點（姓名或 ID 皆可查），與 KinEditor 的親屬姓名欄同一支。 */
+    protected const PERSON_SEARCH_ENDPOINT = '/api/select/search/biog';
+
+    /** 每個 request 內的「指向 BIOG_MAIN 的欄位」快取，避免同一頁重複做外鍵反射。 */
+    protected array $personFkColumnsCache = [];
+
+    /** 每個 request 內快取「-999 是否確定不是真實人物」，見 personSentinelIsSafeToNormalize()。 */
+    protected ?bool $personSentinelSafe = null;
+
     protected $codesrepostory;
     protected $operationRepository;
 
@@ -952,7 +961,7 @@ class CodesController extends Controller {
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
             // 逐欄特殊行為（稽核欄唯讀＋替換預覽、欄位提示、Load Data 動作）。
-            'column_behaviour' => $this->codeColumnBehaviour($table, array_keys($rowArray), 'edit'),
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_keys($rowArray), 'edit', $rowArray),
             'text_title_endpoint' => route('app.codes.text-title', ['textId' => '__TEXT_ID__'], false),
             // TEXT_CODES：附上該書的作者／編者等關係人（唯讀錄入參考）。其餘碼表為 null，前端不渲染。
             // 用 isset 而非 ?? 0：c_textid=0 是真實可編輯的「未知」書目列（其下掛著 37 筆關係人），
@@ -1075,8 +1084,39 @@ class CodesController extends Controller {
      *                                  現在預告一個署名與時間都會不同的值只會誤導。
      * @return array<string, array<string, mixed>>
      */
-    protected function codeColumnBehaviour(string $table, array $columns, string $mode): array {
+    protected function codeColumnBehaviour(string $table, array $columns, string $mode, array $values = []): array {
         $behaviour = [];
+
+        // 人物欄 → 可搜尋的人物選擇器（姓名或 ID 皆可查），對齊舊版 select2；判準見 personFkColumns()。
+        $personColumns = array_values(array_intersect($this->personFkColumns($table), $columns));
+        if ($personColumns !== []) {
+            $currentIds = [];
+            foreach ($personColumns as $column) {
+                $raw = $values[$column] ?? null;
+                if (is_numeric($raw)) {
+                    $currentIds[] = (int) $raw;
+                }
+            }
+            $labels = $this->personLabels($currentIds);
+
+            foreach ($personColumns as $column) {
+                $raw = $values[$column] ?? null;
+                // 有值就一定要有可顯示的文字：查不到人物時退回顯示 ID。
+                // 否則 CodeAutocomplete 會顯示空白，而 form.data 裡仍藏著那個值——
+                // 使用者以為沒填、送出後卻撞外鍵，看到的是「關聯值不存在」而非「必填未填」。
+                $label = null;
+                if (is_numeric($raw)) {
+                    $label = $labels[(int) $raw] ?? (string) $raw;
+                }
+                $behaviour[$column] = [
+                    'picker' => [
+                        'kind' => 'person',
+                        'endpoint' => self::PERSON_SEARCH_ENDPOINT,
+                        'label' => $label,
+                    ],
+                ];
+            }
+        }
 
         // 稽核欄一律由系統蓋章，任何模式都不開放使用者編輯 → 灰底唯讀（可看、可複製、不可改）。
         // 新增與編輯採同一條規則，不做「新增時隱藏」的第二套行為。
@@ -1086,7 +1126,8 @@ class CodesController extends Controller {
             if (!in_array($column, $columns, true)) {
                 continue;
             }
-            $behaviour[$column] = ['readonly' => true];
+            // 用 merge 而非覆寫：目前稽核欄與人物欄不會重疊，但別讓順序決定誰活下來。
+            $behaviour[$column] = array_merge($behaviour[$column] ?? [], ['readonly' => true]);
         }
 
         // 「提交後會被替換為 X」：只有 c_modified_* 會被改寫成當下值，故只有這兩欄給預覽。
@@ -1138,6 +1179,76 @@ class CodesController extends Controller {
         }
 
         return $behaviour;
+    }
+
+    /**
+     * 該表哪些欄位是「人物欄」——判準為**外鍵實際指向 BIOG_MAIN**。
+     *
+     * 以 schema 宣告的外鍵為唯一權威（使用者定調）：外鍵說指向 BIOG_MAIN 就給人物選擇器，
+     * 沒有外鍵就不給。好處是規則只有一條、隨 schema 自動跟上，不必維護人工白名單。
+     * 已知取捨（皆為刻意）：
+     *   - `BIOG_MAIN.c_index_year_source_id` 會被納入（欄名像出處，但外鍵確實宣告指向 BIOG_MAIN）。
+     *   - `MERGED_PERSON_DATA.c_personid` 不會被納入（沒有外鍵——被合併的人可能已不存在）。
+     * 舊版是按欄名硬編碼 `c_personid`／`c_kin_id`，會漏掉 ASSOC_DATA 的 4 個關係人欄與
+     * ENTRY_DATA.c_assoc_id（社會關係「對方是誰」正是最需要搜尋的欄位）。
+     *
+     * 用 Schema::getForeignKeys()（Laravel 11+）而非 information_schema：後者在 SQLite 不存在，
+     * 前者由 driver 各自實作（SQLite 走 PRAGMA foreign_key_list），符合雙資料庫相容要求。
+     *
+     * @return array<int, string>
+     */
+    protected function personFkColumns(string $table): array {
+        if (array_key_exists($table, $this->personFkColumnsCache)) {
+            return $this->personFkColumnsCache[$table];
+        }
+
+        $columns = [];
+
+        try {
+            foreach (Schema::getForeignKeys($table) as $fk) {
+                // 大小寫不敏感比對：MySQL 在 lower_case_table_names=1（Windows 預設）時
+                // 回報的是 biog_main，硬比大寫會讓所有選擇器無聲消失。
+                // 控制器其他處（guardTable／getKeyColumns／isReadOnlyTable）也都先 strtoupper。
+                if (strtoupper((string) ($fk['foreign_table'] ?? '')) !== 'BIOG_MAIN') {
+                    continue;
+                }
+                foreach ($fk['columns'] ?? [] as $column) {
+                    $columns[] = $column;
+                }
+            }
+        } catch (\Throwable $e) {
+            // 外鍵反射失敗（權限不足、driver 不支援等）只該讓選擇器退回純輸入框，
+            // 不該讓整個碼表編輯頁掛掉。
+            report($e);
+            $columns = [];
+        }
+
+        return $this->personFkColumnsCache[$table] = array_values(array_unique($columns));
+    }
+
+    /**
+     * 取回一批人物 ID 的顯示名稱（供人物選擇器初始顯示，否則只看到一個數字）。
+     *
+     * @param  array<int, int>      $personIds
+     * @return array<int, string>   personId => 「中文名 / 拼音名」
+     */
+    protected function personLabels(array $personIds): array {
+        $ids = array_values(array_unique(array_filter($personIds, static fn ($id) => $id !== null)));
+        if ($ids === []) {
+            return [];
+        }
+
+        $labels = [];
+        foreach (DB::table('BIOG_MAIN')->whereIn('c_personid', $ids)->get(['c_personid', 'c_name_chn', 'c_name']) as $row) {
+            $parts = array_filter([$row->c_name_chn, $row->c_name], static fn ($v) => $v !== null && $v !== '');
+            // 保留人物 ID：改成選擇器後欄位本身不再顯示數字，而編目者是以 ID 工作的；
+            // 搜尋端點回傳的候選文字同樣以 ID 開頭，選前選後的讀法一致。
+            $labels[(int) $row->c_personid] = $parts === []
+                ? (string) $row->c_personid
+                : $row->c_personid . ' ' . implode(' / ', $parts);
+        }
+
+        return $labels;
     }
 
     /**
@@ -1204,7 +1315,8 @@ class CodesController extends Controller {
         foreach ($conditions as $column => $value) {
             $query->where($column, $value);
         }
-        $data = Arr::except($request->all(), ['_method', '_token', '__proposal_comment']);
+        // 與提案路徑共用同一個取值收口（控制鍵清單相同），順帶歸一化人物欄的 -999 哨兵。
+        $data = $this->extractFormData($request, $table);
         $data = $this->enforceAuditFieldsForUpdate($data, $originalRow ?: []);
         $data = $this->normalizeCodeTablePinyin($table, $data);
         // 與 performStore 一致：留白的 NOT NULL（有預設值）欄不寫入 null（更新時等於保留原值），
@@ -1302,7 +1414,13 @@ class CodesController extends Controller {
 
         $defaults = [];
         $firstKey = $keyColumns[0] ?? null;
-        if ($firstKey && in_array($firstKey, $columns, true)) {
+        // 人物欄不預填「下一個可用值」：max(c_personid)+1 對人物毫無意義，而 CBDB 的人物 ID 很密集，
+        // 那個猜測值往往真的存在，於是人物選擇器會把它解析成一位真實人物姓名——看起來像是「已選好某人」，
+        // 使用者填完其他欄一存，資料就被歸到一個隨機的人身上（如 BIOG_ADDR_DATA、STATUS_DATA 的
+        // 第一個主鍵欄就是 c_personid）。留空反而能得到正確的「請確認主鍵欄位已填寫完整」提示。
+        // 先前是純數字輸入框，數字看起來就是佔位符，風險較低；改成選擇器後必須擋掉。
+        $isPersonKey = $firstKey !== null && in_array($firstKey, $this->personFkColumns($table), true);
+        if ($firstKey && !$isPersonKey && in_array($firstKey, $columns, true)) {
             $nextValue = $this->guessNextKeyValue($table, $firstKey);
             if ($nextValue !== null) {
                 $defaults[$firstKey] = $nextValue;
@@ -1326,7 +1444,7 @@ class CodesController extends Controller {
             'can_propose' => Auth::check() && Auth::user()->isActive(),
             'tier2_fields' => $this->codeTableTier2Fields($table),
             // 與 edit 共用同一份逐欄行為（此頁的欄位提示原為前端硬編碼中文，改由此處統一供給）。
-            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'create'),
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'create', $defaults),
             'text_title_endpoint' => route('app.codes.text-title', ['textId' => '__TEXT_ID__'], false),
             'urls' => [
                 'store' => route('app.codes.store', ['table_name' => $table], false),
@@ -1362,7 +1480,7 @@ class CodesController extends Controller {
             return $redirect;
         }
 
-        $payload = $this->extractFormData($request);
+        $payload = $this->extractFormData($request, $table);
         $payload = $this->normalizeCodeTablePinyin($table, $payload);
         $keyColumns = $this->getKeyColumns($table);
 
@@ -1457,7 +1575,7 @@ class CodesController extends Controller {
             'is_create_proposal' => (int) $operation['op_type'] === Operation::TYPE_PROPOSAL_CREATE,
             // 提案調整頁同樣不開放編輯稽核欄（三個碼表表單一致）。核准端本來就會剔除並重蓋，
             // 但讓使用者對著一個會被丟棄的輸入框打字沒有意義。mode=proposal → 唯讀但不給替換預覽。
-            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'proposal'),
+            'column_behaviour' => $this->codeColumnBehaviour($table, array_values($columns), 'proposal', $values),
             'urls' => [
                 'update' => route('app.codes.proposals.update', ['table_name' => $table, 'operation' => $operation['id']], false),
                 'return' => route('operations.index', ['proposals_only' => 1], false),
@@ -1474,7 +1592,7 @@ class CodesController extends Controller {
         $payload = $this->ensureProposalEditable($operation, $table);
         $keyColumns = $payload['__key_columns'] ?? $this->getKeyColumns($table);
 
-        $data = $this->extractFormData($request);
+        $data = $this->extractFormData($request, $table);
         $data = $this->normalizeCodeTablePinyin($table, $data); // §D-6：編輯既有提案時亦歸一化 Tier 1，避免核准落庫仍帶 v
         $isCreate = (int) $operation['op_type'] === Operation::TYPE_PROPOSAL_CREATE;
 
@@ -1606,7 +1724,8 @@ class CodesController extends Controller {
 
             return redirect()->route($showRoute, ['table_name' => $table]);
         }
-        $data = Arr::except($request->all(), ['_token', '__proposal_comment']);
+        // 與 performUpdate／提案路徑共用同一個取值收口，順帶歸一化人物欄的 -999 哨兵。
+        $data = $this->extractFormData($request, $table);
         $keyColumns = $this->getKeyColumns($table);
         if (!$this->hasPrimaryKeyValues($keyColumns, $data)) {
             flash('新增失敗：請確認主鍵欄位已填寫完整。', 'error');
@@ -1690,7 +1809,7 @@ class CodesController extends Controller {
         }
 
         $payload = $this->enforceAuditFieldsForUpdate(
-            $this->extractFormData($request),
+            $this->extractFormData($request, $table),
             $originalRow
         );
         $payload = $this->normalizeCodeTablePinyin($table, $payload);
@@ -2554,8 +2673,61 @@ class CodesController extends Controller {
         return null;
     }
 
-    protected function extractFormData(Request $request): array {
-        return Arr::except($request->all(), ['_token', '_method', '__proposal_comment']);
+    /**
+     * 從請求取出要落庫／記入提案的欄位值。
+     *
+     * 傳入 $table 時額外歸一化人物欄的 -999：人物選擇器打的 /api/select/search/biog 刻意把
+     * person 0（未詳）的 option value 編成 -999（ApiController::searchBiog），那是「未設定」的
+     * 前端哨兵、不是人物 ID。BIOG_MAIN 沒有 -999 這一列，直接落庫會撞外鍵 1452，而提案路徑
+     * 不碰資料表、會把 -999 原樣存進 resource_data，讓審核人看到 -999 並在核准時才爆掉。
+     * 使用者選「未詳」的本意就是 person 0（BIOG_MAIN 確實有這一列），故還原成 0。
+     *
+     * 只在「-999 不是真實人物」時才還原：c_personid 是有號 int、無 UNSIGNED／CHECK 限制，
+     * schema 允許負值（現行資料 min=0、無負值、無 -999）。若有人真的建了 person -999，
+     * 無條件改寫會把關係靜默改指到別人身上——寧可停止改寫，讓 searchBiog 的編碼歧義留在原處，
+     * 也不要動別人的資料。同一份顧慮見 ExactCodeMatchGuard（db0f388）。
+     */
+    protected function extractFormData(Request $request, ?string $table = null): array {
+        $data = Arr::except($request->all(), ['_token', '_method', '__proposal_comment']);
+
+        if ($table === null) {
+            return $data;
+        }
+
+        // 先找出「這次真的送了 -999 的人物欄」，沒有就完全不碰資料庫——否則會在沒有 BIOG_MAIN 的
+        // 環境（例如只造了自己那張表的測試）憑空多一次查詢而炸掉不相關的流程。
+        $pending = [];
+        foreach ($this->personFkColumns($table) as $column) {
+            if (array_key_exists($column, $data) && (string) $data[$column] === '-999') {
+                $pending[] = $column;
+            }
+        }
+        if ($pending === [] || !$this->personSentinelIsSafeToNormalize()) {
+            return $data;
+        }
+
+        foreach ($pending as $column) {
+            $data[$column] = '0';
+        }
+
+        return $data;
+    }
+
+    /**
+     * -999 是否確定不是真實人物（因此可安全視為選擇器的「未設定」哨兵）。每 request 查一次。
+     * 查不到 BIOG_MAIN（環境不完整）時回 false：不改寫勝過依猜測改寫別人的資料。
+     */
+    protected function personSentinelIsSafeToNormalize(): bool {
+        if ($this->personSentinelSafe === null) {
+            try {
+                $this->personSentinelSafe = !DB::table('BIOG_MAIN')->where('c_personid', -999)->exists();
+            } catch (\Throwable $e) {
+                report($e);
+                $this->personSentinelSafe = false;
+            }
+        }
+
+        return $this->personSentinelSafe;
     }
 
     protected function hasPrimaryKeyValues(array $keyColumns, array $data): bool {

--- a/resources/js/inertia/components/Codes/CodesColumnField.tsx
+++ b/resources/js/inertia/components/Codes/CodesColumnField.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
+import CodeAutocomplete from '../PersonBrowser/shared/CodeAutocomplete';
 
 /**
  * 泛用 codes 表單的單一欄位。
@@ -33,6 +34,12 @@ export interface ColumnBehaviour {
     hint?: { text: string; link?: { href: string; label: string }; tone?: 'info' | 'warn' };
     /** 額外互動。目前僅 'load_text_title'（依 c_textid 帶入書名）。 */
     action?: string;
+    /**
+     * 該欄改用可搜尋的選擇器而非純輸入框。
+     * 目前只有 kind='person'（外鍵指向 BIOG_MAIN 的欄位，見 CodesController::personFkColumns）。
+     * label 是目前值的顯示名稱，供選擇器初始顯示——否則使用者只看到一個數字。
+     */
+    picker?: { kind: 'person'; endpoint: string; label?: string | null };
 }
 
 interface Props {
@@ -101,6 +108,7 @@ export function CodesColumnField({
 }: Props) {
     const readOnly = behaviour?.readonly === true;
     const hint = behaviour?.hint;
+    const picker = behaviour?.picker;
     const messages = Array.isArray(error) ? error : error ? [error] : [];
     const hasError = messages.length > 0;
     const describedById = `${column}-desc`;
@@ -114,20 +122,38 @@ export function CodesColumnField({
             </LabelPrimitive.Root>
 
             <div className="flex items-start gap-2">
-                <Input
-                    id={column}
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                    readOnly={readOnly}
-                    aria-readonly={readOnly || undefined}
-                    aria-invalid={hasError ? true : undefined}
-                    aria-describedby={hasError || hint || actionMessage ? describedById : undefined}
-                    // 唯讀欄位灰底表示「系統維護」；剛被帶入的欄位黃底表示「這是剛填上的」。
-                    className={
-                        (readOnly ? 'bg-muted text-muted-foreground ' : '')
-                        + (highlighted ? 'bg-yellow-100 dark:bg-yellow-900/40' : '')
-                    }
-                />
+                {picker ? (
+                    // 人物欄：可用姓名或 ID 搜尋。CodeAutocomplete 自行維護選定後的顯示文字，
+                    // 故此處只需回寫代碼；初始顯示名稱由後端 picker.label 提供。
+                    <div className="flex-1">
+                        <CodeAutocomplete
+                            mode="search"
+                            id={column}
+                            endpoint={picker.endpoint}
+                            value={value}
+                            initialLabel={picker.label ?? ''}
+                            disabled={readOnly}
+                            aria-invalid={hasError ? true : undefined}
+                            aria-describedby={hasError || hint || actionMessage ? describedById : undefined}
+                            onChange={(v) => onChange(v)}
+                        />
+                    </div>
+                ) : (
+                    <Input
+                        id={column}
+                        value={value}
+                        onChange={(e) => onChange(e.target.value)}
+                        readOnly={readOnly}
+                        aria-readonly={readOnly || undefined}
+                        aria-invalid={hasError ? true : undefined}
+                        aria-describedby={hasError || hint || actionMessage ? describedById : undefined}
+                        // 唯讀欄位灰底表示「系統維護」；剛被帶入的欄位黃底表示「這是剛填上的」。
+                        className={
+                            (readOnly ? 'bg-muted text-muted-foreground ' : '')
+                            + (highlighted ? 'bg-yellow-100 dark:bg-yellow-900/40' : '')
+                        }
+                    />
+                )}
                 {behaviour?.action && onAction && (
                     <Button
                         type="button"

--- a/tests/Feature/CodesPersonPickerTest.php
+++ b/tests/Feature/CodesPersonPickerTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 泛用 codes 表單的人物選擇器（column_behaviour[col]['picker']）。
+ *
+ * 判準是**外鍵實際指向 BIOG_MAIN**，而非舊版按欄名硬編碼 c_personid／c_kin_id。
+ * 這是刻意的決定：以 schema 宣告為唯一權威，規則只有一條、隨 schema 自動跟上。
+ * 其取捨（納入語義可疑但有外鍵的欄、排除無外鍵的人物欄）亦由測試明文鎖住。
+ */
+class CodesPersonPickerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-codes-person-picker';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            // Schema::getForeignKeys() 在 SQLite 走 PRAGMA foreign_key_list，
+            // 只要建表時宣告了外鍵就讀得到（不需開啟 foreign_key_constraints 強制檢查）。
+        ]);
+        config(['codes.tables' => [
+            'ASSOC_DATA' => '社會關係',
+            'MERGED_PERSON_DATA' => '合併記錄',
+            'TEST_PLAIN_CODES' => '無人物欄的表',
+            'TEST_PERSON_AUDIT' => '同時有人物欄與稽核欄的表',
+        ]]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('BIOG_MAIN', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+        });
+        DB::table('BIOG_MAIN')->insert([
+            ['c_personid' => 0, 'c_name_chn' => '未詳', 'c_name' => 'Weixiang'],
+            ['c_personid' => 11, 'c_name_chn' => '晁公武', 'c_name' => 'Chao Gongwu'],
+            ['c_personid' => 47509, 'c_name_chn' => '陳善', 'c_name' => 'Chen Shan'],
+            ['c_personid' => 68294, 'c_name_chn' => null, 'c_name' => null],
+        ]);
+
+        // ASSOC_DATA：六個欄位都有外鍵指向 BIOG_MAIN。其中 c_assoc_id 等四欄是舊版按欄名
+        // 硬編碼會漏掉的（社會關係「對方是誰」）——本測試的重點之一。
+        Schema::create('ASSOC_DATA', function ($table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_id');
+            $table->integer('c_assoc_code')->default(0);
+            $table->integer('c_kin_id')->nullable();
+            $table->integer('c_assoc_kin_id')->nullable();
+            $table->integer('c_tertiary_personid')->nullable();
+            $table->integer('c_assoc_claimer_id')->nullable();
+            // 非人物欄，用來驗「-999 只在人物欄被歸一化」
+            $table->integer('c_year')->nullable();
+            $table->string('c_notes')->nullable();
+            $table->primary(['c_personid', 'c_assoc_id', 'c_assoc_code']);
+            $table->foreign('c_personid')->references('c_personid')->on('BIOG_MAIN');
+            $table->foreign('c_assoc_id')->references('c_personid')->on('BIOG_MAIN');
+            $table->foreign('c_kin_id')->references('c_personid')->on('BIOG_MAIN');
+            $table->foreign('c_assoc_kin_id')->references('c_personid')->on('BIOG_MAIN');
+            $table->foreign('c_tertiary_personid')->references('c_personid')->on('BIOG_MAIN');
+            $table->foreign('c_assoc_claimer_id')->references('c_personid')->on('BIOG_MAIN');
+        });
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => 11, 'c_assoc_id' => 47509, 'c_assoc_code' => 1,
+            'c_kin_id' => 0, 'c_assoc_kin_id' => null, 'c_tertiary_personid' => 68294,
+            'c_assoc_claimer_id' => null, 'c_year' => null, 'c_notes' => 'x',
+        ]);
+
+        // MERGED_PERSON_DATA：欄名叫 c_personid 但**沒有外鍵**（被合併的人可能已不存在）。
+        // 依規則 B 刻意不給選擇器。
+        Schema::create('MERGED_PERSON_DATA', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_note')->nullable();
+        });
+        DB::table('MERGED_PERSON_DATA')->insert(['c_personid' => 11, 'c_note' => 'merged']);
+
+        Schema::create('TEST_PLAIN_CODES', function ($table) {
+            $table->integer('code_id')->primary();
+            $table->string('description')->nullable();
+        });
+        DB::table('TEST_PLAIN_CODES')->insert(['code_id' => 1, 'description' => 'x']);
+
+        // 同時具備人物欄（有外鍵）與四個稽核欄，用來驗兩段行為互不覆寫。
+        Schema::create('TEST_PERSON_AUDIT', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_label')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->foreign('c_personid')->references('c_personid')->on('BIOG_MAIN');
+        });
+        DB::table('TEST_PERSON_AUDIT')->insert([
+            'c_personid' => 11, 'c_label' => 'x', 'c_created_by' => '原始建立者',
+        ]);
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->string('resource')->nullable();
+            $table->text('resource_id')->nullable();
+            $table->string('op_type')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    private function activeUser(): User {
+        return User::firstOrCreate(
+            ['email' => 'u@example.com'],
+            [
+                'name' => '張三', 'password' => bcrypt('x'),
+                'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+            ]
+        );
+    }
+
+    private function editAssoc() {
+        return $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'ASSOC_DATA', 'id' => '11_._47509_._1']));
+    }
+
+    #[Test]
+    public function every_column_with_a_foreign_key_to_biog_main_gets_a_person_picker(): void {
+        $expected = [
+            'c_personid', 'c_assoc_id', 'c_kin_id',
+            'c_assoc_kin_id', 'c_tertiary_personid', 'c_assoc_claimer_id',
+        ];
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) use ($expected) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach ($expected as $col) {
+                    $this->assertArrayHasKey($col, $b, "{$col} 應有逐欄行為");
+                    $this->assertSame('person', $b[$col]['picker']['kind'], "{$col} 應為人物選擇器");
+                    $this->assertSame('/api/select/search/biog', $b[$col]['picker']['endpoint']);
+                }
+            });
+    }
+
+    #[Test]
+    public function picker_covers_the_columns_the_legacy_name_based_rule_missed(): void {
+        // 舊版只認欄名 c_personid／c_kin_id，於是社會關係的「對方是誰」等四欄只能填數字。
+        $missedByLegacy = ['c_assoc_id', 'c_assoc_kin_id', 'c_tertiary_personid', 'c_assoc_claimer_id'];
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) use ($missedByLegacy) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach ($missedByLegacy as $col) {
+                    $this->assertSame('person', $b[$col]['picker']['kind'], "{$col} 是舊版漏掉的人物欄");
+                }
+            });
+    }
+
+    #[Test]
+    public function non_person_columns_get_no_picker(): void {
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                foreach (['c_assoc_code', 'c_notes'] as $col) {
+                    $this->assertArrayNotHasKey($col, $b, "{$col} 不該有人物選擇器");
+                }
+            });
+    }
+
+    #[Test]
+    public function picker_carries_the_current_persons_display_name(): void {
+        // 否則使用者只看到一個數字，等同沒修。
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                // 標籤帶 ID：改成選擇器後欄位不再顯示數字，而編目者是以 ID 工作的
+                $this->assertSame('11 晁公武 / Chao Gongwu', $b['c_personid']['picker']['label']);
+                $this->assertSame('47509 陳善 / Chen Shan', $b['c_assoc_id']['picker']['label']);
+                // person 0 是「未詳」哨兵，BIOG_MAIN 確實有這一列，照樣解析出名稱
+                $this->assertSame('0 未詳 / Weixiang', $b['c_kin_id']['picker']['label']);
+            });
+    }
+
+    #[Test]
+    public function picker_label_is_null_only_when_the_column_has_no_value(): void {
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                // 欄位值為 null（未填）→ 沒有東西可顯示
+                $this->assertNull($b['c_assoc_kin_id']['picker']['label']);
+                // 人物存在但姓名兩欄皆空 → 退回顯示 ID，不可回傳空字串讓畫面看起來像沒選
+                $this->assertSame('68294', $b['c_tertiary_personid']['picker']['label']);
+            });
+    }
+
+    #[Test]
+    public function picker_label_falls_back_to_the_id_when_the_person_is_missing(): void {
+        // 有值就一定要有可顯示文字。若查不到人物卻回 null，CodeAutocomplete 會顯示空白，
+        // 而 form.data 裡仍藏著那個值——使用者以為沒填、送出後撞外鍵，錯誤訊息還指錯方向。
+        // 提案調整頁尤其會遇到（resource_data 裡的人物可能在送審後被合併掉）。
+        DB::table('ASSOC_DATA')->where('c_personid', 11)->update(['c_assoc_kin_id' => 999111]);
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertSame('999111', $b['c_assoc_kin_id']['picker']['label']);
+            });
+    }
+
+    #[Test]
+    public function create_page_does_not_prefill_a_person_primary_key_with_a_guessed_id(): void {
+        // guessNextKeyValue 對人物欄毫無意義（max(c_personid)+1），而 CBDB 人物 ID 很密集，
+        // 猜測值往往真的存在 → 選擇器會顯示一位真實人物姓名，看起來像「已選好某人」，
+        // 使用者填完其他欄一存就把資料歸到隨機的人身上。必須留空。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'ASSOC_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $props = $page->toArray()['props'];
+                $defaults = (array) $props['defaults'];
+                $this->assertArrayNotHasKey('c_personid', $defaults, '人物主鍵欄不可預填猜測值');
+                // 沒有預填 → 沒有東西可解析 → label 為 null（欄位如實顯示為空）
+                $this->assertNull($props['column_behaviour']['c_personid']['picker']['label']);
+            });
+    }
+
+    #[Test]
+    public function column_named_like_a_person_but_without_a_foreign_key_gets_no_picker(): void {
+        // MERGED_PERSON_DATA.c_personid 沒有外鍵 → 依規則 B 刻意不給（使用者已確認此取捨符合設計）。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'MERGED_PERSON_DATA', 'id' => 11]))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertArrayNotHasKey('c_personid', $b, '無外鍵的人物欄不給選擇器');
+            });
+    }
+
+    #[Test]
+    public function table_without_person_columns_has_no_picker(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEST_PLAIN_CODES', 'id' => 1]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('column_behaviour', []));
+    }
+
+    #[Test]
+    public function create_page_also_gets_pickers_without_a_resolved_label(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'ASSOC_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertSame('person', $b['c_assoc_id']['picker']['kind']);
+                // 新增頁尚無值 → 不該憑空生出一個人名（測試名稱講的正是這件事）
+                $this->assertNull($b['c_assoc_id']['picker']['label']);
+            });
+    }
+
+    // ───────── 「未詳」哨兵：/api/select/search/biog 把 person 0 編成 -999 ─────────
+
+    #[Test]
+    public function selecting_the_unknown_person_is_stored_as_zero_not_minus_999(): void {
+        // 人物搜尋端點刻意把 person 0（未詳）的 option value 編成 -999（ApiController::searchBiog）。
+        // 那是前端「未設定」哨兵、不是人物 ID；BIOG_MAIN 沒有 -999，直接落庫會撞外鍵。
+        // 「未詳」在 CBDB 極常見，這條路徑必須通。
+        $this->actingAs($this->activeUser())
+            ->patch(route('app.codes.update', ['table_name' => 'ASSOC_DATA', 'id' => '11_._47509_._1']), [
+                'c_personid' => 11, 'c_assoc_id' => 47509, 'c_assoc_code' => 1,
+                'c_kin_id' => '-999', 'c_tertiary_personid' => '-999', 'c_notes' => 'x',
+            ])
+            ->assertRedirect();
+
+        $row = DB::table('ASSOC_DATA')->where('c_personid', 11)->where('c_assoc_id', 47509)->first();
+        $this->assertSame(0, (int) $row->c_kin_id, 'c_kin_id 應還原為 person 0（未詳）');
+        $this->assertSame(0, (int) $row->c_tertiary_personid);
+    }
+
+    #[Test]
+    public function minus_999_is_left_alone_when_it_is_a_real_person(): void {
+        // c_personid 是有號 int、無 UNSIGNED／CHECK 限制，schema 允許負值（現行資料無）。
+        // 若真有 person -999，把它改寫成 0 會把關係靜默改指到別人身上——寧可停止改寫。
+        DB::table('BIOG_MAIN')->insert(['c_personid' => -999, 'c_name_chn' => '負號人物', 'c_name' => 'Negative']);
+
+        $this->actingAs($this->activeUser())
+            ->patch(route('app.codes.update', ['table_name' => 'ASSOC_DATA', 'id' => '11_._47509_._1']), [
+                'c_personid' => 11, 'c_assoc_id' => 47509, 'c_assoc_code' => 1,
+                'c_tertiary_personid' => '-999', 'c_notes' => 'x',
+            ])
+            ->assertRedirect();
+
+        $row = DB::table('ASSOC_DATA')->where('c_personid', 11)->where('c_assoc_id', 47509)->first();
+        $this->assertSame(-999, (int) $row->c_tertiary_personid, '-999 是真實人物時不可被改寫成 0');
+    }
+
+    #[Test]
+    public function minus_999_is_not_normalized_on_non_person_columns(): void {
+        // 只歸一化人物欄。-999 在其他欄位可能是合法值（如年份哨兵），不可一律改寫。
+        $this->actingAs($this->activeUser())
+            ->patch(route('app.codes.update', ['table_name' => 'ASSOC_DATA', 'id' => '11_._47509_._1']), [
+                'c_personid' => 11, 'c_assoc_id' => 47509, 'c_assoc_code' => 1,
+                'c_year' => '-999', 'c_notes' => 'x',
+            ])
+            ->assertRedirect();
+
+        $row = DB::table('ASSOC_DATA')->where('c_personid', 11)->where('c_assoc_id', 47509)->first();
+        $this->assertSame(-999, (int) $row->c_year, '非人物欄的 -999 應原樣保留');
+    }
+
+    #[Test]
+    public function proposal_records_zero_instead_of_minus_999(): void {
+        // 提案路徑不碰資料表，若不歸一化就會把 -999 存進 resource_data：
+        // 審核人看到 -999，核准時才爆掉。
+        // 用 c_tertiary_personid（fixture 為 68294）而非 c_kin_id（本來就是 0）——
+        // 後者歸一化後與原值相同，會被正確判定為「沒有變更」而不產生提案。
+        $this->actingAs($this->activeUser())
+            ->post(route('app.codes.propose.update', ['table_name' => 'ASSOC_DATA', 'id' => '11_._47509_._1']), [
+                'c_personid' => 11, 'c_assoc_id' => 47509, 'c_assoc_code' => 1,
+                'c_kin_id' => 0, 'c_tertiary_personid' => '-999', 'c_notes' => 'x',
+            ])
+            ->assertRedirect();
+
+        $op = DB::table('operations')->where('resource', 'ASSOC_DATA')->orderByDesc('id')->first();
+        $this->assertNotNull($op, '應記下提案');
+        $payload = json_decode($op->resource_data, true);
+        $this->assertSame('0', (string) $payload['c_tertiary_personid'], '提案內容不該留下 -999');
+
+        // 資料表本身不該被動到（提案不是直接寫入）
+        $this->assertSame(
+            68294,
+            (int) DB::table('ASSOC_DATA')->where('c_personid', 11)->value('c_tertiary_personid')
+        );
+    }
+
+    #[Test]
+    public function person_picker_and_readonly_audit_columns_do_not_clobber_each_other(): void {
+        // 兩段行為（人物選擇器、稽核欄唯讀）寫進同一份 behaviour 陣列。若其中一段用覆寫而非
+        // merge，後跑的那段會把前一段的結果吃掉。用同時具備兩類欄位的表把這條性質釘住。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.edit', ['table_name' => 'TEST_PERSON_AUDIT', 'id' => 11]))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+
+                // 人物欄：有選擇器、且不該被誤標唯讀
+                $this->assertSame('person', $b['c_personid']['picker']['kind']);
+                $this->assertArrayNotHasKey('readonly', $b['c_personid']);
+
+                // 稽核欄：唯讀、且不該被誤給選擇器
+                foreach (['c_created_by', 'c_modified_by'] as $col) {
+                    $this->assertTrue($b[$col]['readonly']);
+                    $this->assertArrayNotHasKey('picker', $b[$col]);
+                }
+                // 稽核欄的替換預覽仍在（沒被人物欄那段蓋掉）
+                $this->assertStringContainsString('張三', $b['c_modified_by']['hint']['text']);
+            });
+    }
+}


### PR DESCRIPTION
## 這是掃描出的四項缺口的最後一項

舊版 `codes/edit.blade.php` 把人物欄渲染成 select2（姓名或 ID 皆可查），React 版是純數字輸入框——使用者必須先知道人物 ID 才能填。前一個 PR（#1226）補回了稽核欄唯讀、欄位提示與帶入書名；這個 PR 補回人物選擇器。

## 判準改用外鍵，不是欄名

**規則：一個欄位有外鍵指向 `BIOG_MAIN`，就給人物選擇器。** 以 schema 宣告為唯一權威。

舊版按欄名硬編碼 `c_personid`／`c_kin_id`，會漏掉 **5 個真人物欄**，而且漏在最需要的地方：

- `ASSOC_DATA.c_assoc_id`（社會關係「**對方是誰**」）
- `ASSOC_DATA.c_assoc_kin_id`、`c_assoc_claimer_id`、`c_tertiary_personid`
- `ENTRY_DATA.c_assoc_id`

改用外鍵後涵蓋 **17 張碼表、25 個欄位**，且隨 schema 自動跟上，不需維護人工白名單。兩項刻意取捨（已確認符合設計）：`BIOG_MAIN.c_index_year_source_id` 納入（欄名像出處，但 schema 確實宣告外鍵指向 `BIOG_MAIN`；`IndexYearRebuildService` 也確實往那裡寫人物 ID）；`MERGED_PERSON_DATA.c_personid` 不納入（無外鍵——被合併的人可能已不存在）。兩者都有測試明文鎖住。

外鍵反射用 `Schema::getForeignKeys()` 而非 `information_schema`：後者在 SQLite 不存在，會讓測試無法涵蓋這條核心規則。前者由 driver 各自實作（SQLite 走 `PRAGMA foreign_key_list`），所以 PHPUnit 測試是**真的**在跑外鍵推導——把 FK 宣告拿掉測試就會紅。

選擇器沿用既有的 `CodeAutocomplete`（`mode="search"`，端點與親屬編輯頁的「親屬姓名」同一支），因此自動獲得同一份 debounce 與 `a9ff479` 剛加的過期回應守衛，不需另寫一份。

## 審查發現並修掉的問題

- **選「未詳」會寫入 `-999` 而撞外鍵**（MAJOR）。`ApiController::searchBiog` 刻意把 person 0（未詳）的 option value 編成 `-999`——那是前端「未設定」哨兵、不是人物 ID。`BIOG_MAIN` 沒有 `-999`，直接落庫撞外鍵 1452（訊息還指向「必填未填」）；提案路徑不碰資料表，會把 `-999` 原樣存進 `resource_data`，讓審核人看到 `-999` 並在核准時才爆掉。而「未詳」在 CBDB 極常見（`c_kin_id = 0` 到處都是）。改為在 `extractFormData()` 這個單一收口還原成 `0`（五條 codes 寫入／記錄路徑全部經過它）。已用停用該段的方式反向驗證兩個測試會轉紅。
  - **只在「`-999` 確定不是真實人物」時才還原**：`c_personid` 是有號 int、無 UNSIGNED／CHECK 限制，schema 允許負值（實測 min=0、無負值、無 `-999`）。若真有 person `-999`，無條件改寫會把關係靜默改指到別人身上；查不到 `BIOG_MAIN` 時亦不改寫。同一份顧慮見 `ExactCodeMatchGuard`（`db0f388`）。
- **新增頁會把猜測的人物 ID 顯示成一位真實人物**（MAJOR）。`appCreate` 原本把第一個主鍵欄預填成 `max+1`，而 `BIOG_ADDR_DATA`、`STATUS_DATA` 的第一個主鍵欄就是 `c_personid`；CBDB 人物 ID 很密集，猜測值往往真的存在，於是選擇器把它解析成真實姓名，看起來像「已選好某人」——使用者填完其他欄一存，資料就被歸到隨機的人身上。先前是純數字輸入框，數字看起來就是佔位符，風險較低；改成選擇器後必須擋掉。留空反而得到正確的「請確認主鍵欄位已填寫完整」提示。
- **查不到人物時欄位會空白但值還在**（MAJOR sub-issue）。`picker.label` 為 null 時 `CodeAutocomplete` 顯示空白，而 `form.data` 仍藏著那個值——使用者以為沒填、送出後撞外鍵。改為退回顯示 ID。提案調整頁尤其會遇到（`resource_data` 裡的人物可能在送審後被合併掉）。
- **外鍵表名比對大小寫敏感**（MINOR）。MySQL 在 `lower_case_table_names=1`（**Windows 預設**）回報 `biog_main`，硬比大寫會讓所有選擇器**無聲消失**。控制器其他處都先 `strtoupper`，這裡漏了。我的開發機沒有觸發，靠審查抓到。
- **人物 ID 從畫面上消失**（MINOR）。改成選擇器後欄位不再顯示數字，而編目者是以 ID 工作的。顯示文字改為帶 ID（「11 晁公武 / Chao Gongwu」），與搜尋候選同樣以 ID 開頭。
- 兩個測試無效或名稱與斷言不符，已補強。

**另有一個我自己造成、只有全量測試抓得到的回歸**：`-999` 的安全檢查第一版是無條件呼叫，於是每條 codes 寫入路徑都多一次 `BIOG_MAIN` 查詢，弄壞 32 個 fixture 裡沒有 `BIOG_MAIN` 的不相關測試（`no such table: BIOG_MAIN`）。改為「先確認本次真的送了 `-999`，才做那次查詢」並加 try/catch。**過濾式測試是綠的，只有全套抓得到。**

## 測試

- `CodesPersonPickerTest`（15 tests）：六個有外鍵的欄位都有選擇器／涵蓋舊版按欄名會漏掉的 4 欄／非人物欄不給／帶 ID 的顯示名稱／無值與查不到時的退回行為／欄名像人物但無外鍵者不給／無人物欄的表為空／新增頁不預填人物主鍵／選未詳落庫為 0／`-999` 是真實人物時不改寫／非人物欄的 `-999` 原樣保留／提案不留 `-999`／人物選擇器與稽核欄唯讀互不覆寫。
- headless Chrome 對真實 MariaDB 驗證 7 項：`KIN_DATA` 兩個人物欄顯示「11 晁公武 / Chao Gongwu」與「10876 晁冲之 / Chao Chongzhi」而非數字；輸入「陳善」會打 `/api/select/search/biog` 並列出候選；輸入 `47509` 也能查到該人；非人物欄維持純輸入；`MERGED_PERSON_DATA.c_personid` 維持純數字輸入。
- `./vendor/bin/phpunit` 2478 tests 綠；`php-cs-fixer` 零改動；`npm run build` 通過；`tsc` 錯誤行數與改動前相同（51，皆為既有問題）。

## 已知取捨

- 清空選擇器得到空字串，與先前文字框可被清空一致（沿用「不改送出內容」，沒有像 `KinEditor` 那樣強制回填 `0`）。
- 人物欄若同時是主鍵（如 `KIN_DATA.c_personid`），透過選擇器改值與先前用文字框改值走同一條 `performUpdate`（依 URL 主鍵定位、`update()` 就地換鍵，重複鍵與完整性違規各有友善訊息）——**不是本次新增的能力**，只是把門檻降到一次點擊。
- `ASSOC_DATA` 的主鍵有 9 段、其中一段是字面 `[n/a]`，URL 難以構造，故該表的 6 個人物欄以 PHPUnit（SQLite 造 FK）驗證，瀏覽器驗 `KIN_DATA` 與 `MERGED_PERSON_DATA`。
- 選擇器的輸入框沿用 `CodeAutocomplete` 的字級（與相鄰 `ui/Input` 略有差異），屬既有元件樣式，未在此變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
