### PR TITLE
批次匯入官職／社會機構頁補上行號側欄，並修好行號對不準的兩個缺陷

### DIFF
--- a/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadBookTitles/Index.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { router, useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../../Layouts/DashboardLayout';
 import { Button } from '../../../components/ui/Button';
 import { FormField } from '../../../components/ui/FormField';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
+import { LineNumberedTextarea } from '../../../components/ui/LineNumberedTextarea';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { getCsrfToken } from '../../../components/PersonBrowser/shared/csrf';
 import type { SharedProps } from '../../../types/page';
@@ -31,55 +32,6 @@ interface ResultRow {
 interface Toast {
     msg: string;
     type?: 'success' | 'error' | 'warning';
-}
-
-interface EntriesEditorProps {
-    id?: string;
-    value: string;
-    onChange: (value: string) => void;
-    placeholder?: string;
-    'aria-invalid'?: boolean;
-    'aria-describedby'?: string;
-}
-
-// FormField 會把 id / aria-invalid / aria-describedby clone 到單一子元素上；
-// 這裡把這些屬性轉發到真正的 <textarea>，讓行號側欄僅作為視覺裝飾疊加。
-function EntriesEditor({ id, value, onChange, placeholder, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy }: EntriesEditorProps) {
-    const gutterRef = useRef<HTMLPreElement>(null);
-    const lineCount = Math.max(1, value.split('\n').length);
-
-    return (
-        <div
-            className={cn(
-                'flex items-stretch overflow-hidden rounded-md border border-input bg-background shadow-sm focus-within:ring-2 focus-within:ring-ring',
-                ariaInvalid && 'border-destructive'
-            )}
-        >
-            <pre
-                ref={gutterRef}
-                aria-hidden="true"
-                className="m-0 select-none overflow-hidden whitespace-pre border-r border-border bg-muted/50 px-2 py-2 text-right font-mono text-sm leading-normal text-muted-foreground"
-            >
-                {Array.from({ length: lineCount }, (_, i) => i + 1).join('\n')}
-            </pre>
-            <textarea
-                id={id}
-                rows={10}
-                spellCheck={false}
-                aria-invalid={ariaInvalid}
-                aria-describedby={ariaDescribedBy}
-                className="w-full flex-1 resize-y border-0 bg-transparent px-3 py-2 font-mono text-sm leading-normal shadow-none focus-visible:outline-none"
-                placeholder={placeholder}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                onScroll={(e) => {
-                    if (gutterRef.current) {
-                        gutterRef.current.scrollTop = e.currentTarget.scrollTop;
-                    }
-                }}
-            />
-        </div>
-    );
 }
 
 interface BatchBooksPageProps extends SharedProps {
@@ -353,7 +305,7 @@ export default function BatchLoadBookTitles() {
 
                 <form onSubmit={(e) => { e.preventDefault(); submit(false); }}>
                     <FormField label={t('batch_data_tab_sep')} htmlFor="entries" error={form.errors.entries}>
-                        <EntriesEditor
+                        <LineNumberedTextarea
                             value={form.data.entries}
                             onChange={(v) => form.setData('entries', v)}
                             placeholder={t('batch_book_placeholder')}

--- a/resources/js/inertia/Pages/Admin/BatchLoadOffices/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadOffices/Index.tsx
@@ -3,6 +3,7 @@ import { useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../../Layouts/DashboardLayout';
 import { Button } from '../../../components/ui/Button';
 import { FormField } from '../../../components/ui/FormField';
+import { LineNumberedTextarea } from '../../../components/ui/LineNumberedTextarea';
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 
@@ -54,14 +55,10 @@ export default function BatchLoadOffices() {
 
                 <form onSubmit={(e) => { e.preventDefault(); form.post(urls.store, { preserveScroll: true }); }}>
                     <FormField label={t('batch_data_tab_sep')} htmlFor="entries" error={form.errors.entries}>
-                        <textarea
-                            id="entries"
-                            rows={10}
-                            spellCheck={false}
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            placeholder={t('batch_offices_placeholder')}
+                        <LineNumberedTextarea
                             value={form.data.entries}
-                            onChange={(e) => form.setData('entries', e.target.value)}
+                            onChange={(v) => form.setData('entries', v)}
+                            placeholder={t('batch_offices_placeholder')}
                         />
                     </FormField>
                     <div className="flex gap-2">

--- a/resources/js/inertia/Pages/Admin/BatchLoadSocialInstitutes/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadSocialInstitutes/Index.tsx
@@ -3,6 +3,7 @@ import { useForm, usePage } from '@inertiajs/react';
 import DashboardLayout from '../../../Layouts/DashboardLayout';
 import { Button } from '../../../components/ui/Button';
 import { FormField } from '../../../components/ui/FormField';
+import { LineNumberedTextarea } from '../../../components/ui/LineNumberedTextarea';
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 
@@ -57,14 +58,10 @@ export default function BatchLoadSocialInstitutes() {
 
                 <form onSubmit={(e) => { e.preventDefault(); form.post(urls.store, { preserveScroll: true }); }}>
                     <FormField label={t('batch_data_tab_sep')} htmlFor="entries" error={form.errors.entries}>
-                        <textarea
-                            id="entries"
-                            rows={10}
-                            spellCheck={false}
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            placeholder={t('batch_social_placeholder')}
+                        <LineNumberedTextarea
                             value={form.data.entries}
-                            onChange={(e) => form.setData('entries', e.target.value)}
+                            onChange={(v) => form.setData('entries', v)}
+                            placeholder={t('batch_social_placeholder')}
                         />
                     </FormField>
                     <div className="flex gap-2">

--- a/resources/js/inertia/components/ui/LineNumberedTextarea.tsx
+++ b/resources/js/inertia/components/ui/LineNumberedTextarea.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useLayoutEffect, useRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export interface LineNumberedTextareaProps {
+    id?: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    rows?: number;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+}
+
+/**
+ * 帶行號側欄的 textarea：批次匯入頁的錯誤訊息以「第 N 行」定位，
+ * 需要側欄讓使用者直接對照（後端行號＝原始輸入以 \r\n|\n|\r 切分後的 index + 1，
+ * 與此處 value.split('\n') 的計數一致；空行不重新編號，兩邊逐行對齊）。
+ *
+ * 對齊靠三件事，改動時請一併確認：
+ * 1. textarea 必須 `wrap="off"`（改為水平捲動）。預設的軟換行會把一筆過長的
+ *    tab 分隔資料折成多個視覺列，而側欄每個編號固定佔一列，之後所有編號都會錯位。
+ * 2. 側欄以 absolute 疊放、不參與 flex 交叉軸高度計算。否則側欄的自然高度（＝行數）
+ *    會把容器撐高，textarea 跟著被拉伸，失去 rows 的固定高度與內部捲動
+ *    （貼上數百行時輸入框會長到數百列高，把送出按鈕推走）。
+ * 3. 垂直同步用 `transform: translateY(-scrollTop)`，不用側欄自己的 scrollTop。
+ *    水平捲軸會吃掉 textarea 的可視高度，使兩者的 scrollTop 上限不同；
+ *    寫 scrollTop 會在捲到最底時被 clamp，造成約半行的偏移。
+ *
+ * FormField 會把 id / aria-invalid / aria-describedby clone 到單一子元素上；
+ * 這裡把這些屬性轉發到真正的 <textarea>，讓行號側欄僅作為視覺裝飾疊加。
+ */
+export function LineNumberedTextarea({
+    id,
+    value,
+    onChange,
+    placeholder,
+    rows = 10,
+    'aria-invalid': ariaInvalid,
+    'aria-describedby': ariaDescribedBy,
+}: LineNumberedTextareaProps) {
+    const gutterRef = useRef<HTMLPreElement>(null);
+    const gutterColRef = useRef<HTMLDivElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const lineCount = Math.max(1, value.split('\n').length);
+    // 側欄寬度隨最大行號位數成長；1.25rem 覆蓋 pre 的左右內距（各 0.5rem）、
+    // 外層 border-r 的 1px，並留一點餘裕，避免 font-mono fallback 到非等寬字型時
+    // 最左邊的數字被 overflow-hidden 靜默裁掉。最少 3 位數以降低寬度跳動頻率。
+    const gutterWidth = `calc(${Math.max(3, String(lineCount).length)}ch + 1.25rem)`;
+
+    const syncGutterOffset = useCallback(() => {
+        const textarea = textareaRef.current;
+        if (textarea && gutterRef.current) {
+            gutterRef.current.style.transform = `translateY(${-textarea.scrollTop}px)`;
+        }
+    }, []);
+
+    // textarea 出現水平捲軸時，其可視高度比側欄少一個捲軸的高度；把差額寫進側欄外層的
+    // padding-bottom，讓 overflow 的裁切邊（padding box）與 textarea 內容區同高，
+    // 避免最底部多畫一個沒有對應文字的行號。textarea 是 border-0，故
+    // offsetHeight - clientHeight 即捲軸高度（若日後給它加 border 需連同扣除）。
+    // 順帶重算 transform：value 變短時瀏覽器會 clamp scrollTop，靠這裡在 paint 前收斂，
+    // 不必依賴 clamp 是否派發 scroll 事件。
+    const syncGutterMetrics = useCallback(() => {
+        const textarea = textareaRef.current;
+        const column = gutterColRef.current;
+        if (!textarea || !column) {
+            return;
+        }
+
+        column.style.paddingBottom = `${Math.max(0, textarea.offsetHeight - textarea.clientHeight)}px`;
+        syncGutterOffset();
+    }, [syncGutterOffset]);
+
+    useLayoutEffect(() => {
+        syncGutterMetrics();
+    }, [value, syncGutterMetrics]);
+
+    useLayoutEffect(() => {
+        const textarea = textareaRef.current;
+        if (!textarea) {
+            return;
+        }
+
+        // 觀察 content-box：捲軸出現／消失、容器寬度變化、使用者手動 resize 都會觸發。
+        const observer = new ResizeObserver(syncGutterMetrics);
+        observer.observe(textarea);
+
+        return () => observer.disconnect();
+    }, [syncGutterMetrics]);
+
+    return (
+        <div
+            className={cn(
+                'flex items-stretch overflow-hidden rounded-md border border-input bg-background shadow-sm focus-within:ring-2 focus-within:ring-ring',
+                ariaInvalid && 'border-destructive'
+            )}
+        >
+            <div
+                ref={gutterColRef}
+                aria-hidden="true"
+                // font-mono text-sm 是必要的：gutterWidth 的 ch 單位在此解析。
+                className="relative shrink-0 overflow-hidden border-r border-border bg-muted/50 font-mono text-sm"
+                style={{ width: gutterWidth }}
+            >
+                <pre
+                    ref={gutterRef}
+                    className="absolute inset-x-0 top-0 m-0 select-none whitespace-pre px-2 py-2 text-right font-mono text-sm leading-normal text-muted-foreground"
+                >
+                    {Array.from({ length: lineCount }, (_, i) => i + 1).join('\n')}
+                </pre>
+            </div>
+            <textarea
+                ref={textareaRef}
+                id={id}
+                rows={rows}
+                wrap="off"
+                spellCheck={false}
+                aria-invalid={ariaInvalid}
+                aria-describedby={ariaDescribedBy}
+                className="min-w-0 flex-1 resize-y overflow-auto border-0 bg-transparent px-3 py-2 font-mono text-sm leading-normal shadow-none focus-visible:outline-none"
+                placeholder={placeholder}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onScroll={syncGutterOffset}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## 問題

`/app/admin/batch-load-offices` 與 `/app/admin/batch-load-social-institutes` 的匯入錯誤訊息以行號定位：

> ・第 19 行來源 TEXT_ID 必須為整數

但輸入框沒有行號側欄，使用者無法對照到底是哪一行。book-titles 頁先前已補過（791ef028），這兩頁遺漏。

## 修法

把 book-titles 內嵌的 `EntriesEditor` 抽成共用元件 `components/ui/LineNumberedTextarea.tsx`，三頁共用，避免第四頁又漏一次。

三個 controller 的行號語義已核對一致：`preg_split('/\r\n|\n|\r/')` 後 `index + 1`，空行 `continue` 但不重新編號，與側欄 `value.split('\n')` 逐行對齊。

同時修掉原 book-titles 實作就存在、抽出後會擴散到另兩頁的三個對齊缺陷：

| # | 缺陷 | 實測（300 列 6 欄資料） | 修法 |
|---|---|---|---|
| 1 | 預設軟換行把一筆長資料折成多個視覺列，側欄每個編號固定一列 → 編號整段偏移，行號功能形同失效 | textarea 每邏輯行 48px vs 側欄 24px | `wrap="off"` + 水平捲動 |
| 2 | 側欄自然高度（＝行數）把容器撐高，textarea 被 `items-stretch` 拉伸 → 失去內部捲動，送出按鈕被推走 | 容器高 **7218px** | 側欄改 `absolute` 疊放，不參與交叉軸高度 |
| 3 | 寫側欄 `scrollTop` 同步：水平捲軸吃掉 textarea 可視高度後兩者上限不同，捲到最底被 clamp | 偏移 15px ≈ 0.6 行 | 改 `transform: translateY(-scrollTop)`；外層依捲軸高度補 `padding-bottom`，讓裁切邊與內容區同高 |

## 行為變更

offices／social-institutes 兩頁原本是軟換行，長列會折行完整顯示；改為水平捲動後需左右捲看完整列。這是行號對齊的必要條件，且 tab 分隔資料以欄位對齊呈現更好讀。

## 驗證

headless Chrome + 專案編譯後的 Tailwind CSS 實測 8 個情境（300／1234 行、長列／短列、捲到頂／中段／最底、value 縮短、手動 resize 放大）：

| 情境 | 行號偏移（首行 / 末行） | 容器高度 | 裁切邊 == 內容區底緣 |
|---|---|---|---|
| 300 長列・捲到底 | 0 / 0 | 258px | ✅ |
| 300 長列・中段 | 0 / 0 | 258px | ✅ |
| 300 長列・頂部 | 0 / 0 | 258px | ✅ |
| 300 短列・捲到底 | 0 / 0 | 258px | ✅ |
| 1234 長列・捲到底 | 0 / 0 | 258px | ✅ |
| 捲到底後 value 縮短為 3 行 | 0 / 0 | 258px | ✅ |
| 捲到底後清空 | 0 / 0 | 258px | ✅ |
| 手動 resize 600px 後捲到底 | 0 / 0 | 602px | ✅ |

- `npm run build`、`npx tsc --noEmit`（變更檔零錯誤）
- `phpunit --filter BatchLoad`：71 tests, 363 assertions 全過
- `npm test`：90 passed

無 API 改動，`API.md` 不需更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)