### PR TITLE
C:/Program Files/Git/api/user 不再外洩 confirmation_token（#1248）

### DIFF
--- a/API.md
+++ b/API.md
@@ -1445,7 +1445,7 @@ Authorization: Bearer <token>
 
 | 方法 | 路徑 | 認證 | 說明 |
 | ------ | ------ | ------ | ------ |
-| GET | `/api/user` | Bearer（`auth:sanctum`） | 回傳目前 token 對應的使用者資料。追蹤提案時 `GET /api/v2/operations?editor=` 要用的就是這裡的 `id`。帳號未啟用時回 403 |
+| GET | `/api/user` | Bearer（`auth:sanctum`） | 回傳目前 token 對應的帳號資料（欄位見下）。追蹤提案時 `GET /api/v2/operations?editor=` 要用的就是這裡的 `id`。帳號未啟用時回 403 |
 | GET | `/api-tokens` | Session | 列出自己的 token（不含明文） |
 | POST | `/api-tokens` | Session | 簽發新 token。可帶 `name`（必填）、`abilities`（預設 `["mcp:read"]`，通配 `*` 已停用）、`expires_in`（1～3650 天，未帶＝永不過期）。**明文只在此回傳一次** |
 | DELETE | `/api-tokens/{tokenId}` | Session | 撤銷指定 token |
@@ -1453,7 +1453,35 @@ Authorization: Bearer <token>
 
 `/api-tokens` 系列掛在 `web` 群組且需要登入 session，**無法只憑既有 token 換發新 token**；請在網站個人資料頁操作。
 
-⚠️ **`/api/user` 回傳的是使用者資料列的全部欄位**（只隱藏 `password` 與 `remember_token`），因此除了 `id`／`name`／`email`／`is_admin`／`is_active` 之外，也包含 `institution`／`settings`／`avatar`／時間欄，**以及 `confirmation_token`**——那正是 14.3 舊通道使用的長期憑證。呼叫端請只取需要的欄位，不要把整包回應記錄到日誌或轉發給第三方。
+`GET /api/user` 回傳固定的白名單欄位：
+
+```json
+{
+  "id": 42,
+  "name": "王小明",
+  "email": "u@example.com",
+  "institution": "Harvard",
+  "avatar": "avatar0.png",
+  "is_admin": 0,
+  "is_active": 1,
+  "created_at": "2026-03-01T02:11:04.000000Z",
+  "updated_at": "2026-08-14T03:22:41.000000Z"
+}
+```
+
+| 屬性名 | 屬性類型 | 說明 |
+| ------ | ------ | ------ |
+| id | 數字 | 帳號 ID，即 `GET /api/v2/operations?editor=` 要用的值 |
+| name | 字串 | 顯示名稱（也是稽核欄 `c_created_by`／`c_modified_by` 會蓋的署名） |
+| email | 字串 | 帳號 email |
+| institution | 字串/null | 所屬機構 |
+| avatar | 字串 | 頭像檔名，資料庫預設 `avatar0.png`（NOT NULL，實務上不會是 null） |
+| is_admin | 數字 | 角色：0=一般、1=專家、2=眾包、3=系統管理員 |
+| is_active | 數字 | 帳號啟用狀態。此端點在帳號未啟用時直接回 403，因此**成功回應中恆為 `1`** |
+| created_at | 字串 | 建立時間（ISO 8601，UTC） |
+| updated_at | 字串 | 更新時間（ISO 8601，UTC） |
+
+**不回傳**任何憑證欄位（`password`、`remember_token`、`confirmation_token`），也不回傳使用者偏好 `settings`。若日後需要新欄位，請在 `Api\UserController::show()` 顯式加入並同步本節。
 
 **`POST /api/v1/user/login` 已無實際用途**：它是 OAuth 時代的遺留，帳密驗證通過後會轉發到早已不存在的 `oauth/token` 路由，因此最終回 **404**、拿不到任何憑證。要注意兩個副作用：它實際用的是 session guard（不是 token guard），所以在 session 有被啟動的情境下，**驗證成功會先留下一個已登入的 session cookie 再回 404**；且此路由掛「訪客專用」中間件（見舊版章節的說明）。要程式化存取請改用上表簽發的 Bearer token。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## 2026-08
 
+### `/api/user` 不再外洩 `confirmation_token`（#1248）
+- 起因：`Api\UserController@show` 是 `return $request->user()`，序列化範圍全靠 `User::$hidden` 的黑名單，而 `confirmation_token` 不在其中。它不是普通欄位，而是**第二套長期憑證**——`/api/operations/token` 直接把它當眾包 API token 發出去，`/api/operations/{add,update,delete}` 只憑它認證，且**無到期、無撤銷、不驗欄位白名單**。因此一個只被授予唯讀能力的 Sanctum token，可以換到一個能繞過 v2 全部白名單／主鍵校驗、直接往 `operations` 寫入的憑證：這是提權路徑，不只是欄位過度曝露。
+- 端點改為**顯式白名單**（id／name／email／institution／avatar／is_admin／is_active／時間欄），而不是繼續維護黑名單——根因是「`users` 加一欄就默默對外」，白名單才治得住。順帶不再回傳 `settings`，它內含 `registration_ip`／`last_login_ip`。
+- `User::$hidden` 補上 `confirmation_token` 作縱深防禦，擋住其他把模型整包序列化的路徑。`$hidden` 只影響序列化，屬性讀取不受影響，故 `/api/operations/token` 與 `resolveActiveUserByToken()` 不會壞（有測試反向鎖住）。
+- 另修兩處 `$hidden` **擋不到**的同類洞：`AiFillLogController::logUsers()` 與 `QueryPlaygroundController::nlQueryLogUsers()` 用 query builder 撈 `users` 全欄列（stdClass，`$hidden` 對它零作用），補上 `select('id','name')`。目前 Blade 消費端只取 id/name 所以尚未實際印出，但同檔的 Inertia 分支都得手動收窄才安全——正說明這個形狀是陷阱。
+- 回歸測試 `ApiUserPayloadTest`（6 tests）：白名單以「鍵名相等」斷言（新增欄位必須是刻意決定）、不得出現任何憑證欄、模型整包序列化也不得帶、屬性讀取仍可用、無 token 回 401、只回 token 主人的資料。已驗證抽掉修改後測試會紅。
+
 ### API.md 補完所有現行對外 API（v2 寫入端＋其餘開放端點）
 - 起因：有外部協作者要以眾包帳號向 `/api/v2` 提交提案，但 `API.md` 原本只有讀取端（`persons`／`operations`），寫入端一字未提；寫入端的實用說明散在 `.claude/skills/mutation-api-record-editing.md`（內部技能檔、且通篇以 `mode=direct` 為前提）與不完整的 `docs/openapi/openapi.yaml`，沒有一份能直接交付給外部的文件。
 - 新增 v2 第一～十四章：通用約定（認證、`Origin`/`Referer` 會讓 Bearer 失效、CORS 不含 `Authorization`、CSRF 豁免清單、限流、空字串一律轉 null）、寫入 API 總覽（direct／proposal 權限矩陣、提案占位規則、`target.pk` 與主鍵哨兵值、錯誤碼總表）、`get`／`create`／`mutate`／`delete`／`batch_mutate`／`resubmit`／`opposite-edges` 逐端點規格、14 個資源的欄位白名單、互逆鏡像的衝突與復原、代碼表與複合實體聚合、以及其餘開放端點（`texts`、`api/user`、api-tokens、`select/*`、AI 輔助、MCP、`cbdbapi/person`）。

--- a/app/Http/Controllers/AiFillLogController.php
+++ b/app/Http/Controllers/AiFillLogController.php
@@ -57,9 +57,18 @@ class AiFillLogController extends Controller {
         }
     }
 
-    /** 有日誌記錄的用戶清單。 */
+    /**
+     * 有日誌記錄的用戶清單（篩選下拉用，只需 id 與名稱）。
+     *
+     * **必須顯式 select。** 這是 query builder，回傳 stdClass 全欄列，`User::$hidden`
+     * 對它完全不生效——不收窄就會把 password hash、`confirmation_token`（舊眾包通道的
+     * 長期憑證）、`remember_token`、`settings`（內含註冊／登入 IP）整包帶進視圖作用域。
+     * 目前消費端只取 id/name，但一旦有人把它丟進 `@json()` 或 Inertia props 就會外洩
+     * 全部有日誌記錄帳號（含系統管理員）的憑證。見 issue #1248。
+     */
     protected function logUsers() {
         return DB::table('users')
+            ->select('id', 'name')
             ->whereIn('id', function ($query) {
                 $query->select('user_id')->from('ai_fill_logs')->whereNotNull('user_id')->distinct();
             })

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -3,16 +3,36 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class UserController extends Controller {
     /**
-     * Get the authenticated user.
+     * 回傳目前 bearer token 對應的帳號資料。
      *
-     * @param Request $request
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * **顯式白名單，不是回傳整個模型。** 先前這裡是 `return $request->user()`，序列化範圍
+     * 全靠 `User::$hidden` 的黑名單決定，於是 `confirmation_token`（`/api/operations/*`
+     * 舊通道用的長期憑證，無到期、無撤銷）會一併交給任何持有 Sanctum token 的呼叫者，
+     * 等於讓唯讀 token 換到可直接寫 operations 的憑證。改成白名單後，日後 `users`
+     * 新增欄位也不會再默默流出去——要對外就得在這裡顯式加。
+     *
+     * 刻意不回傳 `settings`（使用者偏好的自由格式 JSON，對呼叫端無用且內容不可預期）。
+     *
+     * 欄位契約記於 API.md §14.2；變動請同步該處。
      */
-    public function show(Request $request) {
-        return $request->user();
+    public function show(Request $request): JsonResponse {
+        $user = $request->user();
+
+        return response()->json([
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'institution' => $user->institution,
+            'avatar' => $user->avatar,
+            'is_admin' => $user->is_admin,
+            'is_active' => $user->is_active,
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+        ]);
     }
 }

--- a/app/Http/Controllers/QueryPlaygroundController.php
+++ b/app/Http/Controllers/QueryPlaygroundController.php
@@ -589,9 +589,16 @@ class QueryPlaygroundController extends Controller {
         return $query->orderBy('nl_query_logs.created_at', 'desc');
     }
 
-    /** 有日誌記錄的使用者清單（篩選用）。 */
+    /**
+     * 有日誌記錄的使用者清單（篩選用，只需 id 與名稱）。
+     *
+     * **必須顯式 select**：query builder 回傳 stdClass 全欄列，`User::$hidden` 不生效，
+     * 不收窄就會把 password hash、`confirmation_token`、`remember_token`、`settings`
+     * （內含 IP）帶進視圖作用域。見 issue #1248 與 `AiFillLogController::logUsers()`。
+     */
     protected function nlQueryLogUsers() {
         return DB::table('users')
+            ->select('id', 'name')
             ->whereIn('id', function ($query) {
                 $query->select('user_id')->from('nl_query_logs')->whereNotNull('user_id')->distinct();
             })

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,10 +51,22 @@ class User extends Authenticatable {
     /**
      * The attributes that should be hidden for arrays.
      *
+     * `confirmation_token` 必須在此：它不是普通欄位，而是**第二種長期憑證**——
+     * `/api/operations/token` 直接把它當眾包 API token 發出去
+     * （`Api\OperationsController::token()`），而 `/api/operations/{add,update,delete}`
+     * 只憑它認證（`resolveActiveUserByToken()`），且沒有任何到期或撤銷機制。
+     * 先前它不在 `$hidden`，於是 `GET /api/user`（回傳整個模型）會把它交給任何持有
+     * Sanctum token 的呼叫者——一個只被授予唯讀能力的 token 因此能換到可繞過 v2
+     * 白名單／主鍵校驗、直接寫 operations 的憑證。
+     *
+     * 這是縱深防禦：`/api/user` 已改為顯式白名單輸出（`Api\UserController::show()`），
+     * 此處再擋住任何把 User 整包序列化的路徑（回應、日誌、事件 payload）。
+     * **屬性讀取（`$user->confirmation_token`）不受影響**，故舊通道本身不會壞。
+     *
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password', 'remember_token', 'confirmation_token',
     ];
 
     protected $casts = [

--- a/tests/Feature/ApiUserPayloadTest.php
+++ b/tests/Feature/ApiUserPayloadTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * #1248：`GET /api/user` 不得外洩 `confirmation_token`。
+ *
+ * 背景：該端點原本 `return $request->user()`，序列化範圍由 `User::$hidden` 決定，而
+ * `confirmation_token` 不在其中。它是 `/api/operations/*` 舊眾包通道的長期憑證
+ * （無到期、無撤銷、不驗白名單），因此任何 Sanctum token 都能經此換到一個
+ * 可直接寫 operations 的憑證——提權路徑，不只是欄位過度曝露。
+ *
+ * 這裡釘住三件事：
+ *  1. 端點回應是顯式白名單（含呼叫端需要的欄位，不含任何憑證欄）；
+ *  2. User 模型的整包序列化也不再帶 `confirmation_token`（縱深防禦）；
+ *  3. 屬性讀取仍可取得該值——否則 `/api/operations/token` 會被這次改動弄壞。
+ */
+class ApiUserPayloadTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        config(['cache.default' => 'array']);
+        config(['session.driver' => 'array']);
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('institution')->nullable();
+            $table->json('settings')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->smallInteger('is_active')->default(0);
+            $table->smallInteger('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+
+        // 舊眾包通道的整合測試需要這兩張表：token 端點會寫安全審計，add 端點會寫 operations。
+        Schema::dropIfExists('operations');
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('c_personid')->default(0);
+            $table->smallInteger('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data');
+            $table->longText('resource_original')->nullable();
+            $table->smallInteger('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('audit_log');
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->char('operation_id', 26);
+            $table->json('row_pk');
+            $table->string('row_pk_text', 512);
+            $table->json('old_data')->nullable();
+            $table->json('new_data')->nullable();
+        });
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('audit_log');
+        Schema::dropIfExists('operations');
+        Schema::dropIfExists('personal_access_tokens');
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    private function makeActiveUser(): User {
+        return User::unguarded(fn () => User::create([
+            'name' => '王小明',
+            'email' => 'u@example.com',
+            'password' => bcrypt('secret'),
+            'institution' => 'Harvard',
+            'settings' => ['locale' => 'zh-TW'],
+            'avatar' => 'avatars/u.png',
+            'confirmation_token' => 'super-secret-legacy-credential',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_REGULAR,
+        ]));
+    }
+
+    #[Test]
+    public function api_user_does_not_expose_credential_columns(): void {
+        $user = $this->makeActiveUser();
+        $token = $user->createToken('cli')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/user')
+            ->assertOk();
+
+        $body = $response->json();
+
+        // 憑證欄一律不得出現。confirmation_token 是本次的主角（見類別註解）。
+        $this->assertArrayNotHasKey('confirmation_token', $body);
+        $this->assertArrayNotHasKey('password', $body);
+        $this->assertArrayNotHasKey('remember_token', $body);
+        // 連字串比對也做一次：避免將來有人換個鍵名輸出同一個值。
+        $response->assertDontSee('super-secret-legacy-credential');
+    }
+
+    #[Test]
+    public function api_user_returns_exactly_the_documented_whitelist(): void {
+        // 白名單以「相等」而非「包含」斷言：新增欄位必須是刻意的決定，
+        // 否則 users 加一欄就會靜默對外（正是本次要治的根因）。
+        $user = $this->makeActiveUser();
+        $token = $user->createToken('cli')->plainTextToken;
+
+        $body = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/user')
+            ->assertOk()
+            ->json();
+
+        $this->assertSame([
+            'avatar',
+            'created_at',
+            'email',
+            'id',
+            'institution',
+            'is_active',
+            'is_admin',
+            'name',
+            'updated_at',
+        ], collect(array_keys($body))->sort()->values()->all());
+
+        $this->assertSame($user->id, $body['id']);
+        $this->assertSame('王小明', $body['name']);
+        $this->assertSame('u@example.com', $body['email']);
+        $this->assertSame(User::STATUS_ACTIVE, $body['is_active']);
+    }
+
+    #[Test]
+    public function api_user_requires_a_token(): void {
+        // 沒有憑證時不得回任何帳號資料（未啟用帳號的 403 已由 InactiveAccountAccessTest 覆蓋）。
+        $this->getJson('/api/user')->assertUnauthorized();
+    }
+
+    #[Test]
+    public function api_user_returns_the_token_owner_not_another_account(): void {
+        $owner = $this->makeActiveUser();
+        $other = User::unguarded(fn () => User::create([
+            'name' => '另一個人',
+            'email' => 'other@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => 'other-secret',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]));
+
+        $body = $this->withHeader('Authorization', 'Bearer '.$owner->createToken('cli')->plainTextToken)
+            ->getJson('/api/user')
+            ->assertOk()
+            ->json();
+
+        $this->assertSame($owner->id, $body['id']);
+        $this->assertNotSame($other->id, $body['id']);
+        $this->assertSame(User::ROLE_REGULAR, $body['is_admin']);
+    }
+
+    #[Test]
+    public function user_model_serialization_hides_confirmation_token(): void {
+        // 縱深防禦：任何把 User 整包序列化的路徑（回應、日誌、事件 payload）都不該帶憑證。
+        $user = $this->makeActiveUser();
+
+        $this->assertArrayNotHasKey('confirmation_token', $user->toArray());
+        $this->assertStringNotContainsString('super-secret-legacy-credential', $user->toJson());
+    }
+
+    #[Test]
+    public function confirmation_token_is_still_readable_as_an_attribute(): void {
+        // $hidden 只影響序列化。舊眾包通道（/api/operations/token 回傳此值、
+        // resolveActiveUserByToken() 以此查人）走屬性讀取，必須維持可用。
+        $user = $this->makeActiveUser();
+
+        $this->assertSame('super-secret-legacy-credential', $user->confirmation_token);
+        $this->assertSame(
+            $user->id,
+            User::where('confirmation_token', 'super-secret-legacy-credential')->first()->id
+        );
+    }
+
+    #[Test]
+    public function legacy_crowdsourcing_channel_still_issues_and_accepts_the_token(): void {
+        // 端到端釘住「這次改動沒有弄壞舊通道」：上面那條只驗屬性讀取，證明力不足——
+        // token 端點與寫入端才是真正的使用者。眾包身分 + 啟用 + 密碼正確才發 token。
+        $user = User::unguarded(fn () => User::create([
+            'name' => '眾包投稿者',
+            'email' => 'crowd@example.com',
+            'password' => bcrypt('secret-password'),
+            'confirmation_token' => 'legacy-channel-credential',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_CROWDSOURCING,
+        ]));
+
+        // 1) 發放：回應 body 就是 confirmation_token 原文。
+        $issued = $this->get('/api/operations/token?q=crowd@example.com&p=secret-password')
+            ->assertOk()
+            ->getContent();
+        $this->assertSame('legacy-channel-credential', $issued);
+
+        // 2) 認證：用該 token 走舊寫入端點，應被接受並寫進 operations。
+        $this->postJson('/api/operations/add', [
+            'token' => $issued,
+            'resource' => 'BIOG_MAIN',
+            'json' => '{"c_personid":1762,"c_notes":"crowdsourced note"}',
+        ])->assertOk()->assertJson(['status_code' => 200]);
+
+        $this->assertDatabaseHas('operations', [
+            'user_id' => $user->id,
+            'resource' => 'BIOG_MAIN',
+            'crowdsourcing_status' => 2,
+            'op_type' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #1248

## 問題

`Api\UserController@show` 是 `return $request->user()`，序列化範圍全靠 `User::$hidden` 的黑名單，而 `confirmation_token` 不在其中。

該欄不是普通欄位，而是**第二套長期憑證**：`/api/operations/token` 直接把它當眾包 API token 發出去，`/api/operations/{add,update,delete}` 只憑它認證，且**無到期、無撤銷、不驗欄位白名單**。因此一個只被授予唯讀能力的 Sanctum token，可以換到能繞過 v2 全部白名單與主鍵校驗、直接往 `operations` 寫入的憑證——這是提權路徑，不只是欄位過度曝露。

## 修法

- **端點改為顯式白名單**（`id`／`name`／`email`／`institution`／`avatar`／`is_admin`／`is_active`／時間欄），不再維護黑名單。根因是「`users` 加一欄就默默對外」，只有白名單治得住。順帶不再回傳 `settings`——它內含 `registration_ip`／`last_login_ip`。
- `User::$hidden` 補上 `confirmation_token` 作**縱深防禦**，擋住其他把模型整包序列化的路徑。`$hidden` 只影響序列化，屬性讀取不受影響，所以舊通道本身不會壞。
- **另修兩處 `$hidden` 擋不到的同類洞**：`AiFillLogController::logUsers()` 與 `QueryPlaygroundController::nlQueryLogUsers()` 用 query builder 撈 `users` 全欄列（stdClass，`$hidden` 對它零作用），補上 `select('id','name')`。目前 Blade 消費端只取 id/name 所以尚未實際印出，但同檔的 Inertia 分支都得手動收窄才安全——正說明這個形狀是陷阱。四個消費端（Blade × 2、React × 2）已逐一確認只用 id 與 name。

## 測試

新增 `tests/Feature/ApiUserPayloadTest.php`（7 tests）：

- 回應不得含 `confirmation_token`／`password`／`remember_token`，並以字串比對確保該值不會換個鍵名輸出
- 白名單以**鍵名相等**斷言——日後新增欄位必須是刻意決定
- 模型整包序列化（`toArray`／`toJson`）也不得帶憑證
- 無 token 回 401；只回 token 主人的資料
- **端到端釘住舊眾包通道仍可用**：`/api/operations/token` 發放 → 用該 token 打 `/api/operations/add` → 確認寫進 `operations`

已驗證抽掉修改後測試會紅（4 條斷言中 3 條失敗）。`phpunit --filter 'ApiUserPayloadTest|InactiveAccountAccessTest|AiFillLog|QueryPlayground'` → 107 tests 全綠。cs-fixer 清 cache 後以 dist config dry-run，641 檔 0 需修。

## 刻意不做的事

- `confirmation_token` 仍在 `User::$fillable`：回歸面比本次修的東西大（要同步改註冊／CLI／腳本與多個測試），記在 #1248 留言追。
- **匯出命令會把整張 `users`（password hash、`confirmation_token`、IP）寫進 SQLite** → 已另開 #1251，嚴重度高於本 issue。

## 文檔

`API.md` §14.2 改為逐欄的回應契約表並註明變動須同步；`CHANGELOG.md` 記一筆。

🤖 Generated with [Claude Code](https://claude.com/claude-code)