### PR TITLE
收斂使用者管理授權與未啟用帳號的認證邊界

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
 class LoginController extends Controller {
@@ -116,6 +117,19 @@ class LoginController extends Controller {
      * The user has been authenticated.
      */
     protected function authenticated(Request $request, $user) {
+        // 未啟用（含被停用）帳號一律不得取得登入 session——即使帳密正確。
+        // 這是全站「未啟用不可操作」假設的入口防線：先前登入流程不檢查 is_active，
+        // 未啟用帳號可拿到 session 再觸及 auth-only 端點（例如建立 API token）。
+        if (!$user->isActive()) {
+            $this->guard()->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            throw ValidationException::withMessages([
+                $this->username() => ['帳號尚未啟用或已停用，請聯繫管理員。'],
+            ]);
+        }
+
         $settings = $user->settings ?? [];
         unset($settings['last_login_at'], $settings['registration_at']);
         $settings['last_login_ip'] = $request->ip();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -71,6 +71,12 @@ class RegisterController extends Controller {
      * @param  \App\Models\User  $user
      */
     protected function registered(Request $request, $user) {
+        // 新帳號預設未啟用（is_active=0）：不保留 RegistersUsers 自動建立的登入 session，
+        // 否則未啟用帳號可帶著 session 觸及 auth-only 端點（例如 POST /api-tokens 建立 API token）。
+        // 待管理員啟用後再由使用者自行登入。維持既有導向（Inertia location / 預設 redirect）不變。
+        $this->guard()->logout();
+        session()->flash('status', '註冊成功，帳號待管理員啟用後即可登入。');
+
         if ($request->header('X-Inertia')) {
             return Inertia::location($this->redirectPath());
         }

--- a/app/Http/Controllers/EmailController.php
+++ b/app/Http/Controllers/EmailController.php
@@ -15,6 +15,15 @@ class EmailController extends Controller {
 
             return route('/');
         }
+        // 未啟用（含被停用）帳號不得經此連結取得 session——此端點不再負責啟用
+        // （is_active 的設定早已停用，見下方註解），故它只能登入「已啟用」帳號，
+        // 不可成為繞過 is_active 檢查的登入後門。
+        if (!$user->isActive()) {
+            flash('帳號尚未啟用，請聯繫管理員。 '.Carbon::now(), 'error');
+
+            return redirect()->route('login');
+        }
+
         //        $user->is_active = 2;
         $user->confirmation_token = Str::random(40);
         $user->save();

--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Services\AuditLogService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 
 class ManagementController extends Controller {
@@ -281,8 +283,11 @@ class ManagementController extends Controller {
      * 更新/軟刪除使用者的共用實作；$indexRoute 控制完成後重導目標。
      */
     protected function performUserUpdate(Request $request, User $user, string $indexRoute) {
+        $actor = Auth::user();
+
         // 检查是否要删除用戶
         if ($request->has('delete_user') && $request->delete_user == 1) {
+            $before = ['is_active' => (int) $user->is_active, 'is_admin' => (int) $user->is_admin];
             $email = $user->email;
             $user->email = $email . '-' . Carbon::now();
             $user->password = '-';
@@ -290,6 +295,11 @@ class ManagementController extends Controller {
             $user->remember_token = '-';
             $user->updated_at = Carbon::now();
             $user->save();
+
+            // 刪除/停用帳號一律撤銷其 API token（sanctum token 不會因帳號失效而自動失效）。
+            $this->revokeApiTokens($user);
+            $this->auditUserChange($user, $before, ['is_active' => (int) $user->is_active, 'is_admin' => (int) $user->is_admin], $actor, 'DELETE');
+
             flash('用戶已刪除 @ '.Carbon::now(), 'danger');
 
             return redirect()->route($indexRoute);
@@ -301,14 +311,84 @@ class ManagementController extends Controller {
             'is_admin' => 'required|integer|in:0,1,2,3',
         ]);
 
+        $currentActive = (int) $user->is_active;
+        $currentAdmin = (int) $user->is_admin;
+        $newActive = (int) $validated['is_active'];
+        $newAdmin = (int) $validated['is_admin'];
+
+        // 角色（is_admin）變更為高敏感操作，於 canManageUsers() 之上再收斂授權：
+        //  1) 僅系統管理員可變更角色——專家（is_admin=1）雖能管理帳號啟用，但不得授予/調整
+        //     任何帳號的角色，杜絕「專家把自己或他人提為系統管理員」這條提權路徑；
+        //  2) 不得變更自己的角色——避免自我提權，或自我降權後失去管理權而鎖死。
+        // （不採「不得授予高於自身」的數值比較：角色值非線性——2=眾包並不高於 1=專家；
+        //   規則 1 僅允許系統管理員改角色、其本身已是最高級，數值比較無實質意義。）
+        if ($newAdmin !== $currentAdmin) {
+            if (!$actor->isSuperAdmin()) {
+                flash('僅系統管理員可變更使用者角色 @ '.Carbon::now(), 'error');
+
+                return redirect()->back();
+            }
+            if ((int) $actor->id === (int) $user->id) {
+                flash('不可變更自己的角色 @ '.Carbon::now(), 'error');
+
+                return redirect()->back();
+            }
+        }
+
         // 更新用戶設定
-        $user->is_active = $validated['is_active'];
-        $user->is_admin = $validated['is_admin'];
+        $user->is_active = $newActive;
+        $user->is_admin = $newAdmin;
         $user->save();
+
+        // 停用或角色異動時撤銷既有 API token（停用不再保留可用憑證；改權亦重置憑證）。
+        if ($newActive === User::STATUS_INACTIVE || $newAdmin !== $currentAdmin) {
+            $this->revokeApiTokens($user);
+        }
+
+        // 應用層審計：記錄操作者與 old→new，與 DB trigger 互為獨立佐證，且能帶到 app 端操作者。
+        $this->auditUserChange(
+            $user,
+            ['is_active' => $currentActive, 'is_admin' => $currentAdmin],
+            ['is_active' => $newActive, 'is_admin' => $newAdmin],
+            $actor,
+            'UPDATE'
+        );
 
         flash('用戶設定已更新 @ '.Carbon::now(), 'success');
 
         return redirect()->route($indexRoute);
+    }
+
+    /** 撤銷指定使用者的所有 personal access token；表不存在時為 no-op（兼容未建該表的測試）。 */
+    private function revokeApiTokens(User $user): void {
+        if (Schema::hasTable('personal_access_tokens')) {
+            $user->tokens()->delete();
+        }
+    }
+
+    /**
+     * 寫入 users 表變更的應用層審計（audit_log 不存在時為 no-op）。
+     * 審計寫入失敗絕不可回退已完成的帳號變更，故以 try/catch 包住、僅記 warning——
+     * DB trigger 才是權威 tripwire，此處是帶 app 端操作者的補充佐證。
+     */
+    private function auditUserChange(User $user, array $before, array $after, ?User $actor, string $operation): void {
+        if (!Schema::hasTable('audit_log')) {
+            return;
+        }
+
+        try {
+            app(AuditLogService::class)->write(
+                'users',
+                $operation,
+                ['id' => (int) $user->id],
+                $before,
+                $after,
+                'user',
+                $actor ? (string) $actor->id : null
+            );
+        } catch (\Throwable $e) {
+            \Log::warning('performUserUpdate 審計寫入失敗: '.$e->getMessage());
+        }
     }
 
     /**

--- a/app/Http/Middleware/OptionalAuthentication.php
+++ b/app/Http/Middleware/OptionalAuthentication.php
@@ -38,6 +38,12 @@ class OptionalAuthentication {
                 } catch (\Exception $e) {
                     abort(401, 'Invalid API token.');
                 }
+
+                // 未啟用（含被停用）帳號的 token 一律拒絕——停用帳號不應仍能以既有 token 認證。
+                // 置於 try/catch 之外，避免 abort(403) 被上面的 catch(\Exception) 吞成 401。
+                if (!$request->user()->isActive()) {
+                    abort(403, '帳號未啟用或已停用。');
+                }
             }
         }
 

--- a/docs/USER_PRIVILEGES.md
+++ b/docs/USER_PRIVILEGES.md
@@ -7,7 +7,7 @@
 ## 一、帳號啟用狀態（`users.is_active`）
 | 值 | 名稱 | 說明 | 實際行為 |
 |----|------|------|-----------|
-| `0` | 未啟用 | 預設值、待審 / 停用狀態 | 可登入，但所有寫入動作會被 Controller 拒絕。 |
+| `0` | 未啟用 | 預設值、待審 / 停用狀態 | **不可登入**（登入流程、email 驗證連結、Sanctum token 皆直接拒絕未啟用帳號；註冊完成也不保留自動登入 session）；即使經其他途徑取得 session，所有寫入動作仍會被 Controller 拒絕。 |
 | `1` | 已啟用 | 正式啟用 | 能照角色權限執行對資料庫的新增 / 修改。 |
 | `2` | 保留 | Migration 註解為「寄送激活郵件」 | 目前程式視同未啟用；不具任何寫入權限。 |
 
@@ -52,10 +52,29 @@
 
 - **應用層寫入一律顯式單欄賦值**：`$user->is_admin = ...; $user->save();`。線上唯一的寫入端點是
   `ManagementController::performUserUpdate()`。
-- 這是**縱深防禦**，不是唯一防線。`performUserUpdate()` 目前的閘門只是 `canManageUsers()`
-  （活躍的專家或系統管理員），驗證只有 `in:0,1,2,3`，**尚未**依操作者自身等級限制可授予的
-  目標角色——專家（`is_admin=1`）仍能把任意帳號（包含自己）提為系統管理員，也能軟刪除任何帳號。
-  收斂 `$fillable` 不會擋住這條路，那是獨立待修項。
+- 這是**縱深防禦**，不是唯一防線。線上唯一寫入端點 `performUserUpdate()` 除了 `canManageUsers()`
+  （活躍的專家或系統管理員）外，已再收斂**角色變更**授權（2026-08，見 `ManagementController`）：
+    - **僅系統管理員可變更 `is_admin`**——專家仍可調整帳號啟用（`is_active`），但不得授予/調整任何
+      帳號的角色，封死「專家把自己或他人提為系統管理員」的提權路徑；
+    - **不得變更自己的角色**（避免自我提權，或自我降權後失去管理權而鎖死）；
+    - **停用或角色異動時撤銷該帳號的 API token**（`personal_access_tokens`）——停用帳號不再保留可用憑證；
+    - 每次變更寫入應用層審計（`audit_log`，操作者 + old→new），與 users 表的 DB trigger tripwire
+      互為獨立佐證。
+  （未採「不得授予高於自身」的數值比較：角色值非線性——`2`＝眾包並不比 `1`＝專家高權；而「僅系統
+    管理員可改角色」已使該比較無實質意義。）
+
+## 三之二、未啟用（`is_active != 1`）帳號不得取得可用 session
+
+「未啟用不可操作」這條假設，過去只由各 Controller 的寫入檢查把守；登入本身不檢查 `is_active`，
+未啟用帳號仍能拿到 session、再觸及 `auth`-only 端點（例如 `POST /api-tokens` 建立 API token）。
+現已在**認證邊界**逐條封死（2026-08）：
+
+- **登入**（`LoginController::authenticated`）：帳密正確但未啟用 → 登出並回驗證錯誤，不建立 session。
+- **註冊**（`RegisterController::registered`）：`RegistersUsers` 自動登入的 session 立即登出，
+  待管理員啟用後再由使用者自行登入。
+- **email 驗證連結**（`EmailController::verify`）：僅能登入「已啟用」帳號，不再是繞過 `is_active` 的後門。
+- **Sanctum token**（`OptionalAuthentication`）：Bearer token 對應帳號未啟用 → `403`。搭配上節
+  「停用即撤銷 token」，被停用帳號既無法登入、既有 token 也失效。
 - **不要**用 `create()` / `update()` / `fill()` / `firstOrCreate()` / `updateOrCreate()` 的陣列參數
   傳這兩欄——Laravel 未啟用 strict mode，未 fillable 的欄位會被**靜默丟棄**，不會報錯，
   只會讓帳號默默停在「未啟用的一般用戶」。

--- a/tests/Feature/InactiveAccountLoginTest.php
+++ b/tests/Feature/InactiveAccountLoginTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 未啟用（is_active != 1）帳號不得取得登入 session（見 docs/USER_PRIVILEGES.md 三之二）。
+ */
+class InactiveAccountLoginTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    private function makeUser(int $active): User {
+        return User::forceCreate([
+            'name' => 'Tester',
+            'email' => 'tester@example.com',
+            'password' => Hash::make('secret123'),
+            'confirmation_token' => 'tok',
+            'is_active' => $active,
+            'is_admin' => User::ROLE_REGULAR,
+        ]);
+    }
+
+    #[Test]
+    public function inactive_user_cannot_log_in(): void {
+        $this->makeUser(User::STATUS_INACTIVE);
+
+        $response = $this->from('/login')->post('/login', [
+            'email' => 'tester@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+
+    #[Test]
+    public function active_user_can_log_in(): void {
+        $this->makeUser(User::STATUS_ACTIVE);
+
+        $response = $this->post('/login', [
+            'email' => 'tester@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $response->assertRedirect('/home');
+        $this->assertAuthenticated();
+    }
+}

--- a/tests/Feature/ManagePagesLoadTest.php
+++ b/tests/Feature/ManagePagesLoadTest.php
@@ -71,7 +71,7 @@ class ManagePagesLoadTest extends TestCase {
             'name' => 'Admin User',
             'email' => 'admin@example.com',
             'is_active' => 1,
-            'is_admin' => 1,  // 管理员权限
+            'is_admin' => User::ROLE_SUPER_ADMIN,  // 系統管理員（變更他人角色需超級管理員）
             'confirmation_token' => 'admin_token_' . time(),
             'remember_token' => 'admin_remember_' . time(),
         ]);

--- a/tests/Feature/ManageRoleChangeAuthorizationTest.php
+++ b/tests/Feature/ManageRoleChangeAuthorizationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * performUserUpdate 角色變更授權收斂（見 docs/USER_PRIVILEGES.md 三之一）：
+ *  - 僅系統管理員可變更 is_admin（專家不得授予/調整角色）；
+ *  - 不得變更自己的角色；
+ *  - 專家仍可調整帳號啟用（is_active）。
+ */
+class ManageRoleChangeAuthorizationTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-manage-role';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('institution')->nullable();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->string('remember_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    private function makeUser(string $name, int $role, int $active = 1): User {
+        return User::forceCreate([
+            'name' => $name,
+            'email' => strtolower($name) . '@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'token',
+            'is_active' => $active,
+            'is_admin' => $role,
+            'institution' => 'Inst',
+        ]);
+    }
+
+    #[Test]
+    public function expert_cannot_elevate_user_to_super_admin(): void {
+        $expert = $this->makeUser('Expert', User::ROLE_EXPERT);
+        $target = $this->makeUser('Victim', User::ROLE_REGULAR);
+
+        $this->actingAs($expert)
+            ->from(route('app.manage.index'))
+            ->patch(route('app.manage.update', ['manage' => $target->id]), [
+                'is_active' => 1,
+                'is_admin' => User::ROLE_SUPER_ADMIN,
+            ])
+            ->assertRedirect(route('app.manage.index'));
+
+        $target->refresh();
+        $this->assertSame(User::ROLE_REGULAR, (int) $target->is_admin, '專家不應能把他人提為系統管理員');
+    }
+
+    #[Test]
+    public function expert_can_still_activate_without_changing_role(): void {
+        $expert = $this->makeUser('Expert2', User::ROLE_EXPERT);
+        $target = $this->makeUser('Pending', User::ROLE_REGULAR, 0);
+
+        $this->actingAs($expert)
+            ->patch(route('app.manage.update', ['manage' => $target->id]), [
+                'is_active' => 1,
+                'is_admin' => User::ROLE_REGULAR,
+            ])
+            ->assertRedirect(route('app.manage.index'));
+
+        $target->refresh();
+        $this->assertSame(1, (int) $target->is_active, '專家應仍可啟用帳號');
+        $this->assertSame(User::ROLE_REGULAR, (int) $target->is_admin);
+    }
+
+    #[Test]
+    public function super_admin_cannot_change_their_own_role(): void {
+        $admin = $this->makeUser('Root', User::ROLE_SUPER_ADMIN);
+
+        $this->actingAs($admin)
+            ->from(route('app.manage.index'))
+            ->patch(route('app.manage.update', ['manage' => $admin->id]), [
+                'is_active' => 1,
+                'is_admin' => User::ROLE_REGULAR,
+            ])
+            ->assertRedirect(route('app.manage.index'));
+
+        $admin->refresh();
+        $this->assertSame(User::ROLE_SUPER_ADMIN, (int) $admin->is_admin, '不應能變更自己的角色');
+    }
+
+    #[Test]
+    public function super_admin_can_change_another_users_role(): void {
+        $admin = $this->makeUser('Root2', User::ROLE_SUPER_ADMIN);
+        $target = $this->makeUser('Promotee', User::ROLE_REGULAR);
+
+        $this->actingAs($admin)
+            ->patch(route('app.manage.update', ['manage' => $target->id]), [
+                'is_active' => 1,
+                'is_admin' => User::ROLE_SUPER_ADMIN,
+            ])
+            ->assertRedirect(route('app.manage.index'));
+
+        $target->refresh();
+        $this->assertSame(User::ROLE_SUPER_ADMIN, (int) $target->is_admin, '系統管理員應可變更他人角色');
+    }
+}


### PR DESCRIPTION
## 目的

兩項使用者權限的縱深防禦，延續近期的提權欄位收斂（`is_admin`／`is_active` 已移出 `$fillable`）：把「角色變更」收斂到系統管理員，並讓「未啟用帳號」在所有認證邊界都拿不到可用 session。

## 變更

### 1. 角色變更授權（`ManagementController::performUserUpdate`）
線上唯一寫入 `is_admin`／`is_active` 的端點，除既有 `canManageUsers()` 外再收斂：
- **僅系統管理員可變更 `is_admin`（角色）**——專家仍可調整帳號啟用，但不得授予/調整任何帳號的角色（封死「專家把自己或他人提為系統管理員」）。
- **不得變更自己的角色**（避免自我提權，或自我降權鎖死）。
- **停用或角色異動時撤銷該帳號的 API token**（`personal_access_tokens`）——停用帳號不再保留可用憑證。
- 每次變更寫入應用層審計（`audit_log`，操作者 + old→new）；表不存在時 no-op、審計失敗僅記 warning，絕不回退帳號變更。
- （未採「不得授予高於自身」的數值比較：角色值非線性——`2`＝眾包並不比 `1`＝專家高權；「僅系統管理員可改角色」已使該比較無意義。）

### 2. 未啟用帳號不得取得可用 session
過去「未啟用不可操作」只由各 Controller 的寫入檢查把守，登入本身不查 `is_active`。現於認證邊界逐條封死：
- **登入**（`LoginController::authenticated`）：帳密正確但未啟用 → 登出並回驗證錯誤。
- **註冊**（`RegisterController::registered`）：登出 `RegistersUsers` 自動建立的 session（維持既有導向）。
- **email 驗證連結**（`EmailController::verify`）：僅能登入已啟用帳號，不再是繞過 `is_active` 的後門。
- **Sanctum token**（`OptionalAuthentication`）：token 對應帳號未啟用 → `403`（置於既有 try/catch 之外，避免被吞成 401）。

## 相容性

- 啟用中的正常使用者行為不變；專家仍可在 `/manage` 調整帳號啟用，只是不能再改角色。
- 讀取端點不受影響。

## 測試

- 新增 `ManageRoleChangeAuthorizationTest`（專家不得提權、不得改自己角色、系統管理員可改他人角色、專家仍可啟用）與 `InactiveAccountLoginTest`（未啟用不可登入、已啟用可登入）。
- `ManagePagesLoadTest` 的角色更新測試改以系統管理員為操作者（角色管理現需超管）。
- 本地（docker php 8.4 + in-memory sqlite）執行 **全套 phpunit：OK（2502 tests, 11410 assertions）**。
- `php-cs-fixer`：無格式變更。

## 文件

- `docs/USER_PRIVILEGES.md`：改寫「三之一」（角色閘門已實作，移除待修註記）、新增「三之二」（未啟用帳號認證邊界）。