### PR TITLE
碼表人物欄可直接跳轉到人物基本資料

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -1113,6 +1113,15 @@ class CodesController extends Controller {
                         'kind' => 'person',
                         'endpoint' => self::PERSON_SEARCH_ENDPOINT,
                         'label' => $label,
+                        // 這個值是否真的對應一位存在的人物。前端據此決定要不要給「前往人物基本資料」
+                        // 連結，以及能不能把 label 當姓名用：查不到人時 label 是退回的原始 ID
+                        // （見上方），拿去當姓名會讓 ID 假扮成人名，連結也會開到 404。
+                        // 提案調整頁尤其會遇到——resource_data 裡的人物可能在送審後被合併掉。
+                        'exists' => is_numeric($raw) ? isset($labels[(int) $raw]) : null,
+                        // 人物編輯頁 URL 由後端組（flag-aware，見 person_page_url()），前端只換 __ID__；
+                        // 不在元件裡寫死 /app/... 路徑，否則 basicinformation.editor flag 翻回 old 時
+                        // 只有這裡還指著 React 版。
+                        'edit_url_template' => person_page_url('__ID__', 'edit'),
                     ],
                 ];
             }

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -499,6 +499,12 @@ class CodesController extends Controller {
             'boolean_filter_available' => $payload['booleanFilterAvailable'] ?? false,
             'filter_errors' => (object) ($payload['filterErrors'] ?? []),
             'filter_descriptions' => (object) ($payload['filterDescriptions'] ?? []),
+            // 人物欄（外鍵指向 BIOG_MAIN，判準見 personFkColumns()）→ 列表格內把 ID 本身做成
+            // 可跳轉的連結，否則瀏覽 KIN_DATA 這類表只看到一整欄數字、要查人得先點「編輯」。
+            // 只給實際出現在表頭的欄；URL 模板與表單頁同樣走 flag-aware 的 person_page_url()。
+            // 以 thead 為基準取交集，順序才與畫面欄序一致（外鍵反射的順序依 driver 而異）。
+            'person_fk_columns' => array_values(array_intersect($payload['thead'], $this->personFkColumns($table))),
+            'person_edit_url_template' => person_page_url('__ID__', 'edit'),
             // 操作連結（建立/編輯/刪除）依 codes flag 解析（新版就緒前回退 Blade）。
             'can_edit' => \Illuminate\Support\Facades\Auth::check() && !($payload['isReadOnly'] ?? false),
             'urls' => [

--- a/resources/js/inertia/Pages/Codes/Show.tsx
+++ b/resources/js/inertia/Pages/Codes/Show.tsx
@@ -51,6 +51,10 @@ interface CodesShowPageProps extends SharedProps {
     boolean_filter_available: boolean;
     filter_errors: Record<string, string>;
     filter_descriptions: Record<string, string>;
+    /** 外鍵指向 BIOG_MAIN 的欄位；這些欄的 ID 直接做成連往人物基本資料的連結。 */
+    person_fk_columns: string[];
+    /** 人物編輯頁 URL 模板（後端 flag-aware 產生），把 `__ID__` 換成人物 ID。 */
+    person_edit_url_template: string;
     can_edit: boolean;
     urls: {
         index: string;
@@ -73,6 +77,11 @@ export default function CodesShow() {
         computed_columns, copyright_note, sort_by, sort_dir, boolean_enabled, boolean_filter_available,
         filter_errors, filter_descriptions, can_edit, urls,
     } = props;
+
+    // 兩個新 prop 都取防禦值：缺了就退回純文字，不要因為少一個 prop 就整頁白畫面。
+    const person_edit_url_template = props.person_edit_url_template ?? '';
+
+    const personFkColumns = useMemo(() => new Set(props.person_fk_columns ?? []), [props.person_fk_columns]);
 
     const [search, setSearch] = useState(props.search ?? '');
     const [filters, setFilters] = useState<Record<string, string>>(props.filters ?? {});
@@ -178,6 +187,41 @@ export default function CodesShow() {
             if (dynasty_map[key]) v = `${v} - ${dynasty_map[key]}`;
         }
         return v == null ? '' : String(v);
+    };
+
+    /**
+     * 儲存格內容。人物欄（外鍵指向 BIOG_MAIN）的 ID 本身做成連往該人物基本資料的連結，
+     * 讓瀏覽者不必先點「編輯」才能查那個人；與 Admin/MergePreview 的人物 ID 儲存格同一種樣式。
+     *
+     * 一律新分頁開啟：這頁帶著使用者的搜尋／篩選／分頁狀態，同分頁跳走等於要他重新找回原處。
+     * 只連正整數：0（未詳）與空值不是可查的人物。列表資料直接來自資料表、受外鍵保證，
+     * 故不像表單頁那樣需要額外確認人物是否存在。
+     */
+    const renderCell = (row: Row, col: string): React.ReactNode => {
+        const text = cellValue(row, col);
+        if (!personFkColumns.has(col) || !person_edit_url_template) {
+            return text;
+        }
+        const id = Number(row[col]);
+        if (!Number.isInteger(id) || id <= 0) {
+            return text;
+        }
+
+        return (
+            <a
+                href={person_edit_url_template.replace('__ID__', String(id))}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={t('goto_person_edit_page_title')}
+                // 一列可能有多個人物欄（ASSOC_DATA 有 6 個），可見文字都只是數字；
+                // 以 aria-label 補上欄名，螢幕閱讀器列出連結時才分得出哪個是哪個。
+                aria-label={`${text} (${col})`}
+                // 底線而非只靠顏色：整欄都是數字，顏色是唯一線索就不夠（WCAG 1.4.1）。
+                className="text-primary underline decoration-dotted underline-offset-2"
+            >
+                {text}
+            </a>
+        );
     };
 
     const colSpan = thead.length + (can_edit ? 1 : 0);
@@ -346,7 +390,7 @@ export default function CodesShow() {
                                 return (
                                     <tr key={id} className="border-t border-border hover:bg-muted/30">
                                         {thead.map((col) => (
-                                            <td key={col} className="px-3 py-1.5">{cellValue(row, col)}</td>
+                                            <td key={col} className="px-3 py-1.5">{renderCell(row, col)}</td>
                                         ))}
                                         {can_edit && (
                                             <td className="px-3 py-1.5">

--- a/resources/js/inertia/components/Codes/CodesColumnField.tsx
+++ b/resources/js/inertia/components/Codes/CodesColumnField.tsx
@@ -3,6 +3,8 @@ import * as LabelPrimitive from '@radix-ui/react-label';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import CodeAutocomplete from '../PersonBrowser/shared/CodeAutocomplete';
+import PersonJumpLink from '../PersonEditorShared/PersonJumpLink';
+import { useTranslation } from '../../hooks/useTranslation';
 
 /**
  * 泛用 codes 表單的單一欄位。
@@ -39,7 +41,19 @@ export interface ColumnBehaviour {
      * 目前只有 kind='person'（外鍵指向 BIOG_MAIN 的欄位，見 CodesController::personFkColumns）。
      * label 是目前值的顯示名稱，供選擇器初始顯示——否則使用者只看到一個數字。
      */
-    picker?: { kind: 'person'; endpoint: string; label?: string | null };
+    picker?: {
+        kind: 'person';
+        endpoint: string;
+        label?: string | null;
+        /**
+         * 目前值是否對應一位存在的人物。查不到時 label 是退回的原始 ID（見後端 codeColumnBehaviour），
+         * 故 false 時既不可把 label 當姓名、也不該給跳轉連結（會開到 404）。
+         * null＝目前沒有數值可判定。
+         */
+        exists?: boolean | null;
+        /** 人物編輯頁 URL 模板（後端 flag-aware 產生），把 `__ID__` 換成人物 ID。 */
+        edit_url_template?: string;
+    };
 }
 
 interface Props {
@@ -113,6 +127,26 @@ export function CodesColumnField({
     const hasError = messages.length > 0;
     const describedById = `${column}-desc`;
 
+    // 人物欄的「前往人物基本資料」連結文案。此元件的三個使用頁（Create／Edit／ProposalEdit）
+    // 都以 codes group 作為 page_translations，故直接在元件內取譯，不必逐頁再傳一個 tr。
+    const t = useTranslation('codes');
+    const tr = (k: string, fb: string) => { const v = t(k); return v && v !== k ? v : fb; };
+
+    /**
+     * 使用者在本頁自行選過的人物（值＋顯示名稱）。
+     *
+     * picker.label／picker.exists 只描述「隨頁面送來的那個值」；使用者改選他人後就過期了，
+     * 照樣沿用會把別人的姓名標到新的人身上。選擇器本身在 onChange 就給了新選項的 label，
+     * 這裡把它留住即可——既拿回姓名，也不需要去猜「現在的值還是不是原本那個」。
+     * 從選擇器選出來的一定是搜尋端點回傳的真實人物，故 exists 視為 true。
+     */
+    const [picked, setPicked] = React.useState<{ value: string; label: string } | null>(null);
+    const pickedHere = picked !== null && picked.value === value;
+    const personName = pickedHere ? picked.label : (picker?.exists ? (picker.label ?? undefined) : undefined);
+    // 連結只在「確定存在的人物」上出現：查不到的殘留 ID（例如提案送審後被合併掉的人物）
+    // 給了連結只會開到 404。
+    const personLinkable = picker?.kind === 'person' && (pickedHere || picker.exists === true);
+
     return (
         <div className="space-y-1">
             <LabelPrimitive.Root htmlFor={column} className="text-sm font-medium">
@@ -135,7 +169,7 @@ export function CodesColumnField({
                             disabled={readOnly}
                             aria-invalid={hasError ? true : undefined}
                             aria-describedby={hasError || hint || actionMessage ? describedById : undefined}
-                            onChange={(v) => onChange(v)}
+                            onChange={(v, label) => { setPicked({ value: v, label }); onChange(v); }}
                         />
                     </div>
                 ) : (
@@ -190,6 +224,20 @@ export function CodesColumnField({
                     </p>
                 ))}
             </div>
+
+            {/* 人物欄已選定一位真實人物 → 就近給一個可直達其基本資料的連結（與 KinEditor／
+                AssocEditor 的人物參照欄同一個元件、同一種樣式）。放在提示／錯誤之後，
+                驗證訊息才緊貼輸入框。 */}
+            {personLinkable && (
+                <PersonJumpLink
+                    personId={value}
+                    name={personName}
+                    tr={tr}
+                    to="edit"
+                    hrefTemplate={picker?.edit_url_template}
+                    context={column}
+                />
+            )}
         </div>
     );
 }

--- a/resources/js/inertia/components/PersonEditorShared/PersonJumpLink.tsx
+++ b/resources/js/inertia/components/PersonEditorShared/PersonJumpLink.tsx
@@ -14,32 +14,57 @@ import React from 'react';
  *  - 樣式低調（小字、品牌色、外部連結圖示），置於輸入框下方，不與輸入框搶視覺；
  *    顏色用 var(--primary) 隨深色模式翻轉。人物姓名置於 title（tooltip），可見文字保持精簡
  *    （姓名已顯示在上方輸入框，不重複佔版面）。
+ *  - to='edit' 改連基本資料編輯頁，供碼表編輯頁的人物欄使用：在那裡使用者正在編目一筆人物參照，
+ *    要去的是「那個人的基本資料」而非唯讀詳情中樞。文案／tooltip 另用一組 key，避免顯示
+ *    「詳情頁」卻連到編輯頁。四組 key 在 biogmains 與 codes 兩個 group 都有定義，因此無論
+ *    呼叫端取譯自哪一個 group，兩種 to 都不會退回硬編碼中文（英文語境會漏字）。
+ *  - hrefTemplate：呼叫端已有 flag-aware URL 模板（後端 person_page_url('__ID__', …)）時傳入，
+ *    優先於元件內建路徑。刻意收模板而非成品 URL：`__ID__` 由此處以**正規化後的整數** id 代入，
+ *    與顯示與否的判準用同一個值。若由呼叫端拿原始欄位值去代，'100.0' 這種 is_numeric 但非整數
+ *    字面的值會通過兩邊的檢查卻組出撞不到路由（`where('id','[0-9]+')`）的 404 連結。
+ *  - context：同一個表單有多個人物欄時（如 ASSOC_DATA 有 5 個），可見文字都一樣，
+ *    以 aria-label 補上欄名，螢幕閱讀器才分得出這個連結屬於哪一欄。
  */
 export default function PersonJumpLink({
     personId,
     name,
     tr,
+    to = 'show',
+    hrefTemplate,
+    context,
 }: {
     personId?: string | number | null;
     name?: string;
     tr: (k: string, fb: string) => string;
+    to?: 'show' | 'edit';
+    hrefTemplate?: string;
+    context?: string;
 }) {
     const id = Number(personId);
     if (!Number.isInteger(id) || id <= 0) {
         return null;
     }
     const nm = (name ?? '').trim();
-    const title = tr('goto_person_page_title', '在新分頁開啟此人物的詳情頁') + (nm ? `：${nm}` : '');
+    const isEdit = to === 'edit';
+    const titleText = isEdit
+        ? tr('goto_person_edit_page_title', '在新分頁開啟此人物的基本資料編輯頁')
+        : tr('goto_person_page_title', '在新分頁開啟此人物的詳情頁');
+    const title = titleText + (nm ? `：${nm}` : '');
+    const text = isEdit ? tr('goto_person_edit_page', '前往人物基本資料') : tr('goto_person_page', '前往人物頁面');
+    const href = hrefTemplate
+        ? hrefTemplate.replace('__ID__', String(id))
+        : (isEdit ? `/app/basicinformation/${id}/edit` : `/app/basicinformation/${id}`);
     return (
         <a
-            href={`/app/basicinformation/${id}`}
+            href={href}
             target="_blank"
             rel="noopener noreferrer"
             title={title}
+            aria-label={context ? `${text} (${context})` : undefined}
             style={linkStyle}
         >
             <i className="fas fa-external-link-alt" aria-hidden style={{ fontSize: '0.78em' }} />
-            {tr('goto_person_page', '前往人物頁面')}
+            {text}
         </a>
     );
 }

--- a/resources/lang/en/biogmains.php
+++ b/resources/lang/en/biogmains.php
@@ -216,6 +216,10 @@ return [
     // "Go to person page" link shown under a person-reference field (Associated Person / Relative Name)
     'goto_person_page' => 'Open person page',
     'goto_person_page_title' => "Open this person's page in a new tab",
+    // Same component's to='edit' variant (used by the code-table person columns); defined here too
+    // so switching a person editor to that mode later cannot silently lose the translation.
+    'goto_person_edit_page' => "Open person's basic info",
+    'goto_person_edit_page_title' => "Open this person's basic information editor in a new tab",
     'paired_kinship' => 'Paired Kinship',
     'no_paired_kinship' => 'No corresponding kinship',
     'reverse_pair_label' => 'Reciprocal pair code',

--- a/resources/lang/en/codes.php
+++ b/resources/lang/en/codes.php
@@ -132,6 +132,13 @@ return [
     // :link is replaced by a real <a> in the frontend (keeps the legacy in-sentence link without HTML in the string)
     'hint_text_codes_copy' => 'Make sure the book\'s c_textid exists in the :link table, then copy the ID here.',
     'hint_addr_copy' => 'Copy c_addr_id from the :link table.',
+    // Person columns (FK to BIOG_MAIN) → jump straight to that person's basic-information editor.
+    // Both PersonJumpLink variants are defined here so the component never falls back to its
+    // hardcoded Chinese strings when translated from this group.
+    'goto_person_edit_page' => "Open person's basic info",
+    'goto_person_edit_page_title' => "Open this person's basic information editor in a new tab",
+    'goto_person_page' => 'Open person page',
+    'goto_person_page_title' => "Open this person's page in a new tab",
     // TEXT_INSTANCE_DATA "Load Data" (fill the titles from c_textid)
     'load_text_title_btn' => 'Load title',
     'load_text_title_filled' => 'Filled: :fields',

--- a/resources/lang/zh-TW/biogmains.php
+++ b/resources/lang/zh-TW/biogmains.php
@@ -216,6 +216,9 @@ return [
     // 人物參照欄下方的「前往此人物頁」連結（關聯人物 / 親屬姓名共用）
     'goto_person_page' => '前往人物頁面',
     'goto_person_page_title' => '在新分頁開啟此人物的詳情頁',
+    // 同一元件的 to='edit' 版（碼表人物欄在用）；此 group 也定義，避免日後從人物編輯頁改用該模式時漏譯
+    'goto_person_edit_page' => '前往人物基本資料',
+    'goto_person_edit_page_title' => '在新分頁開啟此人物的基本資料編輯頁',
     'paired_kinship' => '成對親屬關係',
     'no_paired_kinship' => '無對應親屬關係',
     'reverse_pair_label' => '互逆配對碼',

--- a/resources/lang/zh-TW/codes.php
+++ b/resources/lang/zh-TW/codes.php
@@ -130,6 +130,12 @@ return [
     // :link 由前端替換成真正的 <a>（保留舊版「連結在句中」的讀法，又不必回到 HTML 字串）
     'hint_text_codes_copy' => '請確保 :link 表中存在這本書的 c_textid，再複製 ID 填入',
     'hint_addr_copy' => '請從 :link 表中複製 c_addr_id 填入',
+    // 人物欄（外鍵指向 BIOG_MAIN）→ 就近直達該人物的基本資料編輯頁。
+    // PersonJumpLink 兩種模式的 key 都定義在此，避免元件被以本 group 取譯時退回硬編碼中文。
+    'goto_person_edit_page' => '前往人物基本資料',
+    'goto_person_edit_page_title' => '在新分頁開啟此人物的基本資料編輯頁',
+    'goto_person_page' => '前往人物頁面',
+    'goto_person_page_title' => '在新分頁開啟此人物的詳情頁',
     // TEXT_INSTANCE_DATA 的「Load Data」（依 c_textid 帶入書名）
     'load_text_title_btn' => '帶入書名',
     'load_text_title_filled' => '已帶入：:fields',

--- a/tests/Feature/CodesPersonPickerTest.php
+++ b/tests/Feature/CodesPersonPickerTest.php
@@ -281,6 +281,46 @@ class CodesPersonPickerTest extends TestCase {
             });
     }
 
+    // ───────── 列表頁（app.codes.show）：人物欄的 ID 本身可跳轉 ─────────
+
+    #[Test]
+    public function listing_page_marks_the_person_columns_and_ships_the_url_template(): void {
+        // 沒有這兩個 prop，列表就只能把 c_personid 印成一整欄數字（要查人得先點「編輯」）。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.show', ['table_name' => 'ASSOC_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $props = $page->toArray()['props'];
+                // 順序跟著 thead（畫面欄序），不受外鍵反射順序影響
+                $this->assertSame(
+                    ['c_personid', 'c_assoc_id', 'c_kin_id', 'c_assoc_kin_id', 'c_tertiary_personid', 'c_assoc_claimer_id'],
+                    $props['person_fk_columns'],
+                );
+                $this->assertSame(
+                    array_values(array_intersect($props['thead'], $props['person_fk_columns'])),
+                    $props['person_fk_columns'],
+                );
+                $this->assertSame('/app/basicinformation/__ID__/edit', $props['person_edit_url_template']);
+            });
+    }
+
+    #[Test]
+    public function listing_page_marks_no_person_columns_for_a_table_without_them(): void {
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.show', ['table_name' => 'TEST_PLAIN_CODES']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('person_fk_columns', []));
+    }
+
+    #[Test]
+    public function listing_page_does_not_mark_a_person_named_column_without_a_foreign_key(): void {
+        // 與表單頁同一條判準：沒有外鍵就不是人物欄（MERGED_PERSON_DATA 的人物可能已不存在）。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.show', ['table_name' => 'MERGED_PERSON_DATA']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('person_fk_columns', []));
+    }
+
     #[Test]
     public function person_edit_url_template_follows_the_editor_migration_flag(): void {
         // flag 翻回 old 時，碼表的人物連結必須跟著回到 legacy 編輯頁，

--- a/tests/Feature/CodesPersonPickerTest.php
+++ b/tests/Feature/CodesPersonPickerTest.php
@@ -238,6 +238,63 @@ class CodesPersonPickerTest extends TestCase {
             });
     }
 
+    // ───────── 「前往人物基本資料」連結（picker.exists／edit_url_template） ─────────
+
+    #[Test]
+    public function picker_reports_whether_the_referenced_person_exists(): void {
+        // 前端據此決定要不要給跳轉連結、能不能把 label 當姓名用。查不到人物時 label 是退回的
+        // 原始 ID，若照樣當姓名顯示就是 ID 假扮人名，連結也會開到 404。
+        DB::table('ASSOC_DATA')->where('c_personid', 11)->update(['c_assoc_kin_id' => 999111]);
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertTrue($b['c_personid']['picker']['exists'], '真實人物 → 可跳轉');
+                $this->assertFalse($b['c_assoc_kin_id']['picker']['exists'], '查不到的殘留 ID → 不可跳轉');
+            });
+    }
+
+    #[Test]
+    public function picker_exists_is_null_when_the_column_has_no_value(): void {
+        // 沒有值就沒有「存在與否」可談；不可回 false 讓它讀起來像「這個人不存在」。
+        $this->actingAs($this->activeUser())
+            ->get(route('app.codes.create', ['table_name' => 'ASSOC_DATA']))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $b = $page->toArray()['props']['column_behaviour'];
+                $this->assertNull($b['c_assoc_id']['picker']['exists']);
+            });
+    }
+
+    #[Test]
+    public function picker_ships_a_person_edit_url_template(): void {
+        // URL 由後端產生、前端只換 __ID__；元件不寫死 /app/ 路徑。
+        // 斷言字面值而非再呼叫 person_page_url()——拿同一個 helper 比對自己等於什麼都沒鎖。
+        config(['migration_flags.pages.basicinformation.editor' => 'new']);
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $template = $page->toArray()['props']['column_behaviour']['c_personid']['picker']['edit_url_template'];
+                $this->assertSame('/app/basicinformation/__ID__/edit', $template);
+            });
+    }
+
+    #[Test]
+    public function person_edit_url_template_follows_the_editor_migration_flag(): void {
+        // flag 翻回 old 時，碼表的人物連結必須跟著回到 legacy 編輯頁，
+        // 不能只有這裡還指著 React 版（這正是不在元件裡寫死路徑的原因）。
+        config(['migration_flags.pages.basicinformation.editor' => 'old']);
+
+        $this->editAssoc()
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $template = $page->toArray()['props']['column_behaviour']['c_personid']['picker']['edit_url_template'];
+                $this->assertSame('/basicinformation/__ID__/edit', $template);
+            });
+    }
+
     #[Test]
     public function create_page_does_not_prefill_a_person_primary_key_with_a_guessed_id(): void {
         // guessNextKeyValue 對人物欄毫無意義（max(c_personid)+1），而 CBDB 人物 ID 很密集，


### PR DESCRIPTION
## 摘要

`/app/codes` 的碼表頁裡，外鍵指向 `BIOG_MAIN` 的人物欄原本只看得到 ID（或一個選擇器），
要查那個人的基本資料得自己另開頁面找。這裡在兩個surface就近加上可跳轉的連結，
直達 `/app/basicinformation/{id}/edit`。

沿用既有設計，未新造一套：表單頁用 `PersonJumpLink`（KinEditor／AssocEditor 的人物參照欄
同一個元件與樣式），列表頁用 Admin/MergePreview 的人物 ID 儲存格做法。

## 兩個環節

**1. 表單頁（新增／編輯／提案調整）** — 人物欄下方的「前往人物基本資料」連結
- `codeColumnBehaviour()` 的 `picker` 增加 `exists`：值是否對應一位存在的人物。查不到時
  `label` 是退回的原始 ID，前端據此不給連結、也不把 ID 當姓名用（提案送審後人物被合併掉
  就會遇到，連結會開到 404）。
- `picker.edit_url_template`：URL 由後端 `person_page_url()` 產生（flag-aware），前端只換
  `__ID__`；不在元件裡寫死 `/app/` 路徑，否則 `basicinformation.editor` flag 翻回 `old` 時
  只有這裡還指著 React 版。
- `CodesColumnField` 保留選擇器 `onChange` 給的 label 作為改選後的姓名，不再用「進頁時的值」
  去猜 label 是否過期。
- `PersonJumpLink` 增加 `to='edit'`／`hrefTemplate`／`context` 三個選用參數，預設值與原本
  完全相同，既有兩處呼叫端行為不變。ASSOC_DATA 一張表有 5–6 個人物欄、連結可見文字相同，
  故以 `aria-label` 補上欄名。

**2. 列表頁 `/app/codes/{table}`** — 人物欄的 ID 本身即連結
- `appShow` 增加 `person_fk_columns`（以 `thead` 取交集，順序與畫面欄序一致，不受外鍵反射
  順序在 MySQL／SQLite 的差異影響）與 `person_edit_url_template`。
- 只連正整數：`0`（未詳）、空值、非整數值維持純文字。列表資料直接來自資料表、受外鍵保證，
  故不需要像表單頁那樣額外確認人物是否存在。
- 連結加虛線底線，不讓顏色成為唯一線索；`aria-label` 帶欄名。

## i18n
四組連結字串在 `codes` 與 `biogmains` 兩個 group、`zh-TW` 與 `en` 皆補齊，避免退回硬編碼中文。

## 相容性
- 既有 `PersonJumpLink` 兩處呼叫端（KinEditor／AssocEditor）行為 byte-identical。
- Blade 版列表未同步（新功能只做在 React 路徑）；`codes` flag 翻回 `old` 時功能消失、不會壞掉。
- `basicinformation.editor` flag 翻回 `old` 時連結跟著回到 legacy 編輯頁（有回歸測試）。

## 測試
- `tests/Feature/CodesPersonPickerTest.php` 新增 7 個案例：`exists` 的三種狀態、URL 模板在
  flag=new／old 兩種形狀、列表頁三種表（有人物欄／無人物欄／欄名像人物但無外鍵）。
- `phpunit --filter Codes` → 224 tests / 1557 assertions OK
- `phpunit --filter PersonBrowser|BasicInfoName|Kinship|Assoc` → 333 tests OK
- `php-cs-fixer` 0 fixable、`tsc --noEmit` 改動檔案零錯誤、`npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)