### PR TITLE
chore(deps): 升級 league/commonmark 2.8.2 → 2.10.0（修 6 個 Dependabot 警報）

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1841,16 +1841,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -1872,8 +1872,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -1887,7 +1887,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -1944,7 +1944,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
## 為什麼要手動處理

Dependabot 目前開啟中的 **6 個警報全部指向同一個套件 `league/commonmark` (< 2.9.0)**。它是 `laravel/framework` v12.62.0 的**傳遞依賴**（`requires league/commonmark ^2.8.1`），不在 `composer.json` 的 `require` 裡 —— 這正是 Dependabot security update 沒能自動開 PR 的原因（傳遞依賴它無法自動改鍵）。

## 修掉的警報

| # | 嚴重度 | GHSA / CVE | 內容 |
|---|---|---|---|
| 415 | high | GHSA-2q4p-g7hv-5rgv / CVE-2026-71488 | 解析特製 Markdown 的二次時間（quadratic-time）DoS |
| 414 | high | GHSA-jfm3-95jq-q3rf | 重複腳註定義造成 DoS |
| 413 | high | GHSA-g2gp-3wwq-f4ph | 相鄰 inline attribute block 造成 DoS |
| 411 | high | GHSA-mh25-x5hq-wrqp | 標題 slug 碰撞造成 DoS |
| 412 | medium | GHSA-29pj-957v-52mc / CVE-2026-71478 | AttributesExtension 的 href/src unsafe-link 過濾可被內嵌控制位元組繞過 |
| 410 | medium | GHSA-mj63-m3rc-8ppr | 深度嵌套 XML 輸出造成 DoS |

全部的修補版本都是 **2.9.0**，本 PR 升到當前最新的 **2.10.0**（同屬 2.x，無 BC break）。

## 實際暴露面評估

`app/` 內**沒有任何**呼叫 `Str::markdown()` / CommonMark 轉換的程式碼 —— commonmark 純粹因框架依賴而存在，本專案不解析使用者提供的 Markdown。因此上述 DoS 在目前的程式碼裡沒有可觸發路徑，屬「補齊依賴衛生」而非緊急修補。

## 變更範圍

只動 `composer.lock` 的一個套件（8 行）：

```
- "league/commonmark": "2.8.2"
+ "league/commonmark": "2.10.0"
```

`composer.json` 不需改（框架的 `^2.8.1` 已涵蓋 2.10.0）。刻意用 `composer update league/commonmark`（不帶 `--with-all-dependencies`）以避免順帶動到 `nette/utils` 等無關套件。

## 驗證

- `composer audit --locked` → No security vulnerability advisories found
- `composer validate` → 通過
- **Unit：453 tests / 1165 assertions 全綠**
- **Feature：2122 tests / 12749 assertions 全綠**

（部署端 `deploy.sh` 已有 `composer install --optimize-autoloader`，合併後照常部署即會套用新版本。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
