### PR TITLE
chore(deps): 升級 nanoid 3.3.16 → 3.3.18（修 Dependabot #417）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4093,9 +4093,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 警報

| # | 嚴重度 | GHSA | 內容 |
|---|---|---|---|
| 417 | high | GHSA-2v37-7h3g-55p8 | nanoid 的 custom generator 在 `size` 為 0 時會無限迴圈 |

修補版本 **3.3.18**。這是繼 #1244（league/commonmark）之後 Dependabot 剩下的唯一開啟中警報。

## 為什麼要手動處理

`nanoid` 是 **postcss 的傳遞依賴**（`postcss requires nanoid ^3.3.16`），不在 `package.json` 的 dependencies 裡，Dependabot 無法自動改鍵開 PR。用 `npm update nanoid --package-lock-only` 在既有 semver 範圍內做最小升級。

## 變更範圍

只動 `package-lock.json` 的 3 行（version / resolved / integrity），`package.json` 不動，其他套件不牽動。

## 剩餘的 npm audit 項目（本 PR 不處理）

`npm audit` 還有 3 個 moderate —— bootstrap 3.4.1（x2，來自 `bootstrap-switch`）與 summernote，都是 `admin-lte` 的**未使用**傳遞依賴，對應 Dependabot #345–#347 已由維護者以 `not_used` 關閉；修法需升到 `admin-lte@4.x`（breaking change），應另案評估。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
