### PR TITLE
任官編輯器「另存新檔」按鈕移至右側按鈕組

### DIFF
--- a/resources/js/inertia/components/OfficeEditor.tsx
+++ b/resources/js/inertia/components/OfficeEditor.tsx
@@ -439,10 +439,10 @@ export default function OfficeEditor({
 
             <div style={gSubmitRow}>
                 {canEdit && !isResubmit ? <button type="button" style={gPrimaryBtn} disabled={saving || (mode === 'edit' && !dirty)} onClick={() => void save('direct')}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : tr('save_directly', '直接保存')}</button> : null}
-                {mode === 'edit' && canEdit && !isResubmit ? <button type="button" style={gSuccessBtn} disabled={saving} onClick={() => void save('direct', true)}>{tr('save_as', '另存新檔')}</button> : null}
                 {(canEdit || canPropose) ? <button type="button" style={gInfoBtn} disabled={saving || (mode === 'edit' && !dirty && !isResubmit)} onClick={() => (canEdit && !isResubmit ? setConfirmProposalMode(true) : void save('proposal'))}>{saving ? <><BtnSpinner />{tr('saving', '儲存中…')}</> : (isResubmit ? tr('resubmit_proposal', '更新提案') : tr('submit_proposal', '提交建議'))}</button> : null}
                 <ActionStatus saving={saving} deleting={deleting} message={message} error={error} t={t} />
                 <div style={gBtnGroupRight}>
+                    {mode === 'edit' && canEdit && !isResubmit ? <button type="button" style={gSuccessBtn} disabled={saving} onClick={() => void save('direct', true)}>{tr('save_as', '另存新檔')}</button> : null}
                     {mode === 'edit' && canEdit && deleteEndpoint && !isResubmit ? <button type="button" style={gDangerBtn} disabled={deleting} onClick={() => void doDelete()}>{tr('delete', '刪除')}</button> : null}
                     <a href={indexUrl} style={gCancelBtn}>{tr('cancel', '取消')}</a>
                 </div>


### PR DESCRIPTION
## 摘要
- 將 OfficeEditor（`/app/basicinformation/{id}/offices/edit-v2`）的「另存新檔」按鈕從左側主要動作區移到右側 `gBtnGroupRight`（與刪除、取消同組），避免緊鄰「直接保存」造成誤觸。
- 渲染條件（`mode === 'edit' && canEdit && !isResubmit`）與 onClick/disabled 邏輯均未變動。

## 測試
- 內部 review agent 與 codex review 均無嚴重 issues。
- `npm run build` 目前於 develop 即因 @tanstack/react-table 9.0.1 升版（4facbc78）的既有 MISSING_EXPORT 問題失敗，與本次改動無關（已以 stash 驗證）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)