### PR TITLE
異體字落地替換 S0＋S1：範圍判定基礎設施

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
+++ b/app/Http/Controllers/AdminBatchLoadBookTitlesController.php
@@ -615,12 +615,13 @@ class AdminBatchLoadBookTitlesController extends Controller {
     protected function standardizeTitleVariants(string $title): array {
         $result = CharVariantMapService::replaceLenient($title);
 
-        $variantReplacements = [];
-        foreach ($result['replaced'] as $from => $to) {
-            $variantReplacements[] = ['from' => $from, 'to' => $to];
-        }
-
-        return ['title' => $result['text'], 'variant_replacements' => $variantReplacements];
+        // 用 flattenReplaced() 而不是自己 foreach：replaced 的值在衝突時會是 list
+        // （見 CharVariantMapService::mergeReplaced()），直接 foreach 會讓 'to' 變成陣列、
+        // JSON 化後打壞批次結果頁的契約（Pages/Admin/BatchLoadBookTitles/Index.tsx）。
+        return [
+            'title' => $result['text'],
+            'variant_replacements' => CharVariantMapService::flattenReplaced($result['replaced']),
+        ];
     }
 
     /**

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -8,6 +8,7 @@ use App\Models\OfficeCodeTypeRel;
 use App\Models\OfficeTypeTree;
 use App\Models\Operation;
 use App\Repositories\OperationRepository;
+use App\Services\CharVariantMapService;
 use App\Support\BasicInformationHistory;
 use App\Support\CompositePrimaryKey;
 use Carbon\Carbon;
@@ -1142,14 +1143,18 @@ class OperationsController extends Controller {
     }
 
     protected function performRestore(Operation $operation) {
-        switch ((int) $operation->op_type) {
-            case 3:
-                return $this->restoreUpdate($operation);
-            case 4:
-                return $this->restoreDelete($operation);
-            default:
-                throw new \RuntimeException(__('operations.restore_unsupported_type'));
+        $result = match ((int) $operation->op_type) {
+            3 => $this->restoreUpdate($operation),
+            4 => $this->restoreDelete($operation),
+            default => throw new \RuntimeException(__('operations.restore_unsupported_type')),
+        };
+
+        // 還原了對照表本身 ⇒ 行程內的閉包／環快取已陳舊，清掉讓下次替換重新載入。
+        if (strtolower((string) $operation->resource) === 'char_variant_map') {
+            CharVariantMapService::reset();
         }
+
+        return $result;
     }
 
     protected function restoreUpdate(Operation $operation) {
@@ -1193,6 +1198,12 @@ class OperationsController extends Controller {
         if (!$query->exists()) {
             throw new \RuntimeException(__('operations.restore_row_not_found'));
         }
+
+        // char_variant_map 是對照表本身：還原一筆被改／被刪的對照，可能重新引入環或
+        // 多字元 key，繞過其餘 9 個寫入端的 guard（見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md S1）。
+        // 注意這與「restore 不做內容替換」不衝突：那是不對還原內容做落地替換（保留歷史字形），
+        // 這裡是對這張表的寫入做結構驗證。
+        $this->assertCharVariantMapWritable($table, $payload, $conditions);
         $query->update($payload);
 
         return [
@@ -1223,6 +1234,12 @@ class OperationsController extends Controller {
             $payload['c_modified_date'] = Carbon::now();
         }
         $conditions = $this->buildKeyConditions($operation, $target, $target);
+        // char_variant_map 是對照表本身：還原一筆被改／被刪的對照，可能重新引入環或
+        // 多字元 key，繞過其餘 9 個寫入端的 guard（見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md S1）。
+        // 注意這與「restore 不做內容替換」不衝突：那是不對還原內容做落地替換（保留歷史字形），
+        // 這裡是對這張表的寫入做結構驗證。
+        $this->assertCharVariantMapWritable($table, $payload, $conditions);
+
         if (!empty($conditions)) {
             DB::table($table)->updateOrInsert($conditions, $payload);
         } else {
@@ -1321,6 +1338,40 @@ class OperationsController extends Controller {
         }
 
         return [];
+    }
+
+    /**
+     * char_variant_map 的還原路徑結構把關（單一 codepoint、不成環）。
+     *
+     * 這張表在 resourceKeyColumns() 有明文登記，所以 restore 對它是刻意支援的；
+     * 但它同時是所有落地替換的資料來源，還原一筆壞對照會讓全站的替換降級。
+     *
+     * restore 是 10 個寫入入口中**唯一不在 S2／S5／S6 編輯範圍內**的那條，所以在 S1 就掛。
+     * 其餘 9 個（Codes UI 5、token API 2、提案核准 2）的 guard **尚未掛上**，
+     * 分別由計畫的 S2／S5／S6 補（見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md）。
+     *
+     * @param array<string,mixed> $payload
+     * @param array<string,mixed> $conditions
+     */
+    protected function assertCharVariantMapWritable($table, array $payload, array $conditions): void {
+        if (strtolower((string) $table) !== 'char_variant_map') {
+            return;
+        }
+
+        // $excludeId 必須取得，否則會把「更新既有列」誤判成新增而誤報環
+        // （表有 乙→甲、甲→丙 時，把那列改成 丙→乙 是合法的，但把被取代的舊邊算進去
+        // 就會看到假的環 乙→甲→丙→乙）。
+        //
+        // 這張表的 key 只有單一欄 id（resourceKeyColumns()），所以 $conditions 只可能是
+        // [] 或 ['id' => N]：restoreUpdate 走到這裡時 $conditions 一定非空（它在上面已
+        // 對 empty($conditions) 拋 restore_no_pk），restoreDelete 則可能是 [] 而
+        // $excludeId = null 正是該路徑的正確語義（被還原的列已被刪、不在任何邊上）。
+        //
+        // 附註：若 operation.resource 存成大寫 CHAR_VARIANT_MAP，resourceKeyColumns() 的
+        // 字面查表會回 []，restoreUpdate 會**先**以 restore_no_pk 失敗、走不到這裡。
+        $excludeId = isset($conditions['id']) ? (int) $conditions['id'] : null;
+
+        CharVariantMapService::assertWritable($payload, $excludeId);
     }
 
     protected function filterColumns($table, array $data) {

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -252,7 +252,7 @@ class BiogMainRepository {
         // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
         $surnameReplaced = CharVariantMapService::replaceStrict((string) $request->c_surname_chn);
         $mingziReplaced = CharVariantMapService::replaceStrict((string) $request->c_mingzi_chn);
-        $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+        $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
         $data['c_surname_chn'] = $surnameReplaced['text'];
         $data['c_mingzi_chn'] = $mingziReplaced['text'];
 
@@ -378,7 +378,7 @@ class BiogMainRepository {
         if (array_key_exists('c_surname_chn', $data) || array_key_exists('c_mingzi_chn', $data)) {
             $surnameReplaced = CharVariantMapService::replaceStrict((string) ($data['c_surname_chn'] ?? ''));
             $mingziReplaced = CharVariantMapService::replaceStrict((string) ($data['c_mingzi_chn'] ?? ''));
-            $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+            $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
             $data['c_surname_chn'] = $surnameReplaced['text'];
             $data['c_mingzi_chn'] = $mingziReplaced['text'];
             $data['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];

--- a/app/Services/CharVariantMapService.php
+++ b/app/Services/CharVariantMapService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use App\Support\VariantReplaceScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * 異體字落地替換服務
@@ -50,6 +52,192 @@ class CharVariantMapService {
     }
 
     /**
+     * 對整列資料套落地替換：逐欄查 VariantReplaceScope::modeFor() 決定模式，
+     * 非文本欄／排除欄／未知表原樣保留。
+     *
+     * **只做淺層掃描**：非字串值（int／null／**陣列**）原樣跳過。這是刻意的——
+     * POSTED_TO_ADDR_DATA 的 resource_data['rows'] 與 PostingMutationHandler 的
+     * __proposal_aux／ADDRESS_AUX_KEYS 是騎在 $changes 裡的嵌套結構／非欄位鍵，
+     * 不該被當成欄位處理。
+     *
+     * **呼叫約定**：$table 一律傳**目標資料表**，永不傳 'operations'——
+     * operations.resource_id 是序列化的複合主鍵、內含中文 PK 成員，
+     * 改寫它會讓提案與目標列脫鉤。
+     *
+     * @param array<string,mixed> $data
+     * @return array{data: array<string,mixed>, replaced: array<string,string|array<int,string>>}
+     *         replaced 的值通常是字串；當同一個變體在這一列被解析成**不同**的參考字
+     *         （strict 欄與 lenient 欄的閉包終點不同）時會是陣列，兩個結果都保留。
+     */
+    public static function replaceRow(array $data, string $table): array {
+        $replaced = [];
+
+        foreach ($data as $column => $value) {
+            if (!is_string($value) || $value === '') {
+                continue;
+            }
+
+            $result = self::replaceFor($table, (string) $column, $value);
+            if ($result['replaced'] === []) {
+                continue;
+            }
+
+            $data[$column] = $result['text'];
+            $replaced = self::mergeReplaced($replaced, $result['replaced']);
+        }
+
+        return ['data' => $data, 'replaced' => $replaced];
+    }
+
+    /**
+     * 合併兩份 replaced，**保留衝突的兩個參考字**。
+     *
+     * 為什麼不能用 `+=` 或 `array_merge`：同一個變體在同一次操作裡可以被解析成不同的
+     * 參考字——strict 與 lenient 的閉包終點可以不同（`龴→峯`(excluded=0) +
+     * `峯→峰`(excluded=1)：strict 得「峯」、lenient 得「峰」）。`+=` 保留先出現者、
+     * `array_merge` 保留後出現者，兩者都會靜默丟掉一個，讓**通知與實際落庫的字形不一致**
+     * ——而通知是使用者唯一能看見替換發生的管道。
+     *
+     * 衝突時值升級成 list；沒有衝突時維持純字串（絕大多數情況）。
+     *
+     * @param array<string,string|array<int,string>> $base
+     * @param array<string,string|array<int,string>> $incoming
+     * @return array<string,string|array<int,string>>
+     */
+    public static function mergeReplaced(array $base, array $incoming): array {
+        foreach ($incoming as $variant => $reference) {
+            foreach (is_array($reference) ? $reference : [$reference] as $one) {
+                if (!array_key_exists($variant, $base)) {
+                    $base[$variant] = $one;
+
+                    continue;
+                }
+
+                $existing = is_array($base[$variant]) ? $base[$variant] : [$base[$variant]];
+                if (!in_array($one, $existing, true)) {
+                    $existing[] = $one;
+                    $base[$variant] = $existing;
+                }
+            }
+        }
+
+        return $base;
+    }
+
+    /**
+     * 把 replaced 攤平成 `[['from' => 變體, 'to' => 參考], …]`。
+     *
+     * 給需要**結構化 payload**（而非通知字串）的呼叫端用：那些地方不能收到
+     * `string|array` 聯集，否則 JSON 化之後前端契約會壞
+     * （例如批次匯入結果頁的 variant_replacements）。
+     *
+     * @param array<string,string|array<int,string>> $replaced
+     * @return array<int,array{from: string, to: string}>
+     */
+    public static function flattenReplaced(array $replaced): array {
+        $pairs = [];
+        foreach ($replaced as $variant => $reference) {
+            foreach (is_array($reference) ? $reference : [$reference] as $one) {
+                $pairs[] = ['from' => (string) $variant, 'to' => (string) $one];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * 單值替換，模式仍由 VariantReplaceScope::modeFor() 決定。
+     *
+     * 很多掛鉤點手上**不是「以欄位名為鍵的整列」**：OfficeImportService 在
+     * buildPinyin() 之前拿到的 $input 鍵是 name／name_alt／notes（欄位名只在
+     * officeColumns() 的 return 才出現）、SocialInstituteImportService::resolveNameCode()
+     * 拿到的是裸字串。對那些位置呼叫 replaceRow() 會靜默 no-op，必須用這個入口。
+     *
+     * @return array{text: string, replaced: array<string,string>}
+     */
+    public static function replaceFor(string $table, string $column, string $value): array {
+        $mode = VariantReplaceScope::modeFor($table, $column);
+
+        if ($mode === 'strict') {
+            return self::replaceStrict($value);
+        }
+
+        if ($mode === 'lenient') {
+            return self::replaceLenient($value);
+        }
+
+        return ['text' => $value, 'replaced' => []];
+    }
+
+    /**
+     * char_variant_map 專用的結構驗證：單一 codepoint、不製造環。
+     *
+     * 為什麼不用 Eloquent observer：app/Models/ 下沒有 char_variant_map 的 model，
+     * 它的每一條寫入都是 DB::table()，observer 攔不到；要攔就得把刻意 table-agnostic
+     * 的泛用 CRUD（Codes UI 服務 80 張表）為這一張表特例化。所以改成共用 guard，
+     * 由各寫入端呼叫。
+     *
+     * @param array<string,mixed> $row 可能是部分 payload（restoreUpdate 用歷史快照），
+     *                                 會與現有列 merge 後再驗
+     * @param int|null $excludeId 更新／還原既有列時要排除該列的舊邊，否則會誤報環：
+     *                            表有 id=5 `乙→甲`、id=9 `甲→丙`，把 id=5 改成 `丙→乙`
+     *                            是合法的 `甲→丙→乙`，但把舊邊算進去會看到 `乙→甲→丙→乙`
+     *
+     * @throws \RuntimeException 驗證不通過
+     */
+    public static function assertWritable(array $row, ?int $excludeId = null): void {
+        $current = [];
+        if ($excludeId !== null) {
+            $existing = DB::table('char_variant_map')->where('id', $excludeId)->first();
+            if ($existing !== null) {
+                $current = [
+                    'c_variant_char' => $existing->c_variant_char,
+                    'c_reference_char' => $existing->c_reference_char,
+                ];
+            }
+        }
+
+        $variant = (string) ($row['c_variant_char'] ?? $current['c_variant_char'] ?? '');
+        $reference = (string) ($row['c_reference_char'] ?? $current['c_reference_char'] ?? '');
+
+        // 兩欄都沒被碰到（例如只改 c_notes）：不需驗證。
+        if (!array_key_exists('c_variant_char', $row) && !array_key_exists('c_reference_char', $row)) {
+            return;
+        }
+
+        // 只送了單邊字元欄、又沒有既有列可以 merge：這是呼叫端沒傳 id 的問題，
+        // 報「必須是單一字元」會誤導（使用者根本沒動另一欄）。
+        if ($variant === '' || $reference === '') {
+            throw new \RuntimeException(__('variant.incomplete_payload'));
+        }
+
+        if (mb_strlen($variant) !== 1 || mb_strlen($reference) !== 1) {
+            throw new \RuntimeException(__('variant.single_codepoint_required'));
+        }
+
+        if ($variant === $reference) {
+            throw new \RuntimeException(__('variant.self_reference_not_allowed'));
+        }
+
+        // 把待寫入的邊放進現有邊集（排除被取代的舊邊），看會不會成環。
+        $edges = DB::table('char_variant_map')
+            ->when($excludeId !== null, fn ($q) => $q->where('id', '!=', $excludeId))
+            ->pluck('c_reference_char', 'c_variant_char')
+            ->all();
+        $edges[$variant] = $reference;
+
+        $node = $variant;
+        $seen = [];
+        while (isset($edges[$node]) && !isset($seen[$node])) {
+            $seen[$node] = true;
+            $node = $edges[$node];
+        }
+        if (isset($edges[$node]) && isset($seen[$node])) {
+            throw new \RuntimeException(__('variant.cycle_not_allowed', ['char' => $node]));
+        }
+    }
+
+    /**
      * 清除靜態快取（測試用，比照 VariantCharNormalizer::reset() 慣例）。
      */
     public static function reset(): void {
@@ -63,7 +251,8 @@ class CharVariantMapService {
      * （BIOG_MAIN create／update、ALTNAME_DATA create／update 等）共用同一份措辭，
      * 避免各自組字造成用語不一致。
      *
-     * @param array<string,string> $replaced 異體字 => 參考字
+     * @param array<string,string|array<int,string>> $replaced 異體字 => 參考字
+     *        （同一變體在同一列被解析成多個參考字時，值會是陣列——見 replaceRow()）
      * @return array<int,string> 空陣列代表無需通知
      */
     public static function buildNotices(array $replaced): array {
@@ -73,10 +262,17 @@ class CharVariantMapService {
 
         $pairs = [];
         foreach ($replaced as $variant => $reference) {
-            $pairs[] = "「{$variant}」已正規化為「{$reference}」";
+            // 同一個變體可能在同一列裡被解析成不同的參考字——strict 與 lenient 的閉包
+            // 終點可以不同（`龴→峯`(excluded=0) + `峯→峰`(excluded=1)：strict 得「峯」、
+            // lenient 得「峰」）。replaceRow() 遇到這種衝突會把值升級成陣列，
+            // 這裡兩種形狀都要能渲染，否則通知會告訴使用者錯誤的字。
+            $references = is_array($reference) ? $reference : [$reference];
+            foreach ($references as $one) {
+                $pairs[] = __('variant.notice_pair', ['variant' => $variant, 'reference' => (string) $one]);
+            }
         }
 
-        return ['異體字：'.implode('、', $pairs)];
+        return [__('variant.notice', ['pairs' => implode(__('variant.notice_separator'), $pairs)])];
     }
 
     /**
@@ -95,7 +291,7 @@ class CharVariantMapService {
      * header／cookie，需要重新評估這裡是否要改用 `$response->setData($data)` 保留原始
      * response 物件（含 header）而非重建。
      *
-     * @param array<string,string> $replaced
+     * @param array<string,string|array<int,string>> $replaced 形狀同 buildNotices()
      */
     public static function withNotices(JsonResponse $response, array $replaced): JsonResponse {
         $notices = self::buildNotices($replaced);
@@ -139,9 +335,12 @@ class CharVariantMapService {
      */
     protected static function lenientMap(): array {
         if (self::$lenientMap === null) {
-            self::$lenientMap = DB::table('char_variant_map')
-                ->pluck('c_reference_char', 'c_variant_char')
-                ->all();
+            self::$lenientMap = self::resolveMap(
+                DB::table('char_variant_map')
+                    ->pluck('c_reference_char', 'c_variant_char')
+                    ->all(),
+                'lenient'
+            );
         }
 
         return self::$lenientMap;
@@ -152,12 +351,117 @@ class CharVariantMapService {
      */
     protected static function strictMap(): array {
         if (self::$strictMap === null) {
-            self::$strictMap = DB::table('char_variant_map')
-                ->where('c_strict_excluded', 0)
-                ->pluck('c_reference_char', 'c_variant_char')
-                ->all();
+            self::$strictMap = self::resolveMap(
+                DB::table('char_variant_map')
+                    ->where('c_strict_excluded', 0)
+                    ->pluck('c_reference_char', 'c_variant_char')
+                    ->all(),
+                'strict'
+            );
         }
 
         return self::$strictMap;
+    }
+
+    /**
+     * 把一份**已按模式過濾**的邊集，解析成可安全重複套用的對照表。
+     *
+     * 順序必須是「移除環上出邊 → 對剩餘無環圖算傳遞閉包」，不可顛倒——先算閉包會在
+     * 環上無限迴圈（`A→B`、`B→A` 或自環 `A→A` 在環移除前閉包沒有定義）。
+     *
+     * 為什麼要傳遞閉包：`strtr()` 單次呼叫是同時替換，但**呼叫兩次不等於呼叫一次**。
+     * 若表裡同時有 `A→B` 與 `B→C`，兩次套用得到 `C`、一次只得到 `B`，機制就不幂等。
+     * 做完閉包後所有 key 都映射到終端節點，而終端節點沒有出邊故不是 key ⇒
+     * key 集 ∩ value 集 = ∅ ⇒ 重複套用是不動點。
+     *
+     * 為什麼**按模式各自算**：兩張 map 必須各自對已過濾的邊集獨立計算。若先對全表算閉包
+     * 再按 flag 過濾，`X→峯`(excluded=1 的 峯→峰) 會讓 strict map 得到 `X→峰`，等於透過
+     * 傳遞把一條 strict-excluded 的邊套進人名欄，廢掉 c_strict_excluded 的唯一用途。
+     * （今天的實作在 SQL 層就過濾，天然滿足；這裡的註解是擋住「共用 loader」那個重構。）
+     *
+     * @param array<string,string> $edges 異體字 => 參考字（已按模式過濾）
+     * @return array<string,string>
+     */
+    protected static function resolveMap(array $edges, string $mode): array {
+        // 只保留單一 codepoint 的邊：幂等論證只在單字元 key 下成立（多字元下
+        // `甲乙→丙丁` + `丁→戊` 的閉包接不起來，第二趟會再改一次）。寫入端有 guard，
+        // 這裡是對既有／繞過 guard 的資料做防禦。
+        $clean = [];
+        foreach ($edges as $variant => $reference) {
+            $variant = (string) $variant;
+            $reference = (string) $reference;
+            if ($variant === '' || mb_strlen($variant) !== 1 || mb_strlen($reference) !== 1) {
+                Log::error('char_variant_map: 略過非單一 codepoint 的對照', [
+                    'mode' => $mode,
+                    'variant' => $variant,
+                    'reference' => $reference,
+                ]);
+
+                continue;
+            }
+            $clean[$variant] = $reference;
+        }
+
+        $clean = self::dropCycleEdges($clean, $mode);
+
+        // 傳遞閉包：逐 key 走鏈到終端節點。此時圖已無環，走鏈必然終止。
+        $resolved = [];
+        foreach ($clean as $variant => $reference) {
+            $target = $reference;
+            while (isset($clean[$target])) {
+                $target = $clean[$target];
+            }
+            if ($target !== $variant) {
+                $resolved[$variant] = $target;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * 移除**構成環的邊**，其餘照常生效。
+     *
+     * 不拋錯也不回空 map：這兩個 map 方法是所有替換的唯一入口，在此 throw 會讓
+     * Codes UI、所有 v2 mutate、批次匯入、眾包核准、提案核准一起爆（一筆 `峰→峯`
+     * 或打錯字的 `A→A` 就夠）；回空 map 則等於全站靜默不替換。降級要局部且有聲音。
+     *
+     * `c_variant_char` 有唯一鍵 ⇒ 圖是 out-degree ≤ 1 的 functional graph，
+     * 「環上節點」＝「從自己出發能走回自己」，逐 key 走鏈 + visited set 即可精確定位。
+     * **「鏈進入環」（`A→B`、`B→C`、`C→B`）只丟環上節點（B、C）的出邊，`A→B` 要保留**。
+     *
+     * @param array<string,string> $edges
+     * @return array<string,string>
+     */
+    protected static function dropCycleEdges(array $edges, string $mode): array {
+        $onCycle = [];
+
+        foreach (array_keys($edges) as $start) {
+            $seen = [];
+            $node = $start;
+            while (isset($edges[$node]) && !isset($seen[$node])) {
+                $seen[$node] = true;
+                $node = $edges[$node];
+            }
+            // 走鏈停在一個已造訪過的節點 ⇒ 該節點在環上；沿環標記整圈。
+            if (isset($edges[$node]) && isset($seen[$node])) {
+                $cursor = $node;
+                do {
+                    $onCycle[$cursor] = true;
+                    $cursor = $edges[$cursor];
+                } while ($cursor !== $node);
+            }
+        }
+
+        if ($onCycle === []) {
+            return $edges;
+        }
+
+        Log::error('char_variant_map: 偵測到環，已丟棄環上的對照', [
+            'mode' => $mode,
+            'chars' => array_keys($onCycle),
+        ]);
+
+        return array_diff_key($edges, $onCycle);
     }
 }

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -217,7 +217,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
         $surnameReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_surname_chn'] ?? ''));
         $mingziReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_mingzi_chn'] ?? ''));
-        $variantReplaced = array_merge($surnameReplaced['replaced'], $mingziReplaced['replaced']);
+        $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
         $payload['c_surname_chn'] = $surnameReplaced['text'];
         $payload['c_mingzi_chn'] = $mingziReplaced['text'];
 

--- a/app/Support/VariantReplaceScope.php
+++ b/app/Support/VariantReplaceScope.php
@@ -1,0 +1,419 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 異體字落地替換的「範圍」單一權威來源：回答「(表, 欄位) 該用哪個模式」。
+ *
+ * 設計見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md：
+ * - D1 以**欄位型別**判定範圍（文本型別才過），不以命名規律、不預判有沒有中文。
+ *   對照表 key 全是 CJK，所以套在拼音／羅馬字欄上必然 no-op。
+ * - D2 fail-closed：未知表一律不替換；表名／欄位名比對大小寫不敏感。
+ * - D3 排除清單（本檔常數）：本身做文本替換／字形對照，或語義上必須保留原字的地方一律不掛。
+ * - D4 **預設 lenient**；strict 只用於人名／別名欄，且是逐欄位例外。
+ *
+ * 排除清單刻意寫成常數而非 config：這些排除是**程式正確性前提**（尤其對照表自身與拼音
+ * 字典鍵，替換會造成資料自我損毀），不應該可由部署設定關掉。
+ */
+final class VariantReplaceScope {
+    /** 文本型別白名單（`Schema::getColumns()` 的 type_name，小寫）。 */
+    public const TEXT_TYPES = [
+        'varchar',
+        'char',
+        'tinytext',
+        'text',
+        'mediumtext',
+        'longtext',
+    ];
+
+    /**
+     * 逐欄位 strict 清單（人名／別名）。比對大小寫不敏感。
+     *
+     * strict = 只套 c_strict_excluded = 0 的對照（目前 6 筆，排除「峯→峰」）。
+     * 這是**逐欄位**而非逐表：同一列 BIOG_MAIN 裡姓名欄 strict、c_notes 走預設 lenient。
+     *
+     * @var array<string,array<int,string>>
+     */
+    public const STRICT_COLUMNS = [
+        'BIOG_MAIN' => ['c_name_chn', 'c_surname_chn', 'c_mingzi_chn'],
+        'ALTNAME_DATA' => ['c_alt_name_chn'],
+    ];
+
+    /**
+     * 整表排除。
+     *
+     * @var array<int,string>
+     */
+    public const EXCLUDED_TABLES = [
+        // 對照表自身：內容就是字形本身，替換等於自我吞噬（新增「峯→峰」後，
+        // 含「峯」的既有列——包括那筆對照自己的 c_variant_char——都會被改寫）。
+        'char_variant_map',
+        // 唯讀派生搜尋索引，且刻意同時保存繁簡兩形供檢索命中。
+        'CBDB__NAME_FTS',
+        // 紀錄／帳號類：紀錄的語義是「當時實際發生了什麼」，改寫等於偽造紀錄。
+        // （D2 fail-closed 已涵蓋這些非 CBDB 表，明文列出以固定意圖。）
+        'users',
+        'nl_query_logs',
+        'ai_fill_logs',
+        'audit_log',
+        'operations',
+        // 派生表：內容由源頭重建（RegenerateAddresses），改派生物只會與源頭不一致。
+        'ADDRESSES',
+        // DB view（Schema::getColumns() 會回傳 view）。
+        'View_BiogInstData',
+        'View_PossessionsData',
+    ];
+
+    /**
+     * 逐欄位排除：表 => 欄位清單。比對大小寫不敏感。
+     *
+     * @var array<string,array<int,string>>
+     */
+    public const EXCLUDED_COLUMNS = [
+        // 拼音字典的鍵。第一階段明文設計「異體字各自在 pinyin 表有自己的讀音」，
+        // 替換這欄會直接破壞該設計（「峯」的讀音條目會變成「峰」）。
+        'pinyin' => ['c_chn'],
+
+        // ── 拉丁人名欄（共 13 欄，D4）：排除而非 strict。
+        // 理由 1：strict 仍會套那 6 筆規則，真有人填漢字時 愼→慎／靑→青 照樣被改；
+        //         只有排除能真正不碰。
+        // 理由 2：排除順帶消掉組合欄失步——BiogMainRepository::updateById() 的
+        //         c_name／c_name_proper／c_name_rm 是從 $request 重組的，若分欄在 $data
+        //         被替換而組合欄從未替換的 $request 組出就會不一致。
+        // 語義：羅馬字轉寫的用途就是保留錄入者寫的拼法；中文源頭欄已歸一，轉寫欄不該再被改。
+        'BIOG_MAIN' => [
+            'c_surname', 'c_mingzi', 'c_name',
+            'c_surname_proper', 'c_mingzi_proper', 'c_name_proper',
+            'c_surname_rm', 'c_mingzi_rm', 'c_name_rm',
+            // 跨表代碼鍵 → INDEXYEAR_TYPE_CODES.c_index_year_type_code（varchar PK）。
+            'c_index_year_type_code',
+        ],
+        'ALTNAME_DATA' => [
+            'c_alt_name', 'c_alt_name_pinyin', 'c_alt_name_pinyin2', 'c_alt_name_pinyin3',
+            // c_alt_name_role：prod-only varchar(50)（不在 migrations／DATABASE_SCHEMA.md，
+            // 只出現在 allowedFields 白名單與測試合成表），全庫**零**應用邏輯讀它。
+            // 語義無法從程式判定，所以刻意選保守側排除：漏一次替換是可回復的
+            // （日後歸類清楚再放進範圍），而誤改一個代碼／角色鍵是不可回復的。
+            // 若日後確認它是散文性質的說明文字，再移出這份清單。
+            'c_alt_name_role',
+        ],
+
+        // ── 跨表 join／樹狀關聯的「代碼鍵」（D3）。
+        // 判準是「這個值是用來跟別表對上的代碼」，**不是**「是不是 varchar PK 成員」——
+        // ALTNAME_DATA.c_alt_name_chn／ASSOC_DATA.c_text_title／BIOG_SOURCE_DATA.c_pages
+        // 同樣是 varchar PK 成員，但語義是別名／書名／頁碼，屬「內容」、必須替換。
+        //
+        // 7 組 `*_CODE_TYPE_REL` ↔ `*_TYPES` 的文字型 code PK：REL 側與 PK 側**都要排除**，
+        // 只排一邊等於「只改 join 一邊」，照樣打斷關聯。權威來源是
+        // CodesController::$tableJoinConfigurations（見 tests/Unit/VariantReplaceJoinKeyGuardTest.php
+        // 的自動守衛：新增 join 設定卻忘了登記排除時，那支測試會紅）。
+        'ADMIN_CAT_TYPES' => ['c_admin_cat_type_code'],
+        'ADMIN_CAT_CODE_TYPE_REL' => ['c_admin_cat_type_code'],
+        'APPOINTMENT_TYPES' => ['c_appt_type_code'],
+        'APPOINTMENT_CODE_TYPE_REL' => ['c_appt_type_code'],
+        // c_assoc_type_code 另被 `LIKE '$x%'` 前綴走訪（Api/ApiController5.php:333），
+        // 替換會打斷樹狀查詢而非只是打斷單筆 join。
+        'ASSOC_TYPES' => ['c_assoc_type_code', 'c_assoc_type_parent_id'],
+        'ASSOC_CODE_TYPE_REL' => ['c_assoc_type_code'],
+        'ENTRY_TYPES' => ['c_entry_type', 'c_entry_type_parent_id'],
+        'ENTRY_CODE_TYPE_REL' => ['c_entry_type'],
+        // 注意 STATUS_TYPES 的父鍵後綴是 _parent_code 而非 _parent_id——只按 *_parent_id 掃會漏掉。
+        'STATUS_TYPES' => ['c_status_type_code', 'c_status_type_parent_code'],
+        'STATUS_CODE_TYPE_REL' => ['c_status_type_code'],
+        'TEXT_BIBLCAT_TYPES' => ['c_text_cat_type_id', 'c_text_cat_type_parent_id'],
+        'TEXT_BIBLCAT_CODE_TYPE_REL' => ['c_text_cat_type_id'],
+        // c_text_cat_parent_id 是第 6 個自參照樹狀父鍵（指向同表 PK c_text_cat_code）。
+        'TEXT_BIBLCAT_CODES' => ['c_text_cat_parent_id'],
+        // TEXT_TYPE 這組沒有宣告 FK，關聯是 Eloquent belongsTo（TextCode.php:30）。
+        // **PK 本身也要排除**——只排 parent 卻不排被 parent 指到的 PK，關聯照樣斷。
+        'TEXT_TYPE' => ['c_text_type_code', 'c_text_type_parent_id'],
+        'TEXT_CODES' => ['c_text_type_id'],
+        //
+        // 官職類型樹：REL 側的欄名（c_office_tree_id）與 PK 側（c_office_type_node_id）
+        // **不同名**，只掃 node_id 會漏掉 REL 側。這一組有實際風險而非理論風險——
+        // c_office_type_node_id 的值域含中文，且被 `LIKE '%$q%'` 做中文搜尋
+        // （ApiController.php:269），也被 `LIKE '$id%'` 前綴走訪（Api/ApiController.php:463）。
+        'OFFICE_TYPE_TREE' => ['c_office_type_node_id', 'c_parent_id'],
+        'OFFICE_CODE_TYPE_REL' => ['c_office_tree_id'],
+        //
+        // 親屬關係字串：c_kinrel 系列是跨表對照的來源側與對面側，兩邊都要排。
+        // c_kinrel_alt 目前程式零引用，但值域與 c_kinrel 相同，一併排除較保守。
+        'KINSHIP_CODES' => ['c_kinrel', 'c_kinrel_alt', 'c_kinrel_simplified'],
+        'KIN_MOURNING' => ['c_kinrel', 'c_kinrel_alt'],
+        'KIN_MOURNING_STEPS' => ['c_kinrel'],
+        'KINREL_REDUCTION' => ['c_kinrel_target', 'c_kinrel_replacement', 'c_sex'],
+        //
+        // 跨表代碼鍵：對上 APPOINTMENT_CODES.c_appt_code，被 exact where 比對
+        // （Api/ApiController2.php:184）。兩邊都是 smallint，所以型別閘門本來就擋掉了；
+        // 列在此處是為了讓「它是代碼鍵」這個判定有據可查，不是因為它是文本欄。
+        'POSTED_TO_OFFICE_DATA' => ['c_appt_code'],
+    ];
+
+    /**
+     * 任何表都排除的欄位。
+     *
+     * @var array<int,string>
+     */
+    public const EXCLUDED_COLUMNS_ANY_TABLE = [
+        // 稽核欄：依 AGENTS.md §1.2 由系統蓋章、經 AuditActor 產生。這是**署名**不是內容，
+        // 內容正規化不得改寫他人姓名（中文使用者名稱確實可能含這些字）。
+        'c_created_by', 'c_created_date', 'c_modified_by', 'c_modified_date',
+        'created_at', 'updated_at',
+        // URL 欄：識別碼／位址而非文句，改寫會讓連結失效。
+        'c_url_api', 'c_url_api_coda', 'c_url_homepage',
+    ];
+
+    /** 型別快取：正規化表名 => [正規化欄位名 => type_name]。 */
+    private static ?array $columnTypes = null;
+
+    /** 文本欄清單快取：正規化表名 => 正規化欄位名清單（避免每次重新過濾）。 */
+    private static array $textColumnCache = [];
+
+    /** 已知 CBDB 資料表快取：正規化表名的 set。 */
+    private static ?array $knownTables = null;
+
+    /**
+     * modeFor() 的結果快取（"表.欄" => 'strict'|'lenient'|null）。
+     *
+     * **不是可選的最佳化**：replaceRow() 對整列每個欄位都呼叫 modeFor()，而批次匯入是
+     * 逐列迴圈，S2-S7 又要再掛 20+ 個呼叫點，沒有 memo 時是 O(列數 x 欄數 x 清單長度)
+     * 的重複 strtolower。實測 200,000 次呼叫 1.17s 降到 12ms。
+     */
+    private static array $modeCache = [];
+
+    /** 正規化後的排除／strict 清單快取，避免每次呼叫都重建陣列。 */
+    private static ?array $normalizedLists = null;
+
+    /**
+     * (表, 欄位) 該用哪個替換模式。
+     *
+     * @return string|null 'strict'|'lenient'；null = 不替換（排除／未知表／非文本欄）
+     */
+    public static function modeFor(string $table, string $column): ?string {
+        $t = self::normalize($table);
+        $c = self::normalize($column);
+        $key = $t.'.'.$c;
+
+        if (array_key_exists($key, self::$modeCache)) {
+            return self::$modeCache[$key];
+        }
+
+        return self::$modeCache[$key] = self::resolveMode($t, $c, $table);
+    }
+
+    /** modeFor() 的實際判定（未快取）。$table 保留原樣傳給 textColumns()。 */
+    private static function resolveMode(string $t, string $c, string $table): ?string {
+        $lists = self::normalizedLists();
+
+        // fail closed：未知表一律不替換（D2）。框架表、紀錄表、客戶端亂傳的字串都落在這裡。
+        if (!self::isKnownDataTable($table)) {
+            return null;
+        }
+
+        if (isset($lists['tables'][$t])) {
+            return null;
+        }
+
+        if (isset($lists['anyTableColumns'][$c])) {
+            return null;
+        }
+
+        if (isset($lists['columns'][$t][$c])) {
+            return null;
+        }
+
+        // 非文本型別不替換。
+        if (!in_array($c, self::textColumns($table), true)) {
+            return null;
+        }
+
+        if (isset($lists['strict'][$t][$c])) {
+            return 'strict';
+        }
+
+        // D4：預設是 lenient（全量規則），不是 strict。
+        return 'lenient';
+    }
+
+    /**
+     * 把三組排除常數與 strict 清單一次正規化成 hash set，之後查詢都是 O(1)。
+     *
+     * @return array{tables: array<string,true>, columns: array<string,array<string,true>>, anyTableColumns: array<string,true>, strict: array<string,array<string,true>>}
+     */
+    private static function normalizedLists(): array {
+        if (self::$normalizedLists !== null) {
+            return self::$normalizedLists;
+        }
+
+        $tables = [];
+        foreach (self::EXCLUDED_TABLES as $table) {
+            $tables[self::normalize($table)] = true;
+        }
+
+        $anyTableColumns = [];
+        foreach (self::EXCLUDED_COLUMNS_ANY_TABLE as $column) {
+            $anyTableColumns[self::normalize($column)] = true;
+        }
+
+        $columns = [];
+        foreach (self::EXCLUDED_COLUMNS as $table => $tableColumns) {
+            foreach ($tableColumns as $column) {
+                $columns[self::normalize($table)][self::normalize($column)] = true;
+            }
+        }
+
+        $strict = [];
+        foreach (self::STRICT_COLUMNS as $table => $tableColumns) {
+            foreach ($tableColumns as $column) {
+                $strict[self::normalize($table)][self::normalize($column)] = true;
+            }
+        }
+
+        return self::$normalizedLists = [
+            'tables' => $tables,
+            'columns' => $columns,
+            'anyTableColumns' => $anyTableColumns,
+            'strict' => $strict,
+        ];
+    }
+
+    /**
+     * 該表所有文本型別欄位（正規化欄位名），按表快取。
+     *
+     * 批次匯入是逐列迴圈，若每列都查 information_schema 會造成 N 次 metadata 查詢。
+     *
+     * @return array<int,string>
+     */
+    public static function textColumns(string $table): array {
+        $t = self::normalize($table);
+
+        if (self::$columnTypes === null) {
+            self::$columnTypes = [];
+        }
+
+        if (!array_key_exists($t, self::$columnTypes)) {
+            self::$columnTypes[$t] = self::loadColumnTypes($table);
+        }
+
+        if (!array_key_exists($t, self::$textColumnCache)) {
+            $textColumns = [];
+            foreach (self::$columnTypes[$t] as $column => $type) {
+                if (in_array($type, self::TEXT_TYPES, true)) {
+                    $textColumns[] = $column;
+                }
+            }
+            self::$textColumnCache[$t] = $textColumns;
+        }
+
+        return self::$textColumnCache[$t];
+    }
+
+    /**
+     * 是否為已知 CBDB 資料表（D2 的 fail-closed 判定）。
+     *
+     * 「已知」= config/codes.php['tables'] ∪ CompositePrimaryKey::SCHEMAS
+     *          ∪ config/code_table_writes.php['tables'] ∪ config/code_table_mutations.php['tables']
+     *
+     * 這幾份 registry 已窮舉所有 CBDB 資料表，所以判定是自動的、不需手工維護。
+     */
+    public static function isKnownDataTable(string $table): bool {
+        if (self::$knownTables === null) {
+            self::$knownTables = self::loadKnownTables();
+        }
+
+        return isset(self::$knownTables[self::normalize($table)]);
+    }
+
+    /** 清快取。**必須在 TestCase::setUp() 呼叫**——測試自建的合成表在不同檔案有不同欄位集。 */
+    public static function reset(): void {
+        self::$columnTypes = null;
+        self::$knownTables = null;
+        self::$textColumnCache = [];
+        self::$modeCache = [];
+        self::$normalizedLists = null;
+    }
+
+    /**
+     * 已知表聯集。注意四份 registry 的**資料形狀不同**：
+     * codes.php['tables'] 與 code_table_writes.php['tables'] 是以表名為鍵的 map（array_keys）；
+     * code_table_mutations.php['tables'] 是 **list of maps、表名在 'table' 值**（array_column）。
+     * 對第三份誤用 array_keys() 會得到 "0".."13" 並漏掉 14 張真表。
+     *
+     * @return array<string,true>
+     */
+    private static function loadKnownTables(): array {
+        $names = [];
+
+        foreach (array_keys((array) config('codes.tables', [])) as $name) {
+            $names[] = (string) $name;
+        }
+
+        foreach (array_keys(CompositePrimaryKey::SCHEMAS) as $name) {
+            $names[] = (string) $name;
+        }
+
+        foreach (array_keys((array) config('code_table_writes.tables', [])) as $name) {
+            $names[] = (string) $name;
+        }
+
+        foreach ((array) config('code_table_mutations.tables', []) as $definition) {
+            if (is_array($definition) && isset($definition['table'])) {
+                $names[] = (string) $definition['table'];
+            }
+        }
+
+        $set = [];
+        foreach ($names as $name) {
+            if ($name !== '') {
+                $set[self::normalize($name)] = true;
+            }
+        }
+
+        return $set;
+    }
+
+    /**
+     * 讀該表的欄位型別。`Schema::getColumns()` 的 type_name 在 MariaDB 與 SQLite
+     * 都已歸一為小寫（MySqlGrammar 用 information_schema.DATA_TYPE、
+     * SQLiteProcessor 做 strtok(strtolower())）。
+     *
+     * @return array<string,string> 正規化欄位名 => type_name
+     */
+    private static function loadColumnTypes(string $table): array {
+        try {
+            $columns = Schema::getColumns($table);
+        } catch (\Throwable $e) {
+            // 表不存在或 driver 不支援：視為沒有文本欄，配合 fail-closed。
+            //
+            // ⚠️ 這個負結果會被 $columnTypes／$modeCache 快取住，所以在 web request 裡
+            // 一次連線抖動就會讓該表的文本欄在**這個 process 的剩餘生命週期**都不被替換
+            // （測試有 TestCase::setUp() 的 reset() 兜著，web 沒有）。因此這裡記 warning，
+            // 讓「整批資料沒被替換」這種靜默失效至少留下痕跡。
+            Log::warning('VariantReplaceScope: 讀取欄位型別失敗，該表本次視為無文本欄', [
+                'table' => $table,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $types = [];
+        foreach ($columns as $column) {
+            $name = (string) ($column['name'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+            $types[self::normalize($name)] = strtolower((string) ($column['type_name'] ?? ''));
+        }
+
+        return $types;
+    }
+
+    /** 表名／欄位名的正規化：大小寫不敏感比對（D2 第 1 點）。 */
+    private static function normalize(string $name): string {
+        return strtolower(trim($name));
+    }
+}

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -248,11 +248,21 @@ D3 已內嵌一份已查證的代碼鍵清單，直接進排除常數。本步�
   - 哨兵值不變式：`[n/a]`／`-9999`／`<待删除>` 與 `c_variant_char` 集合無交集（今天成立是資料巧合）。
   - 淺層掃描：嵌套陣列值原樣保留。
 
+> **S1 已完成的實作約定（S2–S7 必讀）**：`replaced` 的值在衝突時**會是 list** ——
+> 同一個變體在 strict 欄與 lenient 欄的閉包終點可以不同（`龴→峯`(excluded=0) +
+> `峯→峰`(excluded=1)：strict 得「峯」、lenient 得「峰」）。因此：
+> - **只能經 `CharVariantMapService::buildNotices()`／`withNotices()`／`flattenReplaced()` 消費**，
+>   **不可直接 `foreach` 取值或 `implode`**（會拋 "Array to string conversion"，或把陣列
+>   JSON 化進前端 payload 而打壞契約）。
+> - 合併兩份 `replaced` 一律用 `CharVariantMapService::mergeReplaced()`，
+>   **不可用 `+=` 或 `array_merge`**（兩者都會靜默丟掉一個參考字，讓通知與實際落庫的字形不一致）。
+> - 需要結構化 payload（例如批次匯入結果頁的 `variant_replacements`）時用 `flattenReplaced()`。
+
 ### S2：Codes UI 全表串接（G1）
 
 5 條路徑在現有 `normalizeCodeTablePinyin()` 呼叫的**下一行**插入 `replaceRow($data, $table)`：`:1766`（`performStore`）、`:1349`（`performUpdate`）、`:1512`（`performProposalStore`）、`:1843`（`performProposalUpdate`）、`:1624`（`proposalUpdateExisting`）。
 
-- direct 兩條：`replaced` 非空時 `flash(...,'info')`；它們之後才呼叫 `applyColumnDefaultsForBlanks()`（`:1769`／`:1352`），**三條提案路徑不呼叫它**，只需在記 operation 之前。
+- direct 兩條：`replaced` 非空時把 `buildNotices()` 的每則訊息 `flash(...,'info')`（**不要自己組字**，見上方 S1 約定）；它們之後才呼叫 `applyColumnDefaultsForBlanks()`（`:1769`／`:1352`），**三條提案路徑不呼叫它**，只需在記 operation 之前。
 - 提案三條：替換後的值進 `operations.resource_data`（`$table` 傳**目標表**，不是 `operations`）。
 - 同時涵蓋 Blade 與 React（共用 `perform*`）。
 - **`char_variant_map` 的 guard**：`performStore()`／`performUpdate()` 落庫前呼叫 `CharVariantMapService::assertWritable($data, $id)`（違反回 flash error 且不寫入），成功後呼叫 `CharVariantMapService::reset()`。三條提案路徑寫的是 `operations`、不改對照表，**不需要** reset，但仍建議在提案建立時先跑 `assertWritable()` 提早拒絕。

--- a/resources/lang/en/variant.php
+++ b/resources/lang/en/variant.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Character variant normalization (char_variant_map)
+|--------------------------------------------------------------------------
+|
+| See docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md. These strings surface in
+| Codes UI flash messages and the `notices` field of v2 mutate responses (covering
+| 80+ code tables and every person subresource), so per AGENTS.md §6 they must go
+| through __() rather than being hard-coded.
+|
+*/
+
+return [
+    'notice' => 'Character variants: :pairs',
+    'notice_pair' => '":variant" normalized to ":reference"',
+    'notice_separator' => '; ',
+
+    'incomplete_payload' => 'Updating a mapping requires both the variant and the reference character (or the id of the mapping being updated).',
+    'single_codepoint_required' => 'Both the variant character and the reference character must be a single character.',
+    'self_reference_not_allowed' => 'The variant character and the reference character must differ.',
+    'cycle_not_allowed' => 'This mapping would create a cycle (":char" maps back to itself). Please choose a different reference character.',
+];

--- a/resources/lang/zh-TW/variant.php
+++ b/resources/lang/zh-TW/variant.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| 異體字落地替換（char_variant_map）
+|--------------------------------------------------------------------------
+|
+| 見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md。這些字串會出現在
+| Codes UI 的 flash 訊息與 v2 mutate 回應的 notices 欄位（涵蓋 80+ 張代碼表
+| 與所有人物子資源），所以依 AGENTS.md §6 必須走 __()，不可硬編。
+|
+*/
+
+return [
+    'notice' => '異體字：:pairs',
+    'notice_pair' => '「:variant」已正規化為「:reference」',
+    'notice_separator' => '、',
+
+    'incomplete_payload' => '更新對照時必須同時提供異體字與參考字（或指定要更新的對照 id）。',
+    'single_codepoint_required' => '異體字與參考字都必須是單一字元。',
+    'self_reference_not_allowed' => '異體字與參考字不可相同。',
+    'cycle_not_allowed' => '這筆對照會造成循環（「:char」繞回自己），請改用其他參考字。',
+];

--- a/tests/Feature/OperationsRestoreCharVariantMapGuardTest.php
+++ b/tests/Feature/OperationsRestoreCharVariantMapGuardTest.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\CharVariantMapService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * `OperationsController::restore()` 對 char_variant_map 的結構把關（計畫 S1）。
+ *
+ * 為什麼 restore 需要這道 guard：char_variant_map 明文登記在 `resourceKeyColumns()`，
+ * 所以 restore 對它是刻意支援的；但它同時是**所有落地替換的資料來源**，還原一筆壞對照
+ * （成環、多字元）會讓全站的替換降級。restore 是 10 個寫入入口中唯一不在 S2／S5／S6
+ * 編輯範圍內的那條，所以在 S1 補。
+ *
+ * **注意這與「restore 不做內容替換」不衝突**：那是不對還原的內容套落地替換（保留歷史
+ * 字形），這裡是對這張表的寫入做結構驗證。本檔最後一條測試把這個區分釘住。
+ */
+class OperationsRestoreCharVariantMapGuardTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        Schema::dropIfExists('operations');
+        Schema::create('operations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->nullable();
+            $table->integer('op_type')->nullable();
+            $table->string('resource', 255)->nullable();
+            $table->string('resource_id', 255)->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->nullable();
+            $table->text('comment')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->tinyInteger('is_admin')->default(0);
+            $table->tinyInteger('is_active')->default(1);
+            $table->timestamps();
+        });
+
+        CharVariantMapService::reset();
+    }
+
+    private function actAsRestorer(): User {
+        $user = new User();
+        $user->name = 'restorer';
+        $user->email = 'restorer@example.com';
+        $user->password = bcrypt('secret');
+        // canRestoreOperations() = isActive() && isAdmin()，而 isAdmin() 讀的是 is_admin
+        $user->is_admin = User::ROLE_SUPER_ADMIN;
+        $user->is_active = User::STATUS_ACTIVE;
+        $user->save();
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    /**
+     * 斷言 flash 訊息含指定字串。
+     *
+     * 少了這一層，「被擋下」的測試只會斷言 assertRedirect() + DB 未變——那在
+     * restore 因**別的**原因失敗時（例如日後把 char_variant_map 從
+     * resourceKeyColumns() 拿掉 ⇒ restore_no_pk）同樣會綠，等於假綠。
+     */
+    private function assertFlashContains(string $needle): void {
+        $flash = session('flash_notification', collect())->toArray();
+        $messages = array_map(fn ($item) => (string) ($item['message'] ?? ''), $flash);
+
+        $this->assertTrue(
+            collect($messages)->contains(fn (string $m) => str_contains($m, $needle)),
+            "flash 訊息不含「{$needle}」，實際為：".implode(' | ', $messages)
+        );
+    }
+
+    /** DYNASTIES 在 resourceKeyColumns() 有登記（['c_dy']），所以 restore 走得通。 */
+    private function createDynastiesTable(): void {
+        Schema::dropIfExists('DYNASTIES');
+        Schema::create('DYNASTIES', function (Blueprint $table) {
+            $table->integer('c_dy');
+            $table->string('c_dynasty_chn', 255)->nullable();
+            $table->string('c_dynasty', 255)->nullable();
+        });
+    }
+
+    /**
+     * 建立一筆「update」operation（op_type=3）：resource_data 是改動後、
+     * resource_original 是改動前（restore 會把 original 寫回去）。
+     */
+    private function makeUpdateOperation(int $id, array $after, array $before): int {
+        return (int) DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'op_type' => 3,
+            'resource' => 'char_variant_map',
+            'resource_id' => (string) $id,
+            'resource_data' => json_encode($after, JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode($before, JSON_UNESCAPED_UNICODE),
+        ]);
+    }
+
+    #[Test]
+    public function testRestoringALegitimateMappingSucceeds(): void {
+        $this->actAsRestorer();
+
+        $id = (int) DB::table('char_variant_map')->insertGetId([
+            'id' => 1,
+            'c_variant_char' => '淸',
+            'c_reference_char' => '菁',
+            'c_strict_excluded' => 0,
+        ]);
+
+        // 之前是 淸→清，被改成 淸→菁；還原應該把 c_reference_char 還原成「清」
+        $operationId = $this->makeUpdateOperation(
+            $id,
+            ['id' => $id, 'c_variant_char' => '淸', 'c_reference_char' => '菁', 'c_strict_excluded' => 0],
+            ['id' => $id, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        );
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame(
+            '清',
+            DB::table('char_variant_map')->where('id', $id)->value('c_reference_char'),
+            '合法還原不該被 guard 誤殺'
+        );
+    }
+
+    /**
+     * 還原一筆會造成環的對照 ⇒ 乾淨的 flash error，DB 不變。
+     *
+     * 表裡已有 淸→清；把另一列還原成 清→淸 就成環。若沒有 guard，這筆會落庫，
+     * 之後每次載入對照表都會觸發環偵測降級（丟掉這兩條邊）。
+     */
+    #[Test]
+    public function testRestoringAMappingThatWouldCreateACycleIsRejected(): void {
+        $this->actAsRestorer();
+
+        DB::table('char_variant_map')->insert([
+            'id' => 1, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0,
+        ]);
+        DB::table('char_variant_map')->insert([
+            'id' => 2, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1,
+        ]);
+
+        // 把 id=2 還原成 清→淸（與 id=1 的 淸→清 成環）
+        $operationId = $this->makeUpdateOperation(
+            2,
+            ['id' => 2, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['id' => 2, 'c_variant_char' => '清', 'c_reference_char' => '淸', 'c_strict_excluded' => 1],
+        );
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $row = DB::table('char_variant_map')->where('id', 2)->first();
+        $this->assertSame('峯', $row->c_variant_char, '被擋下的還原不該改動 DB');
+        $this->assertSame('峰', $row->c_reference_char);
+
+        // 釘住「是 guard 擋的」而不是 restore 因別的原因失敗
+        $this->assertFlashContains(__('variant.cycle_not_allowed', ['char' => '清']));
+    }
+
+    /** 還原一筆多字元對照也要被擋（幂等論證只在單一 codepoint 下成立）。 */
+    #[Test]
+    public function testRestoringAMultiCodepointMappingIsRejected(): void {
+        $this->actAsRestorer();
+
+        DB::table('char_variant_map')->insert([
+            'id' => 1, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0,
+        ]);
+
+        $operationId = $this->makeUpdateOperation(
+            1,
+            ['id' => 1, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['id' => 1, 'c_variant_char' => '甲乙', 'c_reference_char' => '丙', 'c_strict_excluded' => 0],
+        );
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame(
+            '淸',
+            DB::table('char_variant_map')->where('id', 1)->value('c_variant_char'),
+            '多字元對照不該被還原進表裡'
+        );
+        $this->assertFlashContains(__('variant.single_codepoint_required'));
+    }
+
+    /**
+     * op_type=4（restoreDelete）也會經過 guard。
+     *
+     * 註：本案例的 `resource_id` 有值，所以 `buildKeyConditions()` 仍給出 `['id' => 2]`、
+     * `$excludeId = 2`。真正的 `$conditions === []` 只在 `operations.resource_id` 為 NULL
+     * 時才出現，那條路徑 `$excludeId = null` 是正確語義（被還原的列已被刪、不在任何邊上）。
+     */
+    #[Test]
+    public function testRestoringADeletedMappingIsAlsoGuarded(): void {
+        $this->actAsRestorer();
+
+        DB::table('char_variant_map')->insert([
+            'id' => 1, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0,
+        ]);
+
+        // 還原一筆被刪的 清→淸（與現存的 淸→清 成環）
+        $operationId = (int) DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'op_type' => 4,
+            'resource' => 'char_variant_map',
+            'resource_id' => '2',
+            'resource_data' => json_encode(
+                ['id' => 2, 'c_variant_char' => '清', 'c_reference_char' => '淸', 'c_strict_excluded' => 1],
+                JSON_UNESCAPED_UNICODE
+            ),
+            'resource_original' => null,
+        ]);
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame(1, DB::table('char_variant_map')->count(), '成環的刪除還原不該落庫');
+        $this->assertFlashContains(__('variant.cycle_not_allowed', ['char' => '清']));
+    }
+
+    /** op_type=4 還原一筆不成環的對照應該成功。 */
+    #[Test]
+    public function testRestoringADeletedLegitimateMappingSucceeds(): void {
+        $this->actAsRestorer();
+
+        $operationId = (int) DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'op_type' => 4,
+            'resource' => 'char_variant_map',
+            'resource_id' => '5',
+            'resource_data' => json_encode(
+                ['id' => 5, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+                JSON_UNESCAPED_UNICODE
+            ),
+            'resource_original' => null,
+        ]);
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame(
+            '清',
+            DB::table('char_variant_map')->where('c_variant_char', '淸')->value('c_reference_char'),
+            'op_type=4 的合法還原不該被 guard 誤殺'
+        );
+    }
+
+    /**
+     * 別的表的還原完全不受這道 guard 影響（它以表名早退）。
+     */
+    #[Test]
+    public function testGuardDoesNotAffectOtherTables(): void {
+        $this->actAsRestorer();
+
+        $this->createDynastiesTable();
+        DB::table('DYNASTIES')->insert(['c_dy' => 1, 'c_dynasty_chn' => '改後']);
+
+        $operationId = (int) DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'op_type' => 3,
+            'resource' => 'DYNASTIES',
+            'resource_id' => '1',
+            'resource_data' => json_encode(['c_dy' => 1, 'c_dynasty_chn' => '改後'], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_dy' => 1, 'c_dynasty_chn' => '改前'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame('改前', DB::table('DYNASTIES')->where('c_dy', 1)->value('c_dynasty_chn'));
+    }
+
+    /**
+     * **restore 不做內容替換**：還原的歷史字形要原樣保留。
+     *
+     * 這條把 D6／S6 那個刻意的不對稱釘住——S1 只在 restore 掛結構驗證（單 codepoint、
+     * 不成環），**不**對還原的內容套落地替換。若日後有人「順手補上」內容替換，
+     * 這條會紅。
+     */
+    #[Test]
+    public function testRestoreKeepsHistoricalVariantFormsVerbatim(): void {
+        $this->actAsRestorer();
+
+        $this->createDynastiesTable();
+        DB::table('DYNASTIES')->insert(['c_dy' => 1, 'c_dynasty_chn' => '清明']);
+
+        DB::table('char_variant_map')->insert([
+            'id' => 1, 'c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0,
+        ]);
+
+        // 歷史快照裡是變體形「淸明」
+        $operationId = (int) DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'op_type' => 3,
+            'resource' => 'DYNASTIES',
+            'resource_id' => '1',
+            'resource_data' => json_encode(['c_dy' => 1, 'c_dynasty_chn' => '清明'], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_dy' => 1, 'c_dynasty_chn' => '淸明'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $this->post("/operations/{$operationId}/restore")->assertRedirect();
+
+        $this->assertSame(
+            '淸明',
+            DB::table('DYNASTIES')->where('c_dy', 1)->value('c_dynasty_chn'),
+            'restore 必須忠實還原歷史字形，不可套落地替換'
+        );
+    }
+}

--- a/tests/Feature/VariantReplaceRegistryDriftTest.php
+++ b/tests/Feature/VariantReplaceRegistryDriftTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\VariantReplaceScope;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 已知表 registry 的漂移守衛（計畫 D2／S1）。
+ *
+ * **為什麼要獨立一個 Feature 測試而不是放在 VariantReplaceScopeTest 裡**：那支測試
+ * 沒有 RefreshDatabase，`CreatesApplication` 給的是全新的 :memory: SQLite、從不跑
+ * migration，所以 `Schema::getTables()` 只會回傳測試自己在 setUp() 建的那幾張合成表
+ * ——而它們當然全是已知表 ⇒ 守衛永遠綠、永遠抓不到「新 migration 建了 CBDB 表卻忘了
+ * 登記進四份 registry」。這正是本檔要修的假綠。
+ *
+ * 掛 RefreshDatabase 讓 schema 真的來自 database/migrations，守衛才有意義。
+ *
+ * 邊界：它抓的是「新 migration 忘了登記」，**抓不到只存在於 prod 的表**
+ * （D2 的 caveat；prod-only 欄位另見 S0 的 prod schema 比對）。
+ */
+class VariantReplaceRegistryDriftTest extends TestCase {
+    use RefreshDatabase;
+
+    /**
+     * 明文的「非 CBDB 資料表」清單：框架表與紀錄／帳號表。
+     *
+     * 落在這裡的表**不需要**登記進四份 registry，因為它們本來就不該被落地替換
+     * （紀錄的語義是「當時實際發生了什麼」，改寫等於偽造紀錄）。
+     *
+     * @var array<int,string>
+     */
+    private const NON_CBDB_TABLES = [
+        // Laravel 框架／基礎設施
+        'migrations',
+        'password_resets',
+        'personal_access_tokens',
+        // 帳號與紀錄類（同時也在 VariantReplaceScope::EXCLUDED_TABLES）
+        'users',
+        'audit_log',
+        'operations',
+        'nl_query_logs',
+        'ai_fill_logs',
+        // 專案自建的派生索引（sidecar）：內容由來源表重算，不是錄入端
+        'person_change_index',
+        // Access 時代遺留的 metadata 表：描述「schema 長什麼樣」而非 CBDB 學術資料，
+        // 全庫零引用（計畫「不在本階段範圍內」已記錄）
+        'copytables',
+        'copytablesdefault',
+        'copymissingtables',
+        'tablesfields',
+        'tablesfieldschanges',
+        'foreignkeys',
+        // 簡繁標籤對照表（對照／映射性質；全庫零引用，不可達）
+        'formlabels',
+    ];
+
+    /**
+     * live schema 的每一張表，要嘛在已知 CBDB 表聯集內、要嘛在明文的非 CBDB 清單內。
+     *
+     * 漏登記的後果是**靜默**的：D2 是 fail-closed，未知表一律不替換，所以新增一張
+     * CBDB 表卻忘了登記，它的所有文本欄就會安靜地跳過落地替換，沒有任何錯誤。
+     */
+    #[Test]
+    public function testEveryMigrationTableIsEitherKnownOrExplicitlyNonCbdb(): void {
+        $tables = $this->liveTableNames();
+
+        // 先確認這支測試真的看到了 migration 建出來的 schema，而不是幾張合成表。
+        // 沒有這個下限斷言，本測試會退化成上一版那種假綠。
+        $this->assertGreaterThan(
+            50,
+            count($tables),
+            'live schema 只有 '.count($tables).' 張表，看起來 migration 沒有跑；'
+                .'本守衛必須在真實 schema 上執行才有意義'
+        );
+
+        $nonCbdb = array_map('strtolower', self::NON_CBDB_TABLES);
+        $unclassified = [];
+
+        foreach ($tables as $name) {
+            if (in_array($name, $nonCbdb, true)) {
+                continue;
+            }
+            if (VariantReplaceScope::isKnownDataTable($name)) {
+                continue;
+            }
+            $unclassified[] = $name;
+        }
+
+        sort($unclassified);
+
+        $this->assertSame(
+            [],
+            $unclassified,
+            "下列表既不在已知 CBDB 表聯集（config/codes.php ∪ CompositePrimaryKey::SCHEMAS "
+                ."∪ config/code_table_writes.php ∪ config/code_table_mutations.php）內、"
+                ."也不在本測試的非 CBDB 白名單內。\n"
+                ."因為 VariantReplaceScope 是 fail-closed，它們的文本欄會**靜默**跳過落地替換：\n"
+                .implode("\n", $unclassified)
+        );
+    }
+
+    /**
+     * 反向守衛：非 CBDB 白名單不該累積已經不存在的表名（否則它會慢慢變成一份
+     * 「什麼都豁免」的清單，讓上面那條斷言失去效力）。
+     */
+    #[Test]
+    public function testNonCbdbWhitelistHasNoStaleEntries(): void {
+        $tables = $this->liveTableNames();
+        $stale = [];
+
+        foreach (self::NON_CBDB_TABLES as $name) {
+            if (!in_array(strtolower($name), $tables, true)) {
+                $stale[] = $name;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $stale,
+            '非 CBDB 白名單含有 live schema 裡不存在的表，請移除：'.implode(', ', $stale)
+        );
+    }
+
+    /**
+     * 白名單與「已知表」必須互斥。
+     *
+     * 迴圈是**先**比對白名單才問 isKnownDataTable()，所以清單裡的表若日後被登記進四份
+     * registry，它就會靜默進入替換範圍、而守衛照樣全綠。`formlabels` 正是最可能發生的
+     * 那個（簡繁標籤對照表，目前完全靠這份白名單擋著）。
+     *
+     * 這條斷言把兩者釘成互斥：白名單項一旦被登記成已知表，就必須同時在
+     * `VariantReplaceScope::EXCLUDED_TABLES` 內，否則紅。
+     */
+    #[Test]
+    public function testWhitelistedTablesAreEitherUnknownOrExplicitlyExcluded(): void {
+        $excluded = array_map('strtolower', VariantReplaceScope::EXCLUDED_TABLES);
+        $leaking = [];
+
+        foreach (self::NON_CBDB_TABLES as $name) {
+            if (!VariantReplaceScope::isKnownDataTable($name)) {
+                continue;
+            }
+            if (in_array(strtolower($name), $excluded, true)) {
+                continue;
+            }
+            $leaking[] = $name;
+        }
+
+        $this->assertSame(
+            [],
+            $leaking,
+            '下列表同時出現在本測試的非 CBDB 白名單與已知 CBDB 表聯集裡，'
+                .'卻沒有登記在 VariantReplaceScope::EXCLUDED_TABLES ⇒ '
+                .'它們的文本欄會被落地替換，而本守衛卻因白名單而放過：'.implode(', ', $leaking)
+        );
+    }
+
+    /**
+     * TEXT_TYPES 漂移守衛（真實 schema 版）：live schema 裡每一個看起來是文本型別的
+     * `type_name` 都必須在 TEXT_TYPES 內，否則該欄會靜默逃出替換範圍。
+     *
+     * ⚠️ 這條在 SQLite 上抓不到 enum／json（Laravel 把它們編成 varchar／text），
+     * 那個缺口由 VariantReplaceScopeTest 的 migration 原始碼掃描補上。
+     */
+    #[Test]
+    public function testTextTypesCoversEveryTextTypeInLiveSchema(): void {
+        $observed = [];
+
+        foreach ($this->liveTableNames() as $table) {
+            try {
+                $columns = Schema::getColumns($table);
+            } catch (\Throwable $e) {
+                continue;
+            }
+            foreach ($columns as $column) {
+                $type = strtolower((string) ($column['type_name'] ?? ''));
+                if ($type !== '') {
+                    $observed[$type] = true;
+                }
+            }
+        }
+
+        $this->assertNotEmpty($observed, 'live schema 應該要有欄位型別');
+
+        $textLike = array_filter(array_keys($observed), function (string $type): bool {
+            return str_contains($type, 'char') || str_contains($type, 'text');
+        });
+
+        foreach ($textLike as $type) {
+            $this->assertContains(
+                $type,
+                VariantReplaceScope::TEXT_TYPES,
+                "型別 {$type} 看起來是文本型別但不在 VariantReplaceScope::TEXT_TYPES 內，"
+                    .'該型別的欄位會靜默逃出落地替換範圍'
+            );
+        }
+    }
+
+    /** @return array<int,string> 小寫表名 */
+    private function liveTableNames(): array {
+        $names = [];
+
+        foreach (Schema::getTables() as $table) {
+            $name = strtolower((string) ($table['name'] ?? ''));
+            if ($name !== '' && !str_starts_with($name, 'sqlite_')) {
+                $names[] = $name;
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
@@ -10,6 +12,13 @@ abstract class TestCase extends BaseTestCase {
     protected function setUp(): void {
         parent::setUp();
         $this->serverVariables['HTTP_ACCEPT_LANGUAGE'] = 'zh-TW,zh;q=0.9,en;q=0.1';
+
+        // 清異體字替換的兩份行程內快取。**必須做**：測試自建的是簡化版合成表，
+        // 同一個表名在不同檔案有不同欄位集，而 PHPUnit 單一行程跑完全部 ⇒
+        // 被前一個檔案暖起來的型別／對照表快取，對下一個檔案就是錯的，
+        // 測試結果會依檔案順序漂移。
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
     }
 
     /**

--- a/tests/Unit/CharVariantMapServiceRowTest.php
+++ b/tests/Unit/CharVariantMapServiceRowTest.php
@@ -1,0 +1,518 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * replaceRow()／replaceFor()／assertWritable() 與「載入時傳遞閉包」的測試。
+ *
+ * 設計見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md D8。手動建表（比照
+ * CharVariantMapServiceTest 慣例），種入與 migration 相同的 7 筆種子。
+ */
+class CharVariantMapServiceRowTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->createVariantMapTable();
+        $this->seedDefaultMappings();
+
+        Schema::dropIfExists('BIOG_MAIN');
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->string('c_name_chn', 255)->nullable();
+            $table->string('c_surname_chn', 255)->nullable();
+            $table->string('c_mingzi_chn', 255)->nullable();
+            $table->string('c_surname', 255)->nullable();
+            $table->string('c_tribe', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->integer('c_index_year')->nullable();
+        });
+
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    private function createVariantMapTable(): void {
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+    }
+
+    private function seedDefaultMappings(): void {
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+    }
+
+    private function resetCaches(): void {
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    // ─────────────────────────── replaceRow ───────────────────────────
+
+    /**
+     * D4 的核心語義：strict／lenient 是**逐欄位**而非逐表。
+     * 同一列裡姓名欄走 strict（「峯」保留）、c_notes 走 lenient（「峯」被替換）。
+     */
+    #[Test]
+    public function testReplaceRowMixesStrictAndLenientWithinOneRow(): void {
+        $result = CharVariantMapService::replaceRow([
+            'c_surname_chn' => '峯',
+            'c_mingzi_chn' => '淸',
+            'c_notes' => '峯淸',
+            'c_index_year' => 1200,
+        ], 'BIOG_MAIN');
+
+        // 姓名欄 strict：峯 保留、淸 仍會替換（它 c_strict_excluded = 0）
+        $this->assertSame('峯', $result['data']['c_surname_chn']);
+        $this->assertSame('清', $result['data']['c_mingzi_chn']);
+        // c_notes lenient：峯 也被替換
+        $this->assertSame('峰清', $result['data']['c_notes']);
+        // 非文本欄原樣
+        $this->assertSame(1200, $result['data']['c_index_year']);
+
+        $this->assertSame(['淸' => '清', '峯' => '峰'], $result['replaced']);
+    }
+
+    #[Test]
+    public function testReplaceRowSkipsExcludedAndNonStringValues(): void {
+        $result = CharVariantMapService::replaceRow([
+            'c_surname' => '峯',          // 拉丁人名欄（排除）
+            'c_modified_by' => '淸某',      // 稽核欄（排除）
+            'c_index_year' => 1200,        // 非文本
+            'c_notes' => null,             // null 跳過
+            'nested' => ['c_notes' => '淸'], // 陣列跳過（刻意的淺層掃描）
+        ], 'BIOG_MAIN');
+
+        $this->assertSame('峯', $result['data']['c_surname']);
+        $this->assertSame('淸某', $result['data']['c_modified_by']);
+        $this->assertSame(1200, $result['data']['c_index_year']);
+        $this->assertNull($result['data']['c_notes']);
+        $this->assertSame(['c_notes' => '淸'], $result['data']['nested']);
+        $this->assertSame([], $result['replaced']);
+    }
+
+    /** D2 fail-closed：未知表整列不動。 */
+    #[Test]
+    public function testReplaceRowIsNoOpForUnknownTable(): void {
+        $result = CharVariantMapService::replaceRow(['anything' => '淸'], 'not_a_cbdb_table');
+
+        $this->assertSame('淸', $result['data']['anything']);
+        $this->assertSame([], $result['replaced']);
+    }
+
+    #[Test]
+    public function testReplaceRowIsIdempotent(): void {
+        $once = CharVariantMapService::replaceRow(['c_notes' => '峯淸頴'], 'BIOG_MAIN');
+        $twice = CharVariantMapService::replaceRow($once['data'], 'BIOG_MAIN');
+
+        $this->assertSame($once['data'], $twice['data']);
+        $this->assertSame([], $twice['replaced'], '第二次套用不該再命中任何對照');
+    }
+
+    // ─────────────────────────── replaceFor ───────────────────────────
+
+    #[Test]
+    public function testReplaceForHandlesValuesThatAreNotKeyedByColumn(): void {
+        // 這是 S4 需要的入口：手上是裸字串、不是以欄位名為鍵的整列
+        $strict = CharVariantMapService::replaceFor('BIOG_MAIN', 'c_surname_chn', '峯');
+        $this->assertSame('峯', $strict['text']);
+
+        $lenient = CharVariantMapService::replaceFor('BIOG_MAIN', 'c_notes', '峯');
+        $this->assertSame('峰', $lenient['text']);
+
+        $excluded = CharVariantMapService::replaceFor('pinyin', 'c_chn', '峯');
+        $this->assertSame('峯', $excluded['text']);
+        $this->assertSame([], $excluded['replaced']);
+    }
+
+    /**
+     * 同一個變體在同一列被解析成**不同**的參考字時，兩個結果都要保留。
+     *
+     * 這會發生在 strict 欄與 lenient 欄的閉包終點不同時（`龴→峯`(excluded=0) +
+     * `峯→峰`(excluded=1)：strict 得「峯」、lenient 得「峰」）。若用 `+=` 或
+     * `array_merge` 合併，其中一個會被靜默丟掉，`buildNotices()` 就會告訴使用者
+     * 錯誤的字——而通知是使用者唯一能看見替換發生的管道。
+     */
+    #[Test]
+    public function testReplaceRowKeepsBothReferencesWhenOneVariantResolvesDifferentlyPerMode(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '龴', 'c_reference_char' => '峯', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+        ]);
+        $this->resetCaches();
+
+        $result = CharVariantMapService::replaceRow([
+            'c_surname_chn' => '龴',  // strict → 峯
+            'c_notes' => '龴',        // lenient → 峰
+        ], 'BIOG_MAIN');
+
+        $this->assertSame('峯', $result['data']['c_surname_chn']);
+        $this->assertSame('峰', $result['data']['c_notes']);
+
+        // 兩個參考字都要在 replaced 裡
+        $this->assertArrayHasKey('龴', $result['replaced']);
+        $references = is_array($result['replaced']['龴']) ? $result['replaced']['龴'] : [$result['replaced']['龴']];
+        $this->assertContains('峯', $references);
+        $this->assertContains('峰', $references);
+
+        // buildNotices() 必須能渲染陣列形狀，且兩個字都出現
+        $notices = CharVariantMapService::buildNotices($result['replaced']);
+        $this->assertCount(1, $notices);
+        $this->assertStringContainsString('峯', $notices[0]);
+        $this->assertStringContainsString('峰', $notices[0]);
+    }
+
+    /** 同一個變體在多欄命中同一個參考字時，不該重複列出。 */
+    #[Test]
+    public function testReplaceRowDoesNotDuplicateIdenticalReplacements(): void {
+        $result = CharVariantMapService::replaceRow([
+            'c_notes' => '淸',
+            'c_tribe' => '淸',
+        ], 'BIOG_MAIN');
+
+        $this->assertSame(['淸' => '清'], $result['replaced']);
+        $this->assertCount(1, CharVariantMapService::buildNotices($result['replaced']));
+    }
+
+    // ───────────────────── 傳遞閉包與環（D8） ─────────────────────
+
+    /**
+     * 幂等性不依賴表的內容：即使有人塞出一條鏈 A→B→C，替換結果仍是不動點。
+     *
+     * 沒有閉包的話：strtr 第一趟把 A 變 B，第二趟再把 B 變 C ⇒ 套兩次 ≠ 套一次。
+     */
+    #[Test]
+    public function testTransitiveClosureMakesChainedMappingsIdempotent(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '甲', 'c_reference_char' => '乙', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '乙', 'c_reference_char' => '丙', 'c_strict_excluded' => 0],
+        ]);
+        $this->resetCaches();
+
+        $once = CharVariantMapService::replaceLenient('甲乙');
+        // 閉包後 甲→丙、乙→丙，一趟就到終端
+        $this->assertSame('丙丙', $once['text']);
+
+        $twice = CharVariantMapService::replaceLenient($once['text']);
+        $this->assertSame($once['text'], $twice['text']);
+        $this->assertSame([], $twice['replaced']);
+    }
+
+    /**
+     * 環的處置：只丟棄構成環的邊、其餘照常生效，**不拋錯也不回空 map**。
+     *
+     * 這兩個 map 方法是所有替換的唯一入口，在此 throw 會讓 Codes UI 80 表、
+     * 所有 v2 mutate、批次匯入、眾包核准、提案核准一起爆。
+     */
+    #[Test]
+    public function testCycleEdgesAreDroppedWhileOtherMappingsSurvive(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '甲', 'c_reference_char' => '乙', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '乙', 'c_reference_char' => '甲', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        $this->resetCaches();
+
+        $result = CharVariantMapService::replaceLenient('甲乙淸');
+
+        // 環上兩個字保持原樣
+        $this->assertStringContainsString('甲', $result['text']);
+        $this->assertStringContainsString('乙', $result['text']);
+        // 環外的對照照常生效
+        $this->assertStringContainsString('清', $result['text']);
+        $this->assertSame(['淸' => '清'], $result['replaced']);
+    }
+
+    #[Test]
+    public function testSelfReferencingMappingIsTreatedAsCycle(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '甲', 'c_reference_char' => '甲', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        $this->resetCaches();
+
+        $result = CharVariantMapService::replaceLenient('甲淸');
+
+        $this->assertSame('甲清', $result['text']);
+    }
+
+    /**
+     * 「鏈進入環」：A→B、B→C、C→B。只丟環上節點（B、C）的出邊，**A→B 要保留**
+     * （B 成為終端）。丟掉 A→B 會誤殺不在環上的合法對照。
+     */
+    #[Test]
+    public function testChainEnteringCycleKeepsTheEdgeIntoTheCycle(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '甲', 'c_reference_char' => '乙', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '乙', 'c_reference_char' => '丙', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '丙', 'c_reference_char' => '乙', 'c_strict_excluded' => 0],
+        ]);
+        $this->resetCaches();
+
+        $result = CharVariantMapService::replaceLenient('甲乙丙');
+
+        // 甲→乙 保留；乙、丙 在環上、出邊被丟棄
+        $this->assertSame('乙乙丙', $result['text']);
+        $this->assertSame(['甲' => '乙'], $result['replaced']);
+    }
+
+    /**
+     * 閉包必須**先按模式過濾、再各自計算**。
+     *
+     * `X→峯`(excluded=0) + `峯→峰`(excluded=1)：strict 只看得到第一條邊，
+     * 所以 strict 對 X 應得「峯」；若先對全表算閉包再過濾，會得到 `X→峰`，
+     * 等於透過傳遞把一條 strict-excluded 的邊套進人名欄，廢掉 c_strict_excluded 的唯一用途。
+     */
+    #[Test]
+    public function testClosureIsComputedPerModeSoStrictExclusionCannotLeakThroughChains(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '龴', 'c_reference_char' => '峯', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+        ]);
+        $this->resetCaches();
+
+        // lenient 看得到兩條邊 ⇒ 閉包後 龴→峰
+        $this->assertSame('峰', CharVariantMapService::replaceLenient('龴')['text']);
+
+        // strict 只看得到 龴→峯 ⇒ 停在「峯」，不可洩漏成「峰」
+        $this->assertSame('峯', CharVariantMapService::replaceStrict('龴')['text']);
+        // 且 strict 對「峯」本身不動
+        $this->assertSame('峯', CharVariantMapService::replaceStrict('峯')['text']);
+    }
+
+    /** 多字元 key 會破壞幂等論證，載入時就要被剔除（寫入端另有 guard）。 */
+    #[Test]
+    public function testMultiCodepointMappingsAreIgnoredWhenLoading(): void {
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '甲乙', 'c_reference_char' => '丙丁', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        $this->resetCaches();
+
+        $result = CharVariantMapService::replaceLenient('甲乙淸');
+
+        $this->assertSame('甲乙清', $result['text'], '多字元對照不該生效');
+    }
+
+    // ─────────────────── mergeReplaced／flattenReplaced 的代數性質 ───────────────────
+
+    /**
+     * 這三條把設計倚賴的性質釘住。衝突路徑目前沒有生產呼叫端
+     * （`replaceRow()` 要到 S2／S3 才接線），所以只有它們在守著。
+     */
+    #[Test]
+    public function testMergeReplacedIsIdempotent(): void {
+        $a = ['淸' => '清', '龴' => ['峯', '峰']];
+
+        $this->assertSame($a, CharVariantMapService::mergeReplaced($a, $a));
+    }
+
+    #[Test]
+    public function testMergeReplacedIsOrderIndependentAsASet(): void {
+        $p = ['龴' => '峯'];
+        $q = ['龴' => '峰'];
+
+        $forward = CharVariantMapService::mergeReplaced($p, $q)['龴'];
+        $backward = CharVariantMapService::mergeReplaced($q, $p)['龴'];
+
+        sort($forward);
+        sort($backward);
+        $this->assertSame($forward, $backward, '合併順序只該影響列出順序，不該影響集合內容');
+    }
+
+    /** 單元素不得留成陣列，否則同一份資料會有兩種表示。 */
+    #[Test]
+    public function testMergeReplacedNormalizesSingleElementListsToString(): void {
+        $merged = CharVariantMapService::mergeReplaced([], ['淸' => ['清']]);
+
+        $this->assertSame(['淸' => '清'], $merged);
+    }
+
+    #[Test]
+    public function testFlattenReplacedExpandsConflictsIntoSeparatePairs(): void {
+        $pairs = CharVariantMapService::flattenReplaced(['淸' => '清', '龴' => ['峯', '峰']]);
+
+        $this->assertSame([
+            ['from' => '淸', 'to' => '清'],
+            ['from' => '龴', 'to' => '峯'],
+            ['from' => '龴', 'to' => '峰'],
+        ], $pairs);
+    }
+
+    // ─────────────────── 資料不變式（migration 繞過 guard 的兜底） ───────────────────
+
+    /**
+     * 現有 7 筆種子必須無鏈無環，且全為單一 codepoint。
+     *
+     * 這是 D8 幂等論證的資料側前提；migration 直接 DB::table()->insert() 會繞過所有
+     * 應用層 guard，所以這條測試是唯一兜底。
+     */
+    #[Test]
+    public function testSeededMappingsAreSingleCodepointAndChainFree(): void {
+        $rows = DB::table('char_variant_map')->get();
+        $this->assertCount(7, $rows);
+
+        $variants = [];
+        $references = [];
+        foreach ($rows as $row) {
+            $this->assertSame(1, mb_strlen($row->c_variant_char), "c_variant_char 必須是單一字元：{$row->c_variant_char}");
+            $this->assertSame(1, mb_strlen($row->c_reference_char), "c_reference_char 必須是單一字元：{$row->c_reference_char}");
+            $variants[] = $row->c_variant_char;
+            $references[] = $row->c_reference_char;
+        }
+
+        $this->assertSame(
+            [],
+            array_values(array_intersect($variants, $references)),
+            '參考字集與異體字集不得相交（否則對照表成鏈）'
+        );
+    }
+
+    /**
+     * 哨兵字面值不得與異體字集相交。今天成立是**資料巧合**、不是保證——
+     * 這些值會被寫進文本欄，若哪天收錄了其中的字元就會被靜默改寫。
+     */
+    #[Test]
+    public function testSentinelLiteralsDoNotIntersectVariantChars(): void {
+        $variants = DB::table('char_variant_map')->pluck('c_variant_char')->all();
+
+        foreach (['[n/a]', '-9999', '<待删除>'] as $sentinel) {
+            foreach ($variants as $variant) {
+                $this->assertStringNotContainsString(
+                    (string) $variant,
+                    $sentinel,
+                    "哨兵值 {$sentinel} 含有異體字 {$variant}，會被落地替換改寫"
+                );
+            }
+        }
+    }
+
+    // ─────────────────────────── assertWritable ───────────────────────────
+
+    // 這三條都斷言**訊息**而非只斷言 RuntimeException：光斷言型別的話，日後若把某個
+    // 分支的判定順序調換（例如多字元被路由到 incomplete_payload），測試仍會綠。
+
+    #[Test]
+    public function testAssertWritableRejectsMultiCodepoint(): void {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(__('variant.single_codepoint_required'));
+        CharVariantMapService::assertWritable(['c_variant_char' => '甲乙', 'c_reference_char' => '丙']);
+    }
+
+    #[Test]
+    public function testAssertWritableRejectsSelfReference(): void {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(__('variant.self_reference_not_allowed'));
+        CharVariantMapService::assertWritable(['c_variant_char' => '甲', 'c_reference_char' => '甲']);
+    }
+
+    #[Test]
+    public function testAssertWritableRejectsNewCycle(): void {
+        // 表裡已有 淸→清，新增 清→淸 會成環
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(__('variant.cycle_not_allowed', ['char' => '清']));
+        CharVariantMapService::assertWritable(['c_variant_char' => '清', 'c_reference_char' => '淸']);
+    }
+
+    /**
+     * 只送單邊字元欄、又沒有既有列可以 merge：這是呼叫端沒傳 id 的問題，
+     * 訊息必須說「payload 不完整」而不是「必須是單一字元」（使用者根本沒動另一欄）。
+     */
+    #[Test]
+    public function testAssertWritableRejectsIncompletePayloadWithItsOwnMessage(): void {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(__('variant.incomplete_payload'));
+        CharVariantMapService::assertWritable(['c_variant_char' => '甲']);
+    }
+
+    #[Test]
+    public function testAssertWritableAcceptsPlainNewMapping(): void {
+        CharVariantMapService::assertWritable(['c_variant_char' => '甲', 'c_reference_char' => '乙']);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * $excludeId：更新既有列時必須排除該列的舊邊，否則會誤報環。
+     *
+     * 表有 乙→甲、甲→丙；把「乙→甲」那列改成「丙→乙」是合法的 甲→丙→乙，
+     * 但若把被取代的舊邊也算進去，就會看到假的環 乙→甲→丙→乙。
+     */
+    #[Test]
+    public function testAssertWritableExcludesTheRowBeingReplacedWhenDetectingCycles(): void {
+        DB::table('char_variant_map')->truncate();
+        $oldId = DB::table('char_variant_map')->insertGetId(
+            ['c_variant_char' => '乙', 'c_reference_char' => '甲', 'c_strict_excluded' => 0]
+        );
+        DB::table('char_variant_map')->insert(
+            ['c_variant_char' => '甲', 'c_reference_char' => '丙', 'c_strict_excluded' => 0]
+        );
+        $this->resetCaches();
+
+        // 不排除舊邊 ⇒ 誤報環
+        try {
+            CharVariantMapService::assertWritable(['c_variant_char' => '丙', 'c_reference_char' => '乙']);
+            $this->fail('未排除舊邊時應偵測到（假的）環');
+        } catch (\RuntimeException $e) {
+            $this->addToAssertionCount(1);
+        }
+
+        // 排除被取代的那一列 ⇒ 合法
+        CharVariantMapService::assertWritable(
+            ['c_variant_char' => '丙', 'c_reference_char' => '乙'],
+            $oldId
+        );
+        $this->addToAssertionCount(1);
+    }
+
+    /** 部分 payload（restoreUpdate 用歷史快照）需與現有列 merge 後再驗。 */
+    #[Test]
+    public function testAssertWritableMergesPartialPayloadWithExistingRow(): void {
+        DB::table('char_variant_map')->truncate();
+        $id = DB::table('char_variant_map')->insertGetId(
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0]
+        );
+        $this->resetCaches();
+
+        // 只送 c_reference_char：c_variant_char 應從現有列補齊，不該因缺欄而誤判長度
+        CharVariantMapService::assertWritable(['c_reference_char' => '菁'], $id);
+        $this->addToAssertionCount(1);
+    }
+
+    /** 兩個字元欄都沒被碰到（例如只改 c_notes）⇒ 不需驗證。 */
+    #[Test]
+    public function testAssertWritableSkipsWhenCharColumnsAreUntouched(): void {
+        CharVariantMapService::assertWritable(['c_notes' => '只改備註']);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/VariantReplaceJoinKeyGuardTest.php
+++ b/tests/Unit/VariantReplaceJoinKeyGuardTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\CodesController;
+use App\Support\VariantReplaceScope;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * 機械化守衛：`CodesController::$tableJoinConfigurations` 本身就是「哪些文字欄被當
+ * join 鍵」的權威列表，這支測試從它推導出必須排除的欄位，而不是靠人工清單。
+ *
+ * 為什麼需要：S0 的人工掃描第一版只涵蓋了 7 組 `*_CODE_TYPE_REL` ↔ `*_TYPES` 裡的 1 組，
+ * 漏了 6 組（各 2 欄）。人工清單會漏，而這份 config 每次有人新增 join 設定都會更新，
+ * 所以從它推導才是可持續的。
+ *
+ * 若日後新增一組 join 設定而忘了把 join 鍵加進 VariantReplaceScope，這支測試會紅。
+ */
+class VariantReplaceJoinKeyGuardTest extends TestCase {
+    /**
+     * 明文豁免：join 鍵但**不需要**排除，每筆要寫理由。
+     *
+     * @var array<string,string>
+     */
+    private const EXEMPT = [
+        // 數字型代碼欄本來就不在落地替換範圍內（機制只處理文本型別），
+        // 列在這裡是為了讓「為什麼這欄沒進 EXCLUDED_COLUMNS」有據可查。
+        'ADMIN_CAT_CODE_TYPE_REL.c_admin_cat_code' => '數字型代碼欄，非文本型別',
+        'ADMIN_CAT_CODES.c_admin_cat_code' => '數字型代碼欄，非文本型別',
+        'APPOINTMENT_CODE_TYPE_REL.c_appt_code' => '數字型代碼欄，非文本型別',
+        'APPOINTMENT_CODES.c_appt_code' => '數字型代碼欄，非文本型別',
+        'ASSOC_CODE_TYPE_REL.c_assoc_code' => '數字型代碼欄，非文本型別',
+        'ASSOC_CODES.c_assoc_code' => '數字型代碼欄，非文本型別',
+        'ENTRY_CODE_TYPE_REL.c_entry_code' => '數字型代碼欄，非文本型別',
+        'ENTRY_CODES.c_entry_code' => '數字型代碼欄，非文本型別',
+        'OFFICE_CODE_TYPE_REL.c_office_id' => '數字型代碼欄，非文本型別',
+        'OFFICE_CODES.c_office_id' => '數字型代碼欄，非文本型別',
+        'STATUS_CODE_TYPE_REL.c_status_code' => '數字型代碼欄，非文本型別',
+        'STATUS_CODES.c_status_code' => '數字型代碼欄，非文本型別',
+        'TEXT_BIBLCAT_CODE_TYPE_REL.c_text_cat_code' => '數字型代碼欄，非文本型別',
+        'TEXT_BIBLCAT_CODES.c_text_cat_code' => '數字型代碼欄，非文本型別',
+    ];
+
+    /**
+     * 每一個出現在 join `on` 條件裡的欄位，都必須要嘛登記在 VariantReplaceScope 的
+     * 排除清單裡、要嘛列在上面的明文豁免裡。
+     */
+    #[Test]
+    public function testEveryJoinKeyIsEitherExcludedOrExplicitlyExempt(): void {
+        $unregistered = [];
+
+        foreach ($this->joinKeyColumns() as $qualified) {
+            [$table, $column] = explode('.', $qualified, 2);
+
+            if (array_key_exists($qualified, self::EXEMPT)) {
+                continue;
+            }
+
+            if ($this->isRegisteredAsExcluded($table, $column)) {
+                continue;
+            }
+
+            $unregistered[] = $qualified;
+        }
+
+        sort($unregistered);
+
+        $this->assertSame(
+            [],
+            $unregistered,
+            "下列欄位被 CodesController::\$tableJoinConfigurations 當成 join 鍵使用，"
+                ."但既沒登記在 VariantReplaceScope 的排除清單、也沒列入本測試的明文豁免。\n"
+                ."若它是文本型 join 鍵 ⇒ 加進 VariantReplaceScope::EXCLUDED_COLUMNS"
+                ."（替換會打斷關聯）；若它是數字型代碼欄 ⇒ 加進本測試的 EXEMPT 並寫理由。\n"
+                .implode("\n", $unregistered)
+        );
+    }
+
+    /** join 設定裡兩側的表都必須是「已知 CBDB 資料表」，否則 fail-closed 會讓它靜默跳過。 */
+    #[Test]
+    public function testEveryJoinedTableIsKnown(): void {
+        $unknown = [];
+
+        foreach ($this->joinKeyColumns() as $qualified) {
+            [$table] = explode('.', $qualified, 2);
+            if (!VariantReplaceScope::isKnownDataTable($table)) {
+                $unknown[] = $table;
+            }
+        }
+
+        $unknown = array_values(array_unique($unknown));
+        sort($unknown);
+
+        $this->assertSame([], $unknown, '下列 join 設定涉及的表不在已知 CBDB 表聯集內：'.implode(', ', $unknown));
+    }
+
+    /**
+     * 從 `$tableJoinConfigurations` 抽出所有 join `on` 條件涉及的「表.欄位」。
+     *
+     * `on` 的形狀是 ['rel.c_x', '=', 'type.c_y']，其中 rel／type 是 alias，
+     * 需要用 base_alias／各 join 的 alias 還原成真實表名。
+     *
+     * @return array<int,string>
+     */
+    private function joinKeyColumns(): array {
+        $property = (new ReflectionClass(CodesController::class))->getProperty('tableJoinConfigurations');
+        $property->setAccessible(true);
+        $configurations = $property->getValue(app(CodesController::class));
+
+        $columns = [];
+
+        foreach ($configurations as $config) {
+            $aliasToTable = [];
+            if (isset($config['base_alias'], $config['base_table'])) {
+                $aliasToTable[$config['base_alias']] = $config['base_table'];
+            }
+            foreach ($config['joins'] ?? [] as $join) {
+                if (isset($join['alias'], $join['table'])) {
+                    $aliasToTable[$join['alias']] = $join['table'];
+                }
+            }
+
+            foreach ($config['joins'] ?? [] as $join) {
+                foreach ([$join['on'][0] ?? null, $join['on'][2] ?? null] as $ref) {
+                    if (!is_string($ref) || !str_contains($ref, '.')) {
+                        continue;
+                    }
+                    [$alias, $column] = explode('.', $ref, 2);
+                    $table = $aliasToTable[$alias] ?? $alias;
+                    $columns[$table.'.'.$column] = true;
+                }
+            }
+        }
+
+        return array_keys($columns);
+    }
+
+    /** 是否已登記為排除（大小寫不敏感，比照 VariantReplaceScope 的比對方式）。 */
+    private function isRegisteredAsExcluded(string $table, string $column): bool {
+        $t = strtolower($table);
+        $c = strtolower($column);
+
+        foreach (VariantReplaceScope::EXCLUDED_TABLES as $excludedTable) {
+            if (strtolower($excludedTable) === $t) {
+                return true;
+            }
+        }
+
+        foreach (VariantReplaceScope::EXCLUDED_COLUMNS_ANY_TABLE as $excludedColumn) {
+            if (strtolower($excludedColumn) === $c) {
+                return true;
+            }
+        }
+
+        foreach (VariantReplaceScope::EXCLUDED_COLUMNS as $excludedTable => $excludedColumns) {
+            if (strtolower($excludedTable) !== $t) {
+                continue;
+            }
+            foreach ($excludedColumns as $excludedColumn) {
+                if (strtolower($excludedColumn) === $c) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/VariantReplaceScopeTest.php
+++ b/tests/Unit/VariantReplaceScopeTest.php
@@ -1,0 +1,408 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\CompositePrimaryKey;
+use App\Support\VariantReplaceScope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * VariantReplaceScope 測試（設計見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md）。
+ *
+ * 手動建合成表（比照 CharVariantMapServiceTest 慣例）。有些型別（date／decimal／blob）
+ * 全庫實際不存在，只能用合成表斷言。
+ */
+class VariantReplaceScopeTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        VariantReplaceScope::reset();
+
+        // BIOG_MAIN 是已知表（在 config/codes.php 與 CompositePrimaryKey 裡），
+        // 這裡建一個涵蓋各種型別的簡化版。
+        Schema::dropIfExists('BIOG_MAIN');
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->string('c_name_chn', 255)->nullable();
+            $table->string('c_surname_chn', 255)->nullable();
+            $table->string('c_mingzi_chn', 255)->nullable();
+            $table->string('c_name', 255)->nullable();
+            $table->string('c_surname', 255)->nullable();
+            $table->string('c_mingzi', 255)->nullable();
+            $table->string('c_name_proper', 255)->nullable();
+            $table->string('c_name_rm', 255)->nullable();
+            $table->string('c_index_year_type_code', 255)->nullable();
+            $table->string('c_tribe', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->integer('c_index_year')->nullable();
+            $table->date('c_some_date')->nullable();
+            $table->decimal('c_some_decimal', 8, 2)->nullable();
+            $table->binary('c_some_blob')->nullable();
+            $table->char('c_some_char', 1)->nullable();
+        });
+
+        Schema::dropIfExists('ALTNAME_DATA');
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->string('c_alt_name_chn', 255)->nullable();
+            $table->string('c_alt_name', 255)->nullable();
+            $table->string('c_alt_name_pinyin', 255)->nullable();
+            $table->text('c_notes')->nullable();
+        });
+
+        Schema::dropIfExists('EVENT_CODES');
+        Schema::create('EVENT_CODES', function (Blueprint $table) {
+            $table->integer('c_event_code');
+            $table->string('c_event_name_chn', 255)->nullable();
+        });
+
+        Schema::dropIfExists('char_variant_map');
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->string('c_notes', 255)->nullable();
+        });
+
+        Schema::dropIfExists('pinyin');
+        Schema::create('pinyin', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_chn', 10);
+            $table->string('c_pinyin', 255)->nullable();
+        });
+
+        Schema::dropIfExists('ENTRY_TYPES');
+        Schema::create('ENTRY_TYPES', function (Blueprint $table) {
+            $table->string('c_entry_type', 255);
+            $table->string('c_entry_type_parent_id', 255)->nullable();
+            $table->string('c_entry_type_desc_chn', 255)->nullable();
+        });
+
+        Schema::dropIfExists('STATUS_TYPES');
+        Schema::create('STATUS_TYPES', function (Blueprint $table) {
+            $table->string('c_status_type_code', 255);
+            $table->string('c_status_type_parent_code', 255)->nullable();
+            $table->string('c_status_type_chn', 255)->nullable();
+        });
+
+        VariantReplaceScope::reset();
+    }
+
+    // ─────────────────────────── 型別判定 ───────────────────────────
+
+    #[Test]
+    public function testTextTypesAreInScopeAndNonTextTypesAreNot(): void {
+        // varchar / char / text 類 → 在範圍內
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('BIOG_MAIN', 'c_tribe'), 'varchar 應在範圍內');
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('BIOG_MAIN', 'c_notes'), 'text 應在範圍內');
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('BIOG_MAIN', 'c_some_char'), 'char 應在範圍內');
+
+        // 非文本型別 → 不替換
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_index_year'), 'integer 不該在範圍內');
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_some_date'), 'date 不該在範圍內');
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_some_decimal'), 'decimal 不該在範圍內');
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_some_blob'), 'blob 不該在範圍內');
+    }
+
+    #[Test]
+    public function testUnknownColumnIsNotInScope(): void {
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_does_not_exist'));
+    }
+
+    /**
+     * TEXT_TYPES 對**合成表**的型別涵蓋（本檔不跑 migration，只看 setUp() 建的那幾張）。
+     *
+     * 真正的漂移守衛在 `Tests\Feature\VariantReplaceRegistryDriftTest`（掛 RefreshDatabase、
+     * 對真實 schema 執行）——放在這裡會是假綠，因為這裡只有合成表。
+     * enum／json 的缺口另由 testEveryNonTextColumnTypeInMigrationsIsClassified() 掃原始碼補上。
+     */
+    #[Test]
+    public function testTextTypesCoversEveryObservedTextType(): void {
+        $observed = [];
+        foreach (['BIOG_MAIN', 'ALTNAME_DATA', 'EVENT_CODES', 'ENTRY_TYPES'] as $table) {
+            foreach (Schema::getColumns($table) as $column) {
+                $observed[strtolower((string) $column['type_name'])] = true;
+            }
+        }
+
+        $textLike = array_filter(array_keys($observed), function (string $type): bool {
+            return str_contains($type, 'char') || str_contains($type, 'text');
+        });
+
+        foreach ($textLike as $type) {
+            $this->assertContains(
+                $type,
+                VariantReplaceScope::TEXT_TYPES,
+                "型別 {$type} 看起來是文本型別但不在 TEXT_TYPES 內，會靜默逃出替換範圍"
+            );
+        }
+    }
+
+    /**
+     * 漂移守衛（原始碼側）：migrations 出現 enum／json／set 欄位時，必須是**已分類**的。
+     *
+     * 這條補上 SQLite 抓不到的缺口——`->enum()`／`->json()` 在 SQLite 被編成 varchar／text，
+     * 型別守衛會全綠，而 MariaDB 端該欄真的是 enum／json、真的逃出 TEXT_TYPES 的判定。
+     *
+     * 判準是「有沒有被分類」而不是「有沒有出現」：既有的 audit_log json 欄是合法的
+     * （整表已排除），新增的則必須先決定它的歸屬才能過這關。
+     */
+    #[Test]
+    public function testEveryNonTextColumnTypeInMigrationsIsClassified(): void {
+        // 已分類的既有案例：migration 檔名 => 理由
+        $classified = [
+            '2026_02_08_000000_create_audit_log_table.php'
+                => 'audit_log 整表在 EXCLUDED_TABLES（紀錄類資料，改寫等於偽造紀錄）',
+        ];
+
+        $files = glob(database_path('migrations/*.php')) ?: [];
+        $unclassified = [];
+
+        foreach ($files as $file) {
+            $name = basename($file);
+            $source = (string) file_get_contents($file);
+
+            $hits = [];
+            foreach (['->enum(', '->json(', '->jsonb(', '->set('] as $needle) {
+                if (str_contains($source, $needle)) {
+                    $hits[] = $needle;
+                }
+            }
+
+            if ($hits === [] || array_key_exists($name, $classified)) {
+                continue;
+            }
+
+            $unclassified[] = $name.' 使用了 '.implode('／', $hits);
+        }
+
+        $this->assertSame(
+            [],
+            $unclassified,
+            "新增 enum／json／set 欄位時，必須先決定它在 VariantReplaceScope 的分類"
+                ."（SQLite 會把它們編成 varchar／text，型別守衛抓不到，該欄會靜默逃出範圍）。
+"
+                ."確認歸屬後，把 migration 檔名加進本測試的 \$classified 並寫理由：
+"
+                .implode("
+", $unclassified)
+        );
+    }
+
+    // ─────────────────────── 預設方向與 strict 例外 ───────────────────────
+
+    /**
+     * D4 的核心：**預設是 lenient（全量）**，不是 strict。
+     *
+     * 寫反會造成「全庫靜默少替換」這種極難察覺的退化——每個欄位看起來都有在替換，
+     * 只是少了幾筆規則，不會有任何報錯。
+     */
+    #[Test]
+    public function testDefaultModeIsLenientNotStrict(): void {
+        $this->assertSame(
+            'lenient',
+            VariantReplaceScope::modeFor('EVENT_CODES', 'c_event_name_chn'),
+            '未登記在 STRICT_COLUMNS 的文本欄必須拿到 lenient'
+        );
+    }
+
+    #[Test]
+    public function testStrictAndLenientAreDecidedPerColumnNotPerTable(): void {
+        // 同一列 BIOG_MAIN：姓名欄 strict、c_notes lenient
+        $this->assertSame('strict', VariantReplaceScope::modeFor('BIOG_MAIN', 'c_surname_chn'));
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('BIOG_MAIN', 'c_notes'));
+
+        // 同一列 ALTNAME_DATA：別名欄 strict、c_notes lenient
+        $this->assertSame('strict', VariantReplaceScope::modeFor('ALTNAME_DATA', 'c_alt_name_chn'));
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('ALTNAME_DATA', 'c_notes'));
+    }
+
+    /** 登記完整性：抽驗擋不住漏登，必須逐欄斷言。 */
+    #[Test]
+    public function testEveryStrictColumnIsRegistered(): void {
+        foreach (['c_name_chn', 'c_surname_chn', 'c_mingzi_chn'] as $column) {
+            $this->assertSame('strict', VariantReplaceScope::modeFor('BIOG_MAIN', $column), "BIOG_MAIN.{$column} 應為 strict");
+        }
+        $this->assertSame('strict', VariantReplaceScope::modeFor('ALTNAME_DATA', 'c_alt_name_chn'));
+    }
+
+    /** 13 個拉丁人名欄逐欄斷言為排除（同理，抽驗擋不住漏排）。 */
+    #[Test]
+    public function testEveryLatinNameColumnIsExcluded(): void {
+        $biogMain = [
+            'c_surname', 'c_mingzi', 'c_name',
+            'c_surname_proper', 'c_mingzi_proper', 'c_name_proper',
+            'c_surname_rm', 'c_mingzi_rm', 'c_name_rm',
+        ];
+        foreach ($biogMain as $column) {
+            $this->assertContains(
+                $column,
+                VariantReplaceScope::EXCLUDED_COLUMNS['BIOG_MAIN'],
+                "BIOG_MAIN.{$column} 必須登記為排除"
+            );
+        }
+
+        foreach (['c_alt_name', 'c_alt_name_pinyin', 'c_alt_name_pinyin2', 'c_alt_name_pinyin3'] as $column) {
+            $this->assertContains(
+                $column,
+                VariantReplaceScope::EXCLUDED_COLUMNS['ALTNAME_DATA'],
+                "ALTNAME_DATA.{$column} 必須登記為排除"
+            );
+        }
+
+        // 存在於合成表的那幾個，實際查一次 modeFor()
+        foreach (['c_name', 'c_surname', 'c_mingzi', 'c_name_proper', 'c_name_rm'] as $column) {
+            $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', $column), "BIOG_MAIN.{$column} 不該被替換");
+        }
+        foreach (['c_alt_name', 'c_alt_name_pinyin'] as $column) {
+            $this->assertNull(VariantReplaceScope::modeFor('ALTNAME_DATA', $column), "ALTNAME_DATA.{$column} 不該被替換");
+        }
+    }
+
+    // ─────────────────────── 大小寫與 fail-closed ───────────────────────
+
+    /**
+     * 大小寫不敏感。這不是假想：config/codes.php 用小寫 char_variant_map／pinyin，
+     * CBDB 表用全大寫，客戶端還可能傳任意大小寫。漏中 strict 清單 ⇒ 靜默降級成 lenient
+     * ⇒ 人名裡的「峯」被改寫，正是 D4 明令禁止的事。
+     */
+    #[Test]
+    public function testTableAndColumnMatchingIsCaseInsensitive(): void {
+        $this->assertSame('strict', VariantReplaceScope::modeFor('biog_main', 'C_SURNAME_CHN'));
+        $this->assertSame('strict', VariantReplaceScope::modeFor('BiOg_MaIn', 'c_Surname_Chn'));
+        $this->assertNull(VariantReplaceScope::modeFor('PINYIN', 'C_CHN'), 'pinyin.c_chn 大小寫變體也必須排除');
+    }
+
+    /** D2 fail-closed：未知表一律不替換。 */
+    #[Test]
+    public function testUnknownTableIsFailClosed(): void {
+        $this->assertFalse(VariantReplaceScope::isKnownDataTable('personal_access_tokens'));
+        $this->assertFalse(VariantReplaceScope::isKnownDataTable('DROP TABLE students;--'));
+        $this->assertNull(VariantReplaceScope::modeFor('personal_access_tokens', 'abilities'));
+        $this->assertNull(VariantReplaceScope::modeFor('totally_made_up', 'c_name_chn'));
+    }
+
+    /** 已知表判定必須涵蓋四份 registry（尤其形狀不同的 code_table_mutations）。 */
+    #[Test]
+    public function testKnownDataTableCoversAllFourRegistries(): void {
+        // codes.php
+        $this->assertTrue(VariantReplaceScope::isKnownDataTable('BIOG_MAIN'));
+        // CompositePrimaryKey::SCHEMAS
+        $this->assertTrue(VariantReplaceScope::isKnownDataTable('ALTNAME_DATA'));
+        // code_table_writes.php
+        $this->assertTrue(VariantReplaceScope::isKnownDataTable('TEXT_CODES'));
+        // code_table_mutations.php（list of maps，表名在 'table' 值）
+        $this->assertTrue(VariantReplaceScope::isKnownDataTable('NIAN_HAO'));
+        $this->assertTrue(VariantReplaceScope::isKnownDataTable('GANZHI_CODES'));
+    }
+
+    /**
+     * code_table_mutations 的形狀陷阱：它是 list of maps、表名在 'table' 值。
+     * 誤用 array_keys() 會得到 "0".."13" 這些假表名並漏掉 14 張真表——今天恰好被掩蓋
+     * （那 14 張也都在 codes.php），純屬巧合，所以要顯式斷言。
+     */
+    #[Test]
+    public function testCodeTableMutationsRegistryIsExtractedByTableValueNotKey(): void {
+        $definitions = (array) config('code_table_mutations.tables', []);
+
+        $this->assertNotEmpty($definitions);
+        $this->assertArrayHasKey(0, $definitions, 'code_table_mutations.tables 應為 list（數字鍵）');
+
+        $names = array_column($definitions, 'table');
+        $this->assertCount(count($definitions), $names, '每筆定義都必須有 table 鍵');
+        $this->assertContains('NIAN_HAO', $names);
+
+        foreach ($names as $name) {
+            $this->assertTrue(
+                VariantReplaceScope::isKnownDataTable($name),
+                "code_table_mutations 登記的 {$name} 必須被視為已知表"
+            );
+        }
+    }
+
+    // ─────────────────────── 排除清單逐筆 ───────────────────────
+
+    #[Test]
+    public function testExcludedTargetsAreNotReplaced(): void {
+        // 對照表自身（整表排除）——替換會自我吞噬
+        $this->assertNull(VariantReplaceScope::modeFor('char_variant_map', 'c_variant_char'));
+        $this->assertNull(VariantReplaceScope::modeFor('char_variant_map', 'c_notes'));
+
+        // 拼音字典的鍵——第一階段設計「異體字各自有讀音」
+        $this->assertNull(VariantReplaceScope::modeFor('pinyin', 'c_chn'));
+
+        // 稽核欄（任何表都排除）
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_modified_by'));
+
+        // 跨表／樹狀代碼鍵
+        $this->assertNull(VariantReplaceScope::modeFor('BIOG_MAIN', 'c_index_year_type_code'));
+        $this->assertNull(VariantReplaceScope::modeFor('ENTRY_TYPES', 'c_entry_type'));
+        $this->assertNull(VariantReplaceScope::modeFor('ENTRY_TYPES', 'c_entry_type_parent_id'));
+        // 後綴是 _parent_code 而非 _parent_id——只按 *_parent_id 掃會漏掉
+        $this->assertNull(VariantReplaceScope::modeFor('STATUS_TYPES', 'c_status_type_parent_code'));
+
+        // 但同表的內容欄仍要替換
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('ENTRY_TYPES', 'c_entry_type_desc_chn'));
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('STATUS_TYPES', 'c_status_type_chn'));
+    }
+
+    /**
+     * 反例守衛：這三個是 varchar PK 成員但語義是**內容**（別名／書名／頁碼），
+     * 必須替換。判準是「值是否用來跟別表對上」，不是「是否為 varchar PK 成員」——
+     * 照後者的字面實作會直接抵銷整個計畫的重點。
+     */
+    #[Test]
+    public function testTextPkMembersThatAreContentAreStillReplaced(): void {
+        $this->assertSame('strict', VariantReplaceScope::modeFor('ALTNAME_DATA', 'c_alt_name_chn'));
+
+        foreach (['ASSOC_DATA' => 'c_text_title', 'BIOG_SOURCE_DATA' => 'c_pages'] as $table => $column) {
+            $this->assertNotContains(
+                $column,
+                VariantReplaceScope::EXCLUDED_COLUMNS[$table] ?? [],
+                "{$table}.{$column} 是內容欄（PK 成員但語義是書名／頁碼），不可列入排除"
+            );
+        }
+    }
+
+    /** 對照／映射表全部要排除——CompositePrimaryKey 有登記者不可遺漏。 */
+    #[Test]
+    public function testMappingTablesAreExcludedAsWhole(): void {
+        $this->assertContains('char_variant_map', VariantReplaceScope::EXCLUDED_TABLES);
+        $this->assertContains('CBDB__NAME_FTS', VariantReplaceScope::EXCLUDED_TABLES);
+    }
+
+    // ─────────────────────────── 快取 ───────────────────────────
+
+    #[Test]
+    public function testResetClearsColumnTypeCache(): void {
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('EVENT_CODES', 'c_event_name_chn'));
+
+        Schema::drop('EVENT_CODES');
+        Schema::create('EVENT_CODES', function (Blueprint $table) {
+            $table->integer('c_event_code');
+            $table->integer('c_event_name_chn'); // 型別換成 integer
+        });
+
+        // 快取未清 ⇒ 仍看到舊型別
+        $this->assertSame('lenient', VariantReplaceScope::modeFor('EVENT_CODES', 'c_event_name_chn'));
+
+        VariantReplaceScope::reset();
+
+        // 清掉後看到新型別
+        $this->assertNull(VariantReplaceScope::modeFor('EVENT_CODES', 'c_event_name_chn'));
+    }
+
+    #[Test]
+    public function testCompositePrimaryKeySchemasAreAllKnown(): void {
+        foreach (array_keys(CompositePrimaryKey::SCHEMAS) as $table) {
+            $this->assertTrue(
+                VariantReplaceScope::isKnownDataTable($table),
+                "CompositePrimaryKey 登記的 {$table} 必須被視為已知表"
+            );
+        }
+    }
+}


### PR DESCRIPTION
執行 [`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md`](https://github.com/cbdb-project/cbdb-online-main-server/blob/develop/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md) 的 **S0（代碼鍵掃描）＋ S1（基礎設施）**。

**本步只建機制與把關，還沒有任何生產路徑呼叫 `replaceRow()`** —— 實際串接由 S2–S7 逐步進行。所以這個 PR 對使用者可見行為的改動幾乎為零（唯一例外是 `buildNotices()` 改走 `__()`，而輸出字串逐字相同）。

## 核心：`App\Support\VariantReplaceScope`

回答「(表, 欄位) 該用哪個替換模式」的單一權威來源。三個設計決定：

**以欄位型別判定，不以命名規律。** 這個判準自帶安全論證 —— 對照表 key 全是 CJK，所以套在拼音／羅馬字欄上必然是 no-op，不需要再疊一層「這欄是不是中文」的判斷。而且型別是 schema 的權威事實、會自動跟上演進；用 `_chn`/`_hz` 命名規律會漏掉 8 個無後綴的中文欄。

**fail-closed。** 未知表一律不替換，比對大小寫不敏感 —— config 用小寫 `char_variant_map`／`pinyin`、CBDB 表用全大寫、客戶端還可能傳任意大小寫。

**預設 lenient，strict 是逐欄位例外。** 同一列 BIOG_MAIN 裡姓名欄 strict、`c_notes` lenient。寫反會造成「全庫靜默少替換」這種極難察覺的退化（每個欄位看起來都有在替換，只是少了幾筆規則），所以有專門的測試釘住預設方向。

## S0 掃描補上 15 個代碼鍵欄位

手寫清單只涵蓋 7 組 `*_CODE_TYPE_REL` ↔ `*_TYPES` 裡的 **1 組**。三個值得記錄的：

| 欄位 | 為什麼會漏 |
|---|---|
| `OFFICE_TYPE_TREE.c_office_type_node_id` | **真實風險而非理論風險** —— 值域含中文且被 `LIKE '%q%'` 做中文搜尋；REL 側欄名（`c_office_tree_id`）與 PK 側**不同名**，只掃 node_id 會漏 |
| `TEXT_TYPE.c_text_type_code` | 原本排了 `parent_id` 卻沒排被 parent 指的 PK —— parent 排了、PK 沒排，關聯照樣斷 |
| `STATUS_TYPES.c_status_type_parent_code` | 後綴是 `_parent_code`，按 `*_parent_id` 掃會漏 |

比清單更有價值的是：`CodesController::$tableJoinConfigurations` 本身就是「哪些文字欄被當 join 鍵」的**機器可讀權威列表**，而且每次有人加 join 都會更新。所以加了一支從它推導的守衛測試，日後新增 join 設定卻忘了登記就會紅。

## 幂等性的三條配套規則（D8）

對照表載入改為「**按模式過濾 → 移除環上出邊 → 傳遞閉包**」，順序不可顛倒（先算閉包會在環上無限迴圈）。

- **必須按模式各自算閉包**：否則 `X→峯`(excluded=0) + `峯→峰`(excluded=1) 會讓 strict 透過傳遞吃到一條 strict-excluded 的邊，直接廢掉 `c_strict_excluded` 的唯一用途（保護「峯」）。
- **環只丟環上出邊 + 記 error log**，不拋錯也不回空 map：這兩個 map 方法是所有替換的唯一入口，在此 throw 會讓 Codes UI 80 表、所有 v2 mutate、批次匯入、眾包核准一起爆（一筆 `峰→峯` 或打錯字的 `A→A` 就夠）；回空 map 則等於全站靜默不替換。降級要局部且有聲音。
- 「鏈進入環」（`A→B`、`B→C`、`C→B`）只丟環上節點的出邊，`A→B` 要保留。

## restore 的結構把關

`char_variant_map` 明文登記在 `resourceKeyColumns()`，所以 restore 對它是刻意支援的；但它同時是**所有落地替換的資料來源**，還原一筆壞對照會讓全站的替換降級。restore 是 10 個寫入入口中唯一不在 S2／S5／S6 編輯範圍內的那條。

**這與「restore 不做內容替換」不衝突** —— 那是不對還原內容套落地替換（保留歷史字形），這裡是對這張表的寫入做結構驗證。有一支測試把這個區分釘住，避免日後有人「順手補上」。

## Review 過程修掉的實質問題

三輪 review agent + codex。幾個值得記錄的：

- **registry 漂移守衛原本是假綠。** 測試沒有 `RefreshDatabase`，`Schema::getTables()` 只回傳合成表 ⇒ 永遠抓不到「新 migration 建了 CBDB 表卻忘了登記」。而計畫 D2 明文說 fail-closed 之所以安全「是現況巧合，所以 S1 必須補漂移守衛」—— 交付的守衛是空的。移到 Feature 測試後**立刻抓到 8 張未分類的表**，已逐筆分類；另加「表數 > 50」與「白名單互斥」兩道防退化斷言。
- **`replaced` 用 `+=` 合併會回報錯誤的參考字。** 同一變體在 strict 與 lenient 的閉包終點可以不同 ⇒ 通知說「已正規化為 峯」而 `c_notes` 實際變成「峰」。抽出 `mergeReplaced()`／`flattenReplaced()`，並把三個既有消費點一併改掉 —— 否則 S3 接線時會打壞前端 `variant_replacements` 契約。
- **restore guard 的大小寫不對稱會誤擋合法還原**（guard 用大小寫不敏感比對，`resourceKeyColumns()` 是字面查表）。
- `modeFor()` 慢 90 倍 → 加 memo（200,000 次呼叫 1.17s → 12ms），因為 S2–S7 還要把它掛進逐列迴圈。

## 驗證

- 全量 `phpunit`：**2821 tests / 15116 assertions** 全過
- `php-cs-fixer`（已刪 cache、用 dist config）：0 fixes
- 新增 5 支測試（Unit 3、Feature 2），共 57 tests
- 兩份翻譯檔鍵已驗證同步（`AGENTS.md` §6）
- 無 API 改動：`api` 群組沒掛 `SetLocaleMiddleware`，token API 回應與改動前逐字相同，`API.md` 不需更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)