### PR TITLE
修正操作紀錄「查閱」複合主鍵代碼表時顯示「找不到該筆資料」

### DIFF
--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -2598,23 +2598,49 @@ class CodesController extends Controller {
      * 值為字面 'NULL'（buildStoredResourceId 對 null 的編碼）同樣放棄：主鍵欄不可為 null，而
      * MySQL 拿字串 'NULL' 比對 int 欄會轉成 0、可能誤中 id 為 0 的列。
      *
-     * 已知未涵蓋（皆刻意）：
-     *  - 值為空字串的主鍵欄。BIOG_SOURCE_DATA.c_pages 等字串主鍵確實存在「空字串」的資料慣例，
-     *    但空字串比對 int 欄同樣會被 MySQL 轉成 0，在此無法只憑 id 分辨兩者。
+     * 只在「不可能有第二種讀法」的形狀下啟用，因為 $id 是**已被 URL 解碼**的 path 參數：
+     * buildStoredResourceId 用 http_build_query 編碼過的 '&'／'=' 在這裡已還原成字面字元，
+     * 於是「值裡含 &」與「多個參數」在字串層面無法分辨。若照收，一筆 c_alt_name_chn 值為
+     * `A&c_notes=x` 的資料，其 id 會被讀成 c_alt_name_chn='A' 外加一個 c_notes 參數，
+     * 進而開到（並存到）**別人那一列**——正是本函式想避免的後果。故四道限制：
+     *  1. 只有複合主鍵（單主鍵見下方說明）。
+     *  2. 分隔符數量必須恰好對得上主鍵欄數：'&' 有 n-1 個、'=' 有 n 個。這條專門擋
+     *     parse_str 的「同名參數後者覆蓋前者」——注入一組 `&已存在的欄名=數字` 不會讓欄位**數**變多
+     *     （只是把值換掉），單靠比對欄位集合抓不到。
+     *  3. 解析出的欄位必須**恰好**是主鍵欄集合，多一個、少一個都不行。
+     *  4. 整串 id 不得含 '%'。parse_str 會再解一次碼，等於在 route 解碼之後多一層：字面值為
+     *     `%39` 的資料會被存成 `%2539`、解碼成 `%39`、再被 parse_str 解成 `9`，於是通過其餘檢查
+     *     卻指向另一列。純數字主鍵的正規 id 本來就不含 '%'，直接整串拒絕最乾脆。
+     *  5. 每個值必須是純數字（`\A\d+\z`；刻意不收負號與尾端換行）。數字值不可能含
+     *     '&'、'='、'+'、'%'，也不會觸發下游 `edit()` 的「'-' 舊分隔符」相容回退。
+     * 五條同時成立時，「值裡藏分隔符／藏編碼」的第二種讀法必然會在其中一關被擋下。
+     *
+     * 已知未涵蓋（皆刻意，行為與修改前相同＝查不到，不會誤開別列）：
+     *  - 主鍵含**文字欄**的表（OFFICE_CODE_TYPE_REL.c_office_tree_id 這類代碼樹 id，以及
+     *    ALTNAME_DATA.c_alt_name_chn、ASSOC_DATA.c_text_title、BIOG_SOURCE_DATA.c_pages 等）。
+     *    這些表的查閱連結維持既有行為（查不到），不是本次修正造成的；要一併支援，得改成解析
+     *    「尚未解碼」的原始 path 片段（route 參數到手時已解過一次碼），另案處理。
+     *  - 值為空字串或字面 'NULL' 的主鍵欄（空字串／'NULL' 比對 int 欄會被 MySQL 轉成 0，
+     *    可能誤中 id 為 0 的列）。限制 3 已一併涵蓋。
+     *  - 帶多餘欄位的 id（部分匯入路徑會把整個 payload 當 pk 存）。限制 2 一併排除。
      *  - **單一主鍵的表**。單主鍵的 query-string id 早就由
      *    CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute() 在產生連結時就抽成純值，
      *    這裡不需要再兜一次；而若在這裡也接受，`c_textid=a=b` 這種「值本身以 `欄名=` 開頭」的
-     *    舊 id 就會從『查值為 c_textid=a=b 的列』改成『查值為 a=b 的列』——同一個字串有兩種讀法，
-     *    且沒有任何線索能分辨哪個才是原意。只在複合主鍵時啟用，該歧義就不存在
-     *    （複合主鍵要湊出誤判，得讓多個欄名同時以 `欄名=` 形式出現在值裡）。
+     *    舊 id 就會從『查值為 c_textid=a=b 的列』改成『查值為 a=b 的列』。
      */
     protected function buildNamedConditionsFromId(array $keyColumns, string $id): ?array {
-        if (count($keyColumns) < 2 || !str_contains($id, '=') || str_contains($id, '_._')) {
+        $arity = count($keyColumns);
+        if ($arity < 2 || str_contains($id, '_._') || str_contains($id, '%')) {
+            return null;
+        }
+
+        // 分隔符數量須與欄數完全相符（擋 parse_str 的同名參數覆蓋，見 docblock 第 2 條）。
+        if (substr_count($id, '&') !== $arity - 1 || substr_count($id, '=') !== $arity) {
             return null;
         }
 
         parse_str($id, $parsed);
-        if (!is_array($parsed) || $parsed === []) {
+        if (!is_array($parsed) || count($parsed) !== $arity || array_diff(array_keys($parsed), $keyColumns) !== []) {
             return null;
         }
 
@@ -2624,7 +2650,7 @@ class CodesController extends Controller {
                 return null;
             }
             $value = $parsed[$column];
-            if (!is_scalar($value) || $value === '' || $value === 'NULL') {
+            if (!is_scalar($value) || !preg_match('/\A\d+\z/', (string) $value)) {
                 return null;
             }
             $conditions[$column] = (string) $value;

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -1325,6 +1325,19 @@ class CodesController extends Controller {
         $keyColumns = $this->getKeyColumns($table);
         $conditions = $this->buildConditionsFromId($keyColumns, $id);
         $originalRow = $this->fetchRowByKeys($table, $keyColumns, $conditions);
+        // 找不到目標列就停手（提案路徑 performProposalUpdate 早就這麼做，直接寫入這條漏了）。
+        // 兩個實際擋掉的後果：
+        //  1. $conditions 為空時（getKeyColumns 找不到主鍵），下面的 $query 沒有任何 where，
+        //     `update()` 會覆寫**整張表**。
+        //  2. 目標列不存在時，原本仍會照樣 flash「更新成功」並寫一筆 update 的 operations 記錄，
+        //     等於憑空造出一筆沒有對應資料的稽核歷史。
+        // 注意這道門擋不住「字串被 MySQL 轉成 0 而誤中 id=0 的列」：fetchRowByKeys 用的是同一組
+        // 條件，該情境下 SELECT 會同樣命中那一列。要關掉那個洞得對 int 主鍵欄另加數字形狀檢查。
+        if (!$originalRow) {
+            flash('更新失敗：找不到對應的資料列。', 'error');
+
+            return redirect()->back()->withInput();
+        }
 
         $query = DB::table($table);
         foreach ($conditions as $column => $value) {
@@ -2556,12 +2569,65 @@ class CodesController extends Controller {
     }
 
     protected function buildConditionsFromId(array $keyColumns, string $id): array {
+        // 先試「具名」格式：mutation handler 一律把 resource_id 存成 query-string
+        // （CompositePrimaryKey::buildStoredResourceId，如 c_personid=108625&c_merged_from_personid=404794），
+        // 而操作紀錄的「查閱」連結會把它原樣塞進 codes 編輯頁的 path。只認 '_._' 的話整段字串會被
+        // 當成第一個主鍵欄的值，於是複合主鍵的代碼表一點查閱就是「找不到該筆資料」。
+        // 具名比對同時免除欄序假設（SCHEMAS 欄序與資料庫 PK 欄序不必然一致）。
+        $named = $this->buildNamedConditionsFromId($keyColumns, $id);
+        if ($named !== null) {
+            return $named;
+        }
+
         $conditions = [];
         $parts = explode('_._', $id);
         foreach ($keyColumns as $index => $column) {
             if (isset($parts[$index]) && $parts[$index] !== '') {
                 $conditions[$column] = $parts[$index];
             }
+        }
+
+        return $conditions;
+    }
+
+    /**
+     * 把 query-string 格式的 path id 解析成「欄名 => 值」條件；不是該格式時回 null（交回舊解析）。
+     *
+     * 刻意全有全無：只要有任一主鍵欄缺失或值不是純量，就整個放棄。用殘缺條件查詢會撈到同前綴的
+     * 其他資料列（例如少了第二段主鍵時 first() 會回傳「剛好第一欄相同」的另一列），那比查不到更糟。
+     * 值為字面 'NULL'（buildStoredResourceId 對 null 的編碼）同樣放棄：主鍵欄不可為 null，而
+     * MySQL 拿字串 'NULL' 比對 int 欄會轉成 0、可能誤中 id 為 0 的列。
+     *
+     * 已知未涵蓋（皆刻意）：
+     *  - 值為空字串的主鍵欄。BIOG_SOURCE_DATA.c_pages 等字串主鍵確實存在「空字串」的資料慣例，
+     *    但空字串比對 int 欄同樣會被 MySQL 轉成 0，在此無法只憑 id 分辨兩者。
+     *  - **單一主鍵的表**。單主鍵的 query-string id 早就由
+     *    CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute() 在產生連結時就抽成純值，
+     *    這裡不需要再兜一次；而若在這裡也接受，`c_textid=a=b` 這種「值本身以 `欄名=` 開頭」的
+     *    舊 id 就會從『查值為 c_textid=a=b 的列』改成『查值為 a=b 的列』——同一個字串有兩種讀法，
+     *    且沒有任何線索能分辨哪個才是原意。只在複合主鍵時啟用，該歧義就不存在
+     *    （複合主鍵要湊出誤判，得讓多個欄名同時以 `欄名=` 形式出現在值裡）。
+     */
+    protected function buildNamedConditionsFromId(array $keyColumns, string $id): ?array {
+        if (count($keyColumns) < 2 || !str_contains($id, '=') || str_contains($id, '_._')) {
+            return null;
+        }
+
+        parse_str($id, $parsed);
+        if (!is_array($parsed) || $parsed === []) {
+            return null;
+        }
+
+        $conditions = [];
+        foreach ($keyColumns as $column) {
+            if (!array_key_exists($column, $parsed)) {
+                return null;
+            }
+            $value = $parsed[$column];
+            if (!is_scalar($value) || $value === '' || $value === 'NULL') {
+                return null;
+            }
+            $conditions[$column] = (string) $value;
         }
 
         return $conditions;

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -796,7 +796,8 @@ class OperationsController extends Controller {
             $resourceLink = $resourceSpecificLink;
         } elseif ($isCodeResource && $opType !== 4) {
             $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($resourceName, $rawResourceId);
-            $resourceLink = route('codes.edit', ['table_name' => $resourceName, 'id' => $codeRouteId], false);
+            // flag-aware：codes flag=new 時開 React 版編輯頁，不要從 React 操作紀錄掉回舊 Blade 頁。
+            $resourceLink = code_table_edit_url($resourceName, $codeRouteId);
         }
 
         // 每位受影響人物附上編輯連結與資源描述。

--- a/app/Support/CompositePrimaryKey.php
+++ b/app/Support/CompositePrimaryKey.php
@@ -725,6 +725,11 @@ class CompositePrimaryKey {
      * 某些全域代碼表歷史上曾把單主鍵也存成 query-string 格式
      * （如 c_nianhao_id=464）。codes.edit 需要的是純 path segment，
      * 因此這裡在可安全判定為單一主鍵時抽出其值，其餘情況保持原值。
+     *
+     * 複合主鍵**刻意**原樣傳出，由 CodesController::buildConditionsFromId() 以欄名解析。
+     * 不要改成在這裡重組 '_._' 位置式 id：SCHEMAS 的欄序與資料庫 PRIMARY KEY 欄序在
+     * ALTNAME_DATA、ASSOC_DATA、KIN_DATA 等表並不一致，重組會靜默查到錯誤的資料列；
+     * '_._' 也無法表達「空字串主鍵值」（buildCompositeId 會把空段濾掉）。
      */
     public static function normalizeSingleKeyResourceIdForCodeRoute(string $resource, string $resourceId): string {
         $pk = self::parseStoredResourceId($resourceId, $resource);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -127,6 +127,24 @@ if (!function_exists('person_page_url')) {
     }
 }
 
+if (!function_exists('code_table_edit_url')) {
+    /**
+     * 代碼表編輯頁 flag-aware URL：codes flag=new 時導向 React /app 版，否則 legacy Blade。
+     *
+     * 操作紀錄的「查閱」連結原本寫死 route('codes.edit')，於是 flag 已是 new、整站都在 React
+     * 介面的情況下，從 /app/operations 點查閱會掉回舊 Blade 編輯頁（外觀與導覽都不同）。
+     *
+     * @param string     $table 代碼表名
+     * @param int|string $id    codes 編輯頁的 path id（單值、'_._' 複合鍵，或 operations 存的
+     *                          query-string 格式；後者由 CodesController::buildConditionsFromId 解析）
+     */
+    function code_table_edit_url(string $table, $id): string {
+        return (migration_flag_is_new('codes') && \Illuminate\Support\Facades\Route::has('app.codes.edit'))
+            ? route('app.codes.edit', ['table_name' => $table, 'id' => $id], false)
+            : route('codes.edit', ['table_name' => $table, 'id' => $id], false);
+    }
+}
+
 if (!function_exists('person_create_url')) {
     /** 新增人物頁 flag-aware URL：編輯器 flag=new 時導向 React 建立頁，否則 legacy。 */
     function person_create_url(): string {

--- a/resources/views/operations/index.blade.php
+++ b/resources/views/operations/index.blade.php
@@ -200,7 +200,9 @@ $item->resource_data = unionPKDef($item->resource_data);
                                 // 对于代码表资源（无论是否涉及人物），如果没有特定资源链接，则使用 codes 路由
                                 elseif ($isCodeResource && $item->op_type != 4) {
                                     $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($item->resource, $originalResourceId);
-                                    $resourceLink = route('codes.edit', ['table_name' => $item->resource, 'id' => $codeRouteId], false);
+                                    // flag-aware（與上方 person_page_url／buildResourceEditUrl 一致）：
+                                    // 同一段程式碼把人物子資源送去 React 編輯器，代碼表卻寫死舊 Blade 頁並不一致。
+                                    $resourceLink = code_table_edit_url($item->resource, $codeRouteId);
                                 }
                                 $showPerPersonResourceButtons = in_array(strtoupper($item->resource), ['KIN_DATA', 'ASSOC_DATA'], true) && $personRowspan > 1;
                             @endphp

--- a/tests/Feature/CodesPersonPickerTest.php
+++ b/tests/Feature/CodesPersonPickerTest.php
@@ -93,11 +93,19 @@ class CodesPersonPickerTest extends TestCase {
 
         // MERGED_PERSON_DATA：欄名叫 c_personid 但**沒有外鍵**（被合併的人可能已不存在）。
         // 依規則 B 刻意不給選擇器。
+        // 主鍵照實建成 (c_personid, c_merged_from_personid)：正式 schema 就是這兩欄
+        // （import_cbdb_schema + c_merged_to→from 改名），而 CodesController::getKeyColumns()
+        // 帶 process 級 static 快取，同名表在同一次 phpunit 程序內只會反射一次——這裡若簡化成
+        // 單主鍵，會把錯的主鍵形狀留給後面跑到同名表的測試類。
         Schema::create('MERGED_PERSON_DATA', function ($table) {
-            $table->integer('c_personid')->primary();
+            $table->integer('c_personid');
+            $table->integer('c_merged_from_personid')->default(0);
             $table->string('c_note')->nullable();
+            $table->primary(['c_personid', 'c_merged_from_personid']);
         });
-        DB::table('MERGED_PERSON_DATA')->insert(['c_personid' => 11, 'c_note' => 'merged']);
+        DB::table('MERGED_PERSON_DATA')->insert([
+            'c_personid' => 11, 'c_merged_from_personid' => 404794, 'c_note' => 'merged',
+        ]);
 
         Schema::create('TEST_PLAIN_CODES', function ($table) {
             $table->integer('code_id')->primary();

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -116,6 +116,9 @@ class OperationsIndexLinksTest extends TestCase {
 
     #[Test]
     public function test_operations_index_generates_links_for_non_person_code_resources() {
+        // 連結形狀依 codes flag 而定，明確釘住，別讓別人翻 flag 就變紅。
+        config(['migration_flags.pages.codes' => 'new']);
+
         // 创建测试用戶
         $user = User::forceCreate([
             'name' => 'Test User',
@@ -143,8 +146,10 @@ class OperationsIndexLinksTest extends TestCase {
 
         $response->assertStatus(200);
 
-        // 验证页面包含正确的链接
-        $response->assertSee('/codes/TEXT_CODES/68942/edit', false);
+        // 验证页面包含正确的链接。codes flag=new → 連 React 版（含 /app 前綴）；
+        // 只斷言 '/codes/...' 會同時被 '/app/codes/...' 命中，等於什麼都沒釘住，故寫全並排除舊路徑。
+        $response->assertSee('href="/app/codes/TEXT_CODES/68942/edit"', false);
+        $response->assertDontSee('href="/codes/TEXT_CODES/68942/edit"', false);
         $response->assertSee('查閱');
         $response->assertDontSee('>68942</a>', false);
         $response->assertSee('overflow-wrap: anywhere;', false);
@@ -171,13 +176,25 @@ class OperationsIndexLinksTest extends TestCase {
 
         $this->assertTrue($isCodeResource);
 
-        // 验证可以生成正确的路由
-        $expectedLink = route('codes.edit', ['table_name' => $resource, 'id' => $resourceId], false);
-        $this->assertEquals('/codes/OFFICE_CODES/803819/edit', $expectedLink);
+        // 验证可以生成正确的路由。React 操作紀錄實際用的是 flag-aware 的 code_table_edit_url()，
+        // 這裡兩個方向都釘住，避免這條測試繼續斷言與production相反的東西。
+        config(['migration_flags.pages.codes' => 'new']);
+        $this->assertEquals(
+            '/app/codes/OFFICE_CODES/803819/edit',
+            code_table_edit_url($resource, $resourceId)
+        );
+
+        config(['migration_flags.pages.codes' => 'old']);
+        $this->assertEquals(
+            '/codes/OFFICE_CODES/803819/edit',
+            code_table_edit_url($resource, $resourceId)
+        );
     }
 
     #[Test]
     public function test_operations_index_normalizes_single_key_query_string_resource_id_for_code_links(): void {
+        config(['migration_flags.pages.codes' => 'new']);
+
         $user = User::forceCreate([
             'name' => 'Test User',
             'email' => 'nianhao-link@example.com',
@@ -206,7 +223,7 @@ class OperationsIndexLinksTest extends TestCase {
         $response = $this->actingAs($user)->get('/operations');
 
         $response->assertStatus(200);
-        $response->assertSee('/codes/NIAN_HAO/464/edit', false);
+        $response->assertSee('href="/app/codes/NIAN_HAO/464/edit"', false);
         $response->assertDontSee('/codes/NIAN_HAO/c_nianhao_id=464/edit', false);
     }
 
@@ -221,6 +238,10 @@ class OperationsIndexLinksTest extends TestCase {
      */
     #[Test]
     public function test_composite_key_code_resource_view_link_actually_opens_the_row(): void {
+        // 明確釘住 flag：codes flag 本來就可被翻回 old（即時回退、不需改碼），
+        // 若靠預設值，別人一翻 flag 這條就變紅，而且連 id 解析的保證也一起失效。
+        config(['migration_flags.pages.codes' => 'new']);
+
         $user = User::forceCreate([
             'name' => 'Hongsu Wang',
             'email' => 'merged-person-link@example.com',
@@ -260,13 +281,66 @@ class OperationsIndexLinksTest extends TestCase {
             });
 
         // 連結本身就是 bug 的一半：resource_id 原樣進了 path（單主鍵才會被正規化）。
+        // 且 codes flag=new，連結要指向 React 版編輯頁，不該從 React 操作紀錄掉回舊 Blade 頁。
         $this->assertSame(
-            '/codes/MERGED_PERSON_DATA/c_personid=108625&c_merged_from_personid=404794/edit',
+            '/app/codes/MERGED_PERSON_DATA/c_personid=108625&c_merged_from_personid=404794/edit',
             $link
         );
 
         // 另一半：那個 path id 必須真的能開出對應的列，而不是被重導回上一頁並
         // flash「找不到該筆資料」。同時確認用上了第二段主鍵（開出 404794、不是 500001）。
+        $this->actingAs($user)->get($link)
+            ->assertOk()
+            ->assertSessionMissing('flash_notification')
+            ->assertInertia(fn ($page) => $page
+                ->component('Codes/Edit')
+                ->where('values.c_personid', 108625)
+                ->where('values.c_merged_from_personid', 404794));
+    }
+
+    #[Test]
+    public function test_code_resource_view_link_falls_back_to_blade_when_codes_flag_is_old(): void {
+        // codes flag 翻回 old 時，查閱連結要跟著回到 Blade 編輯頁（否則回退不完整）。
+        config(['migration_flags.pages.codes' => 'old']);
+
+        $user = User::forceCreate([
+            'name' => 'Hongsu Wang',
+            'email' => 'merged-person-oldflag@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_CREATE,
+            'resource' => 'MERGED_PERSON_DATA',
+            'resource_id' => 'c_personid=108625&c_merged_from_personid=404794',
+            'resource_data' => json_encode(['c_personid' => 108625]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        \DB::table('MERGED_PERSON_DATA')->insert([
+            ['c_personid' => 108625, 'c_merged_from_personid' => 500001],
+            ['c_personid' => 108625, 'c_merged_from_personid' => 404794],
+        ]);
+
+        $link = null;
+        $this->actingAs($user)
+            ->get('/app/operations')
+            ->assertOk()
+            ->assertInertia(function ($page) use (&$link) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+            });
+
+        $this->assertSame(
+            '/codes/MERGED_PERSON_DATA/c_personid=108625&c_merged_from_personid=404794/edit',
+            $link
+        );
+
+        // id 解析的保證與 flag 無關：Blade 版編輯頁同樣要開出 404794 那一列（不是 500001）。
         $this->actingAs($user)->get($link)
             ->assertOk()
             ->assertSessionMissing('flash_notification')

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -69,6 +69,17 @@ class OperationsIndexLinksTest extends TestCase {
             $table->string('c_nianhao_chn')->nullable();
         });
 
+        // 複合主鍵的代碼表：resource_id 以 query-string 格式儲存，而 codes 編輯頁的 path id
+        // 只認 '_._'。用來釘住「操作紀錄的查閱連結必須真的打得開」。
+        Schema::create('MERGED_PERSON_DATA', function ($table) {
+            $table->integer('c_personid');
+            $table->integer('c_merged_from_personid');
+            $table->text('c_notes')->nullable();
+            $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->primary(['c_personid', 'c_merged_from_personid']);
+        });
+
         Schema::create('KIN_DATA', function ($table) {
             $table->integer('c_personid');
             $table->integer('c_kin_id');
@@ -197,6 +208,70 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertStatus(200);
         $response->assertSee('/codes/NIAN_HAO/464/edit', false);
         $response->assertDontSee('/codes/NIAN_HAO/c_nianhao_id=464/edit', false);
+    }
+
+    /**
+     * 複合主鍵代碼表（MERGED_PERSON_DATA）的查閱連結必須真的打得開。
+     *
+     * mutation handler 一律把 resource_id 存成 query-string 格式
+     * （c_personid=108625&c_merged_from_personid=404794，見 CompositePrimaryKey::buildStoredResourceId），
+     * 而 codes 編輯頁的 path id 歷來只認 '_._'。單主鍵的表已有
+     * normalizeSingleKeyResourceIdForCodeRoute() 兜住，複合主鍵則整段字串被當成第一個主鍵欄的值，
+     * 於是點「查閱」只會得到「找不到該筆資料」。
+     */
+    #[Test]
+    public function test_composite_key_code_resource_view_link_actually_opens_the_row(): void {
+        $user = User::forceCreate([
+            'name' => 'Hongsu Wang',
+            'email' => 'merged-person-link@example.com',
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => 1,
+        ]);
+
+        \DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 108625, 'c_name_chn' => '曾源友', 'c_name' => 'Zeng Yuanyou',
+        ]);
+        // 兩列共用同一個 c_personid，且「不是目標」的那一列先插入：只有真的用上第二段主鍵才會
+        // 開出 404794。否則（例如只以 c_personid 查詢）會撈到 500001，測試就會當場失敗而不是
+        // 靜默地變成一個什麼都沒驗到的 200。
+        \DB::table('MERGED_PERSON_DATA')->insert([
+            ['c_personid' => 108625, 'c_merged_from_personid' => 500001],
+            ['c_personid' => 108625, 'c_merged_from_personid' => 404794],
+        ]);
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 108625,
+            'op_type' => Operation::TYPE_CREATE,
+            'resource' => 'MERGED_PERSON_DATA',
+            'resource_id' => 'c_personid=108625&c_merged_from_personid=404794',
+            'resource_data' => json_encode(['c_personid' => 108625, 'c_merged_from_personid' => 404794]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $link = null;
+        $this->actingAs($user)
+            ->get('/app/operations')
+            ->assertOk()
+            ->assertInertia(function ($page) use (&$link) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+            });
+
+        // 連結本身就是 bug 的一半：resource_id 原樣進了 path（單主鍵才會被正規化）。
+        $this->assertSame(
+            '/codes/MERGED_PERSON_DATA/c_personid=108625&c_merged_from_personid=404794/edit',
+            $link
+        );
+
+        // 另一半：那個 path id 必須真的能開出對應的列，而不是被重導回上一頁並
+        // flash「找不到該筆資料」。同時確認用上了第二段主鍵（開出 404794、不是 500001）。
+        $this->actingAs($user)->get($link)
+            ->assertOk()
+            ->assertSessionMissing('flash_notification')
+            ->assertSee('404794')
+            ->assertDontSee('500001');
     }
 
     #[Test]

--- a/tests/Unit/CodesControllerConditionsFromIdTest.php
+++ b/tests/Unit/CodesControllerConditionsFromIdTest.php
@@ -122,15 +122,85 @@ class CodesControllerConditionsFromIdTest extends TestCase {
     }
 
     #[Test]
-    public function testUnknownExtraColumnsAreIgnored(): void {
-        // 有些寫入路徑會把整個 payload 當 pk 傳（如 OFFICE_CODE_TYPE_REL 的匯入），
-        // 多出來的欄位不該讓解析失敗，也不該進 WHERE。
+    public function testExtraColumnsMakeTheIdAmbiguousAndAreRejected(): void {
+        // 多出來的欄位可能是「值裡的 & 被 URL 解碼後擠出來的假參數」（見下一個測試），
+        // 字串層面分不出兩者，故一律不採用具名解析。
+        $id = 'c_personid=108625&c_merged_from_personid=404794&c_notes=x';
         $this->assertSame(
-            ['c_personid' => '108625', 'c_merged_from_personid' => '404794'],
-            $this->invoke(
-                ['c_personid', 'c_merged_from_personid'],
-                'c_personid=108625&c_merged_from_personid=404794&c_notes=x'
-            )
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
+        );
+    }
+
+    #[Test]
+    public function testValueContainingAnAmpersandCannotHijackAnotherRow(): void {
+        // 這是解碼後的樣子：某列 c_alt_name_chn 的值字面上是 `A&c_alt_name_type_code=99`。
+        // 若照收，會被讀成 c_alt_name_chn='A' + type_code=99，於是開到（並存到）別人那一列。
+        // 期望：拒絕具名解析 → 退回舊行為（查不到），而不是誤開別列。
+        $id = 'c_personid=7&c_alt_name_chn=A&c_alt_name_type_code=99';
+        $conditions = $this->invoke(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'], $id);
+        $this->assertSame(['c_personid' => $id], $conditions);
+    }
+
+    #[Test]
+    public function testNonIntegerValuesAreRejected(): void {
+        // 文字主鍵欄不在支援範圍：文字值可能含 '&'、'='、'+'、'%'，解碼後就無法回推原意。
+        $id = 'c_textid=68942&c_pages=12-15';
+        $this->assertSame(
+            ['c_textid' => $id],
+            $this->invoke(['c_textid', 'c_pages'], $id)
+        );
+
+        // OFFICE_CODE_TYPE_REL 的 c_office_tree_id 是文字代碼樹 id（如 'x01'）→ 同樣維持既有行為。
+        // 這條釘住「已知未涵蓋」而非期望行為，改動支援範圍時應一併更新（見函式 docblock）。
+        $treeId = 'c_office_id=101&c_office_tree_id=x01';
+        $this->assertSame(
+            ['c_office_id' => $treeId],
+            $this->invoke(['c_office_id', 'c_office_tree_id'], $treeId)
+        );
+    }
+
+    #[Test]
+    public function testInjectedDuplicateKeyCannotOverrideAValue(): void {
+        // parse_str 同名參數後者覆蓋前者，所以注入一組「已存在的欄名=數字」不會讓欄位**數**變多，
+        // 單靠比對欄位集合抓不到；分隔符數量檢查才擋得住。
+        // 這串是某列 c_alt_name_chn 值字面為 `5&c_alt_name_type_code=9` 時解碼後的樣子。
+        $id = 'c_personid=7&c_alt_name_chn=5&c_alt_name_type_code=9&c_alt_name_type_code=4';
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'], $id)
+        );
+    }
+
+    #[Test]
+    public function testNegativeValuesAreRejected(): void {
+        // 不收負號：值裡帶 '-' 會讓 edit() 的「'-' 舊分隔符」相容回退在查不到時再切一次，
+        // 切出來的碎片經 MySQL 型別轉換又可能命中別的列。CBDB 的複合主鍵欄實務上沒有負值。
+        $id = 'c_personid=-1&c_merged_from_personid=404794';
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
+        );
+    }
+
+    #[Test]
+    public function testPercentEncodedValueCannotSlipThroughTheDigitCheck(): void {
+        // parse_str 會再解一次碼：字面值為 '%39' 的資料存成 '%2539'、route 解碼成 '%39'，
+        // 若照收會被 parse_str 解成 '9' → 通過數字檢查卻指向另一列。含 '%' 一律拒絕。
+        $id = 'c_personid=108625&c_merged_from_personid=%39';
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
+        );
+    }
+
+    #[Test]
+    public function testTrailingNewlineIsRejected(): void {
+        // '$' 會放過尾端換行，故用 \z 收尾。
+        $id = "c_personid=108625\n&c_merged_from_personid=404794";
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
         );
     }
 

--- a/tests/Unit/CodesControllerConditionsFromIdTest.php
+++ b/tests/Unit/CodesControllerConditionsFromIdTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\CodesController;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 單元測試：CodesController::buildConditionsFromId()。
+ *
+ * codes 編輯頁的 path id 有兩種來源格式：
+ *  - '_._' 分隔（CodesController::buildCompositeId 自己產生的）
+ *  - query-string（mutation handler 存進 operations.resource_id 的標準格式，見
+ *    CompositePrimaryKey::buildStoredResourceId；操作紀錄的「查閱」連結原樣塞進 path）
+ *
+ * 這裡直接驗解析函式而非走 HTTP：getKeyColumns() 帶 process 級 static 快取，
+ * 同一次 phpunit 程序內先跑過的測試類若建了同名但不同主鍵的表，會讓 HTTP 層的期望隨執行順序改變。
+ */
+class CodesControllerConditionsFromIdTest extends TestCase {
+    private function invoke(array $keyColumns, string $id): array {
+        $controller = $this->app->make(CodesController::class);
+        $method = new \ReflectionMethod(CodesController::class, 'buildConditionsFromId');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $keyColumns, $id);
+    }
+
+    #[Test]
+    public function testQueryStringIdIsParsedByColumnName(): void {
+        // 這就是操作紀錄「查閱」連結帶進來的格式（MERGED_PERSON_DATA 的 create 記錄）。
+        $this->assertSame(
+            ['c_personid' => '108625', 'c_merged_from_personid' => '404794'],
+            $this->invoke(
+                ['c_personid', 'c_merged_from_personid'],
+                'c_personid=108625&c_merged_from_personid=404794'
+            )
+        );
+    }
+
+    #[Test]
+    public function testQueryStringIdIgnoresColumnOrderInTheString(): void {
+        // 具名比對 → 字串內欄序與資料庫主鍵欄序不必一致（SCHEMAS 與 PK 欄序不保證相同）。
+        $this->assertSame(
+            ['c_personid' => '108625', 'c_merged_from_personid' => '404794'],
+            $this->invoke(
+                ['c_personid', 'c_merged_from_personid'],
+                'c_merged_from_personid=404794&c_personid=108625'
+            )
+        );
+    }
+
+    #[Test]
+    public function testSingleKeyQueryStringIdIsLeftToTheUpstreamNormalizer(): void {
+        // 單主鍵刻意不在此解析：連結產生時 normalizeSingleKeyResourceIdForCodeRoute() 已抽成 '464'。
+        // 若這裡也接受，值本身以「欄名=」開頭的舊 id 會被改讀成另一個值（見 docblock）。
+        $this->assertSame(
+            ['c_nianhao_id' => 'c_nianhao_id=464'],
+            $this->invoke(['c_nianhao_id'], 'c_nianhao_id=464')
+        );
+    }
+
+    #[Test]
+    public function testSingleKeyValueThatLooksLikeANamedPairIsNotReinterpreted(): void {
+        // c_textid 的值字面上就是 'c_textid=a=b' 時，仍查那個字面值，不可改查 'a=b'（會開到別的列）。
+        $this->assertSame(
+            ['c_textid' => 'c_textid=a=b'],
+            $this->invoke(['c_textid'], 'c_textid=a=b')
+        );
+    }
+
+    #[Test]
+    public function testIncompleteQueryStringIdIsNotParsedIntoPartialConditions(): void {
+        // 全有全無：殘缺條件會讓 first() 撈到「剛好第一段主鍵相同」的另一列，
+        // 把使用者送去編輯錯誤的資料——比查不到更糟。故退回舊解析（整串當第一欄的值 → 查不到）。
+        $this->assertSame(
+            ['c_personid' => 'c_personid=108625'],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], 'c_personid=108625')
+        );
+    }
+
+    #[Test]
+    public function testNullSentinelIsNotParsed(): void {
+        // buildStoredResourceId 把 null 編成字面 'NULL'。主鍵欄不可為 null，而 MySQL 拿 'NULL'
+        // 比對 int 欄會轉成 0、可能誤中 id 為 0 的列，故不採用具名解析。
+        $conditions = $this->invoke(['c_personid', 'c_merged_from_personid'], 'c_personid=108625&c_merged_from_personid=NULL');
+        $this->assertSame(['c_personid' => 'c_personid=108625&c_merged_from_personid=NULL'], $conditions);
+    }
+
+    #[Test]
+    public function testNonScalarValueIsNotParsed(): void {
+        // parse_str 會把 c_personid[]=1 變成陣列；拿陣列去組 WHERE 會炸或撈到非預期結果。
+        $id = 'c_personid[]=108625&c_merged_from_personid=404794';
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
+        );
+    }
+
+    #[Test]
+    public function testEmptyValueIsNotParsed(): void {
+        // 空字串主鍵值刻意不支援（見 buildNamedConditionsFromId 的 docblock）：
+        // 空字串比對 int 欄會被 MySQL 轉成 0，光憑 id 分不出「真的是空字串」還是「缺值」。
+        $id = 'c_personid=108625&c_merged_from_personid=';
+        $this->assertSame(
+            ['c_personid' => $id],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], $id)
+        );
+    }
+
+    #[Test]
+    public function testThreeKeyCodeTableIdIsParsed(): void {
+        // 同一類故障不只 MERGED_PERSON_DATA：TEXT_INSTANCE_DATA（3-key）也以 query-string 存 resource_id。
+        // 欄名取自 config/code_table_mutations.php 的 key_columns（＝資料庫 PRIMARY KEY）。
+        $this->assertSame(
+            ['c_textid' => '68942', 'c_text_edition_id' => '3', 'c_text_instance_id' => '1'],
+            $this->invoke(
+                ['c_textid', 'c_text_edition_id', 'c_text_instance_id'],
+                'c_textid=68942&c_text_edition_id=3&c_text_instance_id=1'
+            )
+        );
+    }
+
+    #[Test]
+    public function testUnknownExtraColumnsAreIgnored(): void {
+        // 有些寫入路徑會把整個 payload 當 pk 傳（如 OFFICE_CODE_TYPE_REL 的匯入），
+        // 多出來的欄位不該讓解析失敗，也不該進 WHERE。
+        $this->assertSame(
+            ['c_personid' => '108625', 'c_merged_from_personid' => '404794'],
+            $this->invoke(
+                ['c_personid', 'c_merged_from_personid'],
+                'c_personid=108625&c_merged_from_personid=404794&c_notes=x'
+            )
+        );
+    }
+
+    #[Test]
+    public function testLegacyUnderscoreSeparatedIdStillWorks(): void {
+        $this->assertSame(
+            ['c_personid' => '108625', 'c_merged_from_personid' => '404794'],
+            $this->invoke(['c_personid', 'c_merged_from_personid'], '108625_._404794')
+        );
+    }
+
+    #[Test]
+    public function testLegacyIdContainingEqualsSignIsNotMisreadAsQueryString(): void {
+        // 欄位值本身含 '=' 的舊格式 id：解析不出主鍵欄名 → 走舊路徑，行為與修改前一致。
+        $this->assertSame(
+            ['c_textid' => 'a=b', 'c_pages' => '12'],
+            $this->invoke(['c_textid', 'c_pages'], 'a=b_._12')
+        );
+    }
+
+    #[Test]
+    public function testPlainSingleValueIdStillWorks(): void {
+        $this->assertSame(['c_textid' => '68942'], $this->invoke(['c_textid'], '68942'));
+    }
+}


### PR DESCRIPTION
## 問題（已重現）

/app/operations 點 `MERGED_PERSON_DATA`（c_personid=108625、c_merged_from_personid=404794）
這類記錄的「查閱」，會被重導回上一頁並 flash「找不到該筆資料」。

成因是兩端對 path id 的格式不一致：

1. mutation handler 一律把 `resource_id` 存成 query-string 格式
   （`CompositePrimaryKey::buildStoredResourceId`，如 `c_personid=108625&c_merged_from_personid=404794`）。
2. `OperationsController` 把它原樣塞進 codes 編輯頁的 path id；**單**主鍵有
   `normalizeSingleKeyResourceIdForCodeRoute` 抽成純值，複合主鍵原樣傳出。
3. `CodesController::buildConditionsFromId()` 只切 `'_._'`，於是整串被當成第一個主鍵欄的值：
   `WHERE c_personid = 'c_personid=108625&...'` → 查不到。

## 修正

**環節 1：id 解析**
`buildConditionsFromId` 先試具名解析（`parse_str`，以欄名比對），失敗才回舊解析。
只在同時滿足下列五條時採用——因為 route 參數到手時**已解過一次碼**，
`buildStoredResourceId` 編碼過的 `&`／`=` 已還原成字面字元，「值裡含 &」與「多個參數」
在字串層面無法分辨，照收會開到（並存到）**別人那一列**：

1. 複合主鍵（單主鍵在產生連結時已正規化；若在此也接受，`c_textid=a=b` 這種舊 id 會有兩種讀法）
2. 不含 `_._`
3. 不含 `%`（`parse_str` 會再解一次碼，字面值 `%39` 會被解成 `9`）
4. 分隔符數量與欄數完全相符（`&` 為 n-1、`=` 為 n）——擋 `parse_str` 同名參數覆蓋，
   注入一組「已存在的欄名=值」不會讓欄位數變多，比對欄位集合抓不到
5. 每個值為純數字（`\A\d+\z`；不收負號與尾端換行）

另補 `performUpdate` 缺的「找不到資料列」前置檢查（提案路徑早就有）。實際擋掉兩件事：
主鍵反射不到時 `$conditions` 為空、`update()` 會覆寫整張表；以及目標列不存在時仍 flash
「更新成功」並寫一筆憑空的 operations 記錄。

**環節 2：連結 flag-aware**
查閱連結原本固定 `route('codes.edit')`，於是 codes flag 已是 new 時會從 React 操作紀錄
掉回舊 Blade 編輯頁。新增全域 helper `code_table_edit_url()`（與 `person_page_url()` 同風格），
React 與 Blade 兩邊都改用它——同一段程式碼本來就已用 flag-aware 的 `person_page_url()`／
`buildResourceEditUrl()` 把人物子資源送去 React 編輯器，代碼表卻寫死舊頁並不一致。

## 涵蓋範圍

修好：**整數複合主鍵**的代碼表（MERGED_PERSON_DATA、TEXT_INSTANCE_DATA 等）。

仍維持既有行為（查不到，非本次造成）：主鍵含**文字欄**的表，如
`OFFICE_CODE_TYPE_REL.c_office_tree_id`、`ALTNAME_DATA.c_alt_name_chn`。
要一併支援需改成解析尚未解碼的原始 path 片段，另案處理——已在 docblock 與測試中明文記錄。

## 測試

- `tests/Unit/CodesControllerConditionsFromIdTest.php`（新增，19 個案例）：正常解析、欄序無關、
  舊 `_._`／`-`／單值 id 不變、以及重複鍵注入／`%` 編碼／負值／尾端換行／文字鍵／多餘欄位的拒絕。
- `tests/Feature/OperationsIndexLinksTest.php`：端到端（/app/operations → 查閱 → React Codes/Edit
  開出正確那一列）＋ flag=old 回退到 Blade 且同樣開出正確那一列。刻意種入共用第一段主鍵的
  第二列，確保「沒真的用上第二段主鍵」會當場失敗而不是靜默通過。兩個方向都明確 config 釘住 flag。
- `tests/Feature/CodesPersonPickerTest.php`：`MERGED_PERSON_DATA` fixture 改為照實建兩欄主鍵
  （`getKeyColumns()` 有 process 級 static 快取，簡化的主鍵形狀會外洩給同程序後續測試類）。
- `phpunit --filter Codes|Operations|FlagAwareUrl|CompositePrimaryKey|Office` → 516 tests OK；
  `php-cs-fixer` 0 fixable。

## 已知、非本次造成（供後續）

- `codes.proposals.cancel`／`codes.proposals.edit` 在 React 操作紀錄仍指向 Blade 端點，
  撤回代碼表提案後會落在舊 `/operations`。
- `_._` 舊解析對複合主鍵仍可能只湊出部分條件；MariaDB 拿非數字字串比對 int 欄會轉成 0，
  可能命中 id=0 的列。與 develop 現狀相同。
- `MIGRATION_FLAG_CODES=old` 時 `CodesColumnBehaviourTest` 有 2 個失敗（hint 內寫死 `/app/codes/...`），
  已確認在 develop 上一模一樣，非本分支造成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)