### PR TITLE
補回 React 殼的 SQL 查詢明細並收斂收集成本，刪除使用者恢復兩段確認

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## 2026-08
 
+### 補回 React 殼的 SQL 查詢明細，並把收集成本收斂到看得到的人身上；刪除使用者恢復兩段確認
+- 起因：`AppServiceProvider` 的 `DB::listen` **無條件**把每筆查詢的 SQL 與 bindings 累進記憶體，而 React layout 從來沒有渲染這份資料——舊版 `layouts/dashboard-v3.blade.php` 底部的「本次查詢共 N 筆，耗時 X ms」＋管理員可開的明細 modal 在遷移時漏移植。等於每個 request（含 artisan 匯入、訪客瀏覽）都照樣收集、卻沒人看得到。
+- **權限分界完全對齊舊版**，而不是順手改掉：舊版那條摘要行 **沒有任何權限閘**（`dashboard-v3.blade.php:346`，訪客也看得到），只有「查看詳細」連結與 modal 限管理員（同檔 `:348`／`:369`）。因此閘的是「**保留明細**」而不是「整個收集」：筆數與耗時一律累計，每筆 SQL／bindings 只在使用者已解析為 `isAdmin()` 時保留。若連筆數都不收，flag 回退到 Blade 的頁面也會少一行，那不在本次範圍。
+- **顯示端自己再授權一次**，不只依賴收集端：`HandleInertiaRequests::queryProfile()` 獨立檢查 `isAdmin()`，非管理員的 `queries` 為空陣列。收集端的閘門長在全域 `DB::listen` 回呼裡、還包著 try/catch，一旦有人為了「讓筆數回到舊版數字」把它放寬，原始 SQL 與 bind 值就會直接出現在每個訪客的 `data-page` JSON（AGENTS.md §5：授權不該只有一道，更不該只長在除錯收集器內）。已用瀏覽器驗證非管理員的 payload 裡完全沒有 `"sql":`。
+- **shared prop 必須延後求值**（實際踩到並修掉的 bug）：inertia-laravel 的 `Middleware::handle` 是在 `$next($request)` **之前**呼叫 `share()`，此刻控制器一筆查詢都還沒跑。原本直接呼叫 `queryProfile()`，摘要永遠只有 session／撈使用者那兩筆——畫面上看起來有東西、數字卻是錯的（實測 codes 頁 2 筆 vs 實際 6～7 筆）。改為 closure，由 `Response::resolveArrayableProperties` 在 `toResponse()` 才求值。
+- 再包一層 `Inertia::always()`：局部重載只回傳 `only` 指定的 props，其餘 shared props 會被丟掉、前端沿用舊值——除錯輔助顯示上一次請求的筆數比不顯示更誤導。此行為以**真正的局部重載**測試鎖住（帶 `X-Inertia-Partial-Data` 指定別的 prop），換回普通 closure 即紅。
+- **局部重載只更新摘要、不夾帶明細**：Inertia 會把整份 page props 存進 `window.history.state`，而切換人物分頁這類局部重載在編目工作中極頻繁；每個 XHR 都夾帶上百句 SQL 與 bind 值，只為了一個偶爾打開的 modal，並不划算，也會把 bind 值留在瀏覽器歷史。前端記住最後一次拿到的明細，讓「查看詳細」不會在局部更新後忽然消失，並在 modal 內明示「以下明細為本頁載入時的查詢」。兩個方向都有測試（局部重載回應不得出現 `"sql"`；整頁載入必須給管理員明細，否則「不夾帶」會退化成「永遠拿不到」）。
+- 閘門判斷**刻意不做跨請求記憶**：`ServiceProvider` 是長生命週期物件，在 Octane／RoadRunner 這類常駐 worker 下會活過請求邊界，一旦某個管理員請求把「可留明細」記成 true，後續訪客請求就會開始保留 SQL——那是跨請求外洩。省下的只是每筆查詢幾個不碰資料庫的屬性讀取（`hasResolvedGuards()` 是 count、`hasUser()` 是 `is_null`、`user()` 走已快取屬性、`isAdmin()` 是 `in_array`），不值得用正確性去換。同理 `QueryProfile` 由 `singleton` 改為 **`scoped`**：它記的是「本次請求的查詢」，語意上就該隨請求結束；傳統 php-fpm 下兩者等價，常駐 worker 下 singleton 會讓筆數愈跑愈大、且管理員留下的明細可能被後續請求讀到。
+- 前端沿用舊明細的條件由後端明說（`details_omitted`），不是「本次沒帶就沿用」：同一個 React 殼會活過登出／被降權／換 session，那時回應是 `queries: []` 且 `details_omitted=false`，前端因此會**清掉**先前的明細，而不是把管理員的 SQL 繼續顯示給已經不是管理員的人。非管理員的回應永遠 `details_omitted=false`（有測試明文鎖住）。
+- 收集端加上記憶體上限（`QueryProfile::MAX_STORED = 200`），但**筆數與總耗時另行累計、永遠精確**——否則管理員在一個跑幾千筆查詢的頁面上只看到「200 筆」，反而掩蓋了要抓的效能問題。`summary()` 改為先切再編碼（先前編碼 200 筆再丟掉一半），`View::composer` 由 `'*'` 收窄到真正使用該變數的 `layouts.dashboard-v3`（先前一個 Blade 頁面渲染數十個 partial 就重複編碼數十遍）。
+- 閘門判斷本身的兩個修正：**明確指定 web guard**（`OptionalAuthentication` 會在執行期 `Auth::shouldUse('sanctum')` 改寫預設 guard，否則「帶 token 打 API 的管理員」也開始留明細，而 JSON 回應永遠不顯示這份資料——正是要消除的浪費）；try/catch 只 **report 第一次**（每筆都 report 會淹沒日誌，完全不記錄則會讓閘門壞掉、功能無聲消失卻查不出原因），且 `report()` 自身再包一層 try/catch——它若丟出去就繞過了外層 catch，讓一個純除錯輔助弄壞請求。
+- 判斷絕不能呼叫 `Auth::check()`／`Auth::user()`：那會在「解析使用者」那句 select 的監聽器裡再次觸發解析（遞迴）。改用 `hasResolvedGuards()` + `hasUser()`（皆不碰資料庫）。此性質改由**真的從 session 解析**的測試守住——先前的測試用 `actingAs()`，那是直接 `setUser()`、永遠走不到解析路徑，把閘門換成 `Auth::user()` 照樣綠燈。已知代價：解析完成前的查詢沒有明細（筆數仍算），故明細列數略少於總筆數，訊息文案因此不寫「前 N 筆」。
+- 顯示端沿用共用 `Modal`（Radix：focus trap／Esc／a11y 內建）而非自製對話框，補回舊版 modal 底部的「關閉」鈕，總毫秒數用千分位（對齊舊版 `number_format`）。
+- **刪除使用者恢復兩段確認**：舊版 `manage/edit.blade.php` 有兩道 `confirm()`（第一段說明不可恢復、第二段最後確認），React 遷移時收斂成一道。改用兩個 `ConfirmDialog` 串接，沿用同一組翻譯鍵；第一段的 `\n\n` 以 `whitespace-pre-line` 保住斷行（舊版走 `window.confirm`，空行就是重點強調）。送出 payload（`delete_user=1`）與後端契約未改動。
+- 收集端與顯示端**用同一個 guard**（皆為 `web`）：兩端若各自看執行期可被改寫的預設 guard，會出現「有收集卻不給看」的不一致。
+- 回歸測試 `QueryProfileGateTest`（15 tests：訪客／一般／眾包使用者有筆數但無明細、超級管理員與專家有明細、非管理員的 shared prop 不帶任何 SQL、延後求值含控制器查詢、真正的局部重載仍帶此 prop 但不帶明細、整頁載入才給明細、`details_omitted` 僅對「本來看得到明細的人」為 true、明細上限與筆數精確、記憶體上限不扭曲總計、從 session 解析使用者時不遞迴且解析前不留明細、summary 形狀穩定）。另以 headless Chrome 對真實庫驗證 11 項（6 項查詢明細，含非管理員 payload 無 SQL；5 項兩段刪除，含第一段按繼續不會刪除、第二段取消不會刪除、兩段都確認才真的刪除）。
+
 ### codes 表單的人物欄改為可搜尋的人物選擇器（判準改用外鍵）
 - 承上一則：泛用 codes 表單漏移植的最後一項。舊版 `codes/edit.blade.php` 把人物欄渲染成 select2（姓名或 ID 皆可查），React 版是純數字輸入框——使用者必須先知道人物 ID 才能填。
 - **判準改為「外鍵實際指向 `BIOG_MAIN`」，以 schema 宣告為唯一權威**（`CodesController::personFkColumns()`）。舊版是按欄名硬編碼 `c_personid`／`c_kin_id`，會漏掉 `ASSOC_DATA` 的 `c_assoc_id`（社會關係「對方是誰」）、`c_assoc_kin_id`、`c_assoc_claimer_id`、`c_tertiary_personid` 與 `ENTRY_DATA.c_assoc_id` 共 5 個真人物欄——恰恰是最需要用姓名搜尋的地方。改用外鍵後涵蓋 **17 張碼表、25 個欄位**，且隨 schema 自動跟上，不需維護人工白名單。

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Support\Navigation;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware {
@@ -72,6 +73,19 @@ class HandleInertiaRequests extends Middleware {
             // flash 訊息橋接：把 laracasts/flash 的 session 訊息轉成陣列，
             // 由 React AppShell 統一渲染 toast/alert（取代 Blade flash::message partial）。
             'flash' => $this->flashMessages(),
+            // SQL 查詢明細（管理員的效能除錯輔助）。舊版 Blade layout 有這一區、React layout 沒有，
+            // 於是 DB::listen 照樣收集卻沒人看得到；連同收集端的閘門一起補回。null＝不顯示。
+            //
+            // ⚠️ 必須是 closure（且用 Inertia::always 包起來），不可直接呼叫：
+            // inertia-laravel 的 Middleware::handle 是在 `$next($request)` **之前**
+            // 呼叫 share()，此刻控制器一筆查詢都還沒跑，直接求值只會拿到 session／撈使用者
+            // 那兩筆，摘要永遠顯示個位數。closure 由 Response::resolveArrayableProperties
+            // 以 App::call() 在 toResponse()（控制器跑完之後）才求值，才是本次請求的真實筆數。
+            //
+            // always()：局部重載（partial reload，如切換人物分頁）只回傳 `only` 指定的 props，
+            // 其餘 shared props 會被丟掉，前端於是沿用舊值——除錯輔助顯示上一次請求的筆數
+            // 比不顯示更誤導。包成 AlwaysProp 讓每個回應都帶上當次的實際筆數。
+            'query_profile' => Inertia::always(fn () => $this->queryProfile($request)),
             // ⚠️ 頁面特定翻譯群組（views、codes、operations、admin）
             //   請由控制器以 'page_translations' key 傳入，不可複用此 'translations' key，
             //   否則 inertia-laravel 的淺合併會覆蓋此處的 shared 翻譯。
@@ -103,6 +117,64 @@ class HandleInertiaRequests extends Middleware {
         }
 
         return null;
+    }
+
+    /**
+     * SQL 查詢明細，供 React layout 顯示。
+     *
+     * 筆數與耗時給所有人（對齊舊版 Blade 那一行本來就沒有權限閘）；**每筆 SQL 與 bindings
+     * 只給管理員**。這裡自己再檢查一次 isAdmin，不只依賴收集端的閘門
+     * （AppServiceProvider::shouldRetainQueryDetails()）：那個閘門長在全域 DB::listen 回呼裡、
+     * 還包著 try/catch，一旦有人為了「讓筆數回到舊版的數字」把它放寬，原始 SQL 與 bind 值
+     * 就會直接出現在每個訪客的 data-page JSON 裡。授權不該只有一道，且不該只長在除錯收集器內
+     * （AGENTS.md §5）。此處不在 DB::listen 內，可以安全呼叫 Auth。
+     *
+     * 明細只取前 100 筆（與舊版 modal 的 array_slice 一致）並回報是否被截斷，避免把一頁上千筆
+     * 查詢全部塞進 Inertia props。沒有任何查詢時回 null，前端就不渲染這一區。
+     *
+     * **局部重載不帶明細**：Inertia 會把整份 page props 存進 window.history.state，而
+     * 局部重載（切換人物分頁等）在管理員操作中非常頻繁；每次都夾帶上百句 SQL 與 bind 值，
+     * 等於為了一個偶爾打開的 modal 讓每個 XHR 都變胖、並把 bind 值留在瀏覽器歷史裡。
+     * 摘要（筆數／耗時）仍每次更新，明細則以整頁載入那次為準。
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function queryProfile(Request $request): ?array {
+        $profiler = app(\App\Services\QueryProfile::class);
+        if ($profiler->count() === 0) {
+            return null;
+        }
+
+        // 與收集端同一個 guard（AppServiceProvider::shouldRetainQueryDetails() 用 web）：
+        // OptionalAuthentication 會在執行期改寫預設 guard，兩端若各看各的預設值，就會出現
+        // 「有收集卻不給看」這種不一致。
+        $user = \Illuminate\Support\Facades\Auth::guard('web')->user();
+        $isAdmin = $user instanceof \App\Models\User && $user->isAdmin();
+        // 兩個 partial header 都要在：inertia-laravel 的 Response::isPartial() 除了 partial-data
+        // 還要求 partial-component 與本次元件相符，只看單一 header 會把畸形請求也當成局部重載
+        // （後果只是不給明細，不會外洩，但沒必要）。
+        $isPartial = $request->hasHeader('X-Inertia-Partial-Data')
+            && $request->hasHeader('X-Inertia-Partial-Component');
+        $canSeeDetails = $isAdmin && !$isPartial;
+
+        $limit = 100;
+        $summary = $profiler->summary($canSeeDetails ? $limit : 0);
+
+        return [
+            'count' => $summary['count'],
+            'time_ms' => round((float) $summary['time_ms'], 2),
+            // 「這次刻意不送明細，但你本來看得到」——前端據此保留上一次整頁載入的明細。
+            // 非管理員永遠是 false，因此降權／登出後的回應會讓前端**清掉**先前的明細，
+            // 而不是繼續顯示（同一個 React 殼會活過這種身分變化）。
+            'details_omitted' => $isAdmin && $isPartial,
+            // 非管理員沒有明細，但那不叫「被截斷」——前端據此決定要不要顯示「查看詳細」。
+            'truncated' => $canSeeDetails && $summary['count'] > count($summary['queries']),
+            'queries' => array_map(static fn (array $q): array => [
+                'time' => round((float) $q['time'], 2),
+                'sql' => $q['sql'],
+                'bindings' => $q['bindings_json'],
+            ], $summary['queries']),
+        ];
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,18 +8,31 @@ use App\Services\PersonChangeIndexService;
 use App\Services\QueryProfile;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider {
     /**
+     * 閘門判斷已失敗並記錄過一次（避免每筆查詢都 report）。
+     *
+     * 這是唯一存在 provider 上的狀態，且**只會讓日誌少寫**、不影響任何授權判斷，
+     * 因此即使在 Octane 這類常駐 worker 下跨請求存活也無害。
+     */
+    private bool $retainGateFailureReported = false;
+
+    /**
      * Register any application services.
      *
      * @return void
      */
     public function register() {
-        $this->app->singleton(QueryProfile::class, function () {
+        // scoped 而非 singleton：這份 profile 是「本次請求的查詢紀錄」，語意上就該隨請求結束。
+        // 在傳統 php-fpm 下兩者等價（程序結束即消滅），但在 Octane／RoadRunner 這類常駐 worker
+        // 下，singleton 會活過請求邊界——筆數會愈跑愈大，管理員請求留下的 SQL 明細還可能被
+        // 後續請求（甚至非管理員的）讀到。scoped 綁定會在每個請求開始時重建。
+        $this->app->scoped(QueryProfile::class, function () {
             return new QueryProfile();
         });
 
@@ -43,14 +56,98 @@ class AppServiceProvider extends ServiceProvider {
         BiogMain::observe(BiogMainObserver::class);
         // 注意：ALTNAME_DATA 使用復合主鍵，不使用 Eloquent，改為在控制器中手動調用索引服務
 
-        $profiler = $this->app->make(QueryProfile::class);
+        // ⚠️ 兩個回呼都在**回呼內**才解析 QueryProfile，不在 boot() 就 make() 起來捕進 closure：
+        // 那樣會把「boot 當下那一個」實例永久綁在回呼裡，scoped 綁定就完全失效——在常駐 worker
+        // 下第二個請求的查詢仍會寫進第一個請求的實例，而 middleware 拿到的又是新的實例。
+        // scoped 綁定本身有快取，回呼內解析只是一次容器查表。
 
-        DB::listen(function (QueryExecuted $query) use ($profiler) {
-            $profiler->add($query);
+        // 只有「看得到明細的人」才付明細的成本。先前是無條件保留：每個 request（含 artisan
+        // 匯入、訪客瀏覽）都把每一筆查詢的 SQL 與 bindings 累進記憶體，而 React layout 根本
+        // 沒渲染這份資料——等於照樣收集、卻沒人看得到。
+        //
+        // 閘的是「保留明細」而不是「整個收集」：舊版 layouts/dashboard-v3.blade.php:346 的
+        // 「本次查詢共 N 筆，耗時 X ms」那一行**沒有任何權限閘**，訪客與一般使用者都看得到，
+        // 只有「查看詳細」連結與 modal 才限管理員（同檔 :348、:369）。若連筆數都不收，
+        // 等於順手改掉舊版對所有人的行為（flag 回退到 Blade 時也一樣少一行），那不在本次範圍。
+        DB::listen(function (QueryExecuted $query) {
+            app(QueryProfile::class)->add($query, $this->shouldRetainQueryDetails());
         });
 
-        View::composer('*', function ($view) use ($profiler) {
-            $view->with('queryProfileSummary', $profiler->summary());
+        // 只掛在真正使用這個變數的 layout 上（全庫僅 layouts/dashboard-v3.blade.php 引用）。
+        // 先前掛 '*'：summary() 會把保留的每一筆 bindings json_encode 一次，而一個 Blade 頁面
+        // 可能渲染數十個 partial，等於同一份資料重複編碼數十遍、其中絕大多數 view 從不使用它。
+        // 不能改成傳 closure 延後求值——Blade 端是 `$queryProfileSummary['count']` 這樣直接
+        // 陣列取值，傳 closure 會直接壞掉。
+        View::composer('layouts.dashboard-v3', function ($view) {
+            $view->with('queryProfileSummary', app(QueryProfile::class)->summary());
         });
+    }
+
+    /**
+     * 是否要保留這一筆查詢的 SQL 與 bindings（明細）。
+     *
+     * 注意：**筆數與耗時一律累計**，這裡只決定要不要留明細——舊版 Blade 的摘要行對所有人
+     * 顯示，只有明細 modal 限管理員（見 boot() 的說明）。
+     *
+     * ⚠️ 這個判斷跑在 DB::listen 的回呼裡，**絕對不能**呼叫 Auth::check()／Auth::user()／
+     * Auth::guard()->user()——那些會在使用者尚未解析時去資料庫撈使用者，而我們正身處
+     * 「查詢被執行」的監聽器中，等於在解析使用者的查詢裡再次觸發解析（遞迴）。
+     * hasResolvedGuards() 只數已建立的 guard 數量，hasUser() 只是 `! is_null($this->user)`
+     * （Illuminate\Auth\GuardHelpers），SessionGuard::user() 在已快取時直接回傳屬性，
+     * 三者都不碰資料庫，因此安全。
+     *
+     * 代價（已知且可接受）：使用者被解析「之前」的查詢（session 讀取、撈 users 那幾筆）
+     * 沒有明細（筆數仍算），故明細列數會略少於總筆數。
+     *
+     * ⚠️ 這裡不做任何跨請求記憶（見函式內說明）——provider 在常駐 worker 下會活過請求邊界。
+     */
+    private function shouldRetainQueryDetails(): bool {
+        // 刻意**不記憶**判斷結果：ServiceProvider 是長生命週期物件，在 Octane／RoadRunner
+        // 這類常駐 worker 下會跨請求存活，一旦某個管理員請求把它設成 true，後續訪客請求
+        // 就會開始保留 SQL 明細——那是跨請求的資料外洩。省下的只是每筆查詢幾個屬性讀取
+        // （hasResolvedGuards 是 count、hasUser 是 is_null、user() 走已快取屬性、isAdmin 是
+        // in_array），全都不碰資料庫，不值得用一個正確性風險去換。
+        //
+        // 不另外檢查 runningInConsole()：artisan／queue 情境下沒有已解析的登入使用者，
+        // 下面的管理員判斷本身就會回 false。多一道 console 判斷反而讓這條路徑無法被測試涵蓋
+        // （PHPUnit 本身就跑在 console）。
+        //
+        // 整段包 try/catch：這是一個純除錯輔助，跑在**全域** DB::listen 回呼裡，
+        // 絕不能因為它而讓任何請求失敗。實際踩過的情況是有測試把 Auth facade 換成 mock
+        // （partial mock 對未預期的呼叫會丟 BadMethodCallException），於是每一次查詢都炸。
+        try {
+            if (!Auth::hasResolvedGuards()) {
+                return false;
+            }
+
+            // 明確指定 web guard，不用預設 guard：App\Http\Middleware\OptionalAuthentication
+            // 會在執行期 Auth::shouldUse('sanctum') 改寫預設值，那時預設 guard 會是 sanctum，
+            // 於是「帶 token 打 API 的管理員」也開始留明細——而 JSON 回應永遠不顯示這份資料，
+            // 正是本次要消除的浪費。
+            $guard = Auth::guard('web');
+            if (!method_exists($guard, 'hasUser') || !$guard->hasUser()) {
+                return false;
+            }
+
+            $user = $guard->user();
+
+            return $user !== null && method_exists($user, 'isAdmin') && $user->isAdmin();
+        } catch (\Throwable $e) {
+            // 判斷不出來就不留明細。只記錄第一次：這裡每筆查詢都會走一次，無條件 report
+            // 會淹沒日誌；完全不記錄則會讓「閘門壞掉、功能無聲消失」查不出原因。
+            if (!$this->retainGateFailureReported) {
+                $this->retainGateFailureReported = true;
+
+                // report() 自己也可能爆（例如測試把 Log／handler 換成 mock）。它若在這裡丟出去，
+                // 就等於繞過了外層 catch、讓一個純除錯輔助弄壞請求——正是要避免的事。
+                try {
+                    report($e);
+                } catch (\Throwable) {
+                    // 連記錄都做不到就算了。
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/app/Services/QueryProfile.php
+++ b/app/Services/QueryProfile.php
@@ -6,12 +6,39 @@ use Illuminate\Database\Events\QueryExecuted;
 
 class QueryProfile {
     /**
+     * 最多保留幾筆明細。這是除錯輔助，不該把一個跑上萬筆查詢的頁面（批次匯入、
+     * 維護工具）的每一句 SQL 與 bindings 全留在記憶體裡。前端／舊版 Blade modal
+     * 都只顯示前 100 筆，留 200 筆已足夠；**筆數與總耗時另行累計，永遠精確**，
+     * 不會因為停止保留明細而變小。
+     */
+    public const MAX_STORED = 200;
+
+    /**
      * @var array<int, array<string, mixed>>
      */
     protected $queries = [];
 
-    public function add(QueryExecuted $event): void {
+    /** 全部查詢筆數（含已不再保留明細的部分）。 */
+    protected int $count = 0;
+
+    /** 全部查詢累計耗時（含已不再保留明細的部分）。 */
+    protected float $totalTime = 0.0;
+
+    /**
+     * @param bool $retainDetails 是否保留這一筆的 SQL 與 bindings。
+     *                            false 時仍計入筆數與耗時——舊版 Blade 的「本次查詢共 N 筆」
+     *                            摘要行對所有人顯示（含訪客，該行沒有權限閘），只有明細
+     *                            modal 才限管理員。昂貴的是保留每筆 SQL／bindings，不是計數。
+     */
+    public function add(QueryExecuted $event, bool $retainDetails = true): void {
         $time = is_numeric($event->time) ? (float) $event->time : 0.0;
+
+        $this->count++;
+        $this->totalTime += $time;
+
+        if (!$retainDetails || count($this->queries) >= self::MAX_STORED) {
+            return;
+        }
 
         $this->queries[] = [
             'sql' => $event->sql,
@@ -21,14 +48,20 @@ class QueryProfile {
     }
 
     public function count(): int {
-        return count($this->queries);
+        return $this->count;
     }
 
     public function totalTime(): float {
-        return array_sum(array_column($this->queries, 'time'));
+        return $this->totalTime;
     }
 
-    public function summary(): array {
+    /**
+     * @param int|null $limit 只取前 N 筆明細。**先切再編碼**——bindings 的 json_encode
+     *                        只對真的會被用到的那幾筆做，不要編碼 200 筆再丟掉一半。
+     */
+    public function summary(?int $limit = null): array {
+        $rows = $limit === null ? $this->queries : array_slice($this->queries, 0, $limit);
+
         $queries = array_map(function ($query) {
             return $query + [
                 'bindings_json' => json_encode(
@@ -36,7 +69,7 @@ class QueryProfile {
                     JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
                 ),
             ];
-        }, $this->queries);
+        }, $rows);
 
         return [
             'count' => $this->count(),

--- a/resources/js/inertia/Layouts/DashboardLayout.tsx
+++ b/resources/js/inertia/Layouts/DashboardLayout.tsx
@@ -6,6 +6,7 @@ import { useFontMode } from '../hooks/useFontMode';
 import Sidebar from '../components/shell/Sidebar';
 import Navbar from '../components/shell/Navbar';
 import FlashMessages from '../components/shell/FlashMessages';
+import QueryProfile from '../components/shell/QueryProfile';
 import { type Crumb } from '../components/shell/Breadcrumbs';
 
 interface DashboardLayoutProps {
@@ -72,6 +73,12 @@ export default function DashboardLayout({ children, title, description, breadcru
 
                     {children}
                 </main>
+
+                {/* SQL 查詢明細（僅管理員；非管理員的 request 連收集都不做）。舊版 Blade layout 有、
+                    React layout 漏移植，導致照樣收集卻沒人看得到。
+                    外層留白由元件自帶：包在這裡的話，非管理員（回傳 null）每頁都會多一個
+                    只有 padding 的空 div，在頁尾上方留下一條無來由的空白。 */}
+                <QueryProfile />
 
                 <footer className="border-t border-border bg-card px-4 py-3 text-sm text-muted-foreground">
                     <div className="flex flex-wrap justify-between gap-2">

--- a/resources/js/inertia/Pages/Admin/Manage/Edit.tsx
+++ b/resources/js/inertia/Pages/Admin/Manage/Edit.tsx
@@ -50,7 +50,10 @@ export default function ManageEdit() {
         is_admin: user.is_admin,
         delete_user: 0,
     });
+    // 刪除帳號不可逆，沿用舊版 manage/edit.blade.php 的**兩段確認**（第一段說明不可恢復、
+    // 第二段最後確認）。React 版遷移時收斂成單一 modal，這裡補回第二道閘。
     const [confirmDelete, setConfirmDelete] = useState(false);
+    const [confirmDeleteFinal, setConfirmDeleteFinal] = useState(false);
 
     const save = (e: React.FormEvent) => {
         e.preventDefault();
@@ -132,15 +135,36 @@ export default function ManageEdit() {
                 </form>
             </div>
 
+            {/* 第一段：說明此操作不可恢復（對齊舊版 manage_confirm_delete_1）。 */}
             <ConfirmDialog
                 open={confirmDelete}
                 onOpenChange={setConfirmDelete}
                 title={t('manage_delete_user')}
-                confirmLabel={tc('delete')}
+                // 翻譯字串本身帶 \n\n（舊版走 window.confirm，空行就是重點強調），
+                // HTML 會把換行摺成空白，故用 whitespace-pre-line 保住斷行。
+                description={<span className="whitespace-pre-line">{t('manage_confirm_delete_1')}</span>}
+                confirmLabel={tc('continue')}
                 cancelLabel={tc('cancel')}
                 destructive
                 onConfirm={() => {
                     setConfirmDelete(false);
+                    setConfirmDeleteFinal(true);
+                }}
+            />
+
+            {/* 第二段：最後確認才真的送出（對齊舊版 manage_confirm_delete_2）。 */}
+            <ConfirmDialog
+                open={confirmDeleteFinal}
+                onOpenChange={setConfirmDeleteFinal}
+                title={t('manage_delete_user')}
+                description={t('manage_confirm_delete_2')}
+                confirmLabel={tc('delete')}
+                cancelLabel={tc('cancel')}
+                destructive
+                // 不傳 loading：onConfirm 會先關掉這個對話框再送出，loading 態永遠不會被看到。
+                // 送出期間的重複點擊由表單裡「刪除此用戶」鈕的 disabled={form.processing} 擋住。
+                onConfirm={() => {
+                    setConfirmDeleteFinal(false);
                     submitDelete();
                 }}
             />

--- a/resources/js/inertia/components/shell/QueryProfile.tsx
+++ b/resources/js/inertia/components/shell/QueryProfile.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { usePage } from '@inertiajs/react';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { useTranslation } from '../../hooks/useTranslation';
+import type { SharedProps } from '../../types/page';
+
+/**
+ * SQL 查詢明細（頁尾的效能除錯輔助）。
+ *
+ * 舊版 layouts/dashboard-v3.blade.php 底部有「本次查詢共 N 筆，耗時 X ms」＋管理員可開的明細
+ * modal；React layout 沒有搬過來，於是 DB::listen 照樣把每筆 SQL 收進記憶體、卻沒人看得到。
+ * 這個元件補回顯示端。
+ *
+ * 對齊舊版的權限分界：**摘要行對所有人顯示**（舊版該行沒有任何權限閘），**明細只給管理員**
+ * （非管理員的 queries 為空陣列，後端連 SQL 都不送——見 HandleInertiaRequests::queryProfile()
+ * 與 AppServiceProvider::shouldRetainQueryDetails()）。
+ *
+ * props.query_profile 為 null 時（本次沒有查詢）整區不渲染。
+ */
+export default function QueryProfile() {
+    // 型別在 types/page.ts 的 SharedProps 上（這是 shared prop，每頁都有），
+    // 不在此另立一份區域型別以免與後端輸出漂移。
+    const { query_profile: profile } = usePage<SharedProps>().props;
+    const t = useTranslation('common');
+    const [open, setOpen] = useState(false);
+
+    // 局部重載（切換分頁等）刻意不帶明細——每個 XHR 夾帶上百句 SQL 只為了一個偶爾打開的
+    // modal，並不划算，且 Inertia 會把 props 留在 window.history.state 裡。這裡記住上一次
+    // 整頁載入的明細，讓「查看詳細」不會在局部更新後忽然消失。
+    //
+    // ⚠️ 只有後端明說 details_omitted 時才沿用舊值。不能改成「本次沒帶就沿用」——同一個
+    // React 殼會活過登出／被降權／換 session，那時回應是 queries: [] 且 details_omitted=false，
+    // 若沿用舊值就等於把管理員的 SQL 繼續顯示給已經不是管理員的人。
+    const [details, setDetails] = useState<NonNullable<SharedProps['query_profile']>['queries']>([]);
+    useEffect(() => {
+        if (profile?.details_omitted) {
+            return;
+        }
+
+        setDetails(profile?.queries ?? []);
+    }, [profile]);
+
+    if (!profile || !profile.count) {
+        return null;
+    }
+
+    // 舊版用 number_format(…, 2)，有千分位；一個慢頁面的總毫秒數正是最需要一眼看懂的地方。
+    const ms = profile.time_ms.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+    // 局部重載時用記住的明細（下方會標明來源），其餘一律以本次回應為準。
+    const rows = profile.details_omitted ? details : profile.queries;
+    const hasDetails = rows.length > 0;
+    const detailsFromPageLoad = profile.details_omitted && rows.length > 0;
+
+    return (
+        <>
+            {/* 外層留白由本元件自帶，讓 layout 在回傳 null 時不留下空的 padding 容器。 */}
+            <div className="px-4 pb-2 text-sm text-muted-foreground">
+                {t('query_profile_count', { count: profile.count.toLocaleString(), ms })}
+                {hasDetails && (
+                    <button
+                        type="button"
+                        className="ml-2 text-primary hover:underline"
+                        onClick={() => setOpen(true)}
+                    >
+                        {t('query_profile_view')}
+                    </button>
+                )}
+            </div>
+
+            {/* 用共用 Modal（Radix：focus trap、Esc、a11y 內建）而非自製對話框。 */}
+            <Modal
+                open={open}
+                onOpenChange={setOpen}
+                title={t('query_profile_title')}
+                className="max-w-5xl"
+                footer={
+                    // 舊版 modal 底部有「關閉」鈕（dashboard-v3.blade.php:410），一併補回。
+                    <Button variant="outline" onClick={() => setOpen(false)}>
+                        {t('close')}
+                    </Button>
+                }
+            >
+                <div className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                        {t('query_profile_summary', { count: profile.count.toLocaleString(), ms })}
+                    </p>
+                    {detailsFromPageLoad && (
+                        <p className="text-xs text-muted-foreground">{t('query_profile_from_page_load')}</p>
+                    )}
+                    {!detailsFromPageLoad && profile.truncated && (
+                        <p className="text-xs text-muted-foreground">
+                            {t('query_profile_truncated', { n: String(rows.length) })}
+                        </p>
+                    )}
+
+                    {/* 寬內容自行橫向滾動，不讓整頁橫向溢出 */}
+                    <div className="max-h-[60vh] overflow-auto">
+                        <table className="w-full border-collapse text-xs">
+                            <thead className="sticky top-0 bg-card">
+                                <tr className="border-b border-border text-left">
+                                    <th scope="col" className="w-12 px-2 py-1">{t('query_profile_no')}</th>
+                                    <th scope="col" className="w-20 px-2 py-1">{t('query_profile_time')}</th>
+                                    <th scope="col" className="px-2 py-1">{t('query_profile_sql')}</th>
+                                    <th scope="col" className="w-56 px-2 py-1">{t('query_profile_bindings')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rows.map((q, i) => (
+                                    // 同一頁可能出現一模一樣的 SQL，故 key 用序號＋內容組合而非只用 SQL。
+                                    <tr key={`${i}-${q.sql.length}`} className="border-b border-border align-top">
+                                        <td className="px-2 py-1 text-muted-foreground">{i + 1}</td>
+                                        <td className="px-2 py-1 tabular-nums">{q.time.toFixed(2)}</td>
+                                        <td className="px-2 py-1">
+                                            <code className="whitespace-pre-wrap break-all">{q.sql}</code>
+                                        </td>
+                                        <td className="px-2 py-1">
+                                            <code className="whitespace-pre-wrap break-all text-muted-foreground">{q.bindings}</code>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </Modal>
+        </>
+    );
+}

--- a/resources/js/inertia/types/page.ts
+++ b/resources/js/inertia/types/page.ts
@@ -74,6 +74,26 @@ export interface NavNode {
     children: NavNode[];
 }
 
+/**
+ * SQL 查詢明細（頁尾的效能除錯輔助）。本次沒有任何查詢時為 null。
+ *
+ * 權限分界對齊舊版 Blade：count／time_ms 給所有人（舊版那條摘要行沒有權限閘），
+ * **queries 只有管理員拿得到**，非管理員為空陣列——後端連 SQL 都不送，
+ * 見 HandleInertiaRequests::queryProfile() 與 AppServiceProvider::shouldRetainQueryDetails()。
+ */
+export interface QueryProfileData {
+    count: number;
+    time_ms: number;
+    /**
+     * 本次刻意不送明細（局部重載），但這位使用者本來看得到——前端可沿用上一次整頁載入的明細。
+     * 非管理員永遠是 false，故降權／登出後的回應會讓前端清掉先前的明細。
+     */
+    details_omitted: boolean;
+    /** 明細只送前 100 筆；true 表示總筆數多於列出的明細筆數。 */
+    truncated: boolean;
+    queries: Array<{ time: number; sql: string; bindings: string }>;
+}
+
 export interface SharedProps {
     app: { name: string | null; version: string };
     auth: { user: AuthUser | null };
@@ -82,6 +102,7 @@ export interface SharedProps {
     flash: FlashMessage[];
     nav: NavNode[];
     shell: ShellRoutes;
+    query_profile: QueryProfileData | null;
     translations: Record<string, TranslationGroup>;
     page_translations?: Record<string, TranslationGroup>;
     [key: string]: unknown;

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -4,6 +4,8 @@ return [
     'save'              => 'Save',
     'confirm'           => 'Confirm',
     'cancel'            => 'Cancel',
+    // First step of a two-step confirmation (e.g. deleting a user: acknowledge, then confirm).
+    'continue'          => 'Continue',
     'search'            => 'Search',
     'delete'            => 'Delete',
     'add'               => 'New',
@@ -156,5 +158,8 @@ return [
     'query_profile_time'    => 'Time (ms)',
     'query_profile_sql'     => 'SQL',
     'query_profile_bindings' => 'Bindings',
-    'query_profile_truncated' => 'Showing first :n queries only.',
+    // Not "first :n": details are only retained once the user is resolved, so the
+    // listed queries are not necessarily the earliest ones.
+    'query_profile_truncated' => 'Only :n of them are listed in detail.',
+    'query_profile_from_page_load' => 'These details are from the initial page load; partial updates refresh the counts above only.',
 ];

--- a/resources/lang/zh-TW/common.php
+++ b/resources/lang/zh-TW/common.php
@@ -4,6 +4,8 @@ return [
     'save'              => '保存',
     'confirm'           => '確定',
     'cancel'            => '取消',
+    // 兩段確認的第一段按鈕（如刪除使用者：先確認知悉不可恢復，再最後確認）
+    'continue'          => '繼續',
     'search'            => '搜尋',
     'delete'            => '刪除',
     'add'               => '新增',
@@ -156,5 +158,7 @@ return [
     'query_profile_time'    => '耗時 (ms)',
     'query_profile_sql'     => 'SQL',
     'query_profile_bindings' => '綁定參數',
-    'query_profile_truncated' => '僅顯示前 :n 筆查詢。',
+    // 不寫「前 :n 筆」：明細從身分解析之後才開始保留，列出的未必是最前面幾筆。
+    'query_profile_truncated' => '僅列出其中 :n 筆明細。',
+    'query_profile_from_page_load' => '以下明細為本頁載入時的查詢；局部更新只更新上方筆數。',
 ];

--- a/tests/Feature/QueryProfileGateTest.php
+++ b/tests/Feature/QueryProfileGateTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\User;
+use App\Services\QueryProfile;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Inertia\AlwaysProp;
+use Inertia\Inertia;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * SQL 查詢 profile 的明細閘門。
+ *
+ * 先前 AppServiceProvider 無條件註冊 DB::listen，每個 request（含 artisan 匯入、訪客瀏覽）
+ * 都把每筆查詢的 SQL 與 bindings 累進記憶體——而 React layout 根本沒渲染這份資料，
+ * 等於照樣收集卻沒人看得到。
+ *
+ * 閘的是「**保留明細**」而不是「整個收集」：舊版 layouts/dashboard-v3.blade.php:346 的
+ * 「本次查詢共 N 筆」摘要行**沒有任何權限閘**（訪客也看得到），只有「查看詳細」與 modal
+ * 才限管理員（:348／:369）。故筆數與耗時一律累計，只有 SQL／bindings 限管理員。
+ *
+ * ⚠️ 判斷跑在 DB::listen 回呼裡，絕不能呼叫會觸發使用者查詢的 Auth::check()／Auth::user()
+ * （那會在解析使用者的查詢裡再次觸發解析）。故用 hasResolvedGuards() + hasUser()，
+ * 兩者都只是屬性檢查。
+ *
+ * 已知代價（刻意的，勿誤判為回歸）：使用者被解析「之前」的查詢（session 讀取、撈 users）
+ * 沒有明細，故管理員看到的明細列數會略少於總筆數，總筆數也因此不與舊版 Blade 的數字直接可比。
+ */
+class QueryProfileGateTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('probe', function ($table) {
+            $table->increments('id');
+            $table->string('label')->nullable();
+        });
+        DB::table('probe')->insert(['label' => 'x']);
+    }
+
+    private function makeUser(int $isAdmin): User {
+        return User::create([
+            'name' => 'U' . $isAdmin, 'email' => "u{$isAdmin}@example.com", 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => $isAdmin,
+        ]);
+    }
+
+    /** 直接觸發一次查詢，讓 DB::listen 的閘門跑到。 */
+    private function runQuery(): void {
+        DB::table('probe')->count();
+    }
+
+    /** 已保留明細的筆數。 */
+    private function detailCount(): int {
+        return count(app(QueryProfile::class)->summary()['queries']);
+    }
+
+    #[Test]
+    public function counts_for_guests_but_keeps_no_details(): void {
+        // 舊版 Blade 的「本次查詢共 N 筆」那一行**沒有權限閘**，訪客也看得到
+        // （layouts/dashboard-v3.blade.php:346），所以筆數要照算；昂貴且僅管理員可見的
+        // 是每筆 SQL／bindings，只有那部分不留。
+        $this->runQuery();
+
+        $this->assertGreaterThan(0, app(QueryProfile::class)->count(), '筆數對所有人都要算（對齊舊版摘要行）');
+        $this->assertSame(0, $this->detailCount(), '訪客不該保留任何 SQL 明細');
+    }
+
+    #[Test]
+    public function keeps_no_details_for_a_regular_user(): void {
+        $this->actingAs($this->makeUser(User::ROLE_REGULAR));
+        $this->runQuery();
+
+        $this->assertGreaterThan(0, app(QueryProfile::class)->count());
+        $this->assertSame(0, $this->detailCount(), '一般使用者不該保留 SQL 明細');
+    }
+
+    #[Test]
+    public function keeps_no_details_for_a_crowdsourcing_user(): void {
+        $this->actingAs($this->makeUser(User::ROLE_CROWDSOURCING));
+        $this->runQuery();
+
+        $this->assertGreaterThan(0, app(QueryProfile::class)->count());
+        $this->assertSame(0, $this->detailCount(), '眾包使用者不該保留 SQL 明細');
+    }
+
+    #[Test]
+    public function keeps_details_for_a_super_admin(): void {
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+        $this->runQuery();
+
+        $this->assertGreaterThan(0, $this->detailCount(), '管理員的查詢應保留明細');
+    }
+
+    #[Test]
+    public function keeps_details_for_an_expert_because_isAdmin_covers_that_role(): void {
+        // User::isAdmin() = EXPERT 或 SUPER_ADMIN，與舊版 Blade layout 的
+        // Auth::user()->isAdmin() 閘門一致（不是只有超級管理員）。
+        $this->actingAs($this->makeUser(User::ROLE_EXPERT));
+        $this->runQuery();
+
+        $this->assertGreaterThan(0, $this->detailCount(), '專家帳號亦屬 isAdmin，應保留明細');
+    }
+
+    #[Test]
+    public function the_shared_prop_gives_non_admins_the_count_without_any_sql(): void {
+        // 這是「顯示端自己也要授權」的鎖：即使收集端的閘門被放寬（它長在全域 DB::listen 回呼裡、
+        // 還包著 try/catch），原始 SQL 與 bind 值也不該出現在非管理員的 data-page JSON。
+        $this->actingAs($this->makeUser(User::ROLE_REGULAR));
+        $this->runQuery();
+
+        $resolved = ((new HandleInertiaRequests())->share(request())['query_profile'])();
+
+        $this->assertNotNull($resolved, '摘要行要給所有人（對齊舊版 Blade）');
+        $this->assertGreaterThan(0, $resolved['count']);
+        $this->assertSame([], $resolved['queries'], '非管理員的回應不該帶任何 SQL');
+        $this->assertFalse($resolved['truncated'], '沒有明細不算「被截斷」');
+    }
+
+    #[Test]
+    public function the_gate_does_not_recurse_while_the_user_is_resolved_from_the_session(): void {
+        // 這條路徑最容易出事：閘門若呼叫會查資料庫的 Auth API（Auth::check()／Auth::user()），
+        // 就會在「解析使用者」那句 select 的監聽器裡再次觸發解析 → 無限遞迴。
+        //
+        // ⚠️ 不能用 actingAs()：那是直接把 User 物件 setUser() 進 guard，`$this->user` 一開始
+        //    就不是 null，永遠走不到真正的解析路徑（先前這個測試就是這樣，把閘門換成
+        //    `Auth::check() && Auth::user()->isAdmin()` 照樣綠燈）。這裡改為只在 session 裡放
+        //    login key、忘掉已解析的 guard，強迫 SessionGuard::user() 真的去 retrieveById()。
+        $admin = $this->makeUser(User::ROLE_SUPER_ADMIN);
+
+        $sessionKey = Auth::guard('web')->getName();
+        session([$sessionKey => $admin->id]);
+        Auth::forgetGuards();
+
+        // 解析之前先跑一筆：此時還沒有人登入，明細不該被保留。
+        // （這一句同時讓本測試對「把閘門拿掉、無條件保留」也會紅，而不只是抓遞迴。）
+        $this->runQuery();
+        $this->assertSame(0, $this->detailCount(), '尚未解析出使用者時不該保留明細');
+
+        // 這一行會發出「撈 users」那句 select，DB::listen 於是在 $this->user 仍為 null 時被呼叫。
+        $this->assertSame($admin->id, Auth::id(), '使用者必須是從 session 真正解析出來的');
+
+        // 解析完成之後的查詢才有明細（解析當下那句沒有，這是已知代價）。
+        $this->runQuery();
+        $this->assertGreaterThan(0, $this->detailCount(), '解析出管理員之後應開始保留明細');
+    }
+
+    #[Test]
+    public function the_shared_prop_is_lazy_so_it_counts_the_controller_queries(): void {
+        // 這是實際踩過的 bug：inertia-laravel 的 Middleware::handle 在 `$next($request)`
+        // **之前**就呼叫 share()，此刻控制器一筆查詢都還沒跑。直接呼叫 queryProfile()
+        // 求值，摘要就永遠只有 session／撈使用者那兩筆（畫面上看起來有東西、數字卻是錯的）。
+        // 必須交出 closure，讓 Inertia 在 toResponse()（控制器跑完後）才求值。
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+
+        $shared = (new HandleInertiaRequests())->share(request());
+        $this->assertArrayHasKey('query_profile', $shared);
+        $this->assertInstanceOf(
+            AlwaysProp::class,
+            $shared['query_profile'],
+            'query_profile 必須是延後求值的 prop，直接求值會漏掉控制器的查詢'
+        );
+
+        // share() 之後才發生的查詢；延後求值才看得到它。
+        $before = app(QueryProfile::class)->count();
+        $this->runQuery();
+        $this->runQuery();
+        $resolved = ($shared['query_profile'])();
+
+        $this->assertNotNull($resolved, '有查詢時不該回 null');
+        $this->assertGreaterThan($before, $resolved['count'], '延後求值必須含 share() 之後的查詢');
+        $this->assertSame(app(QueryProfile::class)->count(), $resolved['count']);
+    }
+
+    #[Test]
+    public function the_shared_prop_survives_a_real_partial_reload(): void {
+        // AlwaysProp（而非單純 closure）：局部重載只回傳 `only` 指定的 props，其餘 shared props
+        // 會被丟掉、前端沿用舊值——除錯輔助顯示上一次請求的筆數比不顯示更誤導。
+        //
+        // 這裡走真正的 Inertia 局部重載（X-Inertia-Partial-Data 指定**別的** prop），
+        // 而不是只斷言型別；把 AlwaysProp 換成普通 closure，這個測試就會紅。
+        // 'inertia' 是具名 middleware（app/Http/Kernel.php:78），不在 web group 裡——
+        // 少了它就不會有任何 shared props，這個測試會因為「連 errors 都沒有」而假性失敗。
+        Route::middleware(['web', 'inertia'])->get('/__query-profile-partial-probe', function () {
+            DB::table('probe')->count();
+
+            return Inertia::render('Probe', ['other' => 'x']);
+        });
+
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+
+        // 版本必須和 middleware 算出來的一致，否則 Inertia 對 GET 會回 409（要求整頁重載）。
+        $response = $this->withHeaders([
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => (string) (new HandleInertiaRequests())->version(request()),
+            'X-Inertia-Partial-Component' => 'Probe',
+            'X-Inertia-Partial-Data' => 'other',
+        ])->get('/__query-profile-partial-probe');
+
+        $response->assertOk();
+        $props = $response->json('props');
+        $this->assertArrayHasKey('other', $props);
+        $this->assertArrayNotHasKey('nav', $props, '局部重載本來就會丟掉一般 shared props');
+        $this->assertArrayHasKey('query_profile', $props, '查詢明細必須繞過局部重載過濾');
+        $this->assertGreaterThan(0, $props['query_profile']['count']);
+
+        // 但局部重載**不夾帶明細**：Inertia 會把整份 props 存進 window.history.state，
+        // 而切換分頁這類局部重載在管理員操作中極頻繁，每次都帶上百句 SQL 與 bind 值不划算。
+        $this->assertSame([], $props['query_profile']['queries'], '局部重載不該夾帶 SQL 明細');
+        $this->assertStringNotContainsString('"sql"', $response->getContent(), '回應內容不該出現任何 SQL');
+    }
+
+    #[Test]
+    public function details_omitted_is_only_true_for_someone_who_could_otherwise_see_them(): void {
+        // 前端會在 details_omitted 時沿用上一次的明細。若非管理員的回應也把它設成 true，
+        // 同一個 React 殼在使用者登出／被降權之後就會繼續顯示先前管理員的 SQL。
+        // 故非管理員一律 false，前端因此會清掉舊明細。
+        $this->actingAs($this->makeUser(User::ROLE_REGULAR));
+        $this->runQuery();
+
+        $plain = ((new HandleInertiaRequests())->share(request())['query_profile'])();
+
+        // 一般使用者即使帶著 partial header 也不該是 true（他本來就看不到明細）。
+        request()->headers->set('X-Inertia-Partial-Data', 'other');
+        request()->headers->set('X-Inertia-Partial-Component', 'Probe');
+        $partialWithHeaders = ((new HandleInertiaRequests())->share(request())['query_profile'])();
+
+        $this->assertFalse($plain['details_omitted']);
+        $this->assertFalse($partialWithHeaders['details_omitted'], '非管理員永遠不得為 true');
+        $this->assertSame([], $partialWithHeaders['queries']);
+    }
+
+    #[Test]
+    public function details_omitted_is_true_for_an_admin_on_a_partial_reload(): void {
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+        $this->runQuery();
+
+        request()->headers->set('X-Inertia-Partial-Data', 'other');
+        request()->headers->set('X-Inertia-Partial-Component', 'Probe');
+        $resolved = ((new HandleInertiaRequests())->share(request())['query_profile'])();
+
+        $this->assertTrue($resolved['details_omitted'], '管理員的局部重載要讓前端沿用舊明細');
+        $this->assertSame([], $resolved['queries'], '局部重載不夾帶明細');
+        $this->assertGreaterThan(0, $resolved['count'], '摘要仍要更新');
+    }
+
+    #[Test]
+    public function a_full_inertia_visit_does_carry_the_details_for_an_admin(): void {
+        // 與上一個測試互為對照：整頁載入（非局部重載）才給明細，否則「不夾帶」會變成
+        // 「永遠拿不到」，整個功能等於沒補回來。
+        Route::middleware(['web', 'inertia'])->get('/__query-profile-full-probe', function () {
+            DB::table('probe')->count();
+
+            return Inertia::render('Probe', ['other' => 'x']);
+        });
+
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+
+        $response = $this->withHeaders([
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => (string) (new HandleInertiaRequests())->version(request()),
+        ])->get('/__query-profile-full-probe');
+
+        $response->assertOk();
+        $profile = $response->json('props.query_profile');
+        $this->assertGreaterThan(0, $profile['count']);
+        $this->assertNotEmpty($profile['queries'], '整頁載入必須給管理員明細');
+    }
+
+    #[Test]
+    public function the_detail_list_is_capped_but_reports_the_true_total(): void {
+        // 明細只送前 100 筆，但筆數要如實回報，否則管理員會以為頁面只跑了 100 筆查詢。
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+
+        for ($i = 0; $i < 105; $i++) {
+            $this->runQuery();
+        }
+        $resolved = ((new HandleInertiaRequests())->share(request())['query_profile'])();
+
+        $this->assertGreaterThan(100, $resolved['count'], '總筆數不該被截斷');
+        $this->assertCount(100, $resolved['queries'], '明細應只有前 100 筆');
+        $this->assertTrue($resolved['truncated']);
+    }
+
+    #[Test]
+    public function collection_is_memory_bounded_without_distorting_the_totals(): void {
+        // 保留明細有上限，但筆數與總耗時必須照實累計——否則管理員在一個跑幾千筆查詢的
+        // 頁面上只會看到「200 筆」，反而掩蓋了要抓的效能問題。
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+
+        $total = QueryProfile::MAX_STORED + 37;
+        for ($i = 0; $i < $total; $i++) {
+            $this->runQuery();
+        }
+
+        $profile = app(QueryProfile::class);
+        $this->assertGreaterThanOrEqual($total, $profile->count(), '筆數不該被上限截掉');
+        $this->assertCount(QueryProfile::MAX_STORED, $profile->summary()['queries'], '明細應停在上限');
+        $this->assertGreaterThan(0.0, $profile->totalTime());
+    }
+
+    #[Test]
+    public function summary_shape_is_stable(): void {
+        $this->actingAs($this->makeUser(User::ROLE_SUPER_ADMIN));
+        $this->runQuery();
+
+        $summary = app(QueryProfile::class)->summary();
+        $this->assertArrayHasKey('count', $summary);
+        $this->assertArrayHasKey('time_ms', $summary);
+        $this->assertArrayHasKey('queries', $summary);
+        $this->assertArrayHasKey('bindings_json', $summary['queries'][0]);
+    }
+}


### PR DESCRIPTION
## 背景

舊版 Blade layout（`layouts/dashboard-v3.blade.php`）底部有「本次查詢共 N 筆，耗時 X ms」摘要行 ＋ 管理員可開的 SQL 明細 modal。React/Inertia 遷移時整區漏移植，但 `AppServiceProvider` 的 `DB::listen` 仍**無條件**把每筆查詢的 SQL 與 bindings 累進記憶體——等於每個 request（含 artisan 匯入、訪客瀏覽）照樣收集，卻沒人看得到。

另外 `/app/manage/{id}/edit` 刪除使用者在遷移時把舊版的**兩道 confirm** 收斂成一道。

## 改動

**權限分界完全對齊舊版，而不是順手改掉**：舊版那條摘要行**沒有任何權限閘**（`dashboard-v3.blade.php:346`，訪客也看得到），只有「查看詳細」連結與 modal 限管理員（`:348`／`:369`）。因此閘的是「**保留明細**」而非「整個收集」：筆數與耗時一律累計，每筆 SQL／bindings 只給 `isAdmin()`。若連筆數都不收，flag 回退到 Blade 的頁面也會少一行。

- **顯示端自己再授權一次**：`HandleInertiaRequests::queryProfile()` 獨立檢查 `isAdmin()`，非管理員的 `queries` 為空陣列。收集端閘門長在全域 `DB::listen` 回呼裡還包著 try/catch，一旦有人為了「讓筆數回到舊版數字」放寬它，原始 SQL 與 bind 值就會直接出現在訪客的 `data-page` JSON（AGENTS.md §5）。
- **shared prop 必須延後求值**（實際踩到的 bug）：inertia-laravel 在 `$next($request)` **之前**呼叫 `share()`，直接求值只拿到 session／撈使用者那兩筆——實測 codes 頁顯示 2 筆、實際 6～7 筆。改為 closure，`toResponse()` 才求值。
- 再包 `Inertia::always()`：局部重載會丟掉一般 shared props，除錯輔助顯示上一次的筆數比不顯示更誤導。但**局部重載刻意不夾帶明細**（Inertia 會把 props 存進 `window.history.state`，切換分頁極頻繁）；前端沿用上次整頁載入的明細並標明來源，條件由後端 `details_omitted` 明說——非管理員永遠 false，故登出／被降權後前端會**清掉**舊明細。
- `QueryProfile`：加明細上限（`MAX_STORED=200`），**筆數與總耗時另行累計、永遠精確**；`summary()` 先切再編碼；`singleton` → **`scoped`** 且在回呼內解析（否則 boot 當下的實例會被永久綁進 closure，scoped 失效）。`View::composer` 由 `'*'` 收窄到 `layouts.dashboard-v3`。
- 閘門判斷：明確用 **web guard**（`OptionalAuthentication` 會執行期改寫預設 guard）、**不做跨請求記憶**（provider 在常駐 worker 下會活過請求邊界）、例外只 `report` 第一次且 `report` 自身再包一層 try/catch。
- **刪除使用者恢復兩段確認**，沿用同一組翻譯鍵，第一段的 `\n\n` 以 `whitespace-pre-line` 保住斷行；送出 payload（`delete_user=1`）與後端契約未改動。

## 已知且刻意的差異

管理員看到的筆數會**略低於舊版**：使用者被解析之前的查詢（session、撈 users）沒有明細（筆數仍算），因此明細列數少於總筆數，數字也不與舊版直接可比。已寫在程式註解、測試 docblock 與 CHANGELOG。

## 驗證

- `tests/Feature/QueryProfileGateTest.php`（15 tests）
- `./vendor/bin/phpunit`：**2493 tests / 11386 assertions 全綠**；`npx vitest run`：51 tests
- `./vendor/bin/php-cs-fixer fix`（清 cache）：0 files；`npm run build` 通過
- headless Chrome 對真實庫驗證 11 項：查詢明細 6 項（含非管理員 `data-page` 完全沒有 `sql:`）、兩段刪除 5 項（第一段按繼續不刪除／第二段取消不刪除／兩段都確認才真的刪除，全程用一次性犧牲帳號）
- 負向控制：把 `Inertia::always` 換回普通 closure，局部重載測試即紅

🤖 Generated with [Claude Code](https://claude.com/claude-code)