### PR TITLE
API token 不再簽發通配能力

### DIFF
--- a/app/Http/Controllers/ApiTokenController.php
+++ b/app/Http/Controllers/ApiTokenController.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
+use App\Support\ApiTokenAbilities;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 
 class ApiTokenController extends Controller {
     /**
@@ -27,22 +31,64 @@ class ApiTokenController extends Controller {
      * 創建新的 API token
      */
     public function store(Request $request) {
+        ApiTokenAbilities::assertMcpAbilityIsIssuable();
+
+        // 先去重再驗證：重複元素對授權毫無意義，不該因此被 422 擋下；但 max 規則要看的是
+        // 去重後的筆數，否則「上千個重複值」會先撐爆 TEXT 欄位（見下方 max 註解）。
+        // SORT_REGULAR：元素可能不是字串（巢狀陣列會由 abilities.* 的 string 規則擋下），
+        // 預設的 SORT_STRING 會先觸發 Array to string conversion。
+        if (is_array($request->input('abilities'))) {
+            $request->merge([
+                'abilities' => array_values(array_unique($request->input('abilities'), SORT_REGULAR)),
+            ]);
+        }
+
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'abilities' => ['sometimes', 'array'],
+            // min:1：顯式傳空陣列會簽出一個「能認證但永遠進不了 MCP」的 token，
+            //   使用者完全看不出原因，寧可當場擋下。
+            // max:count(allowed)：abilities 是 TEXT 欄位而生產 sql_mode 沒有
+            //   STRICT_TRANS_TABLES，數千個重複元素會被靜默截斷到 65535 bytes，
+            //   之後 json_decode 回 null、Sanctum 的 can() 直接拋 TypeError，該 token 永久壞掉。
+            'abilities' => ['sometimes', 'array', 'min:1', 'max:'.count(ApiTokenAbilities::allowed())],
+            // 只接受登記過的能力；通配 '*' 不在清單內，會被這條擋下。
+            'abilities.*' => ['string', Rule::in(ApiTokenAbilities::allowed())],
             'expires_in' => ['sometimes', 'integer', 'min:1', 'max:3650'],
+        ], [
+            // Rule::in 的預設訊息（「所選的 abilities.0 無效」）看不出為什麼，
+            // 而請求通配是最可能的誤用，所以給它一句明確的說明。
+            'abilities.*.in' => '不支援的 token 能力。允許的能力：'
+                .implode('、', ApiTokenAbilities::allowed())
+                .'。通配能力（*）已停用——它等於自動授予日後新增的每一種能力。',
         ]);
 
-        $abilities = $request->input('abilities', ['*']);
+        // 未指定時給「能用的最小權限」，不再是通配（見 ApiTokenAbilities 註解）。
+        // 有指定時已在驗證前去重並通過允許清單，直接用。
+        $abilities = $request->has('abilities')
+            ? array_values($request->input('abilities'))
+            : ApiTokenAbilities::default();
+
         $expiresAt = $request->has('expires_in') && $request->input('expires_in')
             ? now()->addDays($request->input('expires_in'))
             : null;
 
-        $token = $request->user()->createToken(
-            $request->input('name'),
-            $abilities,
-            $expiresAt
-        );
+        // 與 AccountAccessRevoker 序列化：管理員停用帳號會在同一把 users 列鎖下撤銷 token。
+        // 沒有這把鎖時，兩者可能交錯成「撤銷讀到舊清單 → 建立寫入新 token → 停用完成但仍留
+        // 一個有效憑證」，等帳號日後重新啟用就復活。鎖內重讀 is_active，停用先提交就直接 403。
+        $token = DB::transaction(function () use ($request, $abilities, $expiresAt) {
+            $locked = DB::table('users')->where('id', $request->user()->id)->lockForUpdate()->first();
+            abort_if(
+                !$locked || (int) $locked->is_active !== User::STATUS_ACTIVE,
+                403,
+                __('auth.account_inactive')
+            );
+
+            return $request->user()->createToken(
+                $request->input('name'),
+                $abilities,
+                $expiresAt
+            );
+        });
 
         // If this is a JSON request, return JSON response
         if ($request->expectsJson()) {

--- a/app/Services/AccountAccessRevoker.php
+++ b/app/Services/AccountAccessRevoker.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class AccountAccessRevoker {
@@ -20,13 +21,23 @@ class AccountAccessRevoker {
      * @return int 實際刪除的 token 筆數
      */
     public function revokeApiTokens(User $user, string $context): int {
-        $tokens = $user->tokens()->get(['id', 'name', 'abilities', 'last_used_at']);
+        // 讀清單與刪除放在同一把 users 列鎖下，與 ApiTokenController::store() 序列化：
+        // 沒有這把鎖時兩者可能交錯成「這裡讀到舊清單 → 對方寫入新 token → 撤銷完成但仍留
+        // 一個有效憑證」。刻意只鎖住「鎖＋讀＋刪」，審計留在交易外——審計失敗不得回退撤銷。
+        $tokens = DB::transaction(function () use ($user) {
+            DB::table('users')->where('id', $user->id)->lockForUpdate()->first();
+
+            $rows = $user->tokens()->get(['id', 'name', 'abilities', 'last_used_at']);
+            if ($rows->isNotEmpty()) {
+                $user->tokens()->delete();
+            }
+
+            return $rows;
+        });
 
         if ($tokens->isEmpty()) {
             return 0;
         }
-
-        $user->tokens()->delete();
 
         // DELETE 的語義：被銷毀的狀態記在 old_data，new_data 為 null。連 reason／context
         // 一起放進 old_data，日後查「這批 token 是誰在什麼情境下撤掉的」才有線索。

--- a/app/Support/ApiTokenAbilities.php
+++ b/app/Support/ApiTokenAbilities.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * API token 能力（Sanctum abilities）的單一權威來源。
+ *
+ * 背景：`ApiTokenController::store()` 原本的預設值是 `['*']`——Sanctum 的通配能力，
+ * `$token->can(任何字串)` 都會通過。目前全站只有一處消費 abilities
+ * （EnsureMcpAbility，要求 `mcp:read`），所以通配值今天沒有多給任何權限；但它的意思是
+ * 「這個 token 自動擁有將來新增的每一種能力」——只要有人日後加一個 ability-gated 的
+ * 寫入端點，所有既存 token 就立刻獲得授權。這是上了膛的槍，先卸彈。
+ */
+class ApiTokenAbilities {
+    /** Sanctum 的通配能力值；本專案一律不接受。 */
+    public const WILDCARD = '*';
+
+    /**
+     * 允許簽發的能力，寫成字面值清單。
+     *
+     * 刻意**不**從 `config('mcp.cbdb.required_ability')` 推導。曾經那樣寫，有兩個真實後果：
+     *
+     *  1. `MCP_REQUIRED_ABILITY=*` 會讓 allowed() 回傳 `['*']`，於是驗證放行通配、
+     *     降級 migration 也把 `*` 原封不動寫回去——一個環境變數就能無聲地把整個 P1-4 還原，
+     *     而程式碼給出的 422 訊息還在說「通配能力已停用」。
+     *  2. 把 env 改成別的字串（例如 mcp:readonly）會讓所有既存 token 立刻失去 MCP 權限，
+     *     而且使用者連「重新簽一個能用的」都做不到，因為 allowed() 已經不含舊字串——
+     *     只能手動改 SQL 救。在 token 還是 `['*']` 的年代改這個 env 是無害的，收斂之後不是。
+     *
+     * 新增能力時在這裡登記；**淘汰的名稱也要留著**，否則帶舊名稱的既存 token 會變成
+     * 無法修復的孤兒。
+     *
+     * @return list<string>
+     */
+    public const ISSUABLE = [
+        'mcp:read',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function allowed(): array {
+        // 防禦性過濾：就算有人把 WILDCARD 加進 ISSUABLE，也不會真的簽出通配 token。
+        return array_values(array_filter(
+            self::ISSUABLE,
+            fn ($ability) => !self::isWildcard($ability)
+        ));
+    }
+
+    /**
+     * 未指定 abilities 時的預設值。
+     *
+     * 兩個建立 token 的介面（React TokenManager 與舊 Blade profile 頁）都不送 abilities，
+     * 所以這個預設值就是實務上絕大多數 token 拿到的能力。取「能用的最小權限」＝MCP 唯讀，
+     * 而不是空陣列：空陣列會讓從 UI 建的 token 連唯一的既有用途（MCP）都用不了。
+     *
+     * @return list<string>
+     */
+    public static function default(): array {
+        return self::allowed();
+    }
+
+    public static function isWildcard(mixed $ability): bool {
+        return is_string($ability) && trim($ability) === self::WILDCARD;
+    }
+
+    /**
+     * 已回報過的設定漂移值，避免每次建立 token 都寫一筆 log 把檔案洗爆。
+     *
+     * @var array<string, true>
+     */
+    private static array $reportedDrift = [];
+
+    /**
+     * MCP 要求的能力是否真的簽得出來。
+     *
+     * 上面刻意與 config 解耦，代價是兩者可能漂移：若營運把 `MCP_REQUIRED_ABILITY` 改成
+     * ISSUABLE 之外的字串（或清空），任何新簽的 token 都進不了 MCP，而且畫面上不會有任何跡象。
+     * 這是設定錯誤而不是使用者錯誤，所以在這裡記一筆讓它可被發現。
+     *
+     * 刻意**不** fail closed（不拒絕簽發）：`mcp:read` 對 `/api/user` 與 `api/v2/*` 一樣有用
+     * （那些端點根本不檢查 abilities），線上多數 token 其實是 REST 客戶端。因為 MCP 的設定
+     * 打錯就讓整個 token 簽發停擺，是自找的服務中斷，比「簽出一個進不了 MCP 但仍可用的 token」
+     * 更糟。
+     */
+    public static function assertMcpAbilityIsIssuable(): void {
+        $required = trim((string) config('mcp.cbdb.required_ability', 'mcp:read'));
+
+        if ($required !== '' && in_array($required, self::allowed(), true)) {
+            return;
+        }
+
+        // 每個 process 對同一個漂移值只記一次。
+        $key = $required === '' ? '<empty>' : $required;
+        if (isset(self::$reportedDrift[$key])) {
+            return;
+        }
+        self::$reportedDrift[$key] = true;
+
+        Log::error(
+            'MCP_REQUIRED_ABILITY 設為不可簽發的能力，任何新 token 都無法通過 MCP 准入。',
+            [
+                'required_ability' => $key,
+                'issuable' => self::allowed(),
+                'hint' => '請把該值加進 App\Support\ApiTokenAbilities::ISSUABLE，或改回可簽發的能力。',
+            ]
+        );
+    }
+
+    /** 測試用：清掉「只記一次」的去重狀態。 */
+    public static function forgetReportedDrift(): void {
+        self::$reportedDrift = [];
+    }
+}

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -6,6 +6,10 @@ return [
         'max_limit' => (int) env('MCP_MAX_LIMIT', 100),
         'rate_limit_per_minute' => (int) env('MCP_RATE_LIMIT_PER_MINUTE', 120),
         'require_token_abilities' => env('MCP_REQUIRE_TOKEN_ABILITIES', true),
+        // ⚠️ 這個值同時是「簽發 token 時的允許／預設能力」（見 App\Support\ApiTokenAbilities）
+        // 與「MCP 端點的准入判定」（見 App\Http\Middleware\EnsureMcpAbility）。
+        // 改動它會讓所有既存 token 立刻失去 MCP 權限——它們帶的是舊字串。token 還是 ['*']
+        // 的年代改這個值是無害的（通配滿足任何能力），自 P1-4 收斂之後就不是了。
         'required_ability' => env('MCP_REQUIRED_ABILITY', 'mcp:read'),
         'allowed_tables' => array_values(array_unique(array_filter(array_map(
             static fn ($table): string => trim((string) $table),

--- a/database/migrations/2026_08_11_000001_downgrade_wildcard_api_token_abilities.php
+++ b/database/migrations/2026_08_11_000001_downgrade_wildcard_api_token_abilities.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 把既有 token 的通配能力 `*` 降級為登記過的最小能力。
+ *
+ * `ApiTokenController::store()` 的預設值原本是 `['*']`，而兩個建立介面都不送 abilities，
+ * 所以線上每一個 token 都是通配。改掉預設值只影響新 token，既有的仍然「自動擁有將來新增
+ * 的每一種能力」——包含入侵期間可能留下的那些。
+ *
+ * 今天降級不會弄壞任何東西：全站只有 EnsureMcpAbility 會檢查 abilities（要求 mcp:read），
+ * `/api/user` 與 `api/v2/*` 根本不看 abilities，所以把 `*` 換成 mcp:read 之後，
+ * 現有客戶端的行為完全不變。
+ *
+ * ⚠️ 未來注意：線上在用的 token 有幾個名稱明顯是 REST/v2 客戶端（CBDBAPI、Python Scripts…）
+ * 而非 MCP 客戶端。今天把它們標成 mcp:read 是行為中性的，但**等到 api/v2/* 也開始檢查
+ * abilities 的那一天，這些 token 會因為只有 MCP 唯讀而失效**，屆時需要為它們定義並補上
+ * 對應能力（而不是以為 mcp:read 就夠）。
+ */
+return new class () extends Migration {
+    /**
+     * 刻意寫死而不是引用 App\Support\ApiTokenAbilities。
+     *
+     * migration 應該是凍結的快照：若輸出取決於當下的 config／應用類別，`migrate:fresh`
+     * 會在不同環境寫出不同資料，而且那個類別日後被改名或刪掉就會讓全新安裝 migrate 失敗。
+     */
+    private const ALLOWED = ['mcp:read'];
+
+    public function up(): void {
+        if (!Schema::hasTable('personal_access_tokens')) {
+            return;
+        }
+
+        // 判準是「缺少任何一個合法能力」而不是「含有 `*`」：
+        //  - 可重跑（當成修復工具用）；
+        //  - 同時修好 abilities 為 NULL／不可解碼的孤兒列——那種列會讓 Sanctum 的 can()
+        //    直接拋 TypeError（in_array 收到 null），只判 `*` 的話永遠修不到。
+        // chunkById 而非 chunk：offset 分頁在有人同時刪 token 時會位移而靜默跳列，
+        // 且日後若有人加上 where 條件優化，offset 版本會立刻出現經典的跳列 bug。
+        DB::table('personal_access_tokens')
+            ->select('id', 'abilities')
+            ->orderBy('id')
+            ->chunkById(200, function ($rows) {
+                foreach ($rows as $row) {
+                    $abilities = json_decode((string) $row->abilities, true);
+
+                    if (!is_array($abilities)) {
+                        // NULL／壞 JSON：無從保留，補上最小能力讓它至少可用且不會讓 can() 拋錯。
+                        $this->rewrite($row->id, self::ALLOWED);
+
+                        continue;
+                    }
+
+                    // 抽掉 `*` 與任何未登記的字串，保留原有的合法能力。
+                    $kept = array_values(array_unique(array_filter(
+                        $abilities,
+                        fn ($ability) => in_array($ability, self::ALLOWED, true)
+                    )));
+
+                    if ($kept === $abilities) {
+                        // 已經只帶合法能力且無重複 → 不動（重跑時走這條，保證冪等）。
+                        continue;
+                    }
+
+                    // 刻意**不** merge ALLOWED：若日後 ALLOWED 長成多個能力，原本刻意只帶
+                    // 其中一項的 token 會被這個 merge 擴權成全部。只有「一個合法能力都不剩」
+                    // 時才補最小能力，否則保留它自己原有的那組。
+                    $this->rewrite($row->id, $kept === [] ? self::ALLOWED : $kept);
+                }
+            });
+    }
+
+    private function rewrite(int|string $id, array $abilities): void {
+        DB::table('personal_access_tokens')
+            ->where('id', $id)
+            ->update(['abilities' => json_encode(array_values($abilities))]);
+    }
+
+    public function down(): void {
+        // 不可逆：把 `*` 放回去等於把「自動獲得未來所有能力」這個問題放回去。
+        // 原本哪些 token 是通配已無從得知（也不需要知道）。故意留空。
+    }
+};

--- a/docs/MCP_HTTP_INTERFACE_PROPOSAL.md
+++ b/docs/MCP_HTTP_INTERFACE_PROPOSAL.md
@@ -56,8 +56,11 @@
 
 建議將 MCP 權限最小化：
 
-- `mcp:read`（必要）
-- `mcp:schema`（可選）
+- `mcp:read`（必要，且自 P1-4 起是**唯一**可簽發的能力）
+
+> 註：`mcp:schema` 曾列為可選能力，但自 P1-4 起 `ApiTokenController::store()` 只接受
+> `App\Support\ApiTokenAbilities::ISSUABLE` 登記過的能力，未登記者一律回 422。
+> 若要恢復這個能力，需先把它加進 `ISSUABLE`。
 
 於 MCP 工具入口檢查能力：
 

--- a/docs/MCP_USER_GUIDE.md
+++ b/docs/MCP_USER_GUIDE.md
@@ -11,9 +11,13 @@
 
 ## 2. 取得 API Token
 
-請在 CBDB 系統建立 Personal Access Token，並設定能力為至少包含：
+請在 CBDB 系統建立 Personal Access Token（個人資料頁）。**不需要手動設定能力**：介面沒有
+能力選擇器，新建 token 一律自動取得目前唯一可簽發的能力：
 
 - `mcp:read`
+
+（自 P1-4 起，預設值不再是 Sanctum 的通配能力 `*`。若你手上的舊 token 是 `*`，它已被
+migration 降級為 `mcp:read`，MCP 用法不受影響。）
 
 若 token 洩漏，請立即撤銷並重新建立。
 

--- a/tests/Feature/ApiTokenAbilitiesTest.php
+++ b/tests/Feature/ApiTokenAbilitiesTest.php
@@ -1,0 +1,427 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\ApiTokenAbilities;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * P1-4：API token 不再簽發 Sanctum 的通配能力 `*`。
+ *
+ * `*` 的意思是「這個 token 自動擁有將來新增的每一種能力」。全站目前只有 EnsureMcpAbility
+ * 會檢查 abilities，所以通配今天沒有多給權限；但只要日後有人加一個 ability-gated 的寫入
+ * 端點，所有既存 token 就立刻獲得授權。
+ */
+class ApiTokenAbilitiesTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        // 「設定漂移只記一次」是 process 級狀態，測試之間要清掉才不會互相干擾。
+        ApiTokenAbilities::forgetReportedDrift();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['cache.default' => 'array']);
+        config(['session.driver' => 'array']);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    /** 每次 include 都會回傳一個新的匿名 class 實例，可安全重複呼叫。 */
+    private function runDowngradeMigration(): void {
+        (include database_path('migrations/2026_08_11_000001_downgrade_wildcard_api_token_abilities.php'))->up();
+    }
+
+    private function activeUser(): User {
+        return User::unguarded(fn () => User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]));
+    }
+
+    #[Test]
+    public function created_token_defaults_to_the_minimum_ability_not_wildcard(): void {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'laptop'])
+            ->assertOk()
+            ->assertJsonPath('token.abilities', ApiTokenAbilities::default());
+
+        $stored = json_decode(DB::table('personal_access_tokens')->value('abilities'), true);
+        $this->assertNotContains(ApiTokenAbilities::WILDCARD, $stored);
+        $this->assertSame(ApiTokenAbilities::default(), $stored);
+    }
+
+    #[Test]
+    public function wildcard_ability_is_rejected_even_when_asked_for_explicitly(): void {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'pwn', 'abilities' => ['*']])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('abilities.0');
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function unknown_abilities_are_rejected(): void {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'x', 'abilities' => ['biog:write']])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('abilities.0');
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function explicitly_requesting_an_allowed_ability_still_works(): void {
+        $user = $this->activeUser();
+        $allowed = ApiTokenAbilities::allowed()[0];
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'mcp', 'abilities' => [$allowed]])
+            ->assertOk()
+            ->assertJsonPath('token.abilities', [$allowed]);
+    }
+
+    #[Test]
+    public function mcp_still_accepts_a_default_token(): void {
+        // 預設值必須真的能用在唯一的既有消費者上，否則「最小權限」等於「不能用」。
+        $user = $this->activeUser();
+        $token = $user->createToken('mcp', ApiTokenAbilities::default())->accessToken;
+
+        $this->assertTrue($token->can(config('mcp.cbdb.required_ability', 'mcp:read')));
+        $this->assertFalse($token->can('some:future:write'));
+    }
+
+    #[Test]
+    public function no_production_code_calls_createToken_without_explicit_abilities(): void {
+        // Sanctum 的 HasApiTokens::createToken() 第二參數預設是 ['*']，所以只要有人在
+        // 生產碼寫 createToken('name') 就會重新產生通配 token，而且不會有任何報錯。
+        // 這條把「必須顯式傳能力」釘住。
+        $offenders = [];
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(app_path(), \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            foreach ($this->createTokenArgCounts((string) file_get_contents($file->getPathname())) as $line => $args) {
+                if ($args < 2) {
+                    $offenders[] = $file->getPathname().':'.$line.' 只傳了 '.$args.' 個參數';
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "以下呼叫沒有顯式指定 abilities，會落回 Sanctum 的通配預設值：\n".implode("\n", $offenders)
+        );
+    }
+
+    /**
+     * 用 tokenizer 數每個 createToken( 呼叫的頂層參數個數。
+     *
+     * 刻意不用正則：呼叫是多行的、參數本身又含括號（`$request->input('name')`），
+     * 字元類別式的正則會跨行並在第一個內層 `)` 就收尾，把合格的呼叫誤判成違規
+     * （第一版就踩了這個坑）。
+     *
+     * @return array<int, int> line => 頂層參數個數
+     */
+    private function createTokenArgCounts(string $code): array {
+        $tokens = token_get_all($code);
+        $counts = [];
+
+        for ($i = 0; $i < count($tokens); $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_STRING || $token[1] !== 'createToken') {
+                continue;
+            }
+
+            // 找緊接的 '('（中間只可能有空白／註解）。
+            $j = $i + 1;
+            while ($j < count($tokens) && is_array($tokens[$j])
+                && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                $j++;
+            }
+            if (!isset($tokens[$j]) || $tokens[$j] !== '(') {
+                continue;
+            }
+
+            $depth = 0;
+            $commas = 0;
+            $sawContent = false;
+
+            for ($k = $j; $k < count($tokens); $k++) {
+                $t = $tokens[$k];
+
+                if ($t === '(' || $t === '[' || $t === '{') {
+                    $depth++;
+
+                    continue;
+                }
+                if ($t === ')' || $t === ']' || $t === '}') {
+                    $depth--;
+                    if ($depth === 0) {
+                        break;
+                    }
+
+                    continue;
+                }
+                if ($t === ',' && $depth === 1) {
+                    $commas++;
+
+                    continue;
+                }
+                if ($depth === 1 && (!is_array($t) || $t[0] !== T_WHITESPACE)) {
+                    $sawContent = true;
+                }
+            }
+
+            $counts[$token[2]] = $sawContent ? $commas + 1 : 0;
+        }
+
+        return $counts;
+    }
+
+    #[Test]
+    public function a_wildcard_token_would_have_authorized_any_future_ability(): void {
+        // 反向對照：說明為什麼要拿掉 `*`。
+        $user = $this->activeUser();
+        $token = $user->createToken('legacy', ['*'])->accessToken;
+
+        $this->assertTrue($token->can('some:future:write'));
+    }
+
+    #[Test]
+    public function the_migration_downgrades_existing_wildcard_tokens(): void {
+        $user = $this->activeUser();
+        $user->createToken('legacy-a', ['*']);
+        $user->createToken('legacy-b', ['*', ApiTokenAbilities::allowed()[0]]);
+        $user->createToken('already-scoped', ApiTokenAbilities::default());
+
+        $this->runDowngradeMigration();
+
+        foreach (DB::table('personal_access_tokens')->get() as $row) {
+            $abilities = json_decode((string) $row->abilities, true);
+            $this->assertNotContains(ApiTokenAbilities::WILDCARD, $abilities, "token {$row->name} 仍是通配");
+            $this->assertSame(ApiTokenAbilities::default(), $abilities);
+        }
+    }
+
+    #[Test]
+    public function store_rechecks_is_active_inside_the_row_lock(): void {
+        // 這條專門釘住 store() 交易內的重讀，所以必須繞過 middleware——否則 403 是
+        // App\Http\Middleware\Authenticate 給的，把 store() 裡的 abort_if 整塊刪掉也會綠，
+        // 等於假保證（實測過：刪掉後 8 個測試全過）。
+        //
+        // 手法：actingAs 用 setUser() 注入這個實例，middleware 的 isActive() 讀到的是
+        // 記憶體裡還是 1 的舊值而放行；但交易內是重新 SELECT users 列，看到的是 0。
+        // 這正是「管理員在請求進行中把帳號停用」的那個交錯。
+        $user = $this->activeUser();
+        $this->actingAs($user);
+
+        DB::table('users')->where('id', $user->id)->update(['is_active' => User::STATUS_INACTIVE]);
+        $this->assertTrue($user->isActive(), '前置條件：記憶體中的實例必須仍是啟用狀態');
+
+        $this->postJson('/api-tokens', ['name' => 'x'])->assertForbidden();
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function a_deactivated_account_is_blocked_before_reaching_the_controller(): void {
+        $user = $this->activeUser();
+        $user->is_active = User::STATUS_INACTIVE;
+        $user->save();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'x'])
+            ->assertForbidden();
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function an_empty_abilities_array_is_rejected_rather_than_minting_a_useless_token(): void {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'x', 'abilities' => []])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('abilities');
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function duplicate_abilities_are_collapsed_not_rejected(): void {
+        // 重複元素對授權毫無意義，不該因此被擋下——但也不能原樣存進去。
+        $user = $this->activeUser();
+        $allowed = ApiTokenAbilities::allowed()[0];
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'x', 'abilities' => [$allowed, $allowed, $allowed]])
+            ->assertOk()
+            ->assertJsonPath('token.abilities', [$allowed]);
+
+        $this->assertSame(
+            [$allowed],
+            json_decode(DB::table('personal_access_tokens')->value('abilities'), true)
+        );
+    }
+
+    #[Test]
+    public function an_oversized_abilities_payload_is_rejected(): void {
+        // abilities 是 TEXT 且生產 sql_mode 沒有 STRICT_TRANS_TABLES：上千個元素會被靜默
+        // 截斷到 65535 bytes，之後 json_decode 回 null、Sanctum 的 can() 直接拋 TypeError，
+        // 那個 token 就永久壞掉。去重之後仍超過允許能力總數的請求一律擋下。
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/api-tokens', [
+                'name' => 'x',
+                'abilities' => array_map(fn (int $i) => 'bogus:'.$i, range(1, 5000)),
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('abilities');
+
+        $this->assertSame(0, DB::table('personal_access_tokens')->count());
+    }
+
+    #[Test]
+    public function the_migration_does_not_escalate_a_token_that_already_has_allowed_abilities(): void {
+        // 判準是「含通配／不可解碼／完全沒有合法能力」；已帶合法能力的 token 應保留原有
+        // 那一組。若日後 ALLOWED 長成多個能力，merge 式的寫法會把刻意只帶一項的 token 擴權。
+        $user = $this->activeUser();
+        $user->createToken('scoped', ApiTokenAbilities::default());
+        $before = DB::table('personal_access_tokens')->value('abilities');
+
+        $this->runDowngradeMigration();
+
+        $this->assertSame($before, DB::table('personal_access_tokens')->value('abilities'));
+    }
+
+    #[Test]
+    public function config_drift_is_reported_once_per_process_not_per_request(): void {
+        // 每次建立 token 都寫一筆 Log::error 會把 log 洗爆。
+        ApiTokenAbilities::forgetReportedDrift();
+        config(['mcp.cbdb.required_ability' => 'mcp:nonexistent']);
+
+        Log::shouldReceive('error')->once()->withAnyArgs();
+
+        ApiTokenAbilities::assertMcpAbilityIsIssuable();
+        ApiTokenAbilities::assertMcpAbilityIsIssuable();
+        ApiTokenAbilities::assertMcpAbilityIsIssuable();
+    }
+
+    #[Test]
+    public function the_wildcard_cannot_be_re_enabled_through_config(): void {
+        // 曾經 allowed() 是從 config('mcp.cbdb.required_ability') 推導的，於是
+        // MCP_REQUIRED_ABILITY=* 就能讓驗證放行通配、migration 也把 `*` 寫回去——
+        // 一個環境變數無聲還原整個 P1-4。現在 ISSUABLE 是字面值清單且會過濾通配。
+        config(['mcp.cbdb.required_ability' => '*']);
+
+        $this->assertNotContains(ApiTokenAbilities::WILDCARD, ApiTokenAbilities::allowed());
+        $this->assertNotContains(ApiTokenAbilities::WILDCARD, ApiTokenAbilities::default());
+
+        $user = $this->activeUser();
+        $this->actingAs($user)
+            ->postJson('/api-tokens', ['name' => 'x', 'abilities' => ['*']])
+            ->assertStatus(422);
+    }
+
+    #[Test]
+    public function the_migration_heals_tokens_with_unreadable_abilities(): void {
+        // abilities 為 NULL 的列會讓 can() 拋 TypeError；只判「含有 *」的版本永遠修不到它。
+        $user = $this->activeUser();
+        $user->createToken('legacy', ['*']);
+        DB::table('personal_access_tokens')->insert([
+            'tokenable_type' => User::class,
+            'tokenable_id' => $user->id,
+            'name' => 'orphan',
+            'token' => str_repeat('a', 64),
+            'abilities' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->runDowngradeMigration();
+
+        foreach (DB::table('personal_access_tokens')->get() as $row) {
+            $this->assertSame(
+                ApiTokenAbilities::default(),
+                json_decode((string) $row->abilities, true),
+                "token {$row->name} 未被修復"
+            );
+        }
+    }
+
+    #[Test]
+    public function the_migration_is_idempotent(): void {
+        $user = $this->activeUser();
+        $user->createToken('legacy', ['*']);
+
+        $this->runDowngradeMigration();
+        $first = DB::table('personal_access_tokens')->value('abilities');
+
+        $this->runDowngradeMigration();
+
+        $this->assertSame($first, DB::table('personal_access_tokens')->value('abilities'));
+    }
+}


### PR DESCRIPTION
加固清單第 4 項（P1-4）。

## 為什麼

Sanctum 的 `*` 意思是「這個 token **自動擁有將來新增的每一種能力**」。全站目前只有 `EnsureMcpAbility` 檢查 abilities（要求 `mcp:read`），所以通配今天沒有多給權限——但只要日後有人加一個 ability-gated 的寫入端點，所有既存 token 就立刻獲得授權。

線上實測：**10 個 token 全是 `[*]`，4 個曾被使用**。而兩個建立介面（React `TokenManager.tsx`、舊 Blade `profile/edit.blade.php`）都不送 `abilities`，所以預設值就是實務上的全部。

## 改動

- **`app/Support/ApiTokenAbilities.php`（新增）**：`ISSUABLE` 是**字面值**清單（目前只有 `mcp:read`），`allowed()` 額外過濾通配。

  **刻意不從 `config('mcp.cbdb.required_ability')` 推導。** 第一版那樣寫，review 用實際執行證明了兩個後果：
  1. `MCP_REQUIRED_ABILITY=*` 會讓 `allowed()` 回傳 `[*]` → 驗證放行通配、降級 migration 也把 `*` 原封不動寫回去。**一個環境變數就能無聲還原整個修補**，而程式碼給出的 422 訊息還在說「通配能力已停用」。
  2. 改成別的字串（`mcp:readonly`）→ 既有 token 全數失去 MCP 權限，且使用者連「重簽一個能用的」都做不到（`allowed()` 已不含舊名稱），只能手改 SQL 救。在 token 還是 `[*]` 的年代改這個 env 是無害的，收斂之後就是一行設定造成的全面中斷。

  淘汰的能力名稱要留在 `ISSUABLE` 裡，否則帶舊名稱的既存 token 會變成無法修復的孤兒。

- **`ApiTokenController::store()`**：預設改 `default()`；`abilities` 限允許清單、通配一律 422 並附明確說明；**驗證前先去重**，`max` 用去重後筆數。

  `max` 不是防呆而是防資料損壞：`abilities` 是 `TEXT`，而生產 `sql_mode` 沒有 `STRICT_TRANS_TABLES`，上千個重複元素會被**靜默截斷**到 65535 bytes → `json_decode` 回 `null` → Sanctum 的 `can()` 直接拋 `TypeError` → 那個 token 永久壞掉。空陣列同樣擋下（會簽出一個能認證但永遠進不了 MCP 的 token，使用者完全看不出原因）。

- **補掉 P0-2 留下的競態**：`createToken` 與 `AccountAccessRevoker` 都先 `lockForUpdate` `users` 列，`store()` 在鎖內重讀 `is_active`。沒有這把鎖時兩者可能交錯成「撤銷讀到舊清單 → 建立寫入新 token → 停用完成但仍留一個有效憑證」，等帳號日後重新啟用就復活。

- **migration 降級既有通配 token**：內聯字面值（migration 應是凍結快照，不依賴 app 類別與 runtime config，否則 `migrate:fresh` 會依環境寫出不同資料）、`chunkById`、判準是「含通配／不可解碼／完全沒有合法能力」而非「含有 `*`」——所以**可重跑當修復工具**，也能修好 `abilities` 為 `NULL` 的孤兒列（那種列會讓 `can()` 拋 `TypeError`）。刻意**不** merge `ALLOWED`：日後 `ALLOWED` 長成多個能力時，merge 會把原本刻意只帶一項的 token 擴權。

- **設定漂移**：`config` 與 `ISSUABLE` 不一致時記 `Log::error`，但每 process 只記一次（否則每次建 token 寫一筆會洗爆 log）。**刻意不 fail closed**——`mcp:read` 對 `/api/user` 與 `api/v2/*` 一樣有用（那些端點根本不檢查 abilities），因為 MCP 的設定打錯就讓整個 token 簽發停擺，是自找的服務中斷。

## 兩條做過變異測試的守衛

被 review 抓到第一版的 `a_deactivated_account_cannot_mint_a_token` 是**假保證**——把 `lockForUpdate` + `abort_if` 整塊刪掉，8 個測試照樣全綠，因為 403 其實來自 `App\Http\Middleware\Authenticate`。現在改用「`actingAs` 注入的實例仍是 active、但直接改 DB 列」繞過 middleware，真正打到交易內重讀；實測拿掉 `abort_if` → 403 變 200 ✅

`no_production_code_calls_createToken_without_explicit_abilities`：Sanctum 的 `createToken()` 第二參數預設仍是 `['*']`，所以漏傳就會重新產生通配 token 且不會報錯。第一版用正則會誤判合格的多行呼叫（`[^,)]*` 跨行且不理解嵌套括號），已改用 `token_get_all` 正確數頂層參數；實測加一個漏傳的呼叫 → 精準指出行號 ✅

## ⚠️ 已知未解

線上在用的 token 名稱多半是 REST/v2 客戶端（`CBDBAPI`×3、`Python Scripts`、`人物传记`…）而非 MCP 客戶端。今天標成 `mcp:read` 是**行為中性**的（那些端點不檢查 abilities），但等 `api/v2/*` 也開始檢查 abilities 時它們會失效，屆時需為其定義對應能力。已寫進 migration 註解；此處刻意不發明一個沒人強制的假標籤。

## 驗證

- `./vendor/bin/phpunit` 全套：`OK (2540 tests, 11512 assertions)`
- `php-cs-fixer`（先清 cache + dist config）：`Fixed 0 of 637 files`
- 新增 `tests/Feature/ApiTokenAbilitiesTest.php`（18 個案例）
- 降級 migration 已在真實 MariaDB 10.11 上 dry-run 並回滾驗證（10 個 token 全部轉為 `[mcp:read]`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)