### PR TITLE
收斂寫入端點的帳號啟用授權（縱深防禦）

### DIFF
--- a/app/Http/Controllers/Api/MutationController.php
+++ b/app/Http/Controllers/Api/MutationController.php
@@ -25,7 +25,31 @@ class MutationController extends Controller {
         $this->mirrorService = $mirrorService;
     }
 
+    /**
+     * 所有寫入端點（store/create/delete/batchStore/resubmit）的最外層守衛：
+     * 未登入回 401、已登入但帳號未啟用（is_active != 1，含被停用者）回 403。
+     *
+     * 各 handler 內部仍會依 direct／proposal 再做角色級授權（canWriteDirectly／canPropose，
+     * 見 AbstractMutationHandler），此處是縱深防禦——即使未來新增的 handler 漏掉授權，
+     * 未啟用帳號也無法從這裡進入任何寫入路徑。回傳非 null 即代表應直接以該回應中止。
+     */
+    private function guardActiveUser(): ?JsonResponse {
+        $user = Auth::user();
+        if (!$user) {
+            return $this->errorResponse('Unauthenticated.', 401);
+        }
+        if (!$user->isActive()) {
+            return $this->errorResponse('該使用者沒有權限，請聯繫管理員', 403);
+        }
+
+        return null;
+    }
+
     public function store(Request $request): JsonResponse {
+        if ($guard = $this->guardActiveUser()) {
+            return $guard;
+        }
+
         $payload = $request->json()->all();
         if (!is_array($payload) || empty($payload)) {
             $payload = $request->all();
@@ -82,6 +106,10 @@ class MutationController extends Controller {
         }
 
         $user = Auth::user();
+        // 未啟用（含被停用）帳號一律不得重發提案，即使是提案本人。
+        if (!$user->isActive()) {
+            return $this->errorResponse('該使用者沒有權限，請聯繫管理員', 403);
+        }
         $isOwner = (int) $operation->user_id === (int) Auth::id();
         if (!$isOwner && !$user->canReviewProposals()) {
             return $this->errorResponse('只有提案人或審核人可以修改提案', 403);
@@ -335,6 +363,10 @@ class MutationController extends Controller {
     }
 
     public function create(Request $request): JsonResponse {
+        if ($guard = $this->guardActiveUser()) {
+            return $guard;
+        }
+
         $payload = $request->json()->all();
         if (!is_array($payload) || empty($payload)) {
             $payload = $request->all();
@@ -368,6 +400,10 @@ class MutationController extends Controller {
     }
 
     public function delete(Request $request): JsonResponse {
+        if ($guard = $this->guardActiveUser()) {
+            return $guard;
+        }
+
         $payload = $request->json()->all();
         if (!is_array($payload) || empty($payload)) {
             $payload = $request->all();
@@ -411,6 +447,10 @@ class MutationController extends Controller {
      * atomic=true：整批單一交易，任一筆失敗整批回滾，回 409 並帶 failed_index。
      */
     public function batchStore(Request $request): JsonResponse {
+        if ($guard = $this->guardActiveUser()) {
+            return $guard;
+        }
+
         $payload = $request->json()->all();
         if (!is_array($payload) || empty($payload)) {
             $payload = $request->all();

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -8,12 +8,30 @@ use App\Models\OfficeCode;
 use App\Models\OfficeCodeTypeRel;
 use App\Models\OfficeTypeTree;
 use App\Models\Operation;
+use App\Models\User;
 use App\Repositories\BiogMainRepository;
 use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class OperationsController extends Controller {
+    /**
+     * 依 confirmation_token 解析呼叫者，並要求帳號為啟用狀態（is_active=1）。
+     * 找不到對應使用者、或帳號未啟用（含被停用者）一律回 null，寫入端據此拒絕，
+     * 避免未啟用帳號僅憑外洩／自查的 token 就能經此通道寫入 operations。
+     */
+    private function resolveActiveUserByToken($token): ?User {
+        if (!is_string($token) || $token === '') {
+            return null;
+        }
+        $user = User::where('confirmation_token', $token)->first();
+        if (!$user || !$user->isActive()) {
+            return null;
+        }
+
+        return $user;
+    }
+
     public function add(Request $request) {
         //用來將json存入operations
         $x = $this->add_operations($request);
@@ -36,13 +54,11 @@ class OperationsController extends Controller {
     }
 
     public function add_operations($keyword) {
-        $z = $keyword['token'];
-        $token = DB::table('users')->where('confirmation_token', $z)->get();
-        $token = json_decode($token, true);
-        $token = $token[0]['id'];
-        if (empty($token)) {
-            return '500';
+        $user = $this->resolveActiveUserByToken($keyword['token'] ?? null);
+        if (!$user) {
+            return response('403', 403);
         }
+        $token = $user->id;
         $x = $keyword['json'];
         if (empty($x)) {
             return '500';
@@ -72,13 +88,11 @@ class OperationsController extends Controller {
     }
 
     public function update_operations($keyword) {
-        $z = $keyword['token'];
-        $token = DB::table('users')->where('confirmation_token', $z)->get();
-        $token = json_decode($token, true);
-        $token = $token[0]['id'];
-        if (empty($token)) {
-            return '500';
+        $user = $this->resolveActiveUserByToken($keyword['token'] ?? null);
+        if (!$user) {
+            return response('403', 403);
         }
+        $token = $user->id;
         $x = $keyword['json'];
         if (empty($x)) {
             return '500';
@@ -136,13 +150,11 @@ class OperationsController extends Controller {
     }
 
     public function destroy_operations($keyword) {
-        $z = $keyword['token'];
-        $token = DB::table('users')->where('confirmation_token', $z)->get();
-        $token = json_decode($token, true);
-        $token = $token[0]['id'];
-        if (empty($token)) {
-            return '500';
+        $user = $this->resolveActiveUserByToken($keyword['token'] ?? null);
+        if (!$user) {
+            return response('403', 403);
         }
+        $token = $user->id;
         $y = $keyword['resource'];
         if (empty($y)) {
             return '500';


### PR DESCRIPTION
## 目的

為所有資料寫入端點補上一致的「帳號需為啟用狀態（is_active=1）」授權檢查，作為最外層縱深防禦，避免日後新增 handler 時漏掉授權而讓未啟用帳號進入寫入路徑。

## 變更

- **MutationController**：`store`／`create`／`delete`／`batchStore` 入口統一加上 `guardActiveUser()`（未登入回 401、帳號未啟用回 403）；`resubmit` 補上原本「提案本人」分支缺少的 `isActive()` 檢查。各 handler 既有的 direct／proposal 角色授權（`canWriteDirectly`／`canPropose`）維持不變。
- **OperationsController**：token 通道（`add`／`update`／`destroy_operations`）改以 `resolveActiveUserByToken()` 解析 `confirmation_token` 並要求帳號啟用；未啟用或查無使用者回真正的 HTTP 403（`response('403', 403)`，維持原字串 body 相容）。一併收斂原先脆弱的 `users` 直查與取值邏輯。
- 只影響寫入端點；讀取端點（`get`／`oppositeEdges`）行為不變。

## 相容性 / 風險

- MutationController 回應碼與訊息沿用既有 handler（`401 Unauthenticated.` / `403 該使用者沒有權限，請聯繫管理員`），啟用中的正常使用者行為不變。
- OperationsController 拒絕時 body 仍為 `403` 字串，但改帶正確的 403 狀態碼。

## 測試

- `php-cs-fixer`：無格式變更。
- 建議 CI 執行 `./vendor/bin/phpunit --filter 'ApiV2Mutate|Proposal|Operations'`。