### PR TITLE
收斂 User 的提權欄位批量賦值

### DIFF
--- a/app/Console/Commands/ManageUser.php
+++ b/app/Console/Commands/ManageUser.php
@@ -156,14 +156,16 @@ class ManageUser extends Command {
         $role = $roleInputMap[$roleInput] ?? User::ROLE_REGULAR;
 
         // 創建用戶（直接使用模型，避免依賴 dev-only 的 Faker）
-        $user = User::create([
+        // is_active／is_admin 不在 $fillable（提權欄位），必須顯式單欄賦值。
+        $user = new User([
             'name' => $name,
             'email' => $email,
             'password' => Hash::make($password),
-            'is_active' => (int)$active,
-            'is_admin' => $role,
             'confirmation_token' => Str::random(32),
         ]);
+        $user->is_active = (int)$active;
+        $user->is_admin = $role;
+        $user->save();
 
         $this->newLine();
         $this->info('✓ 用戶創建成功！');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,16 @@ class User extends Authenticatable {
     /**
      * The attributes that are mass assignable.
      *
+     * 安全性：`is_admin`（角色）與 `is_active`（啟用狀態）是提權欄位，刻意不放進
+     * $fillable，避免任何 `User::create($request->all())` / `$user->update($validated)`
+     * 之類的寫法被動變成提權漏洞。要改這兩個欄位一律顯式單欄賦值
+     * （`$user->is_admin = ...; $user->save();`）。
+     *
+     * 這是縱深防禦，不是唯一防線：真正的授權判斷仍在寫入端點
+     * （`ManagementController::performUserUpdate()`）。注意該閘門目前只是
+     * `canManageUsers()`（活躍的專家或系統管理員），尚未依操作者等級限制可授予的
+     * 目標角色，專家仍能把任意帳號（含自己）提為系統管理員。
+     *
      * @var array
      */
     protected $fillable = [
@@ -36,8 +46,6 @@ class User extends Authenticatable {
         'password',
         'avatar',
         'confirmation_token',
-        'is_active',
-        'is_admin',
     ];
 
     /**

--- a/docs/USER_PRIVILEGES.md
+++ b/docs/USER_PRIVILEGES.md
@@ -42,6 +42,30 @@
 
 ---
 
+## 三之一、`is_admin` / `is_active` 不可批量賦值（提權防線）
+
+這兩欄是**提權欄位**，刻意不放進 `User::$fillable`（見 `app/Models/User.php`）。原因：一旦
+它們可批量賦值，任何一處 `User::create($request->all())` 或 `$user->update($request->validated())`
+就會立刻變成提權漏洞——請求只要夾帶 `is_admin=3` 就能把自己變成系統管理員。
+
+因此：
+
+- **應用層寫入一律顯式單欄賦值**：`$user->is_admin = ...; $user->save();`。線上唯一的寫入端點是
+  `ManagementController::performUserUpdate()`。
+- 這是**縱深防禦**，不是唯一防線。`performUserUpdate()` 目前的閘門只是 `canManageUsers()`
+  （活躍的專家或系統管理員），驗證只有 `in:0,1,2,3`，**尚未**依操作者自身等級限制可授予的
+  目標角色——專家（`is_admin=1`）仍能把任意帳號（包含自己）提為系統管理員，也能軟刪除任何帳號。
+  收斂 `$fillable` 不會擋住這條路，那是獨立待修項。
+- **不要**用 `create()` / `update()` / `fill()` / `firstOrCreate()` / `updateOrCreate()` 的陣列參數
+  傳這兩欄——Laravel 未啟用 strict mode，未 fillable 的欄位會被**靜默丟棄**，不會報錯，
+  只會讓帳號默默停在「未啟用的一般用戶」。
+- **測試 fixture** 可用 `User::factory()`（factory 本身跑在 `Model::unguarded` 內）、
+  `User::forceCreate([...])`，或 `User::unguarded(fn () => ...)` 包住需要的呼叫。
+- 回歸防線：`tests/Feature/UserMassAssignmentGuardTest.php`。若有人把欄位加回 `$fillable`，
+  該測試會紅。
+
+---
+
 ## 四、User 模型輔助方法
 
 `User` 模型（`app/User.php`）提供以下輔助方法簡化權限檢查：

--- a/tests/Feature/AdminAuditLogHistoryFilterTest.php
+++ b/tests/Feature/AdminAuditLogHistoryFilterTest.php
@@ -53,7 +53,7 @@ class AdminAuditLogHistoryFilterTest extends TestCase {
     }
 
     private function makeAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/AdminAuditLogInertiaTest.php
+++ b/tests/Feature/AdminAuditLogInertiaTest.php
@@ -60,7 +60,7 @@ class AdminAuditLogInertiaTest extends TestCase {
     }
 
     private function makeAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('password'),
@@ -151,7 +151,7 @@ class AdminAuditLogInertiaTest extends TestCase {
     #[Test]
     public function non_admin_gets_403(): void {
         $this->createAuditTable();
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'Reg', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/AdminExplainSqlInertiaTest.php
+++ b/tests/Feature/AdminExplainSqlInertiaTest.php
@@ -44,7 +44,7 @@ class AdminExplainSqlInertiaTest extends TestCase {
     }
 
     private function makeAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -67,7 +67,7 @@ class AdminExplainSqlInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_gets_403(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/AiFillLogInertiaTest.php
+++ b/tests/Feature/AiFillLogInertiaTest.php
@@ -60,7 +60,7 @@ class AiFillLogInertiaTest extends TestCase {
     }
 
     private function makeSuperAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -176,7 +176,7 @@ class AiFillLogInertiaTest extends TestCase {
 
     #[Test]
     public function non_super_admin_gets_403(): void {
-        $expert = User::create([
+        $expert = User::forceCreate([
             'name' => 'Exp', 'email' => 'e@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_EXPERT,
         ]);

--- a/tests/Feature/ApiV2CreateAddressTest.php
+++ b/tests/Feature/ApiV2CreateAddressTest.php
@@ -151,7 +151,7 @@ class ApiV2CreateAddressTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-addr-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateAltnameTest.php
+++ b/tests/Feature/ApiV2CreateAltnameTest.php
@@ -170,7 +170,7 @@ class ApiV2CreateAltnameTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-altname-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateAssociationTest.php
+++ b/tests/Feature/ApiV2CreateAssociationTest.php
@@ -243,7 +243,7 @@ class ApiV2CreateAssociationTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-assoc-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateBiogMainTest.php
+++ b/tests/Feature/ApiV2CreateBiogMainTest.php
@@ -189,7 +189,7 @@ class ApiV2CreateBiogMainTest extends TestCase {
     // ── Helpers ──────────────────────────────────────────────
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-biog-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateEntryTest.php
+++ b/tests/Feature/ApiV2CreateEntryTest.php
@@ -160,7 +160,7 @@ class ApiV2CreateEntryTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-entry-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateEventTest.php
+++ b/tests/Feature/ApiV2CreateEventTest.php
@@ -150,7 +150,7 @@ class ApiV2CreateEventTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-event-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateKinshipTest.php
+++ b/tests/Feature/ApiV2CreateKinshipTest.php
@@ -150,7 +150,7 @@ class ApiV2CreateKinshipTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-kin-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreatePossessionTest.php
+++ b/tests/Feature/ApiV2CreatePossessionTest.php
@@ -131,7 +131,7 @@ class ApiV2CreatePossessionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-poss-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreatePostingTest.php
+++ b/tests/Feature/ApiV2CreatePostingTest.php
@@ -194,7 +194,7 @@ class ApiV2CreatePostingTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-post-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateSocialInstitutionTest.php
+++ b/tests/Feature/ApiV2CreateSocialInstitutionTest.php
@@ -137,7 +137,7 @@ class ApiV2CreateSocialInstitutionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-inst-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateStatusTest.php
+++ b/tests/Feature/ApiV2CreateStatusTest.php
@@ -178,7 +178,7 @@ class ApiV2CreateStatusTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-status-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2CreateTextTest.php
+++ b/tests/Feature/ApiV2CreateTextTest.php
@@ -129,7 +129,7 @@ class ApiV2CreateTextTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'create-text-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteAddressTest.php
+++ b/tests/Feature/ApiV2DeleteAddressTest.php
@@ -144,7 +144,7 @@ class ApiV2DeleteAddressTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-addr-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteAltnameTest.php
+++ b/tests/Feature/ApiV2DeleteAltnameTest.php
@@ -139,7 +139,7 @@ class ApiV2DeleteAltnameTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-altname-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteAssociationTest.php
+++ b/tests/Feature/ApiV2DeleteAssociationTest.php
@@ -171,7 +171,7 @@ class ApiV2DeleteAssociationTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-assoc-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteBiogMainTest.php
+++ b/tests/Feature/ApiV2DeleteBiogMainTest.php
@@ -120,7 +120,7 @@ class ApiV2DeleteBiogMainTest extends TestCase {
     // ── Helpers ──────────────────────────────────────────────
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-biog-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteEntryTest.php
+++ b/tests/Feature/ApiV2DeleteEntryTest.php
@@ -154,7 +154,7 @@ class ApiV2DeleteEntryTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-entry-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteEventTest.php
+++ b/tests/Feature/ApiV2DeleteEventTest.php
@@ -121,7 +121,7 @@ class ApiV2DeleteEventTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-event-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteKinshipTest.php
+++ b/tests/Feature/ApiV2DeleteKinshipTest.php
@@ -141,7 +141,7 @@ class ApiV2DeleteKinshipTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-kin-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeletePossessionTest.php
+++ b/tests/Feature/ApiV2DeletePossessionTest.php
@@ -128,7 +128,7 @@ class ApiV2DeletePossessionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-poss-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeletePostingTest.php
+++ b/tests/Feature/ApiV2DeletePostingTest.php
@@ -141,7 +141,7 @@ class ApiV2DeletePostingTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-post-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteSocialInstitutionTest.php
+++ b/tests/Feature/ApiV2DeleteSocialInstitutionTest.php
@@ -123,7 +123,7 @@ class ApiV2DeleteSocialInstitutionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-inst-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteSourceTest.php
+++ b/tests/Feature/ApiV2DeleteSourceTest.php
@@ -120,7 +120,7 @@ class ApiV2DeleteSourceTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-source-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteStatusTest.php
+++ b/tests/Feature/ApiV2DeleteStatusTest.php
@@ -142,7 +142,7 @@ class ApiV2DeleteStatusTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-status-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2DeleteTextTest.php
+++ b/tests/Feature/ApiV2DeleteTextTest.php
@@ -122,7 +122,7 @@ class ApiV2DeleteTextTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'delete-text-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2GetTest.php
+++ b/tests/Feature/ApiV2GetTest.php
@@ -86,7 +86,7 @@ class ApiV2GetTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'get-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateAddressTest.php
+++ b/tests/Feature/ApiV2MutateAddressTest.php
@@ -151,7 +151,7 @@ class ApiV2MutateAddressTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'addr-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateAltnameTest.php
+++ b/tests/Feature/ApiV2MutateAltnameTest.php
@@ -170,7 +170,7 @@ class ApiV2MutateAltnameTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'altname-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateAssociationTest.php
+++ b/tests/Feature/ApiV2MutateAssociationTest.php
@@ -260,7 +260,7 @@ class ApiV2MutateAssociationTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'assoc-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateBatchTest.php
+++ b/tests/Feature/ApiV2MutateBatchTest.php
@@ -140,7 +140,7 @@ class ApiV2MutateBatchTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'batch@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'batch-tester',
             'email' => $email,
             'confirmation_token' => 'token-b',

--- a/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
@@ -95,7 +95,7 @@ class ApiV2MutateCodeTableCharVariantMapTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'cvm@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Code Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateCodeTableTextCodesTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableTextCodesTest.php
@@ -90,7 +90,7 @@ class ApiV2MutateCodeTableTextCodesTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'tc@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Code Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateCodeTableTextInstanceTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableTextInstanceTest.php
@@ -96,7 +96,7 @@ class ApiV2MutateCodeTableTextInstanceTest extends TestCase {
     }
 
     protected function makeUser(string $email = 'ti@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Instance Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateCodeTablesTest.php
+++ b/tests/Feature/ApiV2MutateCodeTablesTest.php
@@ -132,7 +132,7 @@ class ApiV2MutateCodeTablesTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'codetable-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateEntryTest.php
+++ b/tests/Feature/ApiV2MutateEntryTest.php
@@ -160,7 +160,7 @@ class ApiV2MutateEntryTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'entry-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateEventTest.php
+++ b/tests/Feature/ApiV2MutateEventTest.php
@@ -163,7 +163,7 @@ class ApiV2MutateEventTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'event-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateKinshipTest.php
+++ b/tests/Feature/ApiV2MutateKinshipTest.php
@@ -151,7 +151,7 @@ class ApiV2MutateKinshipTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'kin-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateMergedPersonTest.php
+++ b/tests/Feature/ApiV2MutateMergedPersonTest.php
@@ -89,7 +89,7 @@ class ApiV2MutateMergedPersonTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'mp@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Merge Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateNianHaoTest.php
+++ b/tests/Feature/ApiV2MutateNianHaoTest.php
@@ -124,7 +124,7 @@ class ApiV2MutateNianHaoTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'nianhao-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateOfficeImportTest.php
+++ b/tests/Feature/ApiV2MutateOfficeImportTest.php
@@ -121,7 +121,7 @@ class ApiV2MutateOfficeImportTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'of@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Office Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutatePossessionTest.php
+++ b/tests/Feature/ApiV2MutatePossessionTest.php
@@ -156,7 +156,7 @@ class ApiV2MutatePossessionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'poss-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutatePostingTest.php
+++ b/tests/Feature/ApiV2MutatePostingTest.php
@@ -179,7 +179,7 @@ class ApiV2MutatePostingTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'posting-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateSocialInstituteEntityTest.php
+++ b/tests/Feature/ApiV2MutateSocialInstituteEntityTest.php
@@ -186,7 +186,7 @@ class ApiV2MutateSocialInstituteEntityTest extends TestCase {
     }
 
     protected function makeUser(string $email = 'si@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'SI Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateSocialInstituteImportTest.php
+++ b/tests/Feature/ApiV2MutateSocialInstituteImportTest.php
@@ -130,7 +130,7 @@ class ApiV2MutateSocialInstituteImportTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'si@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'SocialInst Tester',
             'email' => $email,
             'confirmation_token' => 'tok',

--- a/tests/Feature/ApiV2MutateSocialInstitutionTest.php
+++ b/tests/Feature/ApiV2MutateSocialInstitutionTest.php
@@ -140,7 +140,7 @@ class ApiV2MutateSocialInstitutionTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'socinst-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateSourceTest.php
+++ b/tests/Feature/ApiV2MutateSourceTest.php
@@ -145,7 +145,7 @@ class ApiV2MutateSourceTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'mutate-source@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateStatusTest.php
+++ b/tests/Feature/ApiV2MutateStatusTest.php
@@ -178,7 +178,7 @@ class ApiV2MutateStatusTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'status-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateTest.php
+++ b/tests/Feature/ApiV2MutateTest.php
@@ -212,7 +212,7 @@ class ApiV2MutateTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2MutateTextTest.php
+++ b/tests/Feature/ApiV2MutateTextTest.php
@@ -133,7 +133,7 @@ class ApiV2MutateTextTest extends TestCase {
     }
 
     protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'text-tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ApiV2OperationListTest.php
+++ b/tests/Feature/ApiV2OperationListTest.php
@@ -61,7 +61,7 @@ class ApiV2OperationListTest extends TestCase {
     }
 
     protected function makeUser(string $email = 'tester@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'is_active' => User::STATUS_ACTIVE,

--- a/tests/Feature/ApiV2OppositeEdgesTest.php
+++ b/tests/Feature/ApiV2OppositeEdgesTest.php
@@ -91,7 +91,7 @@ class ApiV2OppositeEdgesTest extends TestCase {
     }
 
     private function makeUser(int $role = User::ROLE_REGULAR, string $email = 'oe@example.com'): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester', 'email' => $email, 'confirmation_token' => 't',
             'is_active' => User::STATUS_ACTIVE, 'is_admin' => $role,
         ]);

--- a/tests/Feature/ApiV2PkSegmentBoundaryTest.php
+++ b/tests/Feature/ApiV2PkSegmentBoundaryTest.php
@@ -166,7 +166,7 @@ class ApiV2PkSegmentBoundaryTest extends TestCase {
     }
 
     protected function makeUser(string $email): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'tester',
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/BasicInformationAddressesControllerTest.php
+++ b/tests/Feature/BasicInformationAddressesControllerTest.php
@@ -93,7 +93,7 @@ class BasicInformationAddressesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryWritesAuditPayloadWithOperationId(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'addr-update@example.com',
             'password' => bcrypt('password'),
@@ -156,7 +156,7 @@ class BasicInformationAddressesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryPersistsNewAddrId(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'addr-update-addrid@example.com',
             'password' => bcrypt('password'),
@@ -210,7 +210,7 @@ class BasicInformationAddressesControllerTest extends TestCase {
 
     #[Test]
     public function testLegacyUpdateRedirectsWithErrorOnAddrIdConflict(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'addr-legacy-conflict@example.com',
             'password' => bcrypt('password'),
@@ -266,7 +266,7 @@ class BasicInformationAddressesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryReturns400WhenPathPersonIdMismatchesQueryPk(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'addr-update-mismatch@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/BasicInformationAltnamesControllerTest.php
+++ b/tests/Feature/BasicInformationAltnamesControllerTest.php
@@ -162,7 +162,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testStoreWritesAuditLog() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -204,7 +204,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testStoreReplacesStrictModeVariantAndFlashesNotice(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-store-variant@example.com',
             'password' => bcrypt('password'),
@@ -244,7 +244,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testStoreDoesNotReplaceStrictExcludedVariant(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-store-excluded@example.com',
             'password' => bcrypt('password'),
@@ -269,7 +269,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testStoreDuplicateAltnameShowsErrorAndDoesNotInsertAgain() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'duplicate-altname@example.com',
             'password' => bcrypt('password'),
@@ -307,7 +307,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testEditReturns404WhenAltnameNotFound() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -334,7 +334,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testEditHandlesNullCSource() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -371,7 +371,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testEditHandlesNonExistentTextCode() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -408,7 +408,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testEditLoadsTextCodeSuccessfully() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -448,7 +448,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testDestroyQueryCanDeleteWhenSequenceIsNull() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'null-sequence@example.com',
             'password' => bcrypt('password'),
@@ -483,7 +483,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryWritesProposalCommentIntoOperationNote() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'update-note@example.com',
             'password' => bcrypt('password'),
@@ -530,7 +530,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryReplacesStrictModeVariantAndFlashesNotice(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-update-variant@example.com',
             'password' => bcrypt('password'),
@@ -578,7 +578,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryDoesNotReplaceStrictExcludedVariant(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-update-excluded@example.com',
             'password' => bcrypt('password'),
@@ -613,7 +613,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateReplacesStrictModeVariantAndFlashesNotice(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-update-path-variant@example.com',
             'password' => bcrypt('password'),
@@ -660,7 +660,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     public function testUpdateQueryDetectsPkConflictUsingReplacedValue(): void {
         // 替換後的新 c_alt_name_chn（淸X → 清X）與同一人物下另一筆既有別名衝突：
         // 既有的括號衝突偵測邏輯須用替換後的值判斷，而非替換前的原始輸入。
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'altname-legacy-update-conflict@example.com',
             'password' => bcrypt('password'),
@@ -706,7 +706,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateProposalWithNullSequenceUsesNullPkCorrectly() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'proposal-null-sequence@example.com',
             'password' => bcrypt('password'),
@@ -751,7 +751,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
     #[Test]
     public function testEditHandlesZeroCSource() {
         // 創建用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -794,7 +794,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testEditQueryHandlesNullCSequence() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -828,7 +828,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testUpdateQueryWithNullCSequenceDoesNotThrow() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -891,7 +891,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testStoreNormalizesFullwidthBrackets(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'bracket-store@example.com',
             'password' => bcrypt('password'),
@@ -930,7 +930,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testUpdateQueryNormalizesPinyinBrackets(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'bracket-update@example.com',
             'password' => bcrypt('password'),
@@ -978,7 +978,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testUpdateQueryBlocksBracketConflict(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'bracket-conflict@example.com',
             'password' => bcrypt('password'),
@@ -1034,7 +1034,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testUpdateQueryBlocksTypeCodeConflict(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'type-conflict@example.com',
             'password' => bcrypt('password'),
@@ -1103,7 +1103,7 @@ class BasicInformationAltnamesControllerTest extends TestCase {
      */
     #[Test]
     public function testStoreBlocksBracketConflict(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'bracket-store-conflict@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/BasicInformationSourcesControllerTest.php
+++ b/tests/Feature/BasicInformationSourcesControllerTest.php
@@ -301,7 +301,7 @@ class BasicInformationSourcesControllerTest extends TestCase {
     private function createWriterUser(): User {
         $this->createUsersTable();
 
-        return User::create([
+        return User::forceCreate([
             'name' => 'Writer User',
             'email' => 'writer@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/BasicInformationTextsControllerTest.php
+++ b/tests/Feature/BasicInformationTextsControllerTest.php
@@ -90,7 +90,7 @@ class BasicInformationTextsControllerTest extends TestCase {
 
     #[Test]
     public function testDestroyQueryDeletesRowAndWritesAuditLog(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'texts-delete@example.com',
             'password' => bcrypt('password'),
@@ -138,7 +138,7 @@ class BasicInformationTextsControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryWritesAuditPayloadWithOperationId(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'texts-update@example.com',
             'password' => bcrypt('password'),
@@ -191,7 +191,7 @@ class BasicInformationTextsControllerTest extends TestCase {
 
     #[Test]
     public function testUpdateQueryReturns400WhenPathPersonIdMismatchesQueryPk(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'texts-update-mismatch@example.com',
             'password' => bcrypt('password'),
@@ -227,7 +227,7 @@ class BasicInformationTextsControllerTest extends TestCase {
 
     #[Test]
     public function testStoreDuplicateTextShowsErrorAndDoesNotInsertAgain(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'texts-duplicate@example.com',
             'password' => bcrypt('password'),
@@ -254,7 +254,7 @@ class BasicInformationTextsControllerTest extends TestCase {
 
     #[Test]
     public function testDestroyQueryReturns404WhenRowDoesNotExist(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'texts-delete-missing@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/BasicInformationUpdateTest.php
+++ b/tests/Feature/BasicInformationUpdateTest.php
@@ -142,7 +142,7 @@ class BasicInformationUpdateTest extends TestCase {
     #[Test]
     public function testNoUpdateWhenNoChanges() {
         // 創建測試用戶（活躍且非眾包）
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -233,7 +233,7 @@ class BasicInformationUpdateTest extends TestCase {
     #[Test]
     public function testUpdateWhenChangesExist() {
         // 創建測試用戶（活躍且非眾包）
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -339,7 +339,7 @@ class BasicInformationUpdateTest extends TestCase {
     #[Test]
     public function testFrameworkFieldsAreFilteredCorrectly() {
         // 創建測試用戶（活躍且非眾包）
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -421,7 +421,7 @@ class BasicInformationUpdateTest extends TestCase {
      */
     #[Test]
     public function testUpdateGenderToNullPersistsAsDatabaseNull() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'null-gender@example.com',
             'password' => Hash::make('password'),

--- a/tests/Feature/BatchLoadBookTitlesInertiaTest.php
+++ b/tests/Feature/BatchLoadBookTitlesInertiaTest.php
@@ -52,7 +52,7 @@ class BatchLoadBookTitlesInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -73,7 +73,7 @@ class BatchLoadBookTitlesInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/BatchLoadOfficesInertiaTest.php
+++ b/tests/Feature/BatchLoadOfficesInertiaTest.php
@@ -41,7 +41,7 @@ class BatchLoadOfficesInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -61,7 +61,7 @@ class BatchLoadOfficesInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/BatchLoadSocialInstitutesInertiaTest.php
+++ b/tests/Feature/BatchLoadSocialInstitutesInertiaTest.php
@@ -41,7 +41,7 @@ class BatchLoadSocialInstitutesInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -61,7 +61,7 @@ class BatchLoadSocialInstitutesInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/BiogMainBasicInfoNameMergeTest.php
+++ b/tests/Feature/BiogMainBasicInfoNameMergeTest.php
@@ -536,7 +536,7 @@ class BiogMainBasicInfoNameMergeTest extends TestCase {
      */
     #[Test]
     public function testInactiveUserCannotUpdateNames() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Inactive User',
             'email' => 'inactive@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/BiogMainProposalTest.php
+++ b/tests/Feature/BiogMainProposalTest.php
@@ -132,7 +132,7 @@ class BiogMainProposalTest extends TestCase {
     }
 
     protected function makeActiveUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'activeuser',
             'email' => 'active@example.com',
             'is_active' => 1,
@@ -141,7 +141,7 @@ class BiogMainProposalTest extends TestCase {
     }
 
     protected function makeAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'admin',
             'email' => 'admin@example.com',
             'is_active' => 1,

--- a/tests/Feature/CbdbTableMaintenanceInertiaTest.php
+++ b/tests/Feature/CbdbTableMaintenanceInertiaTest.php
@@ -41,7 +41,7 @@ class CbdbTableMaintenanceInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -79,7 +79,7 @@ class CbdbTableMaintenanceInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/CodesCharVariantMapAuditTest.php
+++ b/tests/Feature/CodesCharVariantMapAuditTest.php
@@ -87,7 +87,7 @@ class CodesCharVariantMapAuditTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);

--- a/tests/Feature/CodesColumnBehaviourTest.php
+++ b/tests/Feature/CodesColumnBehaviourTest.php
@@ -109,13 +109,14 @@ class CodesColumnBehaviourTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::firstOrCreate(
+        // is_active／is_admin 是提權欄位、刻意不在 User::$fillable，測試 fixture 需顯式解除守衛。
+        return User::unguarded(fn () => User::firstOrCreate(
             ['email' => 'u@example.com'],
             [
                 'name' => '張三', 'password' => bcrypt('x'),
                 'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
             ]
-        );
+        ));
     }
 
     // ───────── 稽核欄：任何模式都灰底唯讀（不開放編輯） ─────────

--- a/tests/Feature/CodesControllerAuditTest.php
+++ b/tests/Feature/CodesControllerAuditTest.php
@@ -75,7 +75,7 @@ class CodesControllerAuditTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);

--- a/tests/Feature/CodesCreateInertiaTest.php
+++ b/tests/Feature/CodesCreateInertiaTest.php
@@ -79,7 +79,7 @@ class CodesCreateInertiaTest extends TestCase {
     }
 
     private function activeUser(int $role = User::ROLE_SUPER_ADMIN): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => $role,
         ]);

--- a/tests/Feature/CodesEditInertiaTest.php
+++ b/tests/Feature/CodesEditInertiaTest.php
@@ -70,7 +70,7 @@ class CodesEditInertiaTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);

--- a/tests/Feature/CodesPersonPickerTest.php
+++ b/tests/Feature/CodesPersonPickerTest.php
@@ -134,13 +134,14 @@ class CodesPersonPickerTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::firstOrCreate(
+        // is_active／is_admin 是提權欄位、刻意不在 User::$fillable，測試 fixture 需顯式解除守衛。
+        return User::unguarded(fn () => User::firstOrCreate(
             ['email' => 'u@example.com'],
             [
                 'name' => '張三', 'password' => bcrypt('x'),
                 'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
             ]
-        );
+        ));
     }
 
     private function editAssoc() {

--- a/tests/Feature/CodesProposalEditInertiaTest.php
+++ b/tests/Feature/CodesProposalEditInertiaTest.php
@@ -62,7 +62,7 @@ class CodesProposalEditInertiaTest extends TestCase {
     }
 
     private function activeUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -140,7 +140,7 @@ class CodesProposalEditInertiaTest extends TestCase {
     public function non_submitter_cannot_edit(): void {
         $owner = $this->activeUser();
         $opId = $this->seedProposal($owner->id);
-        $other = User::create([
+        $other = User::forceCreate([
             'name' => 'O', 'email' => 'o@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);

--- a/tests/Feature/CodesTextAuthorsTest.php
+++ b/tests/Feature/CodesTextAuthorsTest.php
@@ -120,13 +120,14 @@ class CodesTextAuthorsTest extends TestCase {
 
     /** 同一個測試可能發多次請求（如 displayLimit()），故取用既有帳號而非每次新建。 */
     private function activeUser(): User {
-        return User::firstOrCreate(
+        // is_active／is_admin 是提權欄位、刻意不在 User::$fillable，測試 fixture 需顯式解除守衛。
+        return User::unguarded(fn () => User::firstOrCreate(
             ['email' => 'u@example.com'],
             [
                 'name' => 'U', 'password' => bcrypt('x'),
                 'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
             ]
-        );
+        ));
     }
 
     private function editTextCode(int $textId) {

--- a/tests/Feature/CrowdsourcingInertiaTest.php
+++ b/tests/Feature/CrowdsourcingInertiaTest.php
@@ -56,7 +56,7 @@ class CrowdsourcingInertiaTest extends TestCase {
     }
 
     private function superAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -105,7 +105,7 @@ class CrowdsourcingInertiaTest extends TestCase {
 
     #[Test]
     public function non_super_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/DashboardInertiaTest.php
+++ b/tests/Feature/DashboardInertiaTest.php
@@ -56,7 +56,7 @@ class DashboardInertiaTest extends TestCase {
 
     #[Test]
     public function it_renders_dashboard_component_with_stats(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Alice', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/EventStatusWriteActionsTest.php
+++ b/tests/Feature/EventStatusWriteActionsTest.php
@@ -386,7 +386,7 @@ class EventStatusWriteActionsTest extends TestCase {
     }
 
     private function createWriterUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Writer User',
             'email' => 'writer@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/HistoricalMapsControllerTest.php
+++ b/tests/Feature/HistoricalMapsControllerTest.php
@@ -45,7 +45,7 @@ class HistoricalMapsControllerTest extends TestCase {
     }
 
     protected function createUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Test User',
             'email' => 'maps@example.com',
             'password' => Hash::make('password'),
@@ -75,7 +75,7 @@ class HistoricalMapsControllerTest extends TestCase {
 
     #[Test]
     public function test_non_superadmin_cannot_access_historical_maps_page(): void {
-        $regularUser = User::create([
+        $regularUser = User::forceCreate([
             'name' => 'Regular User',
             'email' => 'regular@example.com',
             'password' => Hash::make('password'),

--- a/tests/Feature/LegacyBladeFormGateTest.php
+++ b/tests/Feature/LegacyBladeFormGateTest.php
@@ -45,7 +45,7 @@ class LegacyBladeFormGateTest extends TestCase {
     }
 
     protected function actingAsActiveUser(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'gate-tester',
             'email' => 'gate-tester@example.com',
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ManageEditInertiaTest.php
+++ b/tests/Feature/ManageEditInertiaTest.php
@@ -43,7 +43,7 @@ class ManageEditInertiaTest extends TestCase {
     }
 
     private function makeUser(string $name, int $role, int $active = 1): User {
-        return User::create([
+        return User::forceCreate([
             'name' => $name, 'email' => strtolower($name) . '@example.com', 'password' => bcrypt('secret'),
             'confirmation_token' => 'token', 'is_active' => $active, 'is_admin' => $role, 'institution' => 'Inst',
         ]);

--- a/tests/Feature/ManageIndexInertiaTest.php
+++ b/tests/Feature/ManageIndexInertiaTest.php
@@ -43,7 +43,7 @@ class ManageIndexInertiaTest extends TestCase {
     }
 
     private function makeUser(string $name, int $role, int $active = 1): User {
-        return User::create([
+        return User::forceCreate([
             'name' => $name,
             'email' => strtolower($name) . '@example.com',
             'password' => bcrypt('secret'),

--- a/tests/Feature/MergePreviewInertiaTest.php
+++ b/tests/Feature/MergePreviewInertiaTest.php
@@ -41,7 +41,7 @@ class MergePreviewInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -62,7 +62,7 @@ class MergePreviewInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_redirected_home(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/NameSearchIndexAutoSyncTest.php
+++ b/tests/Feature/NameSearchIndexAutoSyncTest.php
@@ -184,7 +184,7 @@ class NameSearchIndexAutoSyncTest extends TestCase {
     }
 
     protected function createActiveExpert(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Admin Tester',
             'email' => 'admin@example.com',
             'password' => bcrypt('secret'),

--- a/tests/Feature/NlQueryLogsInertiaTest.php
+++ b/tests/Feature/NlQueryLogsInertiaTest.php
@@ -56,7 +56,7 @@ class NlQueryLogsInertiaTest extends TestCase {
     }
 
     private function makeSuperAdmin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -129,7 +129,7 @@ class NlQueryLogsInertiaTest extends TestCase {
 
     #[Test]
     public function non_super_admin_gets_403(): void {
-        $expert = User::create([
+        $expert = User::forceCreate([
             'name' => 'E', 'email' => 'e@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_EXPERT,
         ]);

--- a/tests/Feature/OfficeStoreRedirectTest.php
+++ b/tests/Feature/OfficeStoreRedirectTest.php
@@ -124,7 +124,7 @@ class OfficeStoreRedirectTest extends TestCase {
     }
 
     private function createUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Test Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/OperationsAltnameRestoreTest.php
+++ b/tests/Feature/OperationsAltnameRestoreTest.php
@@ -73,7 +73,7 @@ class OperationsAltnameRestoreTest extends TestCase {
     }
 
     protected function actingAsAdmin(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('secret'),

--- a/tests/Feature/OperationsIndexDiffTest.php
+++ b/tests/Feature/OperationsIndexDiffTest.php
@@ -125,7 +125,7 @@ BLADE
     }
 
     protected function actingAsAdmin(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('secret'),

--- a/tests/Feature/OperationsIndexFilterTest.php
+++ b/tests/Feature/OperationsIndexFilterTest.php
@@ -92,7 +92,7 @@ class OperationsIndexFilterTest extends TestCase {
     }
 
     private function makeUser(string $name, string $email, array $overrides = []): User {
-        return User::create(array_merge([
+        return User::forceCreate(array_merge([
             'name' => $name,
             'email' => $email,
             'password' => bcrypt('password'),

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -106,7 +106,7 @@ class OperationsIndexLinksTest extends TestCase {
     #[Test]
     public function test_operations_index_generates_links_for_non_person_code_resources() {
         // 创建测试用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -167,7 +167,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_normalizes_single_key_query_string_resource_id_for_code_links(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'nianhao-link@example.com',
             'password' => bcrypt('password'),
@@ -241,7 +241,7 @@ class OperationsIndexLinksTest extends TestCase {
     #[Test]
     public function test_operations_index_does_not_generate_links_for_deleted_operations() {
         // 创建测试用戶
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => bcrypt('password'),
@@ -276,7 +276,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_hides_editor_full_name_for_guests(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Hidden Editor',
             'email' => 'guest-hidden@example.com',
             'password' => bcrypt('password'),
@@ -305,7 +305,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_shows_multiple_audit_records_for_one_operation() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'audit@example.com',
             'password' => bcrypt('password'),
@@ -374,7 +374,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_renders_composite_rows_for_multi_person_operation(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'multi-person@example.com',
             'password' => bcrypt('password'),
@@ -448,7 +448,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_renders_person_specific_resource_links_for_kin_data(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'kin-links@example.com',
             'password' => bcrypt('password'),
@@ -521,7 +521,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_renders_person_specific_resource_links_for_assoc_data(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'assoc-links@example.com',
             'password' => bcrypt('password'),
@@ -653,7 +653,7 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_does_not_render_person_specific_resource_links_for_deleted_kin_data(): void {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'deleted-kin-links@example.com',
             'password' => bcrypt('password'),

--- a/tests/Feature/OperationsInertiaTest.php
+++ b/tests/Feature/OperationsInertiaTest.php
@@ -61,7 +61,7 @@ class OperationsInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);

--- a/tests/Feature/OperationsOfficeRestoreTest.php
+++ b/tests/Feature/OperationsOfficeRestoreTest.php
@@ -80,7 +80,7 @@ class OperationsOfficeRestoreTest extends TestCase {
     }
 
     protected function actingAsAdmin(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('secret'),

--- a/tests/Feature/ProfileInertiaTest.php
+++ b/tests/Feature/ProfileInertiaTest.php
@@ -44,7 +44,7 @@ class ProfileInertiaTest extends TestCase {
     }
 
     private function makeUser(array $overrides = []): User {
-        return User::create(array_merge([
+        return User::forceCreate(array_merge([
             'name' => 'Alice', 'email' => 'a@example.com', 'password' => bcrypt('secret123'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
             'avatar' => 'avatar0.png',

--- a/tests/Feature/ProposalAuditFieldSemanticsTest.php
+++ b/tests/Feature/ProposalAuditFieldSemanticsTest.php
@@ -112,7 +112,7 @@ class ProposalAuditFieldSemanticsTest extends TestCase {
     }
 
     protected function actingAsReviewer(): User {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'reviewer-a',
             'email' => 'reviewer-a@example.com',
             'confirmation_token' => 'token-123',

--- a/tests/Feature/ProposalNormalizationTest.php
+++ b/tests/Feature/ProposalNormalizationTest.php
@@ -92,7 +92,7 @@ class ProposalNormalizationTest extends TestCase {
     }
 
     protected function makeActiveUser(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'activeuser',
             'email' => 'active@example.com',
             'is_active' => 1,

--- a/tests/Feature/ProposalResubmitTest.php
+++ b/tests/Feature/ProposalResubmitTest.php
@@ -109,7 +109,7 @@ class ProposalResubmitTest extends TestCase {
     }
 
     protected function makeUser(string $name, string $email, int $role = User::ROLE_REGULAR): User {
-        return User::create([
+        return User::forceCreate([
             'name' => $name,
             'email' => $email,
             'confirmation_token' => 'token-123',

--- a/tests/Feature/QueryProfileGateTest.php
+++ b/tests/Feature/QueryProfileGateTest.php
@@ -62,7 +62,7 @@ class QueryProfileGateTest extends TestCase {
     }
 
     private function makeUser(int $isAdmin): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'U' . $isAdmin, 'email' => "u{$isAdmin}@example.com", 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => $isAdmin,
         ]);

--- a/tests/Feature/UnidirectionalRepairInertiaTest.php
+++ b/tests/Feature/UnidirectionalRepairInertiaTest.php
@@ -41,7 +41,7 @@ class UnidirectionalRepairInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -61,7 +61,7 @@ class UnidirectionalRepairInertiaTest extends TestCase {
 
     #[Test]
     public function non_admin_forbidden(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);

--- a/tests/Feature/UserIpLoggingTest.php
+++ b/tests/Feature/UserIpLoggingTest.php
@@ -51,6 +51,9 @@ class UserIpLoggingTest extends TestCase {
                 'institution' => 'Test Institute',
                 'password' => 'secret123',
                 'password_confirmation' => 'secret123',
+                // 模擬有人在註冊表單夾帶提權欄位，必須被忽略。
+                'is_active' => 1,
+                'is_admin' => 3,
             ]);
 
         $response->assertRedirect('/home');
@@ -63,11 +66,15 @@ class UserIpLoggingTest extends TestCase {
         $this->assertSame('123.45.67.89', $settings['last_login_ip'] ?? null);
         $this->assertArrayNotHasKey('registration_at', $settings);
         $this->assertArrayNotHasKey('last_login_at', $settings);
+
+        // 註冊絕不可自帶啟用狀態或角色：兩者都不在 User::$fillable，一律落 DB default 0。
+        $this->assertSame(User::STATUS_INACTIVE, $user->is_active);
+        $this->assertSame(User::ROLE_REGULAR, $user->is_admin);
     }
 
     #[Test]
     public function testLoginUpdatesLastLoginIp() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Login Tester',
             'email' => 'login@example.com',
             'institution' => 'Test Institute',
@@ -97,7 +104,7 @@ class UserIpLoggingTest extends TestCase {
 
     #[Test]
     public function testLoginDoesNotBackfillRegistrationFields() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'No Registration Info',
             'email' => 'noreg@example.com',
             'institution' => null,

--- a/tests/Feature/UserMassAssignmentGuardTest.php
+++ b/tests/Feature/UserMassAssignmentGuardTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * is_admin（角色）與 is_active（啟用狀態）是提權欄位，不可批量賦值。
+ *
+ * 本測試把「不在 $fillable」這件事釘住：只要有人為了方便把欄位加回
+ * User::$fillable，任何 User::create($request->all()) 之類的寫法就會瞬間
+ * 變成提權漏洞，這裡會先紅起來。
+ *
+ * 注意：`create_ignores_privilege_columns` 與 `update_ignores_privilege_columns`
+ * 斷言的是「靜默丟棄」，這依賴本專案未啟用 Eloquent strict mode。若日後有人加上
+ * `Model::preventSilentlyDiscardingAttributes()`，這兩條會改成拋 MassAssignmentException，
+ * 需同步改為 expectException——行為仍然安全，只是斷言形式要換。
+ */
+class UserMassAssignmentGuardTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['cache.default' => 'array']);
+        config(['session.driver' => 'array']);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    #[Test]
+    public function privilege_columns_are_not_in_fillable(): void {
+        $fillable = (new User())->getFillable();
+
+        $this->assertNotContains('is_admin', $fillable);
+        $this->assertNotContains('is_active', $fillable);
+    }
+
+    #[Test]
+    public function create_ignores_privilege_columns(): void {
+        $user = User::create([
+            'name' => 'Mass Assign',
+            'email' => 'mass@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $user->refresh();
+
+        $this->assertSame(User::STATUS_INACTIVE, $user->is_active);
+        $this->assertSame(User::ROLE_REGULAR, $user->is_admin);
+        $this->assertFalse($user->isSuperAdmin());
+    }
+
+    #[Test]
+    public function update_ignores_privilege_columns(): void {
+        $user = User::forceCreate([
+            'name' => 'Regular',
+            'email' => 'regular@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]);
+
+        $user->update([
+            'name' => 'Renamed',
+            'is_active' => User::STATUS_INACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $user->refresh();
+
+        $this->assertSame('Renamed', $user->name);
+        $this->assertSame(User::STATUS_ACTIVE, $user->is_active);
+        $this->assertSame(User::ROLE_REGULAR, $user->is_admin);
+    }
+
+    #[Test]
+    public function explicit_assignment_still_works(): void {
+        $user = User::forceCreate([
+            'name' => 'Regular',
+            'email' => 'regular2@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_INACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]);
+
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->is_admin = User::ROLE_EXPERT;
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertTrue($user->isActive());
+        $this->assertTrue($user->isExpert());
+    }
+}

--- a/tests/Feature/UserProfileTest.php
+++ b/tests/Feature/UserProfileTest.php
@@ -50,7 +50,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testAuthenticatedUserCanAccessProfile() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -70,7 +70,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testUserCanUpdateBasicProfile() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Old Name',
             'email' => 'old@example.com',
             'password' => Hash::make('password'),
@@ -97,7 +97,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testUserCanChangePassword() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('oldpassword'),
@@ -125,7 +125,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testPasswordChangeRequiresCurrentPassword() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('oldpassword'),
@@ -148,7 +148,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testPasswordChangeMustVerifyCurrentPassword() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('oldpassword'),
@@ -175,7 +175,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testPasswordChangeMustBeConfirmed() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('oldpassword'),
@@ -202,7 +202,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testEmailMustBeUnique() {
-        $existingUser = User::create([
+        $existingUser = User::forceCreate([
             'name' => 'Existing User',
             'email' => 'existing@example.com',
             'password' => Hash::make('password'),
@@ -211,7 +211,7 @@ class UserProfileTest extends TestCase {
             'is_active' => 1,
         ]);
 
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -235,7 +235,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testUserCanUpdateProfileWithoutChangingPassword() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -264,7 +264,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testNameIsRequired() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -285,7 +285,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testEmailIsRequired() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -306,7 +306,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testInstitutionIsOptional() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -331,7 +331,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testUserCanUpdateAvatar() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -357,7 +357,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testAvatarIsRequired() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -379,7 +379,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testInvalidAvatarIsRejected() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -404,7 +404,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testAvatarMustBeInValidRange() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),
@@ -430,7 +430,7 @@ class UserProfileTest extends TestCase {
 
     #[Test]
     public function testAllValidAvatarsAreAccepted() {
-        $user = User::create([
+        $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => Hash::make('password'),

--- a/tests/Feature/WikiMaintenanceInertiaTest.php
+++ b/tests/Feature/WikiMaintenanceInertiaTest.php
@@ -73,7 +73,7 @@ class WikiMaintenanceInertiaTest extends TestCase {
     }
 
     private function admin(): User {
-        return User::create([
+        return User::forceCreate([
             'name' => 'Admin', 'email' => 'a@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
         ]);
@@ -179,7 +179,7 @@ class WikiMaintenanceInertiaTest extends TestCase {
 
     #[Test]
     public function active_regular_user_can_access(): void {
-        $regular = User::create([
+        $regular = User::forceCreate([
             'name' => 'R', 'email' => 'r@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_REGULAR,
         ]);
@@ -205,7 +205,7 @@ class WikiMaintenanceInertiaTest extends TestCase {
 
     #[Test]
     public function inactive_user_forbidden(): void {
-        $inactive = User::create([
+        $inactive = User::forceCreate([
             'name' => 'I', 'email' => 'i@example.com', 'password' => bcrypt('x'),
             'confirmation_token' => 't', 'is_active' => 0, 'is_admin' => User::ROLE_REGULAR,
         ]);


### PR DESCRIPTION
## 背景

這是入侵調查後彙整的代碼側加固清單的第 1 項（P0-1）。`is_admin`（角色）與 `is_active`（啟用狀態）是提權欄位，卻可批量賦值。

**這是縱深防禦，不是修掉一個活的漏洞**：HEAD 上並沒有可利用的批量賦值路徑（`RegisterController::create()` 是 7 個 key 的白名單，`ManagementController::performUserUpdate()` 本來就顯式賦值）。目的是卸掉「將來有人寫一處 `User::create($request->all())` 就瞬間變成提權漏洞」這把上膛的槍。

## 改動

- `app/Models/User.php`：`is_admin`／`is_active` 移出 `$fillable`
- `app/Console/Commands/ManageUser.php`：改為 `new User([...])` + 顯式單欄賦值 + `save()`
- `tests/**`：171 處 `User::create(` → `User::forceCreate(`（factory 本身跑在 `Model::unguarded` 內，不需改）
- 3 處 `User::firstOrCreate(` 以 `User::unguarded(fn () => ...)` 包住
- 新增 `tests/Feature/UserMassAssignmentGuardTest.php`
- `tests/Feature/UserIpLoggingTest.php`：補「註冊夾帶 `is_active=1&is_admin=3` 必須被忽略」的斷言
- `docs/USER_PRIVILEGES.md`：記錄規則

## 過程中踩到的坑（值得記下）

機械替換只打到 `User::create(`，漏了 `User::firstOrCreate(` 的**第二個陣列參數**——它一樣走 `$fillable`。本專案未啟用 Eloquent strict mode，所以丟棄是**靜默的**：測試 fixture 悄悄降級成「未啟用的一般用戶」，控制器改走提案分支，症狀偽裝成完全不相干的業務錯誤（稽核欄變 `null`、`-999` 沒被正規化），共 9 個測試紅。

## 已知未修（獨立項）

- `performUserUpdate()` 的閘門只是 `canManageUsers()`，驗證只有 `in:0,1,2,3`，**專家（`is_admin=1`）仍能把任意帳號含自己提為系統管理員**，也能軟刪除任何帳號。已在 `User.php` 註解與 docs 明載，屬清單 P0-3。
- `confirmation_token` 仍在 `$fillable`，而它被當 bearer token 用（`Api/OperationsController`）。目前不可利用（沒有任何路徑把請求輸入餵進該欄），但屬同一類風險。

## 驗證

- `./vendor/bin/phpunit` 全套：`OK (2497 tests, 11398 assertions)`；改動前 baseline `OK (2493 tests, 11386 assertions)` 亦全綠
- `php-cs-fixer fix --config=.php-cs-fixer.dist.php`（先清 cache）：`Fixed 0 of 630 files`
- 反向驗證：把兩欄加回 `$fillable`，`UserMassAssignmentGuardTest` 3 條斷言會紅

🤖 Generated with [Claude Code](https://claude.com/claude-code)