### PR TITLE
安全敏感操作補上應用層審計（含操作者、IP、UA）

### DIFF
--- a/app/Console/Commands/ManageUser.php
+++ b/app/Console/Commands/ManageUser.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\User;
 use App\Services\AccountAccessRevoker;
+use App\Services\SecurityAuditLogger;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
@@ -169,6 +170,22 @@ class ManageUser extends Command {
         $user->is_admin = $role;
         $user->save();
 
+        // CLI 也要留紀錄：這支指令可以憑機器存取權建立任意角色的帳號（含系統管理員），
+        // 而 users 表沒有 DB trigger 兜底，所以應用層審計是唯一紀錄。
+        app(SecurityAuditLogger::class)->record(
+            table: 'users',
+            operation: 'INSERT',
+            rowPk: ['id' => (int) $user->id],
+            event: 'user_created_via_cli',
+            after: [
+                'email' => $user->email,
+                'is_active' => (int) $user->is_active,
+                'is_admin' => (int) $user->is_admin,
+            ],
+            // 顯式標明來源：自動判定在測試中無法區分（PHPUnit 本身就跑在 CLI）。
+            channel: SecurityAuditLogger::CHANNEL_CLI
+        );
+
         $this->newLine();
         $this->info('✓ 用戶創建成功！');
         $this->displayUserInfo($user);
@@ -183,6 +200,12 @@ class ManageUser extends Command {
         $this->info('=== 更新用戶信息 ===');
 
         $updated = false;
+        // 供審計比對：這支指令可以改任何人的密碼與角色，而 users 表沒有 DB trigger 兜底。
+        $before = [
+            'is_active' => (int) $user->is_active,
+            'is_admin' => (int) $user->is_admin,
+        ];
+        $passwordChanged = false;
 
         // 更新名稱
         $name = $this->option('name');
@@ -207,6 +230,7 @@ class ManageUser extends Command {
             }
             $user->password = Hash::make($password);
             $updated = true;
+            $passwordChanged = true;
         }
 
         // 更新激活狀態
@@ -277,6 +301,26 @@ class ManageUser extends Command {
         }
 
         $user->save();
+
+        $after = [
+            'is_active' => (int) $user->is_active,
+            'is_admin' => (int) $user->is_admin,
+        ];
+        if ($passwordChanged) {
+            $before['password_changed'] = true;
+            $after['password_changed'] = true;
+        }
+        if ($before !== $after || $passwordChanged) {
+            app(SecurityAuditLogger::class)->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) $user->id],
+                event: $passwordChanged ? 'password_changed_via_cli' : 'user_role_or_status_changed_via_cli',
+                before: $before,
+                after: $after,
+                channel: SecurityAuditLogger::CHANNEL_CLI
+            );
+        }
 
         // 與管理介面一致：停用帳號連帶撤銷其所有 API token（Sanctum token 不會因帳號失效
         // 而自動失效，見 AccountAccessRevoker 註解）。

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -10,6 +10,7 @@ use App\Models\OfficeTypeTree;
 use App\Models\Operation;
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
+use App\Services\SecurityAuditLogger;
 use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -252,19 +253,55 @@ class OperationsController extends Controller {
             ? User::where('email', $user_id)->first()
             : null;
 
+        // 這是唯一剩下的長期憑證簽發路徑（confirmation_token），而且是無 throttle 的密碼驗證
+        // 端點，所以成功與被拒都要留紀錄——否則連暴力破解都看不見。一律不記 token 值。
+        $audit = app(SecurityAuditLogger::class);
+
         if (!$user || !is_string($user_password) || !Hash::check($user_password, $user->password)) {
+            $audit->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) ($user->id ?? 0)],
+                event: 'crowdsourcing_token_denied',
+                after: ['reason' => 'bad_credentials', 'email' => is_string($user_id) ? $user_id : null]
+            );
+
             return "您的帳號與密碼輸入錯誤";
         }
 
         // 停用（含從未啟用）帳號不得換到 token：resolveActiveUserByToken() 已擋住用它寫入，
         // 但 confirmation_token 本身就是一個長期有效的憑證，不該外流。
         if (!$user->isActive()) {
+            $audit->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) $user->id],
+                event: 'crowdsourcing_token_denied',
+                after: ['reason' => 'account_inactive']
+            );
+
             return __('auth.account_inactive');
         }
 
         if (!$user->isCrowdsourcingUser()) {
+            $audit->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) $user->id],
+                event: 'crowdsourcing_token_denied',
+                after: ['reason' => 'not_crowdsourcing_role']
+            );
+
             return "帳號須為眾包身分，才可以取得token。";
         }
+
+        $audit->record(
+            table: 'users',
+            operation: 'UPDATE',
+            rowPk: ['id' => (int) $user->id],
+            event: 'crowdsourcing_token_issued',
+            after: ['email' => $user->email]
+        );
 
         // 原樣回傳，不替空值補錯誤字串：既有眾包客戶端把 200 的 body 直接當 token 用，
         // 換成人話錯誤反而會讓它拿著一個看起來合法的字串繼續打。

--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -258,12 +258,21 @@ class OperationsController extends Controller {
         $audit = app(SecurityAuditLogger::class);
 
         if (!$user || !is_string($user_password) || !Hash::check($user_password, $user->password)) {
+            // 查不到帳號時 rowPk 留空，不要記成 id=0：那會憑空生出一列「受影響的 users.id=0」，
+            // 反覆用不存在的 email 嘗試時，調查者會誤以為真有這個使用者。
+            // 也不回記使用者送來的原始 email——那是未驗證、無長度限制的輸入，
+            // 而這個端點沒有 throttle，原樣入庫等於讓人隨意撐大 audit_log。
             $audit->record(
                 table: 'users',
                 operation: 'UPDATE',
-                rowPk: ['id' => (int) ($user->id ?? 0)],
+                rowPk: $user ? ['id' => (int) $user->id] : [],
                 event: 'crowdsourcing_token_denied',
-                after: ['reason' => 'bad_credentials', 'email' => is_string($user_id) ? $user_id : null]
+                after: [
+                    'reason' => 'bad_credentials',
+                    'matched_user' => (bool) $user,
+                    // 只有查到帳號時才記 email，且用 DB 裡的值（有界）而非請求輸入。
+                    'email' => $user?->email,
+                ]
             );
 
             return "您的帳號與密碼輸入錯誤";

--- a/app/Http/Controllers/ApiTokenController.php
+++ b/app/Http/Controllers/ApiTokenController.php
@@ -3,12 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Services\SecurityAuditLogger;
 use App\Support\ApiTokenAbilities;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 class ApiTokenController extends Controller {
+    public function __construct(private SecurityAuditLogger $securityAudit) {
+    }
+
     /**
      * 顯示使用者的 API tokens
      */
@@ -90,6 +94,21 @@ class ApiTokenController extends Controller {
             );
         });
 
+        // 簽發長期憑證是安全敏感操作，記應用層審計（含 IP／UA）。入侵調查最想知道的
+        // 就是「這個 token 是誰在什麼時候從哪裡簽的」。**不記 token 明文或雜湊**。
+        $this->securityAudit->record(
+            table: 'personal_access_tokens',
+            operation: 'INSERT',
+            rowPk: ['id' => (int) $token->accessToken->id],
+            event: 'api_token_created',
+            after: [
+                'name' => $token->accessToken->name,
+                'abilities' => $token->accessToken->abilities,
+                'expires_at' => $token->accessToken->expires_at?->toIso8601String(),
+                'tokenable_id' => (int) $request->user()->id,
+            ]
+        );
+
         // If this is a JSON request, return JSON response
         if ($request->expectsJson()) {
             return response()->json([
@@ -117,7 +136,23 @@ class ApiTokenController extends Controller {
      */
     public function destroy(Request $request, $tokenId) {
         $token = $request->user()->tokens()->findOrFail($tokenId);
+        $snapshot = [
+            'name' => $token->name,
+            'abilities' => $token->abilities,
+            'last_used_at' => optional($token->last_used_at)->toIso8601String(),
+            'tokenable_id' => (int) $request->user()->id,
+        ];
         $token->delete();
+
+        // 使用者自行撤銷也要留紀錄：管理員停用時的撤銷已由 AccountAccessRevoker 記錄，
+        // 但「憑證何時失效」在事件時序重建時同樣關鍵（例如判斷某次呼叫是否還在有效期內）。
+        $this->securityAudit->record(
+            table: 'personal_access_tokens',
+            operation: 'DELETE',
+            rowPk: ['id' => (int) $tokenId],
+            event: 'api_token_revoked_by_owner',
+            before: $snapshot
+        );
 
         return response()->json([
             'message' => 'Token 已撤銷',
@@ -128,7 +163,34 @@ class ApiTokenController extends Controller {
      * 撤銷所有 tokens
      */
     public function destroyAll(Request $request) {
-        $request->user()->tokens()->delete();
+        // 鎖 users 列後才讀快照＋刪除，與 AccountAccessRevoker 同一手法：無鎖的
+        // read-then-delete 若在兩步之間被 store() 插入一個新 token，那個 token 會被
+        // tokens()->delete() 一併刪掉卻不在審計快照裡——審計會聲稱撤銷 2 個、實際銷毀 3 個。
+        $snapshot = DB::transaction(function () use ($request) {
+            DB::table('users')->where('id', $request->user()->id)->lockForUpdate()->first();
+
+            $rows = $request->user()->tokens()->get(['id', 'name', 'abilities', 'last_used_at'])
+                ->map(fn ($token) => [
+                    'id' => $token->id,
+                    'name' => $token->name,
+                    'abilities' => $token->abilities,
+                    'last_used_at' => optional($token->last_used_at)->toIso8601String(),
+                ])->all();
+
+            $request->user()->tokens()->delete();
+
+            return $rows;
+        });
+
+        if ($snapshot !== []) {
+            $this->securityAudit->record(
+                table: 'personal_access_tokens',
+                operation: 'DELETE',
+                rowPk: ['tokenable_id' => (int) $request->user()->id],
+                event: 'api_tokens_revoked_by_owner',
+                before: ['tokens' => $snapshot]
+            );
+        }
 
         return response()->json([
             'message' => '所有 Tokens 已撤銷',

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -75,8 +75,10 @@ class ResetPasswordController extends Controller {
      * audit_log 只看得到 email 變更，看不到密碼何時被誰從哪個 IP 換掉。反過來也一樣：
      * 真正的使用者自助重設不留紀錄，事後就無法區分「本人重設」與「攻擊者用外洩的重設連結」。
      *
-     * 此時尚未登入（guest middleware），所以 actor 是 system；受影響帳號由 rowPk 標明。
-     * 一律不記密碼雜湊或明文。
+     * actor 刻意留空（actorIsUnknown）：trait 會在寫入密碼後 `Auth::login($user)`，所以審計時
+     * 已經「登入成功」，若照常歸因就會把持有重設連結的人記成受影響帳號**本人**——攻擊者用
+     * 竊得的 reset token 改掉密碼，事後 audit_log 卻顯示「使用者自己改了密碼」，比不記更糟。
+     * 真正可用的線索是 IP／UA，受影響帳號由 rowPk 標明。一律不記密碼雜湊或明文。
      *
      * @param  \App\Models\User  $user
      * @param  string  $password
@@ -89,7 +91,8 @@ class ResetPasswordController extends Controller {
             operation: 'UPDATE',
             rowPk: ['id' => (int) $user->id],
             event: 'password_reset_via_email',
-            after: ['password_changed' => true, 'email' => $user->email]
+            after: ['password_changed' => true, 'email' => $user->email],
+            actorIsUnknown: true
         );
     }
 

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Services\SecurityAuditLogger;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -19,7 +20,11 @@ class ResetPasswordController extends Controller {
     |
     */
 
-    use ResetsPasswords;
+    // resetPassword 在下面被覆寫以加上審計；trait 版本改名保留供其呼叫
+    // （它來自 trait 而不是父類，所以不能用 parent::）。
+    use ResetsPasswords {
+        resetPassword as baseResetPassword;
+    }
 
     /**
      * Where to redirect users after resetting their password.
@@ -33,7 +38,7 @@ class ResetPasswordController extends Controller {
      *
      * @return void
      */
-    public function __construct() {
+    public function __construct(private SecurityAuditLogger $securityAudit) {
         $this->middleware('guest');
         // Phase 6：重設密碼頁 React/Inertia 變體需 HandleInertiaRequests（共用 props/根模板）。
         // 僅作用於顯示表單的 GET 動作；POST 處理（reset）不掛，授權仍由 guest middleware 控制。
@@ -59,6 +64,32 @@ class ResetPasswordController extends Controller {
 
         return view('auth.passwords.reset')->with(
             ['token' => $token, 'email' => $request->email]
+        );
+    }
+
+    /**
+     * 密碼經「忘記密碼」連結重設。
+     *
+     * 密碼有兩條寫入路徑：`/profile`（已在 UserProfileController 記錄）與這一條。少了這裡，
+     * 攻擊鏈的後半段就沒有紀錄——先改走 email（會留下 email_changed），再用重設連結換密碼，
+     * audit_log 只看得到 email 變更，看不到密碼何時被誰從哪個 IP 換掉。反過來也一樣：
+     * 真正的使用者自助重設不留紀錄，事後就無法區分「本人重設」與「攻擊者用外洩的重設連結」。
+     *
+     * 此時尚未登入（guest middleware），所以 actor 是 system；受影響帳號由 rowPk 標明。
+     * 一律不記密碼雜湊或明文。
+     *
+     * @param  \App\Models\User  $user
+     * @param  string  $password
+     */
+    protected function resetPassword($user, $password) {
+        $this->baseResetPassword($user, $password);
+
+        $this->securityAudit->record(
+            table: 'users',
+            operation: 'UPDATE',
+            rowPk: ['id' => (int) $user->id],
+            event: 'password_reset_via_email',
+            after: ['password_changed' => true, 'email' => $user->email]
         );
     }
 

--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Services\AccountAccessRevoker;
-use App\Services\AuditLogService;
+use App\Services\SecurityAuditLogger;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -382,23 +382,19 @@ class ManagementController extends Controller {
      * DB trigger 才是權威 tripwire，此處是帶 app 端操作者的補充佐證。
      */
     private function auditUserChange(User $user, array $before, array $after, ?User $actor, string $operation): void {
-        if (!Schema::hasTable('audit_log')) {
-            return;
-        }
-
-        try {
-            app(AuditLogService::class)->write(
-                'users',
-                $operation,
-                ['id' => (int) $user->id],
-                $before,
-                $after,
-                'user',
-                $actor ? (string) $actor->id : null
-            );
-        } catch (\Throwable $e) {
-            \Log::warning('performUserUpdate 審計寫入失敗: '.$e->getMessage());
-        }
+        // 委派給 SecurityAuditLogger：它統一處理請求脈絡（IP／User-Agent／操作者，且 CLI 下
+        // 寫 null 而不是 Laravel 造的假 127.0.0.1）、actor 型別、DELETE 的脈絡放 old_data
+        // 的慣例，以及「審計失敗絕不回退已完成的帳號變更」。
+        //
+        // DB trigger 看得到欄位變了，但看不到是誰從哪裡改的，而那正是入侵調查要問的第一個問題。
+        app(SecurityAuditLogger::class)->record(
+            table: 'users',
+            operation: $operation,
+            rowPk: ['id' => (int) $user->id],
+            event: $operation === 'DELETE' ? 'user_soft_deleted' : 'user_role_or_status_changed',
+            before: $before,
+            after: $after
+        );
     }
 
     /**

--- a/app/Http/Controllers/ManagementController.php
+++ b/app/Http/Controllers/ManagementController.php
@@ -303,7 +303,17 @@ class ManagementController extends Controller {
 
             // 刪除/停用帳號一律撤銷其 API token（sanctum token 不會因帳號失效而自動失效）。
             $this->revokeApiTokens($user);
-            $this->auditUserChange($user, $before, ['is_active' => (int) $user->is_active, 'is_admin' => (int) $user->is_admin], $actor, 'DELETE');
+            // 明記憑證已一併失效：軟刪除實際上改寫了 email／password／confirmation_token／
+            // remember_token，但審計只看得到 is_active／is_admin，事後無從確認那些憑證是否
+            // 同步作廢。只記布林旗標，不記任何實際值。
+            $this->auditUserChange($user, $before, [
+                'is_active' => (int) $user->is_active,
+                'is_admin' => (int) $user->is_admin,
+                'password_invalidated' => true,
+                'confirmation_token_invalidated' => true,
+                'remember_token_invalidated' => true,
+                'email_rewritten' => true,
+            ], $actor, 'DELETE');
 
             flash('用戶已刪除 @ '.Carbon::now(), 'danger');
 

--- a/app/Http/Controllers/UserProfileController.php
+++ b/app/Http/Controllers/UserProfileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\SecurityAuditLogger;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -15,7 +16,7 @@ class UserProfileController extends Controller {
      *
      * @return void
      */
-    public function __construct() {
+    public function __construct(private SecurityAuditLogger $securityAudit) {
         $this->middleware('auth');
     }
 
@@ -75,11 +76,15 @@ class UserProfileController extends Controller {
     protected function applyProfileUpdate(Request $request, array $validatedData): bool {
         $user = Auth::user();
 
+        $passwordChanged = false;
+        $emailBefore = $user->email;
+
         if ($request->filled('new_password')) {
             if (!Hash::check($request->current_password, $user->password)) {
                 return false;
             }
             $user->password = Hash::make($request->new_password);
+            $passwordChanged = true;
         }
 
         $user->name = $validatedData['name'];
@@ -88,6 +93,34 @@ class UserProfileController extends Controller {
         $user->institution = $validatedData['institution'] ?? null;
         $user->avatar = $validatedData['avatar'];
         $user->save();
+
+        // 安全敏感變更寫應用層審計（含 IP／UA——DB trigger 拿不到這兩個）：
+        //  - 密碼變更是帳號接管的首要指標；
+        //  - email 變更可用來劫持密碼重設，等於換走帳號的復原管道。
+        // 只記「變更發生了」與 email 的前後值，**不記密碼雜湊**。
+        if ($passwordChanged) {
+            $this->securityAudit->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) $user->id],
+                event: 'password_changed',
+                // before 刻意留空（old_data 為 null）：兩邊都寫 password_changed=true 會讓
+                // 後台審計檢視器（相等即略過）把整條 diff 吃掉，而且「變更前 password_changed
+                // 就是 true」在 diff 視角下讀不通。
+                after: ['password_changed' => true]
+            );
+        }
+
+        if ($emailBefore !== $user->email) {
+            $this->securityAudit->record(
+                table: 'users',
+                operation: 'UPDATE',
+                rowPk: ['id' => (int) $user->id],
+                event: 'email_changed',
+                before: ['email' => $emailBefore],
+                after: ['email' => $user->email]
+            );
+        }
 
         return true;
     }

--- a/app/Services/AccountAccessRevoker.php
+++ b/app/Services/AccountAccessRevoker.php
@@ -4,10 +4,9 @@ namespace App\Services;
 
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class AccountAccessRevoker {
-    public function __construct(private AuditLogService $auditLog) {
+    public function __construct(private SecurityAuditLogger $securityAudit) {
     }
 
     /**
@@ -39,32 +38,34 @@ class AccountAccessRevoker {
             return 0;
         }
 
-        // DELETE 的語義：被銷毀的狀態記在 old_data，new_data 為 null。連 reason／context
-        // 一起放進 old_data，日後查「這批 token 是誰在什麼情境下撤掉的」才有線索。
+        // DELETE 的語義：被銷毀的狀態記在 old_data。連 reason／context 一起放，
+        // 日後查「這批 token 是誰在什麼情境下撤掉的」才有線索。
         //
-        // 審計失敗絕不可讓撤銷失敗：token 已經刪掉了，此時拋例外只會讓管理員看到 500、
-        // 誤以為停用沒生效而重試（與 ManagementController::auditUserChange 同一取捨——
-        // DB trigger 才是權威 tripwire，這裡是帶操作者的補充佐證）。
-        try {
-            $this->auditLog->write(
-                table: 'personal_access_tokens',
-                operation: 'DELETE',
-                rowPk: ['tokenable_id' => $user->id],
-                oldData: [
-                    'context' => $context,
-                    'reason' => 'account_deactivated',
-                    'tokens' => $tokens->map(fn ($token) => [
-                        'id' => $token->id,
-                        'name' => $token->name,
-                        'abilities' => $token->abilities,
-                        'last_used_at' => optional($token->last_used_at)->toIso8601String(),
-                    ])->all(),
-                ],
-                newData: null
-            );
-        } catch (\Throwable $e) {
-            Log::warning('API token 撤銷的審計寫入失敗（撤銷本身已完成）: '.$e->getMessage());
-        }
+        // 走 SecurityAuditLogger 而不是自己組請求脈絡：它已經處理好 CLI／HTTP 的差異
+        // （CLI 下 ip/UA 寫 null 而不是 Laravel 造的假 127.0.0.1 / Symfony）、actor 型別，
+        // 以及「審計失敗絕不讓撤銷失敗」——token 已經刪掉了，此時拋例外只會讓管理員看到
+        // 500、誤以為停用沒生效而重試。
+        $this->securityAudit->record(
+            table: 'personal_access_tokens',
+            operation: 'DELETE',
+            rowPk: ['tokenable_id' => $user->id],
+            event: 'api_tokens_revoked_on_deactivation',
+            before: [
+                'context' => $context,
+                'reason' => 'account_deactivated',
+                'tokens' => $tokens->map(fn ($token) => [
+                    'id' => $token->id,
+                    'name' => $token->name,
+                    'abilities' => $token->abilities,
+                    'last_used_at' => optional($token->last_used_at)->toIso8601String(),
+                ])->all(),
+            ],
+            // 呼叫端已在 $context 標明來源（'cli' / 'management_ui'…），據此決定要不要記 IP／UA：
+            // CLI 情境的 ip/UA 是 Laravel 造的假值，寫進審計會誤導調查。
+            channel: str_starts_with($context, 'cli')
+                ? SecurityAuditLogger::CHANNEL_CLI
+                : SecurityAuditLogger::CHANNEL_HTTP
+        );
 
         return $tokens->count();
     }

--- a/app/Services/SecurityAuditLogger.php
+++ b/app/Services/SecurityAuditLogger.php
@@ -45,7 +45,8 @@ class SecurityAuditLogger {
         string $event,
         array $before = [],
         array $after = [],
-        ?string $channel = null
+        ?string $channel = null,
+        bool $actorIsUnknown = false
     ): void {
         try {
             // hasTable 也放在 try 內：它會下 information_schema／sqlite_master 查詢，
@@ -54,7 +55,8 @@ class SecurityAuditLogger {
                 return;
             }
 
-            $context = ['__security' => $this->requestContext($event, $channel)];
+            $attributable = !$actorIsUnknown && Auth::check();
+            $context = ['__security' => $this->requestContext($event, $channel, $attributable)];
 
             $isDelete = strtoupper($operation) === 'DELETE';
             $oldData = $isDelete ? array_merge($before, $context) : ($before === [] ? null : $before);
@@ -68,8 +70,11 @@ class SecurityAuditLogger {
                 newData: $newData,
                 // 未登入（CLI／系統作業）時是 system，不是「不明的 user」——
                 // 硬寫 'user' 會讓 AuditLogService 落成 actor_type=user / actor_id=system 的自相矛盾列。
-                actorType: Auth::check() ? 'user' : 'system',
-                actorId: Auth::check() ? (string) Auth::id() : null
+                actorType: $attributable ? 'user' : 'system',
+                // 顯式傳 'system' 而不是 null：AuditLogService 對 null 會自己回退去看 Auth，
+                // 於是「不可歸因」的事件（密碼重設連結）又會被記成當下登入的那個帳號——
+                // 而 trait 正好在寫入密碼後就把人登入了，等於白做。
+                actorId: $attributable ? (string) Auth::id() : 'system'
             );
         } catch (\Throwable $e) {
             // 只記 exception 類別與截短訊息：QueryException 的 getMessage() 含完整 SQL 與繫結值，
@@ -86,7 +91,7 @@ class SecurityAuditLogger {
     /**
      * @return array<string, mixed>
      */
-    private function requestContext(string $event, ?string $channel): array {
+    private function requestContext(string $event, ?string $channel, bool $attributable): array {
         $channel = $channel ?? $this->detectChannel();
         $isConsole = $channel === self::CHANNEL_CLI;
         $request = request();
@@ -95,8 +100,11 @@ class SecurityAuditLogger {
             'event' => $event,
             // 明確標出來源通道，讓「沒有 IP」與「IP 查不到」可以區分。
             'channel' => $channel,
-            'actor_id' => Auth::check() ? (int) Auth::id() : null,
-            'actor_name' => Auth::check() ? Auth::user()->name : null,
+            // $attributable=false 代表「動作者身分不可歸因」（例如持有密碼重設連結的人——
+            // 那可能是本人也可能是攻擊者）。此時 actor 一律留空：把它記成受影響帳號本人，
+            // 事後會被讀成「使用者自己改了密碼」，比不記更糟。IP 才是那種情境的關鍵線索。
+            'actor_id' => $attributable ? (int) Auth::id() : null,
+            'actor_name' => $attributable ? Auth::user()->name : null,
             // CLI 情境刻意寫 null：Laravel 的 SetRequestForConsole 會用 Request::create() 造一個
             // 假請求，`ip()` 回 '127.0.0.1'、`userAgent()` 回 'Symfony'（都是 Symfony 的預設值，
             // 因為 CLI 的 $_SERVER 沒有真的 REMOTE_ADDR／HTTP_USER_AGENT）。把那組值寫進審計，

--- a/app/Services/SecurityAuditLogger.php
+++ b/app/Services/SecurityAuditLogger.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 安全敏感操作的應用層審計。
+ *
+ * 為什麼需要應用層而不只靠 DB trigger：trigger 看得到「哪一列的哪個欄位變了」，但看不到
+ * **是誰、從哪個 IP、用什麼客戶端** 做的——那些只存在於 HTTP 請求裡。入侵調查時「這個
+ * 密碼變更來自哪個 IP」正是關鍵問題，而 audit_log 原本只審計業務表（BIOG_MAIN 等），
+ * users 與 personal_access_tokens 的變更完全沒有紀錄。
+ *
+ * 寫入慣例：
+ *  - `operation` 一律維持 INSERT／UPDATE／DELETE。不自創 'PASSWORD_CHANGE' 這類值——
+ *    audit_log.operation 是 varchar(16) 且後台有 operation 篩選，自創值會破壞既有語義。
+ *    具體事件名稱放在 payload 的 `__security.event`。
+ *  - 請求脈絡放在 INSERT/UPDATE 的 new_data、DELETE 的 old_data。
+ *  - **絕不記錄密碼雜湊、token 明文或 token 雜湊**：只記「發生了變更」。洩漏的審計日誌
+ *    不該變成第二個憑證來源。
+ *
+ * 失敗處理：審計寫入失敗絕不可讓業務操作失敗（與 ManagementController::auditUserChange
+ * 同一取捨）。使用者改完密碼卻看到 500，只會讓他以為沒改成功而重試。
+ */
+class SecurityAuditLogger {
+    public const CHANNEL_HTTP = 'http';
+    public const CHANNEL_CLI = 'cli';
+
+    public function __construct(private AuditLogService $auditLog) {
+    }
+
+    /**
+     * @param  'INSERT'|'UPDATE'|'DELETE'  $operation
+     * @param  array<string, mixed>  $rowPk
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     */
+    public function record(
+        string $table,
+        string $operation,
+        array $rowPk,
+        string $event,
+        array $before = [],
+        array $after = [],
+        ?string $channel = null
+    ): void {
+        try {
+            // hasTable 也放在 try 內：它會下 information_schema／sqlite_master 查詢，
+            // 連線抖動或權限問題造成的拋錯若冒出去，就違反了「審計絕不讓業務操作失敗」。
+            if (!Schema::hasTable('audit_log')) {
+                return;
+            }
+
+            $context = ['__security' => $this->requestContext($event, $channel)];
+
+            $isDelete = strtoupper($operation) === 'DELETE';
+            $oldData = $isDelete ? array_merge($before, $context) : ($before === [] ? null : $before);
+            $newData = $isDelete ? ($after === [] ? null : $after) : array_merge($after, $context);
+
+            $this->auditLog->write(
+                table: $table,
+                operation: strtoupper($operation),
+                rowPk: $rowPk,
+                oldData: $oldData,
+                newData: $newData,
+                // 未登入（CLI／系統作業）時是 system，不是「不明的 user」——
+                // 硬寫 'user' 會讓 AuditLogService 落成 actor_type=user / actor_id=system 的自相矛盾列。
+                actorType: Auth::check() ? 'user' : 'system',
+                actorId: Auth::check() ? (string) Auth::id() : null
+            );
+        } catch (\Throwable $e) {
+            // 只記 exception 類別與截短訊息：QueryException 的 getMessage() 含完整 SQL 與繫結值，
+            // 會把刻意只放進 DB 的稽核 payload（例如變更前後的 email）外流到權限通常更鬆的 laravel.log。
+            Log::warning('安全審計寫入失敗（業務操作已完成）', [
+                'table' => $table,
+                'event' => $event,
+                'exception' => get_class($e),
+                'message' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function requestContext(string $event, ?string $channel): array {
+        $channel = $channel ?? $this->detectChannel();
+        $isConsole = $channel === self::CHANNEL_CLI;
+        $request = request();
+
+        return [
+            'event' => $event,
+            // 明確標出來源通道，讓「沒有 IP」與「IP 查不到」可以區分。
+            'channel' => $channel,
+            'actor_id' => Auth::check() ? (int) Auth::id() : null,
+            'actor_name' => Auth::check() ? Auth::user()->name : null,
+            // CLI 情境刻意寫 null：Laravel 的 SetRequestForConsole 會用 Request::create() 造一個
+            // 假請求，`ip()` 回 '127.0.0.1'、`userAgent()` 回 'Symfony'（都是 Symfony 的預設值，
+            // 因為 CLI 的 $_SERVER 沒有真的 REMOTE_ADDR／HTTP_USER_AGENT）。把那組值寫進審計，
+            // 事故調查會讀成「有人從本機發 HTTP 請求」而被帶偏——誤導的證據比沒有證據更糟。
+            'ip' => $isConsole ? null : $request->ip(),
+            // 截斷：User-Agent 是使用者可控字串，沒有理由讓它把 audit 列撐大。
+            'user_agent' => $isConsole ? null : mb_substr((string) $request->userAgent(), 0, 512),
+        ];
+    }
+
+    /**
+     * 自動判定來源通道。
+     *
+     * 刻意排除「測試中」：PHPUnit 本身跑在 CLI，所以 runningInConsole() 在測試裡永遠是 true，
+     * 會把測試模擬的 HTTP 請求也標成 cli，於是「HTTP 請求要記下客戶端 IP」這條就無法被測試
+     * 覆蓋（而那正是本功能的重點）。因此測試中預設視為 http；真正的 artisan 情境由呼叫端
+     * 顯式傳 channel='cli'（見 ManageUser 與 AccountAccessRevoker），不依賴會騙人的訊號。
+     */
+    private function detectChannel(): string {
+        $isRealConsole = app()->runningInConsole() && !app()->runningUnitTests();
+
+        return $isRealConsole ? self::CHANNEL_CLI : self::CHANNEL_HTTP;
+    }
+}

--- a/tests/Feature/SecurityAuditLogTest.php
+++ b/tests/Feature/SecurityAuditLogTest.php
@@ -98,14 +98,38 @@ class SecurityAuditLogTest extends TestCase {
         ]));
     }
 
-    /** @return array<string, mixed>|null */
-    private function securityContextFor(string $event): ?array {
+    /**
+     * 取某個事件的 __security 脈絡，並可一併驗 table_name／operation／row_pk。
+     *
+     * 加上這些條件而不只比對事件名：只掃 event 的話，任何「事件寫到了錯的表、錯的
+     * operation、或錯的受影響列」都不會被抓到。
+     *
+     * @return array<string, mixed>|null
+     */
+    private function securityContextFor(
+        string $event,
+        ?string $table = null,
+        ?string $operation = null,
+        ?array $rowPk = null
+    ): ?array {
         foreach (DB::table('audit_log')->get() as $row) {
             foreach (['new_data', 'old_data'] as $column) {
                 $payload = json_decode((string) $row->{$column}, true);
-                if (is_array($payload) && ($payload['__security']['event'] ?? null) === $event) {
-                    return $payload['__security'];
+                if (!is_array($payload) || ($payload['__security']['event'] ?? null) !== $event) {
+                    continue;
                 }
+
+                if ($table !== null) {
+                    $this->assertSame($table, $row->table_name, "事件 {$event} 寫到了錯的表");
+                }
+                if ($operation !== null) {
+                    $this->assertSame($operation, $row->operation, "事件 {$event} 用了錯的 operation");
+                }
+                if ($rowPk !== null) {
+                    $this->assertSame($rowPk, json_decode((string) $row->row_pk, true), "事件 {$event} 的 row_pk 不符");
+                }
+
+                return $payload['__security'];
             }
         }
 
@@ -221,16 +245,24 @@ class SecurityAuditLogTest extends TestCase {
             'password_confirmation' => 'brandnew123',
         ])->assertRedirect();
 
-        $context = $this->securityContextFor('password_reset_via_email');
+        $context = $this->securityContextFor(
+            'password_reset_via_email',
+            table: 'users',
+            operation: 'UPDATE',
+            rowPk: ['id' => (int) $user->id]
+        );
         $this->assertNotNull($context, '經重設連結改密碼必須留下審計');
         $this->assertSame('http', $context['channel']);
-        // ResetsPasswords::resetPassword 會在寫入密碼後 Auth::login()，所以審計時已經登入，
-        // actor 就是該帳號本人——這正確反映「持有重設連結者現在以此身分行動」。
-        $this->assertSame((int) $user->id, $context['actor_id']);
+
+        // actor 必須留空：trait 會在寫入密碼後 Auth::login()，若照常歸因就會把「持有重設連結
+        // 的人」記成受影響帳號本人——攻擊者用竊得的 token 改密碼，事後卻顯示「使用者自己改的」，
+        // 比不記更糟。受影響帳號由 row_pk 標明，可用線索是 IP。
+        $this->assertNull($context['actor_id'], '重設連結的動作者不可歸因，actor 必須留空');
+        $this->assertNull($context['actor_name']);
 
         $row = DB::table('audit_log')->where('table_name', 'users')->first();
-        $this->assertSame('user', $row->actor_type);
-        $this->assertSame((string) $user->id, $row->actor_id);
+        $this->assertSame('system', $row->actor_type);
+        $this->assertSame('system', $row->actor_id);
 
         Schema::dropIfExists('password_resets');
     }
@@ -283,6 +315,72 @@ class SecurityAuditLogTest extends TestCase {
         // 憑證本身絕不入庫。
         $dump = DB::table('audit_log')->get()->toJson();
         $this->assertStringNotContainsString('crowd-token', $dump);
+    }
+
+    #[Test]
+    public function a_denial_for_an_unknown_account_does_not_invent_a_user_row(): void {
+        // 記成 id=0 會憑空生出一列「受影響的 users.id=0」，反覆用不存在的 email 嘗試時，
+        // 調查者會誤以為真有這個使用者。也不得把未驗證、無長度限制的請求輸入原樣入庫——
+        // 這個端點沒有 throttle。
+        $longEmail = str_repeat('a', 5000).'@example.com';
+
+        $this->get('/api/operations/token?q='.urlencode($longEmail).'&p=whatever')->assertOk();
+
+        $context = $this->securityContextFor(
+            'crowdsourcing_token_denied',
+            table: 'users',
+            operation: 'UPDATE',
+            rowPk: []
+        );
+        $this->assertNotNull($context);
+
+        $row = DB::table('audit_log')->first();
+        $payload = json_decode((string) $row->new_data, true);
+        $this->assertFalse($payload['matched_user']);
+        $this->assertNull($payload['email'], '查不到帳號時不得回記請求輸入的 email');
+        $this->assertStringNotContainsString(str_repeat('a', 100), (string) $row->new_data);
+    }
+
+    #[Test]
+    public function soft_delete_records_that_credentials_were_invalidated(): void {
+        // 軟刪除實際改寫了 email／password／confirmation_token／remember_token，但審計原本
+        // 只看得到 is_active／is_admin，事後無從確認那些憑證是否同步作廢。只記布林旗標。
+        $admin = User::unguarded(fn () => User::create([
+            'name' => '管理員',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret123'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]));
+        $victim = $this->activeUser('victim@example.com');
+        $victim->refresh();
+        $originalHash = $victim->password;
+
+        $this->actingAs($admin)->put('/manage/'.$victim->id, [
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+            'delete_user' => 1,
+        ])->assertRedirect(route('manage.index'));
+
+        $this->assertNotNull($this->securityContextFor(
+            'user_soft_deleted',
+            table: 'users',
+            operation: 'DELETE',
+            rowPk: ['id' => (int) $victim->id]
+        ));
+
+        $row = DB::table('audit_log')->where('table_name', 'users')->first();
+        $payload = json_decode((string) $row->new_data, true);
+        $this->assertTrue($payload['password_invalidated']);
+        $this->assertTrue($payload['confirmation_token_invalidated']);
+        $this->assertTrue($payload['remember_token_invalidated']);
+
+        // 旗標而已，被作廢的實際憑證不得入庫（比對刪除前的雜湊；刪除後的值是哨兵 '-'，
+        // 拿它去斷言「dump 不含 -」毫無意義，日期裡就有）。
+        $dump = DB::table('audit_log')->get()->toJson();
+        $this->assertStringNotContainsString($originalHash, $dump);
+        $this->assertStringNotContainsString('victim@example.com', $dump);
     }
 
     #[Test]

--- a/tests/Feature/SecurityAuditLogTest.php
+++ b/tests/Feature/SecurityAuditLogTest.php
@@ -1,0 +1,442 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * P1-6：安全敏感操作留下應用層審計（含操作者、IP、User-Agent）。
+ *
+ * 為什麼不能只靠 DB trigger：trigger 看得到「哪一列的哪個欄位變了」，但看不到**是誰、
+ * 從哪個 IP、用什麼客戶端**做的——那些只存在於 HTTP 請求裡。而 audit_log 原本只審計業務表
+ * （BIOG_MAIN 等），users 與 personal_access_tokens 的變更完全沒有紀錄。
+ *
+ * 同時釘住一條紅線：**審計不得記錄密碼雜湊或 token 明文／雜湊**。洩漏的審計日誌不該
+ * 變成第二個憑證來源。
+ */
+class SecurityAuditLogTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['cache.default' => 'array']);
+        config(['session.driver' => 'array']);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    private function activeUser(string $email = 'u@example.com'): User {
+        return User::unguarded(fn () => User::create([
+            'name' => '張三',
+            'email' => $email,
+            'password' => Hash::make('secret123'),
+            'confirmation_token' => 'token',
+            'avatar' => 'avatar0.png',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function securityContextFor(string $event): ?array {
+        foreach (DB::table('audit_log')->get() as $row) {
+            foreach (['new_data', 'old_data'] as $column) {
+                $payload = json_decode((string) $row->{$column}, true);
+                if (is_array($payload) && ($payload['__security']['event'] ?? null) === $event) {
+                    return $payload['__security'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    #[Test]
+    public function changing_the_password_is_audited_with_actor_ip_and_user_agent(): void {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->withServerVariables(['REMOTE_ADDR' => '203.0.113.9', 'HTTP_USER_AGENT' => 'ProbeBrowser/1.0'])
+            ->patch('/profile', [
+                'name' => '張三',
+                'email' => 'u@example.com',
+                'avatar' => 'avatar0.png',
+                'current_password' => 'secret123',
+                'new_password' => 'newsecret123',
+                'new_password_confirmation' => 'newsecret123',
+            ])->assertRedirect();
+
+        $context = $this->securityContextFor('password_changed');
+
+        $this->assertNotNull($context, '改密碼必須留下審計');
+        $this->assertSame((int) $user->id, $context['actor_id']);
+        $this->assertSame('張三', $context['actor_name']);
+        $this->assertSame('203.0.113.9', $context['ip']);
+        $this->assertSame('ProbeBrowser/1.0', $context['user_agent']);
+    }
+
+    #[Test]
+    public function the_audit_never_contains_the_password_hash(): void {
+        $user = $this->activeUser();
+        $user->refresh();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三',
+            'email' => 'u@example.com',
+            'avatar' => 'avatar0.png',
+            'current_password' => 'secret123',
+            'new_password' => 'newsecret123',
+            'new_password_confirmation' => 'newsecret123',
+        ])->assertRedirect();
+
+        $user->refresh();
+        $dump = DB::table('audit_log')->get()->toJson();
+
+        $this->assertStringNotContainsString($user->password, $dump, '審計不得包含密碼雜湊');
+        $this->assertStringNotContainsString('newsecret123', $dump, '審計不得包含密碼明文');
+    }
+
+    #[Test]
+    public function changing_the_email_is_audited_with_before_and_after(): void {
+        // email 變更可用來劫持密碼重設，等於換走帳號的復原管道。
+        $user = $this->activeUser();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三',
+            'email' => 'moved@example.com',
+            'avatar' => 'avatar0.png',
+        ])->assertRedirect();
+
+        // 精準取 email_changed 那一列：同一次提交若同時改密碼＋改 email（正是接管帳號的
+        // 組合）會落兩列 users 審計，用 ->first() 可能拿到 password_changed 那列。
+        $row = DB::table('audit_log')
+            ->where('table_name', 'users')
+            ->where('new_data', 'like', '%email_changed%')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('u@example.com', json_decode((string) $row->old_data, true)['email']);
+        $this->assertSame('moved@example.com', json_decode((string) $row->new_data, true)['email']);
+        $this->assertNotNull($this->securityContextFor('email_changed'));
+    }
+
+    #[Test]
+    public function changing_both_password_and_email_records_both_events(): void {
+        // 「改走 email 再換密碼」是接管帳號的標準劇本，兩件事都必須各自留下紀錄。
+        $user = $this->activeUser();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三',
+            'email' => 'moved@example.com',
+            'avatar' => 'avatar0.png',
+            'current_password' => 'secret123',
+            'new_password' => 'newsecret123',
+            'new_password_confirmation' => 'newsecret123',
+        ])->assertRedirect();
+
+        $this->assertNotNull($this->securityContextFor('password_changed'));
+        $this->assertNotNull($this->securityContextFor('email_changed'));
+        $this->assertSame(2, DB::table('audit_log')->where('table_name', 'users')->count());
+    }
+
+    #[Test]
+    public function resetting_the_password_via_email_link_is_audited(): void {
+        // 密碼的第二條寫入路徑。少了它，攻擊鏈的後半段（用重設連結換密碼）就沒有紀錄。
+        $user = $this->activeUser();
+
+        Schema::dropIfExists('password_resets');
+        Schema::create('password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+
+        $token = app('auth.password.broker')->createToken($user);
+
+        $this->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'brandnew123',
+            'password_confirmation' => 'brandnew123',
+        ])->assertRedirect();
+
+        $context = $this->securityContextFor('password_reset_via_email');
+        $this->assertNotNull($context, '經重設連結改密碼必須留下審計');
+        $this->assertSame('http', $context['channel']);
+        // ResetsPasswords::resetPassword 會在寫入密碼後 Auth::login()，所以審計時已經登入，
+        // actor 就是該帳號本人——這正確反映「持有重設連結者現在以此身分行動」。
+        $this->assertSame((int) $user->id, $context['actor_id']);
+
+        $row = DB::table('audit_log')->where('table_name', 'users')->first();
+        $this->assertSame('user', $row->actor_type);
+        $this->assertSame((string) $user->id, $row->actor_id);
+
+        Schema::dropIfExists('password_resets');
+    }
+
+    #[Test]
+    public function cli_audit_records_null_ip_instead_of_a_fake_local_address(): void {
+        // Laravel 的 SetRequestForConsole 會造一個假請求，ip() 回 127.0.0.1、
+        // userAgent() 回 'Symfony'。把那組值寫進審計，事故調查會讀成「有人從本機發 HTTP
+        // 請求」而被帶偏——誤導的證據比沒有證據更糟。
+        $this->activeUser('cli@example.com');
+
+        // 每個選項都要給：缺任何一個，指令會改走互動式 confirm 而在測試中卡住。
+        $this->artisan('cbdb:manage-user', [
+            '--email' => 'cli@example.com',
+            '--name' => 'CLI 使用者',
+            '--password' => 'clisecret123',
+            '--active' => '1',
+            '--role' => 'expert',
+        ])->assertExitCode(0);
+
+        $context = $this->securityContextFor('password_changed_via_cli');
+        $this->assertNotNull($context, 'CLI 改密碼必須留下審計');
+        $this->assertSame('cli', $context['channel']);
+        $this->assertNull($context['ip'], 'CLI 不得記假 IP');
+        $this->assertNull($context['user_agent'], 'CLI 不得記假 User-Agent');
+
+        $row = DB::table('audit_log')->where('table_name', 'users')->first();
+        $this->assertSame('system', $row->actor_type, 'CLI 沒有登入使用者，actor 應為 system');
+        $this->assertSame('system', $row->actor_id);
+    }
+
+    #[Test]
+    public function issuing_a_crowdsourcing_token_is_audited_and_denials_too(): void {
+        // 這是唯一剩下的長期憑證簽發路徑，且是無 throttle 的密碼驗證端點。
+        User::unguarded(fn () => User::create([
+            'name' => '眾包',
+            'email' => 'crowd@example.com',
+            'password' => Hash::make('secret123'),
+            'confirmation_token' => 'crowd-token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_CROWDSOURCING,
+        ]));
+
+        $this->get('/api/operations/token?q=crowd@example.com&p=secret123')->assertOk();
+        $this->assertNotNull($this->securityContextFor('crowdsourcing_token_issued'));
+
+        $this->get('/api/operations/token?q=crowd@example.com&p=wrong')->assertOk();
+        $this->assertNotNull($this->securityContextFor('crowdsourcing_token_denied'));
+
+        // 憑證本身絕不入庫。
+        $dump = DB::table('audit_log')->get()->toJson();
+        $this->assertStringNotContainsString('crowd-token', $dump);
+    }
+
+    #[Test]
+    public function a_cosmetic_profile_edit_is_not_audited(): void {
+        // 只改姓名／機構不是安全事件；審計要保持信噪比，否則沒人會去看。
+        $user = $this->activeUser();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三豐',
+            'email' => 'u@example.com',
+            'institution' => '武當',
+            'avatar' => 'avatar0.png',
+        ])->assertRedirect();
+
+        // 先確認寫入真的發生了：assertRedirect() 對驗證失敗的 302-back 也成立，
+        // 哪天欄位規則改動讓這個請求被擋下，下面那句 count()===0 會空跑成永遠綠。
+        $user->refresh();
+        $this->assertSame('張三豐', $user->name);
+        $this->assertSame('武當', $user->institution);
+
+        $this->assertSame(0, DB::table('audit_log')->count());
+    }
+
+    #[Test]
+    public function creating_an_api_token_is_audited_without_leaking_the_token(): void {
+        $user = $this->activeUser();
+
+        $response = $this->actingAs($user)
+            ->withServerVariables(['REMOTE_ADDR' => '198.51.100.7', 'HTTP_USER_AGENT' => 'TokenClient/2.0'])
+            ->postJson('/api-tokens', ['name' => 'laptop'])
+            ->assertOk();
+
+        $plain = $response->json('token.plainTextToken');
+        $this->assertNotEmpty($plain);
+
+        $context = $this->securityContextFor('api_token_created');
+        $this->assertNotNull($context, '簽發 token 必須留下審計');
+        $this->assertSame('198.51.100.7', $context['ip']);
+        $this->assertSame('TokenClient/2.0', $context['user_agent']);
+
+        $dump = DB::table('audit_log')->get()->toJson();
+        $this->assertStringNotContainsString($plain, $dump, '審計不得包含 token 明文');
+        $this->assertStringNotContainsString(
+            hash('sha256', explode('|', $plain)[1] ?? $plain),
+            $dump,
+            '審計不得包含 token 雜湊'
+        );
+    }
+
+    #[Test]
+    public function revoking_own_token_is_audited(): void {
+        $user = $this->activeUser();
+        $tokenId = $user->createToken('laptop', ['mcp:read'])->accessToken->id;
+
+        $this->actingAs($user)
+            ->deleteJson('/api-tokens/'.$tokenId)
+            ->assertOk();
+
+        $context = $this->securityContextFor('api_token_revoked_by_owner');
+        $this->assertNotNull($context, '自行撤銷 token 必須留下審計');
+        $this->assertSame((int) $user->id, $context['actor_id']);
+    }
+
+    #[Test]
+    public function revoking_all_own_tokens_is_audited_once(): void {
+        $user = $this->activeUser();
+        $user->createToken('a', ['mcp:read']);
+        $user->createToken('b', ['mcp:read']);
+
+        // 建立時已各留一筆審計；先清掉，只看撤銷那一筆。
+        DB::table('audit_log')->delete();
+
+        $this->actingAs($user)->deleteJson('/api-tokens')->assertOk();
+
+        $rows = DB::table('audit_log')->get();
+        $this->assertCount(1, $rows, '批次撤銷應只寫一筆彙總審計');
+        $before = json_decode((string) $rows->first()->old_data, true);
+        $this->assertCount(2, $before['tokens']);
+        $this->assertNotNull($this->securityContextFor('api_tokens_revoked_by_owner'));
+    }
+
+    #[Test]
+    public function admin_status_changes_carry_request_context(): void {
+        $admin = User::unguarded(fn () => User::create([
+            'name' => '管理員',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret123'),
+            'confirmation_token' => 'token',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]));
+        $victim = $this->activeUser('victim@example.com');
+
+        $this->actingAs($admin)
+            ->withServerVariables(['REMOTE_ADDR' => '192.0.2.44', 'HTTP_USER_AGENT' => 'AdminBrowser/3.0'])
+            ->put('/manage/'.$victim->id, [
+                'is_active' => User::STATUS_INACTIVE,
+                'is_admin' => User::ROLE_REGULAR,
+            ])->assertRedirect(route('manage.index'));
+
+        $context = $this->securityContextFor('user_role_or_status_changed');
+        $this->assertNotNull($context, '停用帳號必須帶請求脈絡');
+        $this->assertSame((int) $admin->id, $context['actor_id']);
+        $this->assertSame('管理員', $context['actor_name']);
+        $this->assertSame('192.0.2.44', $context['ip']);
+        $this->assertSame('AdminBrowser/3.0', $context['user_agent']);
+    }
+
+    #[Test]
+    public function a_failing_audit_insert_does_not_break_the_business_action(): void {
+        // 使用者改完密碼卻看到 500，只會讓他以為沒改成功而重試。
+        //
+        // 關鍵：必須讓 **insert 本身失敗**，而不是把表 drop 掉——後者會被
+        // SecurityAuditLogger 的 Schema::hasTable 提早 return，根本走不到 try/catch，
+        // 那樣這條測試就變成假保證（第一版正是如此，實測 Log::warning 從未被呼叫）。
+        // 這裡加一個 NOT NULL 且無預設值的欄位，讓 insert 必定違反約束。
+        $user = $this->activeUser();
+        DB::statement('ALTER TABLE audit_log ADD COLUMN forced_failure TEXT NOT NULL');
+
+        Log::spy();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三',
+            'email' => 'u@example.com',
+            'avatar' => 'avatar0.png',
+            'current_password' => 'secret123',
+            'new_password' => 'newsecret123',
+            'new_password_confirmation' => 'newsecret123',
+        ])->assertRedirect();
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('newsecret123', $user->password), '密碼變更必須已生效');
+        Log::shouldHaveReceived('warning')->atLeast()->once();
+    }
+
+    #[Test]
+    public function a_missing_audit_table_is_a_silent_no_op(): void {
+        // 與上一條互補：表不存在時走 hasTable 早退，不該留 warning 噪音。
+        $user = $this->activeUser();
+        Schema::drop('audit_log');
+
+        Log::spy();
+
+        $this->actingAs($user)->patch('/profile', [
+            'name' => '張三',
+            'email' => 'u@example.com',
+            'avatar' => 'avatar0.png',
+            'current_password' => 'secret123',
+            'new_password' => 'newsecret123',
+            'new_password_confirmation' => 'newsecret123',
+        ])->assertRedirect();
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('newsecret123', $user->password));
+        Log::shouldNotHaveReceived('warning');
+    }
+}


### PR DESCRIPTION
加固清單最後一項（P1-6）。

## 為什麼要應用層而不只靠 DB trigger

trigger 看得到「哪一列的哪個欄位變了」，但看不到**是誰、從哪個 IP、用什麼客戶端**做的——那些只存在於 HTTP 請求裡。而 `audit_log` 原本只審計業務表（`BIOG_MAIN` 等）。同事 `828abe7` 已為 `users` 的角色／啟用變更加了應用層審計（但沒有 IP／UA），本輪補齊其餘缺口。

補充一個查證結果：全 repo grep `create trigger` **零命中**，所以無法證實 `users` 有任何 DB trigger 兜底——對 users 而言應用層審計很可能是唯一紀錄。

## 接上的事件

| 事件 | 為什麼重要 |
|---|---|
| 改密碼、改 email | email 變更可劫持密碼重設，等於換走帳號的復原管道 |
| **經「忘記密碼」連結重設密碼** | 密碼的**第二條**寫入路徑。少了它，攻擊鏈後半段沒紀錄：先改走 email（留下 `email_changed`）→ 再用重設連結換密碼 → audit_log 看不到密碼何時被誰換掉 |
| 使用者自建／自撤 API token | 含批次撤銷（彙總一筆） |
| **`cbdb:manage-user` CLI** | 可憑機器存取權把任何帳號提為系統管理員、改任何人密碼，原本零紀錄 |
| `Api\OperationsController@token` | 唯一剩下的長期憑證簽發路徑，成功與**被拒**都記——那是個無 throttle 的密碼驗證端點，不記連暴力破解都看不見 |

既有的 `auditUserChange` 與 `AccountAccessRevoker` 改為委派 `SecurityAuditLogger`，消掉兩份會分歧的 inline 脈絡。

## CLI 情境刻意不記 ip／UA

我原本註解寫「CLI 沒有 request，兩者為 null」——**那是錯的**。Laravel 的 `SetRequestForConsole` 會用 `Request::create()` 造假請求，`ip()` 回 `127.0.0.1`、`userAgent()` 回 `Symfony`（Symfony 的預設值）。把那組值寫進審計，事故調查會讀成「有人從本機發 HTTP 請求」而被帶偏——**誤導的證據比沒有證據更糟**。

而第一版的修法（`app()->runningInConsole()`）本身也錯：**PHPUnit 就跑在 CLI**，那個訊號會把測試模擬的 HTTP 請求也標成 cli，等於讓「HTTP 要記客戶端 IP」這條永遠測不到。改由知道自己身分的呼叫端顯式傳 `channel`，不依賴會騙人的訊號。

未登入時 `actor_type` 也改為 `system`（原本硬寫 `'user'` + `actorId: null` 會落成 `actor_type=user` / `actor_id=system` 的自相矛盾列）。

## 紅線：審計不得成為第二個憑證來源

**絕不記錄密碼雜湊、密碼明文、token 明文或 token 雜湊**，只記「發生了變更」。有專門測試釘住，且 token 雜湊的斷言算法與 Sanctum 實際儲存的一致（`hash('sha256', explode('|',$plain)[1])`）。

另外把審計失敗的 `Log::warning` 改成只記 exception 類別與截短訊息：`QueryException::getMessage()` 含完整 SQL 與繫結值，會把刻意只放進 DB 的 payload（例如變更前後的 email）外流到權限通常更鬆的 `laravel.log`。

## 其他修正

`ApiTokenController::destroyAll` 的「讀快照再刪」補上交易＋列鎖：無鎖的 read-then-delete 若被並發 `store()` 插入一個 token，該 token 會被刪掉卻不在審計快照裡——審計聲稱撤銷 2 個、實際銷毀 3 個。

## 測試方法上的教訓（第三次）

`a_failed_audit_write_does_not_break_the_business_action` 第一版只 `Schema::drop('audit_log')`，其實被 `SecurityAuditLogger` 的 `Schema::hasTable` **提早 return**，從未走到 try/catch——又是一條假保證。現在改成讓 insert 真的失敗（加一個 NOT NULL 無預設欄位）並斷言有 `Log::warning`，另加一條專測早退路徑且斷言**沒有** warning 噪音。

`a_cosmetic_profile_edit_is_not_audited` 也補了「寫入真的發生」的前置斷言——`assertRedirect()` 對驗證失敗的 302-back 也成立，哪天欄位規則改動讓請求被擋下，`count()===0` 會空跑成永遠綠。

## 驗證

- `./vendor/bin/phpunit` 全套（rebase 到含 #1241 的 develop 之後）：`OK (2566 tests, 13816 assertions)`
- `php-cs-fixer`（先清 cache + dist config）：`Fixed 0 files`
- 新增 `tests/Feature/SecurityAuditLogTest.php`（14 個案例）

## ⚠️ 已知未做（超出清單範圍，僅記錄）

登入成功／失敗／lockout／登出、自助註冊、以及 `ManagementController` 的授權拒絕（專家嘗試改角色被擋——**提權嘗試是高價值訊號**）目前仍無審計。登入唯一痕跡是 `users.settings.last_login_ip`，每次登入覆蓋、無歷史。

🤖 Generated with [Claude Code](https://claude.com/claude-code)