### PR TITLE
異體字落地替換 S2：Codes UI 全表串接

### DIFF
--- a/app/Exceptions/VariantMappingException.php
+++ b/app/Exceptions/VariantMappingException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exceptions;
+
+/**
+ * `char_variant_map` 的結構驗證失敗（單一 codepoint、不成環、payload 完整）。
+ *
+ * **為什麼需要一個專屬型別而不是直接用 `\RuntimeException`**：
+ * `Illuminate\Database\QueryException` 繼承 `PDOException`、而 `PDOException`
+ * 繼承 `\RuntimeException`。`CharVariantMapService::assertWritable()` 內部會查兩次
+ * `char_variant_map`，所以呼叫端若 `catch (\RuntimeException)`，任何資料庫錯誤都會被
+ * 當成「驗證失敗」，把原始 SQLSTATE 與 SQL 字串 flash 給使用者（資訊洩漏 + 無法據以行動
+ * 的訊息），而且該次寫入會被靜默跳過而不是誠實地 500。
+ *
+ * 呼叫端一律只 catch 這個型別，讓真正的資料庫錯誤照常往上冒。
+ */
+class VariantMappingException extends \RuntimeException {
+}

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -2,13 +2,16 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\VariantMappingException;
 use App\Models\Operation;
 use App\Repositories\CodesRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Services\CharVariantMapService;
 use App\Support\ColumnFilterExpression;
 use App\Support\ColumnFilterParseException;
 use App\Support\PinyinUmlaut;
+use App\Support\VariantReplaceScope;
 use Carbon\Carbon;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Http\RedirectResponse;
@@ -1347,6 +1350,13 @@ class CodesController extends Controller {
         $data = $this->extractFormData($request, $table);
         $data = $this->enforceAuditFieldsForUpdate($data, $originalRow ?: []);
         $data = $this->normalizeCodeTablePinyin($table, $data);
+        // 異體字落地替換：只碰要寫入的 $data，$conditions（來自 URL 主鍵的定位器）不動。
+        [$data, $variantReplaced] = $this->applyVariantReplacement($table, $data);
+        if ($guardError = $this->guardCharVariantMapWrite($table, $data, $conditions)) {
+            flash($guardError, 'error');
+
+            return redirect()->back()->withInput()->withErrors(['char_variant_map' => $guardError]);
+        }
         // 與 performStore 一致：留白的 NOT NULL（有預設值）欄不寫入 null（更新時等於保留原值），
         // 避免觸發完整性違規；留白但無預設值的 NOT NULL 欄仍交由資料庫拋出誠實錯誤。
         $data = $this->applyColumnDefaultsForBlanks($table, $data);
@@ -1356,6 +1366,9 @@ class CodesController extends Controller {
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isDuplicateKeyException($e)) {
                 flash('更新失敗：主鍵或唯一值已存在。', 'error');
+                // 這個衝突可能是落地替換自己造成的（使用者輸入的是自認為不同的字形），
+                // 不附上通知的話使用者無從得知系統改了字。
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()
                     ->withInput()
@@ -1366,6 +1379,7 @@ class CodesController extends Controller {
             if ($this->isIntegrityConstraintException($e)) {
                 \Illuminate\Support\Facades\Log::warning('Codes 更新完整性違規', ['table' => $table, 'error' => $e->getMessage()]);
                 flash('更新失敗：必填欄位未填寫或關聯值不存在。', 'error');
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()
                     ->withInput()
@@ -1380,6 +1394,8 @@ class CodesController extends Controller {
         $this->recordOperation(2, $table, $keyColumns, $updatedRow, $originalRow ?: []);
 
         flash('Update success @ '.Carbon::now(), 'success');
+        $this->flashVariantNotices($variantReplaced);
+        $this->resetVariantMapCacheIfNeeded($table);
 
         $id = $this->buildCompositeId($keyColumns, $updatedRow);
 
@@ -1510,6 +1526,14 @@ class CodesController extends Controller {
 
         $payload = $this->extractFormData($request, $table);
         $payload = $this->normalizeCodeTablePinyin($table, $payload);
+        // 異體字落地替換：必須在下面的主鍵查重之前，否則會出現「查重用替換前值、
+        // 落庫（核准時）用替換後值」的錯位。
+        [$payload, $variantReplaced] = $this->applyVariantReplacement($table, $payload);
+        if ($guardError = $this->guardCharVariantMapWrite($table, $payload)) {
+            flash($guardError, 'error');
+
+            return redirect()->back()->withInput();
+        }
         $keyColumns = $this->getKeyColumns($table);
 
         if (!$this->hasPrimaryKeyValues($keyColumns, $payload)) {
@@ -1519,15 +1543,26 @@ class CodesController extends Controller {
         }
 
         $conditions = $this->buildConditionsFromRow($keyColumns, $payload);
-        $existing = $this->fetchRowByKeys($table, $keyColumns, $conditions);
+        $existing = $this->fetchRowByKeys($table, $keyColumns, $conditions)
+            // D7：也要以主鍵的等價字形查一次，否則既有的變體形列會被錯過（見 helper 說明）。
+            ?: $this->findExistingRowInEitherVariantForm($table, $keyColumns, $payload);
         if ($existing) {
             flash('提案失敗：資料已存在，請改用修改提案。', 'warning');
+            // 這個結果可能是落地替換造成的：使用者打的是變體字形、被換成參考字形之後
+            // 才撞上既有列（或才變成「沒有修改」）。少了通知，加上 withInput() 回填的是
+            // **替換前**的原始輸入，使用者會完全無從理解為什麼。
+            $this->flashVariantNotices($variantReplaced);
 
             return redirect()->back()->withInput();
         }
 
-        if ($this->hasActiveCreateProposalConflict($table, $keyColumns, $payload)) {
+        if ($this->hasActiveCreateProposalConflict($table, $keyColumns, $payload)
+            // D7：待審提案也要用等價字形比對——S2 之前留下的 pending 提案帶的是變體形
+            // resource_id，完全相等比對不會衝突，兩筆並存、依序核准就落成兩筆列。
+            || $this->hasVariantEquivalentCreateProposalConflict($table, $keyColumns, $payload)) {
             flash('提案失敗：已有其他新增提案使用相同主鍵，請調整後再提交。', 'warning');
+            // 同上：這個衝突可能是落地替換造成的。
+            $this->flashVariantNotices($variantReplaced);
 
             return redirect()->back()->withInput();
         }
@@ -1545,6 +1580,10 @@ class CodesController extends Controller {
         if ($operation) {
             flash('已提交新增提案，等待管理員審核 @ '.Carbon::now(), 'info');
         }
+        // 提案路徑同樣要告知：D6 之下既有列保留變體字形，所以使用者只要打開一列
+        // 含異體字的資料再原樣送出，替換就會產生 diff、記成一筆他自己沒察覺的提案。
+        // 至少要讓他看到「系統把字改了」。
+        $this->flashVariantNotices($variantReplaced);
 
         return redirect()->route($showRoute, ['table_name' => $table]);
     }
@@ -1622,7 +1661,23 @@ class CodesController extends Controller {
 
         $data = $this->extractFormData($request, $table);
         $data = $this->normalizeCodeTablePinyin($table, $data); // §D-6：編輯既有提案時亦歸一化 Tier 1，避免核准落庫仍帶 v
+        // 異體字落地替換：同上，在主鍵查重之前。
+        [$data, $variantReplaced] = $this->applyVariantReplacement($table, $data);
         $isCreate = (int) $operation['op_type'] === Operation::TYPE_PROPOSAL_CREATE;
+        // 修改既有對照的提案時必須把「被取代的舊邊」排除，否則合法的改動會被誤報成環
+        // （表有 乙→甲、甲→丙，把那列改成 丙→乙 是合法的 甲→丙→乙）。
+        // create 提案沒有既有列可排除，傳空條件即可。
+        // 定位器要用**權威來源** operation.resource_id，不是使用者送出的 $data['id']：
+        // body 裡的 id 可能被改、可能是空字串或非數字（(int) 會變 0 ⇒ 不排除任何邊 ⇒
+        // 合法修改被誤報成環），也可能指向別列（⇒ 排除錯的邊）。
+        $guardConditions = $isCreate
+            ? []
+            : $this->buildConditionsFromId($keyColumns, (string) ($operation['resource_id'] ?? ''));
+        if ($guardError = $this->guardCharVariantMapWrite($table, $data, $guardConditions)) {
+            flash($guardError, 'error');
+
+            return redirect()->back()->withInput();
+        }
 
         if ($isCreate) {
             if (!$this->hasPrimaryKeyValues($keyColumns, $data)) {
@@ -1632,14 +1687,23 @@ class CodesController extends Controller {
             }
 
             $conditions = $this->buildConditionsFromRow($keyColumns, $data);
-            if (!empty($conditions) && $this->fetchRowByKeys($table, $keyColumns, $conditions)) {
+            $existingRow = !empty($conditions) ? $this->fetchRowByKeys($table, $keyColumns, $conditions) : null;
+            // D7：同上，主鍵的等價字形也要查一次。
+            $existingRow = $existingRow
+                ?: $this->findExistingRowInEitherVariantForm($table, $keyColumns, $data);
+            if ($existingRow) {
                 flash('提案失敗：資料已存在，請改用修改提案。', 'warning');
+                // 同 performProposalStore 的同名分支：衝突可能是落地替換造成的。
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()->withInput();
             }
 
-            if ($this->hasActiveCreateProposalConflict($table, $keyColumns, $data, $operation['id'])) {
+            if ($this->hasActiveCreateProposalConflict($table, $keyColumns, $data, $operation['id'])
+                || $this->hasVariantEquivalentCreateProposalConflict($table, $keyColumns, $data, $operation['id'])) {
                 flash('提案失敗：已有其他新增提案使用相同主鍵，請調整後再提交。', 'warning');
+                // 同上：這個衝突可能是落地替換造成的。
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()->withInput();
             }
@@ -1681,6 +1745,7 @@ class CodesController extends Controller {
         DB::table('operations')->where('id', $operation['id'])->update($updates);
 
         flash('提案內容已更新，等待審核 @ '.Carbon::now(), 'success');
+        $this->flashVariantNotices($variantReplaced);
 
         return redirect()->route('operations.index', ['proposals_only' => 1]);
     }
@@ -1764,6 +1829,24 @@ class CodesController extends Controller {
         }
         $data = $this->enforceAuditFieldsForCreate($table, $data);
         $data = $this->normalizeCodeTablePinyin($table, $data);
+        // 異體字落地替換。發生在落庫（與資料庫的重複鍵偵測）之前，所以主鍵含文本欄的表
+        // 其查重看到的是替換後的值。
+        [$data, $variantReplaced] = $this->applyVariantReplacement($table, $data);
+        // D7：既有列的文本主鍵可能還是變體形，只用替換後的值查重會錯過它而鑄出重複列。
+        // 資料庫唯一鍵擋不住（兩個字形是不同鍵值），所以必須自己多查一次。
+        if ($this->findExistingRowInEitherVariantForm($table, $keyColumns, $data)) {
+            flash('新增失敗：主鍵或唯一值已存在。', 'error');
+            $this->flashVariantNotices($variantReplaced);
+
+            return redirect()->back()
+                ->withInput()
+                ->withErrors(['duplicate' => '新增失敗：主鍵或唯一值已存在。']);
+        }
+        if ($guardError = $this->guardCharVariantMapWrite($table, $data)) {
+            flash($guardError, 'error');
+
+            return redirect()->back()->withInput()->withErrors(['char_variant_map' => $guardError]);
+        }
         // 留白的 NOT NULL 欄（空字串經 ConvertEmptyStringsToNull 已成 null）改套用資料庫預設值，
         // 避免把 null 寫入 NOT NULL 欄觸發完整性違規（例如 pinyin.c_lastname 留白應視為預設 0）。
         $data = $this->applyColumnDefaultsForBlanks($table, $data);
@@ -1773,6 +1856,9 @@ class CodesController extends Controller {
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isDuplicateKeyException($e)) {
                 flash('新增失敗：主鍵或唯一值已存在。', 'error');
+                // 這個衝突可能是落地替換自己造成的（使用者輸入的是自認為不同的字形），
+                // 不附上通知的話使用者無從得知系統改了字。
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()
                     ->withInput()
@@ -1784,6 +1870,7 @@ class CodesController extends Controller {
                 // 友善訊息會吞掉例外，仍記一筆 warning 以保留可觀測性（非預期 FK/NOT NULL bug 才好追）。
                 \Illuminate\Support\Facades\Log::warning('Codes 新增完整性違規', ['table' => $table, 'error' => $e->getMessage()]);
                 flash('新增失敗：必填欄位未填寫或關聯值不存在。', 'error');
+                $this->flashVariantNotices($variantReplaced);
 
                 return redirect()->back()
                     ->withInput()
@@ -1800,6 +1887,10 @@ class CodesController extends Controller {
         $id = $this->buildCompositeId($keyColumns, $rowData);
 
         flash('Store success @ '.Carbon::now(), 'success');
+        // 讓錄入者知道系統改了字（落地替換是無條件套用、沒有「保留」選項，所以用非阻塞
+        // 的 flash 而不是要使用者做決定的彈窗）。
+        $this->flashVariantNotices($variantReplaced);
+        $this->resetVariantMapCacheIfNeeded($table);
 
         return redirect()->route($editRoute, ['table_name' => $table, 'id' => $id]);
     }
@@ -1841,10 +1932,23 @@ class CodesController extends Controller {
             $originalRow
         );
         $payload = $this->normalizeCodeTablePinyin($table, $payload);
+        // 異體字落地替換：在 diff 之前，讓提案記錄的是替換後的值（核准端會照樣落庫）。
+        [$payload, $variantReplaced] = $this->applyVariantReplacement($table, $payload);
+        // $conditions 在本方法上方已無條件賦值（不需要 ?? 兜底——加了反而會在日後重構時
+        // 靜默退化成 excludeId = null，也就是「更新既有對照被誤報成環」那個 bug）。
+        if ($guardError = $this->guardCharVariantMapWrite($table, $payload, $conditions)) {
+            flash($guardError, 'error');
+
+            return redirect()->back()->withInput();
+        }
 
         $diff = $this->operationRepository->getArrDiff($payload, $originalRow, $originalRow);
         if ($diff === null) {
             flash('提案失敗：未偵測到任何修改內容。', 'warning');
+            // 這個結果可能是落地替換造成的：使用者打的是變體字形、被換成參考字形之後
+            // 才撞上既有列（或才變成「沒有修改」）。少了通知，加上 withInput() 回填的是
+            // **替換前**的原始輸入，使用者會完全無從理解為什麼。
+            $this->flashVariantNotices($variantReplaced);
 
             return redirect()->back()->withInput();
         }
@@ -1862,6 +1966,10 @@ class CodesController extends Controller {
         if ($operation) {
             flash('已提交修改提案，等待管理員審核 @ '.Carbon::now(), 'info');
         }
+        // 提案路徑同樣要告知：D6 之下既有列保留變體字形，所以使用者只要打開一列
+        // 含異體字的資料再原樣送出，替換就會產生 diff、記成一筆他自己沒察覺的提案。
+        // 至少要讓他看到「系統把字改了」。
+        $this->flashVariantNotices($variantReplaced);
 
         return redirect()->route($editRoute, ['table_name' => $table, 'id' => $id]);
     }
@@ -1972,10 +2080,28 @@ class CodesController extends Controller {
         return $this->getTableColumns($table);
     }
 
+    /**
+     * getKeyColumns() 的主鍵欄快取。
+     *
+     * 原本是方法內的 `static $cache`，改成類別屬性是為了**能在測試間清掉**：
+     * schema 在同一個 process 內不會變，所以生產環境快取整個 process 是安全的；
+     * 但測試會為同一個表名建不同的合成 schema（甚至完全不建），
+     * 一旦某個測試把某表快取成錯的主鍵欄，後面的測試就會拿到污染值
+     * （症狀是「請確認主鍵欄位已填寫完整」這種與該測試無關的失敗）。
+     * TestCase::setUp() 會呼叫 resetKeyColumnCache()。
+     *
+     * @var array<string,array<int,string>>
+     */
+    private static array $keyColumnCache = [];
+
+    /** 清主鍵欄快取（測試用；見 $keyColumnCache 的說明）。 */
+    public static function resetKeyColumnCache(): void {
+        self::$keyColumnCache = [];
+    }
+
     protected function getKeyColumns(string $table): array {
-        static $cache = [];
-        if (isset($cache[$table])) {
-            return $cache[$table];
+        if (isset(self::$keyColumnCache[$table])) {
+            return self::$keyColumnCache[$table];
         }
 
         $upperTable = strtoupper($table);
@@ -1984,7 +2110,7 @@ class CodesController extends Controller {
         if (isset($this->tablePrimaryKeyOverrides[$upperTable])) {
             $overrideKeys = array_values(array_unique(array_filter($this->tablePrimaryKeyOverrides[$upperTable])));
             if (!empty($overrideKeys)) {
-                return $cache[$table] = $overrideKeys;
+                return self::$keyColumnCache[$table] = $overrideKeys;
             }
         }
 
@@ -2026,7 +2152,7 @@ class CodesController extends Controller {
             }
         }
 
-        return $cache[$table] = array_values(array_unique(array_filter($keys)));
+        return self::$keyColumnCache[$table] = array_values(array_unique(array_filter($keys)));
     }
 
     /**
@@ -2302,6 +2428,304 @@ class CodesController extends Controller {
      * @param array<string, mixed> $data
      * @return array<string, mixed>
      */
+    /**
+     * 異體字落地替換（計畫 S2）：Codes UI 的 5 條寫入路徑共用這個收口。
+     *
+     * 範圍與模式全由 VariantReplaceScope 決定（型別導向、預設 lenient、人名欄 strict、
+     * 代碼鍵與對照表自身排除），呼叫端不需要知道哪些欄位該替換。
+     *
+     * **只能替換「要寫入的值」，不可替換「用來定位既有列的條件」**：
+     * performUpdate 的 $conditions 來自 URL 主鍵、在此之前就組好了，所以這裡只碰 $data；
+     * 提案路徑的 dup 檢查是拿 $payload 的主鍵值去查，所以替換必須發生在那個檢查之前
+     * （本方法的呼叫點都在 normalizeCodeTablePinyin 之後、dup 檢查之前，順序正確）。
+     *
+     * @param array<string,mixed> $data
+     * @return array{0: array<string,mixed>, 1: array<string,string|array<int,string>>} [替換後的 data, replaced]
+     */
+    protected function applyVariantReplacement(string $table, array $data): array {
+        $result = CharVariantMapService::replaceRow($data, $table);
+
+        return [$result['data'], $result['replaced']];
+    }
+
+    /**
+     * 主鍵欄位分成「在替換範圍內的文本欄」與「其餘」。
+     *
+     * @param array<int,string> $keyColumns
+     * @return array{0: array<int,string>, 1: array<int,string>} [替換範圍內的, 其餘的]
+     */
+    protected function splitKeyColumnsByVariantScope(string $table, array $keyColumns): array {
+        $inScope = [];
+        $fixed = [];
+
+        foreach ($keyColumns as $column) {
+            if (VariantReplaceScope::modeFor($table, $column) === null) {
+                $fixed[] = $column;
+            } else {
+                $inScope[] = $column;
+            }
+        }
+
+        return [$inScope, $fixed];
+    }
+
+    /**
+     * D7「兩形並存」的去重：找出**歸一後與本次輸入相同**的既有列。
+     *
+     * D6 不做回溯校正，所以既有列的文本主鍵可能還是任一個變體形；而對照是**多對一**
+     * （多個變體可指向同一參考字），所以「歸一後相同」的字形可能很多。
+     * 只用替換後的值查重會錯過那些列，鑄出語義重複的列——而資料庫唯一鍵擋不住
+     * （不同字形是不同鍵值），**比不替換更糟**。
+     *
+     * 做法：**把不在替換範圍內的主鍵欄固定在 SQL 條件裡，取回那一小群候選列，
+     * 再在 PHP 端把它們的文本主鍵歸一後比對**。這樣是**精確**的（不管對照表是什麼形狀）、
+     * 而且只要**一次查詢**。
+     *
+     * 早期版本改用「列舉所有等價字形再逐一查」，那個做法有兩個缺點：查詢次數是等價字形數
+     * （最壞可達數十次），而且為了避免組合爆炸設的上限本身是**正確性缺口**——超過上限就
+     * 退回只比對正規形，等於完全失去這道去重。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<string,mixed> $after 替換後的資料
+     * @return mixed 既有列（stdClass）或 null
+     */
+    protected function findExistingRowInEitherVariantForm(string $table, array $keyColumns, array $after) {
+        [$inScope, $fixed] = $this->splitKeyColumnsByVariantScope($table, $keyColumns);
+
+        // 主鍵沒有任何可替換的文本欄 ⇒ 一般查重就夠，零額外成本。
+        if ($inScope === []) {
+            return null;
+        }
+
+        // 全部主鍵欄都可替換 ⇒ 沒有能收斂候選集的 SQL 條件，會變成全表掃描。
+        // 目前沒有這種表（ALTNAME_DATA 是 3 鍵、只有 1 個文本欄可替換），
+        // 真的出現時記 warning 並跳過，不要靜默做全表掃描。
+        if ($fixed === []) {
+            \Illuminate\Support\Facades\Log::warning('D7 去重跳過：主鍵全部在替換範圍內，無法收斂候選集', [
+                'table' => $table,
+                'key_columns' => $keyColumns,
+            ]);
+
+            return null;
+        }
+
+        $query = DB::table($table);
+        foreach ($fixed as $column) {
+            if (!array_key_exists($column, $after)) {
+                return null;
+            }
+            $query->where($column, $after[$column]);
+        }
+
+        foreach ($query->get() as $row) {
+            if ($this->rowMatchesAfterNormalization($table, $inScope, (array) $row, $after)) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * D7：待審的新增提案裡有沒有「歸一後與本次輸入相同」的一筆。
+     *
+     * `hasActiveCreateProposalConflict()` 是拿 `resource_id` 做完全相等比對，
+     * 所以 S2 之前留下的 pending 提案（帶變體形 resource_id）不會與新提案（帶歸一後
+     * resource_id）衝突 ⇒ 兩筆並存、依序核准就落成兩種字形的兩筆列。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<string,mixed> $after
+     */
+    protected function hasVariantEquivalentCreateProposalConflict(
+        string $table,
+        array $keyColumns,
+        array $after,
+        ?int $excludeOperationId = null
+    ): bool {
+        [$inScope] = $this->splitKeyColumnsByVariantScope($table, $keyColumns);
+        if ($inScope === []) {
+            return false;
+        }
+
+        if (!Schema::hasTable('operations')) {
+            return false;
+        }
+
+        $query = DB::table('operations')
+            ->where('resource', $table)
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE);
+        if ($excludeOperationId !== null) {
+            $query->where('id', '!=', $excludeOperationId);
+        }
+
+        // 用「前導的非替換範圍主鍵欄」組出 resource_id 前綴來收斂候選集。
+        // resource_id 是 buildCompositeId() 以 '_._' 串起來的複合主鍵，所以前導欄可以做
+        // 前綴 LIKE，而 operations 上的 (resource, resource_id, op_type) 索引吃得到。
+        // 少了這個條件就會把該表**所有歷史** create proposal（含已核准／已取消）全部撈回來
+        // 反序列化，集合隨歷史無上限成長。
+        if (($pattern = $this->variantProposalResourceIdPattern($keyColumns, $inScope, $after)) !== null) {
+            $query->where('resource_id', 'like', $pattern);
+        }
+
+        // 分批而非一次載入：候選集理論上無上限（**不能用 limit 截斷**——截斷會重現
+        // 「漏抓重複」的正確性缺口）。用 lazyById() 而不是 cursor()：PDO MySQL 預設是
+        // buffered query（config/database.php 沒關掉 MYSQL_ATTR_USE_BUFFERED_QUERY），
+        // cursor() 仍會把整個結果集先讀進 PHP 記憶體；lazyById() 以 id 分頁，
+        // 每批大小固定，記憶體才真的有界。
+        foreach ($query->lazyById(500) as $operation) {
+            $payload = json_decode((string) $operation->resource_data, true);
+            if (!is_array($payload)) {
+                continue;
+            }
+            if (!in_array($payload['__review_status'] ?? null, ['pending', 'rejected'], true)) {
+                continue;
+            }
+            // 其餘主鍵欄必須相同，文本主鍵欄則比對歸一後的值
+            foreach ($keyColumns as $column) {
+                if (in_array($column, $inScope, true)) {
+                    continue;
+                }
+                if ((string) ($payload[$column] ?? '') !== (string) ($after[$column] ?? '')) {
+                    continue 2;
+                }
+            }
+            if ($this->rowMatchesAfterNormalization($table, $inScope, $payload, $after)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 用「非替換範圍的主鍵欄」組出 `resource_id` 的 LIKE 樣式，把候選集收斂在 SQL 層。
+     *
+     * `resource_id` 是 `buildCompositeId()` 以 `'_._'` 串起的**位置式**序列化，所以可以
+     * 逐位置組樣式：在替換範圍內的欄位放 `%`、其餘放實際值。
+     *
+     * **不能只做「前導前綴」**：production 的 `ALTNAME_DATA` 主鍵順序是
+     * `(c_alt_name_chn, c_alt_name_type_code, c_personid)`——第一欄正是可替換的文字欄，
+     * 前導前綴會直接失效而退回全掃。位置式樣式在任何順序下都能收斂。
+     *
+     * 這個樣式是**寬鬆的預篩**（分隔符裡的 `_` 本身是 LIKE 單字元通配、且值含 `%`／`_`
+     * 時會退成 `%`），只會多撈不會少撈——精確比對在 PHP 端由
+     * `rowMatchesAfterNormalization()` 完成，所以寬鬆是安全的。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<string,mixed> $after
+     * @return string|null null = 無法收斂（所有主鍵欄都是通配），呼叫端就別加這個條件
+     */
+    protected function variantProposalResourceIdPattern(array $keyColumns, array $inScope, array $after): ?string {
+        $parts = [];
+        $hasLiteral = false;
+
+        foreach ($keyColumns as $column) {
+            if (in_array($column, $inScope, true)) {
+                $parts[] = '%';
+
+                continue;
+            }
+
+            $value = array_key_exists($column, $after) && $after[$column] !== null
+                ? (string) $after[$column]
+                : '';
+
+            // 值本身含 LIKE 通配字元時退成 '%'：跨 driver 的 ESCAPE 語法不一致
+            // （SQLite 需要顯式 ESCAPE），而寬鬆預篩本來就安全。
+            if ($value === '' || strpbrk($value, '%_') !== false) {
+                $parts[] = '%';
+
+                continue;
+            }
+
+            $parts[] = $value;
+            $hasLiteral = true;
+        }
+
+        if (!$hasLiteral) {
+            return null;
+        }
+
+        return implode('_._', $parts);
+    }
+
+    /**
+     * 候選列的文本主鍵歸一後是否與本次輸入相同。
+     *
+     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<string,mixed> $candidate
+     * @param array<string,mixed> $after 替換後的資料
+     */
+    protected function rowMatchesAfterNormalization(string $table, array $inScope, array $candidate, array $after): bool {
+        foreach ($inScope as $column) {
+            $candidateValue = $candidate[$column] ?? null;
+            if (!is_string($candidateValue)) {
+                return false;
+            }
+
+            $normalized = CharVariantMapService::replaceFor($table, $column, $candidateValue)['text'];
+            if ($normalized !== (string) ($after[$column] ?? '')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 把落地替換的結果 flash 給使用者（direct 寫入路徑用）。
+     *
+     * **不要自己組字**：replaced 的值在衝突時會是 list（同一變體在 strict 欄與 lenient 欄
+     * 的閉包終點可以不同），implode 會拋 "Array to string conversion"。一律走 buildNotices()。
+     *
+     * @param array<string,string|array<int,string>> $replaced
+     */
+    protected function flashVariantNotices(array $replaced): void {
+        foreach (CharVariantMapService::buildNotices($replaced) as $notice) {
+            flash($notice, 'info');
+        }
+    }
+
+    /**
+     * char_variant_map 的結構把關（單一 codepoint、不成環）＋寫入後清快取。
+     *
+     * 這張表是所有落地替換的資料來源，寫進一筆壞對照會讓全站的替換降級
+     * （載入時只能丟掉環上的邊求生）。所以在應用層擋住，而不是等載入端降級。
+     *
+     * @param array<string,mixed> $data
+     * @param array<string,mixed> $conditions 更新時用來定位既有列；用於取得要排除的舊邊
+     * @return string|null null = 通過；非 null = 錯誤訊息
+     */
+    protected function guardCharVariantMapWrite(string $table, array $data, array $conditions = []): ?string {
+        if (strtolower($table) !== 'char_variant_map') {
+            return null;
+        }
+
+        // 主鍵欄名刻意寫死 'id'，與 CharVariantMapService::assertWritable() 內部的
+        // where('id', …) 保持一致。早期版本改成從 getKeyColumns() 取，但那是**半套的**
+        // ——服務端仍寫死 'id'，所以主鍵若改名，這裡會拿新欄的值去查舊的 id 欄，
+        // 比兩邊都寫死更難查。要改就兩邊一起改（把欄名一路傳進服務）。
+        $excludeId = isset($conditions['id']) ? (int) $conditions['id'] : null;
+
+        try {
+            CharVariantMapService::assertWritable($data, $excludeId);
+        } catch (VariantMappingException $e) {
+            // 只 catch 專屬型別：QueryException 繼承 PDOException 繼承 RuntimeException，
+            // 用 \RuntimeException 會把資料庫錯誤變成「驗證失敗」並把原始 SQL flash 出去。
+            return $e->getMessage();
+        }
+
+        return null;
+    }
+
+    /** 寫入 char_variant_map 之後清行程內快取，讓下次替換讀到新的對照。 */
+    protected function resetVariantMapCacheIfNeeded(string $table): void {
+        if (strtolower($table) === 'char_variant_map') {
+            CharVariantMapService::reset();
+        }
+    }
+
     /**
      * §D-6 保存止血：對本表的 **Tier 1** 拼音欄（config/code_table_mutations.php）靜默套 v→ü 歸一化。
      *

--- a/app/Services/CharVariantMapService.php
+++ b/app/Services/CharVariantMapService.php
@@ -2,10 +2,12 @@
 
 namespace App\Services;
 
+use App\Exceptions\VariantMappingException;
 use App\Support\VariantReplaceScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * 異體字落地替換服務
@@ -32,6 +34,19 @@ class CharVariantMapService {
      * @var array<string,string>|null
      */
     protected static ?array $strictMap = null;
+
+    /**
+     * 對照表是否缺表（null = 尚未判定）。
+     *
+     * 缺表是**確定性**條件，所以可以在 process 內快取；reset() 會清掉。
+     * 不快取的代價是逐欄放大：replaceRow() 對整列每個欄位都會走一次 map 載入，
+     * 缺表時就變成「每欄一次 metadata 查詢 + 每欄一行 warning」——一次 20 欄的儲存
+     * ＝20 次查詢，而 S3 接上批次匯入後會變成「列數 × 欄數」。
+     *
+     * 這與「不快取瞬時錯誤」的決定不衝突：瞬時錯誤現在一律往上拋（見 loadEdges()），
+     * 所以根本沒有「把失敗結果快取住」的路徑。
+     */
+    protected static ?bool $tableMissing = null;
 
     /**
      * 寬鬆模式：對整段文字做落地替換，表裡任何一筆都套用（忽略 c_strict_excluded）。
@@ -183,7 +198,7 @@ class CharVariantMapService {
      *                            表有 id=5 `乙→甲`、id=9 `甲→丙`，把 id=5 改成 `丙→乙`
      *                            是合法的 `甲→丙→乙`，但把舊邊算進去會看到 `乙→甲→丙→乙`
      *
-     * @throws \RuntimeException 驗證不通過
+     * @throws VariantMappingException 驗證不通過
      */
     public static function assertWritable(array $row, ?int $excludeId = null): void {
         $current = [];
@@ -208,15 +223,15 @@ class CharVariantMapService {
         // 只送了單邊字元欄、又沒有既有列可以 merge：這是呼叫端沒傳 id 的問題，
         // 報「必須是單一字元」會誤導（使用者根本沒動另一欄）。
         if ($variant === '' || $reference === '') {
-            throw new \RuntimeException(__('variant.incomplete_payload'));
+            throw new VariantMappingException(__('variant.incomplete_payload'));
         }
 
         if (mb_strlen($variant) !== 1 || mb_strlen($reference) !== 1) {
-            throw new \RuntimeException(__('variant.single_codepoint_required'));
+            throw new VariantMappingException(__('variant.single_codepoint_required'));
         }
 
         if ($variant === $reference) {
-            throw new \RuntimeException(__('variant.self_reference_not_allowed'));
+            throw new VariantMappingException(__('variant.self_reference_not_allowed'));
         }
 
         // 把待寫入的邊放進現有邊集（排除被取代的舊邊），看會不會成環。
@@ -233,7 +248,7 @@ class CharVariantMapService {
             $node = $edges[$node];
         }
         if (isset($edges[$node]) && isset($seen[$node])) {
-            throw new \RuntimeException(__('variant.cycle_not_allowed', ['char' => $node]));
+            throw new VariantMappingException(__('variant.cycle_not_allowed', ['char' => $node]));
         }
     }
 
@@ -243,6 +258,7 @@ class CharVariantMapService {
     public static function reset(): void {
         self::$lenientMap = null;
         self::$strictMap = null;
+        self::$tableMissing = null;
     }
 
     /**
@@ -335,12 +351,11 @@ class CharVariantMapService {
      */
     protected static function lenientMap(): array {
         if (self::$lenientMap === null) {
-            self::$lenientMap = self::resolveMap(
-                DB::table('char_variant_map')
-                    ->pluck('c_reference_char', 'c_variant_char')
-                    ->all(),
-                'lenient'
-            );
+            $edges = self::loadEdges(null);
+            if ($edges === null) {
+                return [];
+            }
+            self::$lenientMap = self::resolveMap($edges, 'lenient');
         }
 
         return self::$lenientMap;
@@ -351,16 +366,49 @@ class CharVariantMapService {
      */
     protected static function strictMap(): array {
         if (self::$strictMap === null) {
-            self::$strictMap = self::resolveMap(
-                DB::table('char_variant_map')
-                    ->where('c_strict_excluded', 0)
-                    ->pluck('c_reference_char', 'c_variant_char')
-                    ->all(),
-                'strict'
-            );
+            $edges = self::loadEdges(0);
+            if ($edges === null) {
+                return [];
+            }
+            self::$strictMap = self::resolveMap($edges, 'strict');
         }
 
         return self::$strictMap;
+    }
+
+    /**
+     * 讀對照表的邊集。
+     *
+     * **只在「表不存在」時降級為不替換**（回 null，呼叫端不快取這個結果）。
+     * 這一步從 S2 起變成必要：落地替換現在掛在 Codes UI 全部 5 條寫入路徑上，若在
+     * 尚未 migrate／部分遷移的環境因為缺表而拋錯，**整個代碼表的寫入功能都會 500**
+     * ——為了一個正規化的加值功能讓核心錄入功能停擺是不對的取捨。
+     *
+     * **其餘錯誤一律往上拋**（連線問題、欄位被改名、權限…）。早期版本對所有 Throwable
+     * 都降級並把空 map 快取起來，後果是「一次瞬時錯誤就讓這個 worker 之後所有寫入都
+     * 不再替換」，而且只留下一行 warning——那正是本階段最想避免的靜默失效。
+     *
+     * @param int|null $strictExcluded null = 不過濾（lenient）；0 = 只取可用於人名的（strict）
+     * @return array<string,string>|null null = 表不存在，本次不替換（且不要快取）
+     */
+    protected static function loadEdges(?int $strictExcluded): ?array {
+        if (self::$tableMissing === null) {
+            self::$tableMissing = !Schema::hasTable('char_variant_map');
+            if (self::$tableMissing) {
+                Log::warning('char_variant_map 不存在，本次不做落地替換');
+            }
+        }
+
+        if (self::$tableMissing) {
+            return null;
+        }
+
+        $query = DB::table('char_variant_map');
+        if ($strictExcluded !== null) {
+            $query->where('c_strict_excluded', $strictExcluded);
+        }
+
+        return $query->pluck('c_reference_char', 'c_variant_char')->all();
     }
 
     /**

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -132,8 +132,21 @@ D6 之下，同一個概念會同時以變體形（既有列）與參考形（�
 
 1. **兩欄必須是單一 codepoint**（`mb_strlen() === 1`）。幂等論證只在單字元 key 下成立：`甲乙→丙丁` + `丁→戊`，閉包接不起來（exact match），第一次得 `丙丁`、第二次得 `丙戊`。非 BMP 不會誤擋（mbstring 算 1）。**此決定取代第一階段 `:49`／`:53` 那句「varchar(10) 為變體選擇符留餘裕」**——在實作出替代不變式（「value 集不得含任何 key 為子字串」）之前不收錄組合字符；欄位長度不變，只是多一道驗證。
 2. **先按模式過濾、再各自算閉包與環**，且 `$lenientMap`／`$strictMap` 維持兩份獨立快取。**今天的實作已滿足**（`strictMap():153` 在 SQL 層 `where(...):156`），這條是**擋住「共用 loader 載入全表算一次閉包、strict 再按 flag 過濾」那個誘人重構**的護欄——別去找現存的 bug，沒有。若做了該重構：`X→峯`(0)+`峯→峰`(1) ⇒ 全表閉包得 `X→峰`，其 flag 為 0 於是留在 strict map ⇒ strict 透過傳遞把 strict-excluded 的邊套進人名欄，廢掉 `c_strict_excluded` 的唯一用途。
-3. **執行順序必須是「按模式過濾 → 偵測並移除環上出邊 → 對剩餘無環圖算閉包」**。反過來（先算閉包再偵環）**不可實作**：對 `A→B`+`B→A` 或自環 `A→A`，閉包在環移除前沒有定義，一般的走鏈寫法會**無限迴圈**。
-4. **環的處置：只丟棄構成該環的邊 + 記 error log，其餘照常**。兩個 map 方法是所有替換的唯一入口，在此 throw 會讓 Codes UI 80 表、所有 v2 mutate、三支批次匯入、眾包核准、提案核准**一起爆**（一個 `峰→峯` 或打錯字的 `A→A` 就夠）；回空 map 則等於全站靜默不替換。定位精確：functional graph 下「環上節點」＝「從自己出發能走回自己」，逐 key 走鏈 + visited set 即可，`A→A` 自然當長度 1 的環丟掉；改動侷限在兩個 map 方法，**不需動 `replaceUsing()`**。**「鏈進入環」（`A→B`、`B→C`、`C→B`）只丟環上節點（B、C）的出邊，`A→B` 要保留**。
+3. **對照表缺表時降級為「不替換」，其餘錯誤一律往上拋**（S2 實作時新增的決定）。
+   落地替換從 S2 起掛在 Codes UI 全部 5 條寫入路徑上，若在尚未 migrate／部分遷移的環境
+   因為缺表而拋錯，**整個代碼表的寫入功能都會 500**——為了加值功能讓核心錄入功能停擺
+   是錯的取捨。但降級**只限「表不存在」這個確定性條件**：早期寫法對所有 Throwable 都降級
+   並把空 map 快取起來，後果是「一次瞬時錯誤就讓這個 worker 之後所有寫入都不再替換」，
+   只留一行 warning——那正是本階段最想避免的靜默失效。**瞬時錯誤現在一律往上拋**，
+   所以沒有「把失敗結果快取住」的路徑。
+   「表不存在」這個確定性結果**可以**在 process 內快取（`$tableMissing`，`reset()` 會清）：
+   不快取的話 `replaceRow()` 會逐欄各做一次 `Schema::hasTable()`，一次 20 欄的儲存＝20 次
+   metadata 查詢，S3 接上批次匯入後放大成「列數 × 欄數」。
+   **已知限制**：PHP-FPM 每個 request 會重建 static，所以這個快取實務上只活在單一 request 內；
+   長駐程序（queue worker）若在**尚未 migrate** 的環境啟動過一次，之後即使建了表也會持續
+   不替換，需重啟 worker（部署本來就會重啟）。
+4. **執行順序必須是「按模式過濾 → 偵測並移除環上出邊 → 對剩餘無環圖算閉包」**。反過來（先算閉包再偵環）**不可實作**：對 `A→B`+`B→A` 或自環 `A→A`，閉包在環移除前沒有定義，一般的走鏈寫法會**無限迴圈**。
+5. **環的處置：只丟棄構成該環的邊 + 記 error log，其餘照常**。兩個 map 方法是所有替換的唯一入口，在此 throw 會讓 Codes UI 80 表、所有 v2 mutate、三支批次匯入、眾包核准、提案核准**一起爆**（一個 `峰→峯` 或打錯字的 `A→A` 就夠）；回空 map 則等於全站靜默不替換。定位精確：functional graph 下「環上節點」＝「從自己出發能走回自己」，逐 key 走鏈 + visited set 即可，`A→A` 自然當長度 1 的環丟掉；改動侷限在兩個 map 方法，**不需動 `replaceUsing()`**。**「鏈進入環」（`A→B`、`B→C`、`C→B`）只丟環上節點（B、C）的出邊，`A→B` 要保留**。
 
 ### D9：搜尋路徑完全沒有異體字歸一化（必須明講）
 
@@ -186,8 +199,13 @@ public static function replaceFor(string $table, string $column, string $value):
  *  表有 id=5 `乙→甲`、id=9 `甲→丙`，把 id=5 改成 `丙→乙` 是合法的 `甲→丙→乙`，
  *  但把舊邊算進去會看到 `乙→甲→丙→乙`。
  *  $row 可能是部分 payload（restoreUpdate 用歷史快照），需與現有列 merge 後再驗。 */
-public static function assertWritable(array $row, ?int $excludeId = null): void;
+public static function assertWritable(array $row, ?int $excludeId = null): void;  // throws VariantMappingException
 ```
+
+**`assertWritable()` 必須拋專屬型別 `App\Exceptions\VariantMappingException`，呼叫端也只能 catch 它。**
+`Illuminate\Database\QueryException` 繼承 `PDOException` 繼承 `\RuntimeException`，而 `assertWritable()`
+內部會查兩次 `char_variant_map`——呼叫端若 `catch (\RuntimeException)`，任何資料庫錯誤都會被當成
+「驗證失敗」，把原始 SQLSTATE 與 SQL 字串顯示給使用者，而且該次寫入會被靜默跳過而不是誠實地 500。
 
 ### 通知通道與 i18n
 
@@ -264,6 +282,16 @@ D3 已內嵌一份已查證的代碼鍵清單，直接進排除常數。本步�
 
 - direct 兩條：`replaced` 非空時把 `buildNotices()` 的每則訊息 `flash(...,'info')`（**不要自己組字**，見上方 S1 約定）；它們之後才呼叫 `applyColumnDefaultsForBlanks()`（`:1769`／`:1352`），**三條提案路徑不呼叫它**，只需在記 operation 之前。
 - 提案三條：替換後的值進 `operations.resource_data`（`$table` 傳**目標表**，不是 `operations`）。
+- **D7 兩形並存的去重（S2 實作時發現、原本漏掉）**：`ALTNAME_DATA.c_alt_name_chn` 同時是**文本主鍵成員**又在替換範圍內（strict），而 `ALTNAME_DATA` 是 Codes UI 可寫的表——這是 Codes UI 裡唯一會踩到 D7 的形狀。D6 之下既有列的主鍵可能還是變體形，只用**替換後**的值查重就會錯過它、鑄出語義重複的第二列（**比不替換更糟**），而資料庫唯一鍵擋不住（兩個字形是不同的鍵值）。因此三條 create 路徑（`performStore`／`performProposalStore`／`proposalUpdateExisting` 的 create 分支）都要**再以主鍵的「等價字形集合」查一次**。
+  ⚠️ **只探「輸入值 + 替換後值」兩形是不夠的**：對照是**多對一**（`c_variant_char` 有唯一鍵、`c_reference_char` 沒有），所以既有列可能是**另一個**變體——既有 `菁客`（菁→青）、新輸入 `靑客`（靑→青），兩者都歸一成 `青客`，但拿 `靑客`／`青客` 去查都找不到 `菁客`。
+  ⚠️ **也不要用「列舉所有等價字形再逐一查」**（第二版這樣寫、被 codex 抓到）：查詢次數等於等價字形數（最壞數十次），而為了避免組合爆炸設的上限**本身是正確性缺口**——超過上限就退回只比對正規形，等於完全失去這道去重，且那是可由合法對照表資料觸發的（一個參考字有 6 個變體、主鍵含 2 個這樣的字就是 7×7=49）。
+  **正確做法**：把**不在替換範圍內**的主鍵欄固定在 SQL 條件裡取回那一小群候選列，再在 PHP 端把它們的文本主鍵歸一後比對。這是**精確**的（不管對照表什麼形狀）、而且只要**一次查詢**。全部主鍵欄都可替換的表會退化成全表掃描——目前沒有這種表，真的出現時記 warning 並跳過，不要靜默掃全表。
+  待審提案那一側則是以 `resource_id` 的**位置式 LIKE 樣式**收斂（在替換範圍內的欄位放 `%`、其餘放實際值）＋ `lazyById()` 分批。兩個實作陷阱：
+  (a) **不能只做「前導前綴」**——production 的 `ALTNAME_DATA` 主鍵順序是 `(c_alt_name_chn, c_alt_name_type_code, c_personid)`，第一欄正是可替換的文字欄，前導前綴會直接失效而退回全掃。
+  (b) **不能用 `cursor()` 當作「記憶體有界」**——PDO MySQL 預設是 buffered query（`config/database.php` 沒關 `MYSQL_ATTR_USE_BUFFERED_QUERY`），整個結果集仍會先進 PHP 記憶體；要用 `lazyById()`。
+  **測試 fixture 的主鍵順序必須與 production 一致**，否則就會像第一版那樣測不到 (a)。
+  ⚠️ **待審提案也要用等價字形比對**：`hasActiveCreateProposalConflict()` 是拿 `resource_id` 做完全相等比對，S2 之前留下的 pending 提案帶的是變體形 `resource_id`，新提案帶歸一後的 ⇒ 不會衝突 ⇒ 兩筆待審並存，依序核准就落成兩種字形的兩筆列。
+  update 路徑不受影響——它的定位器來自 URL 主鍵。
 - 同時涵蓋 Blade 與 React（共用 `perform*`）。
 - **`char_variant_map` 的 guard**：`performStore()`／`performUpdate()` 落庫前呼叫 `CharVariantMapService::assertWritable($data, $id)`（違反回 flash error 且不寫入），成功後呼叫 `CharVariantMapService::reset()`。三條提案路徑寫的是 `operations`、不改對照表，**不需要** reset，但仍建議在提案建立時先跑 `assertWritable()` 提早拒絕。
 - 測試：`ADDR_CODES.c_name_chn` 含「淸」→ 落庫「清」+ flash；拼音欄拉丁字串 no-op；數字欄不變；`char_variant_map` 自身 `c_notes` 含「淸」**不**被替換；`pinyin` 表新增「峯」讀音 → `c_chn` 保持「峯」；提案 `resource_data` 是替換後值且 `resource_id` 未被改寫。
@@ -317,6 +345,7 @@ D3 已內嵌一份已查證的代碼鍵清單，直接進排除常數。本步�
 
 - **主分支先說清**：`applyProposal():405` 把 `HANDLER_ROUTED_RESOURCES` 內的資源導到 `applyViaMutationHandler():483` 以 v2 direct handler 重放，所以**大多數人物子資源提案由 S3 的基底掛鉤自動覆蓋**，走不到下面兩條。
 - `applyCreateProposal():744`／`applyUpdateProposal():772`（服務代碼表與尚未遷移的表）：**掛鉤點在方法最上方、`buildKeyConditions()` 之前**，不是「insert／update 之前」。`applyCreateProposal()` 的重複檢查在 `:752`，早於 `:757` 的 insert；寫成「落庫前」會重演 §1.3 禁止的錯位（查重用替換前值、落庫用替換後值）。`applyUpdateProposal()` 的 `$conditions` 同理（update `:798`）。今天實際影響小（該分支的文本型 PK 成員都在排除清單），但**措辭會被複製**。
+- **`char_variant_map` 的核准也要 guard ＋ 清快取**：該表**不在** `HANDLER_ROUTED_RESOURCES`，所以它的提案核准就走上面那兩條泛用分支（`applyCreateProposal():757` insert／`applyUpdateProposal():798` update）。S2 已在 Codes UI 的 direct 路徑補了 `assertWritable()` ＋ `CharVariantMapService::reset()`，同樣的理由適用於核准端——核准一筆對照之後若不清快取，這個 worker 之後的替換都還在用舊對照。**兩者要一起補，別只補 guard 漏掉 reset。**
 - `applyKinshipProposal():597`／`applyAssocProposal():637`：不重放 handler、直接呼叫 `BiogMainRepository` 的 kinship／assoc 寫入方法，S3 覆蓋不到，必須獨立補。部分 repository 方法只是薄轉發，真正寫入在 `OfficePostingRepository.php`／`EventStatusRepository.php`，掛鉤要放在真正落庫那層。
 - 實體聚合提案核准（`:226 approveEntityAggregateProposal()` → `:273` 以 direct 重放，注入的正是 S4 那兩個 ImportService）由 S4 覆蓋，本步只需驗證——**含 S4 新增的三個 v2 lookup site**。
 - 雙保險：提案建立端（S2／S3／S5）已替換，核准端再替換一次，依 D8 幂等。與 S2 不衝突：S2 讓存進 payload 的已是替換後值，本步是對歷史遺留 payload 補網。

--- a/tests/Feature/CodesCharVariantMapAuditTest.php
+++ b/tests/Feature/CodesCharVariantMapAuditTest.php
@@ -152,10 +152,14 @@ class CodesCharVariantMapAuditTest extends TestCase {
             'c_strict_excluded' => 1,
         ]);
 
+        // 參考字必須是單一字元：CharVariantMapService::assertWritable() 從 S2 起會擋下
+        // 多字元的對照（幂等論證只在單一 codepoint 下成立，見計畫 D8）。原本這裡用的
+        // 「新參考字」是 4 個字、本來就不是合法的「參考字」，改用單一字元。
+        // 本測試的主體是稽核紀錄，不是多字元是否放行。
         $response = $this->put('/codes/char_variant_map/101', [
             'id' => 101,
             'c_variant_char' => '舊',
-            'c_reference_char' => '新參考字',
+            'c_reference_char' => '新',
             'c_strict_excluded' => 0,
         ]);
 
@@ -164,6 +168,6 @@ class CodesCharVariantMapAuditTest extends TestCase {
         $audit = DB::table('audit_log')->where('table_name', 'char_variant_map')->where('operation', 'UPDATE')->first();
         $this->assertNotNull($audit);
         $this->assertSame('旧', json_decode($audit->old_data, true)['c_reference_char']);
-        $this->assertSame('新參考字', json_decode($audit->new_data, true)['c_reference_char']);
+        $this->assertSame('新', json_decode($audit->new_data, true)['c_reference_char']);
     }
 }

--- a/tests/Feature/CodesVariantReplacementTest.php
+++ b/tests/Feature/CodesVariantReplacementTest.php
@@ -1,0 +1,792 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * S2：Codes UI 全表串接異體字落地替換。
+ *
+ * 見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md S2。Codes UI 的 5 條寫入路徑
+ * （performStore／performUpdate／performProposalStore／performProposalUpdate／
+ * proposalUpdateExisting）共用同一個掛鉤，且 Blade 與 React 版共用 perform*，
+ * 所以一次涵蓋兩個入口。
+ *
+ * 註：`operations.resource_id`（序列化主鍵）在 Codes UI 這條路徑上**結構上不可能**被替換
+ * ——該表的主鍵欄要嘛是數字，要嘛是已排除的代碼鍵（`ENTRY_TYPES.c_entry_type`、
+ * `SOCIAL_INSTITUTION_TYPES.c_inst_type_code` 等）。用數字主鍵去斷言「它沒被改寫」
+ * 證明不了任何事，所以這裡不做那條測試；排除本身由 `VariantReplaceScopeTest` 斷言。
+ */
+class CodesVariantReplacementTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiled = sys_get_temp_dir().'/cbdb-test-views-codes-variant-replacement';
+        if (!is_dir($compiled)) {
+            mkdir($compiled, 0777, true);
+        }
+        config(['view.compiled' => $compiled]);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+        config(['codes.tables' => [
+            'ADDR_CODES' => '地址代碼',
+            'ALTNAME_DATA' => '人物別名資料表',
+            'char_variant_map' => '異體字落地替換對照表',
+            'pinyin' => '拼音字典',
+        ]]);
+        config(['codes.ui_hidden' => []]);
+
+        Schema::create('users', function ($t) {
+            $t->increments('id');
+            $t->string('name');
+            $t->string('email')->unique();
+            $t->string('password');
+            $t->string('confirmation_token')->nullable();
+            $t->tinyInteger('is_active')->default(0);
+            $t->tinyInteger('is_admin')->default(0);
+            $t->timestamps();
+        });
+
+        // 代表「一般代碼表」：有中文欄、拼音欄、數字欄
+        Schema::create('ADDR_CODES', function ($t) {
+            $t->integer('c_addr_id')->primary();
+            $t->string('c_name_chn', 255)->nullable();
+            $t->string('c_name', 255)->nullable();
+            $t->integer('c_admin_type')->nullable();
+            $t->string('c_notes', 255)->nullable();
+        });
+
+        // 文本主鍵成員（c_alt_name_chn）且在替換範圍內（strict）——Codes UI 裡
+        // 唯一會踩到 D7「兩形並存」去重問題的形狀。
+        Schema::create('ALTNAME_DATA', function ($t) {
+            $t->integer('c_personid');
+            $t->string('c_alt_name_chn', 255);
+            $t->integer('c_alt_name_type_code');
+            $t->string('c_notes', 255)->nullable();
+            // ⚠️ 主鍵順序必須與 production 一致：
+            // (c_alt_name_chn, c_alt_name_type_code, c_personid)
+            // ——見 database/migrations/2025_01_01_000000_import_cbdb_schema.php:168。
+            // 這個順序讓**可替換的文字欄排在第一位**，正是 resource_id 前綴收斂會失效
+            // 的情形；早期版本把 c_personid 排前面，於是測不到 production 的實際行為。
+            $t->primary(['c_alt_name_chn', 'c_alt_name_type_code', 'c_personid']);
+        });
+
+        Schema::create('char_variant_map', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('c_variant_char', 10);
+            $t->string('c_reference_char', 10);
+            $t->tinyInteger('c_strict_excluded')->default(1);
+            $t->string('c_notes', 255)->nullable();
+            $t->timestamps();
+
+            $t->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        Schema::create('pinyin', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('c_chn', 10);
+            $t->string('c_pinyin', 255)->nullable();
+        });
+
+        Schema::create('operations', function ($t) {
+            $t->increments('id');
+            $t->unsignedBigInteger('user_id')->nullable();
+            $t->integer('c_personid')->default(0);
+            $t->string('resource')->nullable();
+            $t->text('resource_id')->nullable();
+            $t->string('op_type')->nullable();
+            $t->longText('resource_data')->nullable();
+            $t->longText('resource_original')->nullable();
+            $t->integer('crowdsourcing_status')->default(0);
+            $t->timestamps();
+        });
+
+        Schema::create('audit_log', function ($t) {
+            $t->bigIncrements('id');
+            $t->dateTime('occurred_at');
+            $t->dateTime('created_at');
+            $t->string('table_name', 64);
+            $t->string('operation', 16);
+            $t->string('actor_type', 32);
+            $t->string('actor_id', 128);
+            $t->string('operation_id', 64);
+            $t->text('row_pk');
+            $t->string('row_pk_text', 512)->nullable();
+            $t->longText('old_data')->nullable();
+            $t->longText('new_data')->nullable();
+        });
+
+        $this->seedMappings();
+
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    protected function tearDown(): void {
+        foreach (['audit_log', 'operations', 'pinyin', 'char_variant_map', 'ALTNAME_DATA', 'ADDR_CODES', 'users'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    private function seedMappings(): void {
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+        ]);
+    }
+
+    private function activeUser(): User {
+        return User::forceCreate([
+            'name' => 'U', 'email' => 'u@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    /** @return array<int,string> flash 訊息 */
+    private function flashMessages(): array {
+        $flash = session('flash_notification', collect())->toArray();
+
+        return array_map(fn ($item) => (string) ($item['message'] ?? ''), $flash);
+    }
+
+    private function assertFlashContains(string $needle): void {
+        $messages = $this->flashMessages();
+        $this->assertTrue(
+            collect($messages)->contains(fn (string $m) => str_contains($m, $needle)),
+            "flash 訊息不含「{$needle}」，實際為：".implode(' | ', $messages)
+        );
+    }
+
+    // ─────────────────────── direct 寫入（performStore／performUpdate） ───────────────────────
+
+    #[Test]
+    public function testStoreReplacesChineseTextColumnAndFlashesNotice(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/ADDR_CODES', [
+            'c_addr_id' => 1,
+            'c_name_chn' => '淸河縣',
+            'c_name' => 'Qinghe',
+            'c_admin_type' => 3,
+        ])->assertStatus(302);
+
+        $this->assertSame('清河縣', DB::table('ADDR_CODES')->where('c_addr_id', 1)->value('c_name_chn'));
+        // 拼音欄是拉丁字串 ⇒ 必然 no-op（對照表 key 全是 CJK）
+        $this->assertSame('Qinghe', DB::table('ADDR_CODES')->where('c_addr_id', 1)->value('c_name'));
+        // 數字欄不受影響
+        $this->assertSame(3, (int) DB::table('ADDR_CODES')->where('c_addr_id', 1)->value('c_admin_type'));
+
+        $this->assertFlashContains('清');
+    }
+
+    #[Test]
+    public function testUpdateReplacesChineseTextColumnAndFlashesNotice(): void {
+        $this->actingAs($this->activeUser());
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 1, 'c_name_chn' => '某縣']);
+
+        $this->put('/codes/ADDR_CODES/1', [
+            'c_addr_id' => 1,
+            'c_name_chn' => '淸河縣',
+        ])->assertStatus(302);
+
+        $this->assertSame('清河縣', DB::table('ADDR_CODES')->where('c_addr_id', 1)->value('c_name_chn'));
+        $this->assertFlashContains('清');
+    }
+
+    /** 沒有命中任何對照時不該冒出通知（避免每次儲存都跳訊息）。 */
+    #[Test]
+    public function testNoNoticeWhenNothingWasReplaced(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/ADDR_CODES', [
+            'c_addr_id' => 2,
+            'c_name_chn' => '無異體字',
+        ])->assertStatus(302);
+
+        $messages = $this->flashMessages();
+        $this->assertFalse(
+            collect($messages)->contains(fn (string $m) => str_contains($m, '正規化')),
+            '沒有替換時不該出現異體字通知：'.implode(' | ', $messages)
+        );
+    }
+
+    // ─────────────────────── 排除清單在真實路徑上生效 ───────────────────────
+
+    /**
+     * 對照表自身整表排除——否則新增一筆「淸→清」之後，任何含「淸」的既有列
+     * （包括那筆對照自己的 c_variant_char）都會被改寫，對照表自我吞噬。
+     */
+    #[Test]
+    public function testCharVariantMapItselfIsNeverReplaced(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/char_variant_map', [
+            'id' => 900,
+            'c_variant_char' => '龴',
+            'c_reference_char' => '乂',
+            'c_strict_excluded' => 1,
+            'c_notes' => '淸峯',
+        ])->assertStatus(302);
+
+        $row = DB::table('char_variant_map')->where('c_variant_char', '龴')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('淸峯', $row->c_notes, '對照表自身的欄位不可被落地替換');
+
+        // 正向對照：同一條路徑對**沒有**被排除的表確實會替換。少了這一段，
+        // 上面的斷言在「掛鉤根本不存在」時也會綠（純負向斷言的假綠）。
+        $this->post('/codes/ADDR_CODES', [
+            'c_addr_id' => 77,
+            'c_name_chn' => '淸',
+        ])->assertStatus(302);
+        $this->assertSame(
+            '清',
+            DB::table('ADDR_CODES')->where('c_addr_id', 77)->value('c_name_chn'),
+            '正向對照失敗：這條路徑根本沒有掛上落地替換，上面的排除斷言等於假綠'
+        );
+    }
+
+    /**
+     * 拼音字典的鍵排除——第一階段明文設計「異體字各自在 pinyin 表有自己的讀音」，
+     * 替換這欄會直接破壞該設計。
+     */
+    #[Test]
+    public function testPinyinDictionaryKeyIsNeverReplaced(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/pinyin', [
+            'id' => 901,
+            'c_chn' => '淸',
+            'c_pinyin' => 'qing',
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            1,
+            DB::table('pinyin')->where('c_chn', '淸')->count(),
+            'pinyin.c_chn 必須保持原字形，否則異體字就沒有自己的讀音條目'
+        );
+
+        // 正向對照（同上，防假綠）
+        $this->post('/codes/ADDR_CODES', [
+            'c_addr_id' => 78,
+            'c_name_chn' => '淸',
+        ])->assertStatus(302);
+        $this->assertSame(
+            '清',
+            DB::table('ADDR_CODES')->where('c_addr_id', 78)->value('c_name_chn'),
+            '正向對照失敗：這條路徑根本沒有掛上落地替換'
+        );
+    }
+
+    // ─────────────────────── char_variant_map 的結構把關 ───────────────────────
+
+    #[Test]
+    public function testStoreRejectsMultiCodepointMapping(): void {
+        $this->actingAs($this->activeUser());
+
+        $this->post('/codes/char_variant_map', [
+            'id' => 902,
+            'c_variant_char' => '甲乙',
+            'c_reference_char' => '丙',
+            'c_strict_excluded' => 1,
+        ])->assertStatus(302);
+
+        $this->assertSame(0, DB::table('char_variant_map')->where('c_variant_char', '甲乙')->count());
+        $this->assertFlashContains(__('variant.single_codepoint_required'));
+    }
+
+    #[Test]
+    public function testStoreRejectsMappingThatWouldCreateACycle(): void {
+        $this->actingAs($this->activeUser());
+
+        // 表裡已有 淸→清；新增 清→淸 會成環
+        $this->post('/codes/char_variant_map', [
+            'id' => 903,
+            'c_variant_char' => '清',
+            'c_reference_char' => '淸',
+            'c_strict_excluded' => 1,
+        ])->assertStatus(302);
+
+        $this->assertSame(0, DB::table('char_variant_map')->where('c_variant_char', '清')->count());
+        $this->assertFlashContains(__('variant.cycle_not_allowed', ['char' => '清']));
+    }
+
+    /**
+     * 更新既有列時必須排除它自己的舊邊，否則會誤報環。
+     *
+     * 表有 淸→清；把那一列改成 淸→菁 是完全合法的，但若把被取代的舊邊（淸→清）
+     * 也算進去，就會看到假的環。
+     */
+    #[Test]
+    public function testUpdatingAnExistingMappingIsNotFalselyReportedAsACycle(): void {
+        $this->actingAs($this->activeUser());
+        $id = DB::table('char_variant_map')->where('c_variant_char', '淸')->value('id');
+
+        $this->put("/codes/char_variant_map/{$id}", [
+            'id' => $id,
+            'c_variant_char' => '淸',
+            'c_reference_char' => '菁',
+            'c_strict_excluded' => 0,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            '菁',
+            DB::table('char_variant_map')->where('id', $id)->value('c_reference_char'),
+            '更新既有對照不該被誤判成環'
+        );
+    }
+
+    /** 寫入對照表之後，行程內快取要被清掉，下一次替換才會讀到新對照。 */
+    #[Test]
+    public function testWritingTheMappingTableResetsTheInProcessCache(): void {
+        $this->actingAs($this->activeUser());
+
+        // 先讓快取暖起來（此時「厰」還沒有對照）
+        $this->assertSame('厰', CharVariantMapService::replaceLenient('厰')['text']);
+
+        $this->post('/codes/char_variant_map', [
+            'id' => 904,
+            'c_variant_char' => '厰',
+            'c_reference_char' => '廠',
+            'c_strict_excluded' => 0,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            '廠',
+            CharVariantMapService::replaceLenient('厰')['text'],
+            '新增對照後快取應已清除，替換要立刻生效'
+        );
+    }
+
+    // ─────────────────────── 提案路徑 ───────────────────────
+
+    /**
+     * 提案路徑存進 operations.resource_data 的必須是**替換後**的值——核准端不做前處理，
+     * 所以若這裡存原字形，核准落庫就會是原字形。
+     */
+    #[Test]
+    public function testProposalStoreRecordsReplacedValues(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'p@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        $this->post('/codes/ADDR_CODES/proposal', [
+            'c_addr_id' => 9,
+            'c_name_chn' => '淸河縣',
+        ])->assertStatus(302);
+
+        $operation = DB::table('operations')->where('resource', 'ADDR_CODES')->first();
+        $this->assertNotNull($operation, '提案應被記錄');
+
+        $payload = json_decode((string) $operation->resource_data, true);
+        $this->assertSame('清河縣', $payload['c_name_chn'] ?? null, '提案 payload 必須是替換後的值');
+    }
+
+    /**
+     * performProposalUpdate（修改提案）：payload 必須是替換後的值，且要有通知。
+     *
+     * 這條路徑原本零測試覆蓋——而「使用者原樣送出一列含異體字的既有資料、於是產生一筆
+     * 他自己沒察覺的提案」這個行為就住在這裡。
+     */
+    #[Test]
+    public function testProposalUpdateRecordsReplacedValuesAndNotifies(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pu@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 21, 'c_name_chn' => '淸河縣']);
+
+        // 使用者把表單原樣送回（值與既有列一致），替換仍會把它歸一成參考字形
+        $this->post('/codes/ADDR_CODES/21/proposal', [
+            'c_addr_id' => 21,
+            'c_name_chn' => '淸河縣',
+        ])->assertStatus(302);
+
+        $operation = DB::table('operations')->where('resource', 'ADDR_CODES')->first();
+        $this->assertNotNull($operation, '修改提案應被記錄');
+
+        $payload = json_decode((string) $operation->resource_data, true);
+        $this->assertSame('清河縣', $payload['c_name_chn'] ?? null, '提案 payload 必須是替換後的值');
+
+        // 使用者沒有主動改任何字，所以一定要告知系統改了什麼——否則他會拿到一筆
+        // 自己沒察覺的提案。
+        $this->assertFlashContains('清');
+    }
+
+    /**
+     * proposalUpdateExisting（編輯既有提案）：修改一筆 char_variant_map 的 update 提案
+     * **不可**被誤報成環。
+     *
+     * 表有 乙→甲 與 甲→丙；把那筆提案改成 丙→乙 的最終狀態是合法的 甲→丙→乙，
+     * 但若 guard 沒有排除「被取代的舊邊」，就會看到假的環 乙→甲→丙→乙 而擋下合法修改。
+     */
+    #[Test]
+    public function testEditingAnExistingMappingProposalIsNotFalselyReportedAsACycle(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pe@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        DB::table('char_variant_map')->truncate();
+        DB::table('char_variant_map')->insert([
+            ['id' => 2, 'c_variant_char' => '乙', 'c_reference_char' => '甲', 'c_strict_excluded' => 1],
+            ['id' => 3, 'c_variant_char' => '甲', 'c_reference_char' => '丙', 'c_strict_excluded' => 1],
+        ]);
+        CharVariantMapService::reset();
+
+        // 一筆針對 id=2 的 update 提案
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'resource' => 'char_variant_map',
+            'resource_id' => '2',
+            'op_type' => \App\Models\Operation::TYPE_PROPOSAL_UPDATE,
+            'resource_data' => json_encode([
+                'id' => 2,
+                'c_variant_char' => '乙',
+                'c_reference_char' => '甲',
+                'c_strict_excluded' => 1,
+                '__proposal_meta' => ['submitted_by_id' => $user->id],
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'id' => 2, 'c_variant_char' => '乙', 'c_reference_char' => '甲', 'c_strict_excluded' => 1,
+            ], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        // 刻意**不送 id**：excludeId 必須取自權威來源 operation.resource_id。
+        // 舊寫法讀 request body 的 id，缺值時 (int)'' = 0 ⇒ 不排除 id=2 的舊邊
+        // ⇒ 合法修改被誤報成環。這一行就是 #3 那個改動的全部意義。
+        $this->patch("/codes/char_variant_map/proposals/{$operationId}", [
+            'c_variant_char' => '丙',
+            'c_reference_char' => '乙',
+            'c_strict_excluded' => 1,
+        ])->assertStatus(302);
+
+        $payload = json_decode(
+            (string) DB::table('operations')->where('id', $operationId)->value('resource_data'),
+            true
+        );
+        $this->assertSame('丙', $payload['c_variant_char'] ?? null, '合法的提案修改不該被誤判成環而擋下');
+        $this->assertSame('乙', $payload['c_reference_char'] ?? null);
+    }
+
+    /**
+     * 最誤導的那條錯誤訊息必須附上通知。
+     *
+     * 既有列已是參考字形「清」，使用者輸入變體「淸」→ 替換後 payload 等於原值 →
+     * diff 為 null → 使用者被告知「你什麼都沒改」，而 `withInput()` 回填的還是他打的「淸」。
+     * 沒有通知的話他完全無法理解發生了什麼。
+     */
+    #[Test]
+    public function testNoDiffProposalStillTellsTheUserTheGlyphWasNormalized(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pn@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        // 既有列已經是參考字形
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 31, 'c_name_chn' => '清河縣']);
+
+        // 使用者送出變體字形 → 被替換回「清河縣」→ 與既有列一致 → 無 diff
+        $this->post('/codes/ADDR_CODES/31/proposal', [
+            'c_addr_id' => 31,
+            'c_name_chn' => '淸河縣',
+        ])->assertStatus(302);
+
+        $this->assertSame(0, DB::table('operations')->count(), '無 diff 不該記提案');
+        $this->assertFlashContains('未偵測到任何修改內容');
+        $this->assertFlashContains(__('variant.notice_pair', ['variant' => '淸', 'reference' => '清']));
+    }
+
+    /**
+     * 提案的「資料已存在」也要附通知——衝突可能是落地替換自己造成的
+     * （使用者打的是自認為不同的字形）。
+     */
+    #[Test]
+    public function testProposalStoreDuplicateConflictTellsTheUserTheGlyphWasNormalized(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pd@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 41, 'c_name_chn' => '清河縣']);
+
+        // 主鍵撞既有列 → 走「資料已存在，請改用修改提案」
+        $this->post('/codes/ADDR_CODES/proposal', [
+            'c_addr_id' => 41,
+            'c_name_chn' => '淸河縣',
+        ])->assertStatus(302);
+
+        $this->assertFlashContains('資料已存在');
+        $this->assertFlashContains(__('variant.notice_pair', ['variant' => '淸', 'reference' => '清']));
+    }
+
+    // ─────────────── D7：兩形並存的去重（文本主鍵成員） ───────────────
+
+    /**
+     * 既有列的文本主鍵還是變體形時，輸入同樣的變體形**不可**鑄出第二列。
+     *
+     * D6 不做回溯校正 ⇒ 既有列的 `c_alt_name_chn` 可能還是「淸」。使用者輸入「淸」，
+     * 替換把它歸一成「清」，於是**只用替換後的值查重就會錯過那一列**，插入語義重複的
+     * 第二列——比不替換更糟。資料庫唯一鍵也擋不住（兩個字形是不同的鍵值）。
+     */
+    #[Test]
+    public function testCreateDoesNotMintADuplicateWhenTheExistingRowStillHasTheVariantForm(): void {
+        $this->actingAs($this->activeUser());
+
+        // 既有列仍是變體形（D6：不回溯）
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1, 'c_alt_name_chn' => '淸客', 'c_alt_name_type_code' => 4,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA', [
+            'c_personid' => 1,
+            'c_alt_name_chn' => '淸客',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            1,
+            DB::table('ALTNAME_DATA')->count(),
+            '替換後查不到既有的變體形列，鑄出了語義重複的第二列'
+        );
+        $this->assertFlashContains('主鍵或唯一值已存在');
+        $this->assertFlashContains(__('variant.notice_pair', ['variant' => '淸', 'reference' => '清']));
+    }
+
+    /** 提案路徑同理：不可對既有的變體形列開一筆「新增提案」。 */
+    #[Test]
+    public function testProposalStoreDoesNotProposeADuplicateOfAVariantFormRow(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pv@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 2, 'c_alt_name_chn' => '淸客', 'c_alt_name_type_code' => 4,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA/proposal', [
+            'c_personid' => 2,
+            'c_alt_name_chn' => '淸客',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(0, DB::table('operations')->count(), '不該為既有的變體形列開新增提案');
+        $this->assertFlashContains('資料已存在');
+    }
+
+    /**
+     * **不同**變體收斂到同一參考字時，也不可鑄出重複列。
+     *
+     * 對照是多對一（`c_variant_char` 有唯一鍵、`c_reference_char` 沒有），所以只探
+     * 「輸入值 + 替換後值」兩形仍會漏掉「既有列是另一個變體」的情形：
+     * 既有 `菁客`（菁→青）、新輸入 `靑客`（靑→青），兩者都歸一成 `青客`，
+     * 但拿 `靑客`／`青客` 去查都找不到 `菁客`。
+     */
+    #[Test]
+    public function testCreateDoesNotMintADuplicateWhenADifferentVariantConvergesToTheSameReference(): void {
+        $this->actingAs($this->activeUser());
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '菁', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+
+        // 既有列是**另一個**變體形
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 7, 'c_alt_name_chn' => '菁客', 'c_alt_name_type_code' => 4,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA', [
+            'c_personid' => 7,
+            'c_alt_name_chn' => '靑客',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            1,
+            DB::table('ALTNAME_DATA')->count(),
+            '兩個不同變體都歸一成「青客」，不該因為既有列是另一個變體就鑄出第二列'
+        );
+    }
+
+    /**
+     * 待審的舊版（變體形）新增提案也要被視為衝突。
+     *
+     * S2 之前留下的 pending 提案帶的是變體形 `resource_id`，新提案帶的是歸一後的
+     * `resource_id`，完全相等比對不會衝突 ⇒ 兩筆待審提案並存，依序核准就落成兩筆列。
+     */
+    #[Test]
+    public function testProposalStoreConflictsWithAPendingProposalThatUsesTheVariantForm(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'pp@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        // 既有的待審提案用變體形主鍵（S2 之前留下的樣子）
+        DB::table('operations')->insert([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '淸客_._4_._9',
+            'op_type' => \App\Models\Operation::TYPE_PROPOSAL_CREATE,
+            'resource_data' => json_encode([
+                'c_personid' => 9, 'c_alt_name_chn' => '淸客', 'c_alt_name_type_code' => 4,
+                // hasPendingCreateProposal() 只認 __review_status 為 pending／rejected 的提案
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by_id' => $user->id],
+            ], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA/proposal', [
+            'c_personid' => 9,
+            'c_alt_name_chn' => '淸客',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            1,
+            DB::table('operations')->count(),
+            '不該與既有的變體形待審提案並存——兩筆依序核准會落成兩種字形的兩筆列'
+        );
+        $this->assertFlashContains('已有其他新增提案使用相同主鍵');
+    }
+
+    /**
+     * 去重必須**不受對照表規模影響**——早期版本靠「列舉所有等價字形再逐一查」，
+     * 為了避免組合爆炸設了上限，而超過上限就退回只比對正規形，**等於完全失去這道去重**。
+     * 那不是效能取捨，是可由合法對照表資料觸發的正確性缺口。
+     *
+     * 這裡讓一個參考字有 6 個變體、主鍵含 2 個這樣的字（完整組合 7×7 = 49 > 舊上限 32），
+     * 現行做法（固定其餘主鍵欄查一次、在 PHP 端歸一比對）必須照樣抓到。
+     */
+    #[Test]
+    public function testDedupIsExactRegardlessOfHowManyVariantsShareAReferenceChar(): void {
+        $this->actingAs($this->activeUser());
+
+        $rows = [];
+        foreach (['㆒', '㆓', '㆔', '㆕', '㆖', '㆗'] as $variant) {
+            $rows[] = ['c_variant_char' => $variant, 'c_reference_char' => '甲', 'c_strict_excluded' => 0];
+        }
+        DB::table('char_variant_map')->insert($rows);
+        CharVariantMapService::reset();
+
+        // 既有列用其中兩個變體（歸一後是「甲甲」）
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 51, 'c_alt_name_chn' => '㆒㆓', 'c_alt_name_type_code' => 4,
+        ]);
+
+        // 新輸入用**另外兩個**變體，歸一後同樣是「甲甲」
+        $this->post('/codes/ALTNAME_DATA', [
+            'c_personid' => 51,
+            'c_alt_name_chn' => '㆔㆕',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            1,
+            DB::table('ALTNAME_DATA')->count(),
+            '等價字形組合數超過舊上限時仍必須抓到重複——去重不可因對照表規模而失效'
+        );
+    }
+
+    /**
+     * resource_id 前綴收斂**不可**把該抓的漏掉：不同 `c_personid` 的提案不該互相衝突，
+     * 同一個 `c_personid` 的變體形提案則必須抓到。
+     */
+    #[Test]
+    public function testPendingProposalConflictIsScopedByTheLeadingKeyColumn(): void {
+        $user = User::forceCreate([
+            'name' => 'P', 'email' => 'ps@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => 0,
+        ]);
+        $this->actingAs($user);
+
+        // 另一個人物（c_personid 不同）的變體形待審提案 ⇒ 不該衝突
+        DB::table('operations')->insert([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => '淸客_._4_._61',
+            'op_type' => \App\Models\Operation::TYPE_PROPOSAL_CREATE,
+            'resource_data' => json_encode([
+                'c_personid' => 61, 'c_alt_name_chn' => '淸客', 'c_alt_name_type_code' => 4,
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['submitted_by_id' => $user->id],
+            ], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA/proposal', [
+            'c_personid' => 62,
+            'c_alt_name_chn' => '淸客',
+            'c_alt_name_type_code' => 4,
+        ])->assertStatus(302);
+
+        $this->assertSame(2, DB::table('operations')->count(), '不同人物的同名提案不該互相攔截');
+    }
+
+    /** 對照組：主鍵真的不同時，仍要能正常新增（去重不可過度攔截）。 */
+    #[Test]
+    public function testCreateStillSucceedsWhenTheKeyGenuinelyDiffers(): void {
+        $this->actingAs($this->activeUser());
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 3, 'c_alt_name_chn' => '淸客', 'c_alt_name_type_code' => 4,
+        ]);
+
+        $this->post('/codes/ALTNAME_DATA', [
+            'c_personid' => 3,
+            'c_alt_name_chn' => '淸客',
+            'c_alt_name_type_code' => 5, // 不同的 type code ⇒ 不同主鍵
+        ])->assertStatus(302);
+
+        $this->assertSame(2, DB::table('ALTNAME_DATA')->count());
+        $this->assertSame(
+            1,
+            DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '清客')->count(),
+            '新列應以參考字形落庫'
+        );
+    }
+
+    /** performUpdate 也要擋多字元對照（既有測試只涵蓋 performStore）。 */
+    #[Test]
+    public function testUpdateRejectsMultiCodepointMapping(): void {
+        $this->actingAs($this->activeUser());
+        $id = DB::table('char_variant_map')->where('c_variant_char', '淸')->value('id');
+
+        $this->put("/codes/char_variant_map/{$id}", [
+            'id' => $id,
+            'c_variant_char' => '淸',
+            'c_reference_char' => '兩個字',
+            'c_strict_excluded' => 0,
+        ])->assertStatus(302);
+
+        $this->assertSame(
+            '清',
+            DB::table('char_variant_map')->where('id', $id)->value('c_reference_char'),
+            '多字元參考字不該被寫入'
+        );
+        $this->assertFlashContains(__('variant.single_codepoint_required'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Http\Controllers\CodesController;
 use App\Services\CharVariantMapService;
 use App\Support\VariantReplaceScope;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
@@ -19,6 +20,11 @@ abstract class TestCase extends BaseTestCase {
         // 測試結果會依檔案順序漂移。
         CharVariantMapService::reset();
         VariantReplaceScope::reset();
+
+        // CodesController 的主鍵欄快取同理：測試會為同一個表名建不同的合成 schema，
+        // 一旦被某個測試快取成錯的主鍵欄，後面的測試就會拿到污染值（症狀是
+        // 「請確認主鍵欄位已填寫完整」這類與該測試無關的失敗）。
+        CodesController::resetKeyColumnCache();
     }
 
     /**

--- a/tests/Unit/CharVariantMapServiceRowTest.php
+++ b/tests/Unit/CharVariantMapServiceRowTest.php
@@ -325,6 +325,56 @@ class CharVariantMapServiceRowTest extends TestCase {
         $this->assertSame('甲乙清', $result['text'], '多字元對照不該生效');
     }
 
+    // ─────────────────── 對照表缺表時的降級（S2 引入） ───────────────────
+
+    /**
+     * 表不存在時降級為「不替換」，而不是拋錯。
+     *
+     * 從 S2 起落地替換掛在 Codes UI 全部 5 條寫入路徑上，若缺表就拋錯，
+     * **整個代碼表的寫入功能都會 500**——為了一個正規化的加值功能讓核心錄入功能停擺
+     * 是不對的取捨（尚未 migrate／部分遷移的環境會踩到）。
+     */
+    #[Test]
+    public function testMissingMappingTableDegradesToNoReplacementInsteadOfThrowing(): void {
+        Schema::dropIfExists('char_variant_map');
+        $this->resetCaches();
+
+        $this->assertSame('淸', CharVariantMapService::replaceLenient('淸')['text']);
+        $this->assertSame('淸', CharVariantMapService::replaceStrict('淸')['text']);
+        $this->assertSame([], CharVariantMapService::replaceLenient('淸')['replaced']);
+    }
+
+    /**
+     * 缺表狀態可以在 process 內快取（它是確定性條件），但 `reset()` 必須能清掉它。
+     *
+     * 為什麼要快取：`replaceRow()` 逐欄呼叫，缺表時每欄都會做一次 `Schema::hasTable()`
+     * 並寫一行 warning——一次 20 欄的儲存＝20 次 metadata 查詢，S3 接上批次匯入後
+     * 會放大成「列數 × 欄數」。
+     *
+     * 為什麼 `reset()` 必須清得掉：測試會在同一個 process 內建／刪表，而寫入端
+     * （Codes UI 等）在成功寫入對照表後也會 `reset()`。
+     *
+     * 注意這與「不快取**瞬時錯誤**」不衝突：瞬時錯誤現在一律往上拋，
+     * 所以沒有「把失敗結果快取住」的路徑（見 loadEdges()）。
+     */
+    #[Test]
+    public function testMissingTableStateIsClearedByReset(): void {
+        Schema::dropIfExists('char_variant_map');
+        $this->resetCaches();
+
+        $this->assertSame('淸', CharVariantMapService::replaceLenient('淸')['text'], '缺表時不替換');
+
+        $this->createVariantMapTable();
+        $this->seedDefaultMappings();
+        $this->resetCaches();
+
+        $this->assertSame(
+            '清',
+            CharVariantMapService::replaceLenient('淸')['text'],
+            'reset() 之後應重新判定缺表狀態並恢復替換'
+        );
+    }
+
     // ─────────────────── mergeReplaced／flattenReplaced 的代數性質 ───────────────────
 
     /**


### PR DESCRIPTION
執行 [`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md`](https://github.com/cbdb-project/cbdb-online-main-server/blob/develop/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md) 的 **S2**。Codes UI 的 5 條寫入路徑全部掛上落地替換；Blade 與 React 共用 `perform*`，一次涵蓋兩個入口。

**這是第一個真正改變使用者可見行為的步驟** —— 從此透過 Codes UI 寫入約 80 張代碼表時，含這 7 個異體字的文本欄會被歸一化，並 flash 一則非阻塞通知。

## 掛鉤與通知

替換一律只碰「要寫入的值」，不碰「用來定位既有列的條件」（D7 第四類）。`performUpdate` 的 `$conditions` 來自 URL 主鍵、在 `extractFormData` 之前就組好；提案路徑的主鍵查重則在替換之後 —— 所以不存在「查重用替換前值、落庫用替換後值」的錯位。

**成功與失敗分支都通知。** 失敗分支特別重要：唯一鍵衝突、以及「未偵測到任何修改內容」都可能是替換自己造成的，而 `withInput()` 回填的是**替換前**的原始輸入。不附通知的話，使用者會看到「你什麼都沒改」而完全無從理解 —— 這是本 PR 修掉的最誤導的一條訊息。

## D7「兩形並存」的去重（原計畫漏了，codex 抓到）

`ALTNAME_DATA.c_alt_name_chn` 同時是**文本主鍵成員**又在替換範圍內（strict），而 `ALTNAME_DATA` 是 Codes UI 可寫的表 —— 這是 Codes UI 裡唯一會踩到 D7 的形狀。D6 不回溯，所以既有列的主鍵可能還是變體形，只用替換後的值查重會**錯過它、鑄出語義重複的第二列**，而資料庫唯一鍵擋不住（不同字形是不同鍵值）—— **比不替換更糟**。

前兩版做法都是錯的，記錄下來避免重演：

| 做法 | 為什麼不行 |
|---|---|
| ❌ 只探「輸入值 + 替換後值」兩形 | 對照是**多對一**，既有列可能是**另一個**變體（既有「菁客」、新輸入「靑客」，兩者都歸一成「青客」） |
| ❌ 列舉所有等價字形再逐一查 | 查詢次數等於等價字形數；而為避免組合爆炸設的上限**本身是正確性缺口**（超過就退回只比對正規形＝完全失去去重），且可由**合法**對照表資料觸發（一個參考字 6 個變體、主鍵含 2 個這樣的字就是 7×7=49） |
| ✅ 固定「不在替換範圍內」的主鍵欄，在 PHP 端歸一比對候選列 | 精確（不管對照表什麼形狀）、只要**一次查詢**、沒有可調的上限 |

待審提案那一側同理 —— `hasActiveCreateProposalConflict()` 是拿 `resource_id` 做完全相等比對，S2 之前留下的 pending 提案帶變體形 `resource_id`、新提案帶歸一後的 ⇒ 不會衝突 ⇒ 兩筆並存、依序核准就落成兩種字形的兩筆列。改以 `resource_id` 的**位置式 LIKE 樣式**收斂 + `lazyById()` 分批。兩個陷阱：**前導前綴在 production 的 `ALTNAME_DATA` 會失效**（主鍵第一欄就是可替換的文字欄，而我的測試 fixture 原本用了不同順序所以測不到）；**`cursor()` 在 PDO MySQL 預設 buffered query 下記憶體並非有界**。

## 其他實質修正

- **缺表降級**：落地替換現在掛在全部寫入路徑上，若因缺表拋錯會讓**整個代碼表的寫入功能 500** —— 為加值功能讓核心錄入停擺是錯的取捨。只在「表不存在」時降級（確定性、可快取、`reset()` 會清），其餘錯誤一律往上拋。早期寫法對所有 `Throwable` 降級並快取空 map，後果是**一次瞬時錯誤就讓整個 process 不再替換**，只留一行 warning。
- **新增 `VariantMappingException`**：`QueryException → PDOException → RuntimeException`，而 `assertWritable()` 內部會查表 —— `catch (\RuntimeException)` 會把資料庫錯誤當成驗證失敗、把**原始 SQL 顯示給使用者**，而且該次寫入被靜默跳過而不是誠實 500。
- **`proposalUpdateExisting` 的 `excludeId` 改用權威來源** `operation.resource_id`，而非使用者送出的 body id（body 的 id 可能被改、可能是空字串 ⇒ `(int)` 變 0 ⇒ 不排除舊邊 ⇒ **合法修改被誤報成環**）。
- **`getKeyColumns()` 的方法內 `static` cache 改成可重置**：那是**既有**的測試隔離地雷（測試會為同一個表名建不同的合成 schema，一旦被快取成錯的主鍵欄，後面的測試就會拿到污染值，症狀是與該測試無關的「請確認主鍵欄位已填寫完整」）。生產語義不變 —— schema 在同一 process 內不會變。

## 既有測試的調整

`CodesCharVariantMapAuditTest` 原本把 `c_reference_char` 設成「新參考字」（**4 個字**），新 guard 會擋下多字元對照。改成單一字元 —— 該值本來就不是合法的「參考字」，而該測試的主體是稽核紀錄、不是多字元是否放行。

## 驗證

三輪 review agent + **六輪 codex**。實測鑑別力（neuter 對應機制後會紅的測試數）：替換 hook 6/22、通知 5、去重 4、提案側去重 1、定位器 1。

- 全量 `phpunit`：**2845 tests / 15190 assertions** 全過
- `php-cs-fixer`（已刪 cache、用 dist config）：0 fixes
- 新增 `CodesVariantReplacementTest`（22 tests）；`CharVariantMapServiceRowTest` 新增缺表降級 2 支

無 API 改動（web 表單，非 v2 API）；`notices` 適用範圍擴大是 S9 的項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)