### PR TITLE
異體字落地替換 S3：人物子資源與 BIOG_MAIN 全面串接，並補上兩形並存查重

### DIFF
--- a/app/Http/Controllers/Api/MutationController.php
+++ b/app/Http/Controllers/Api/MutationController.php
@@ -61,7 +61,7 @@ class MutationController extends Controller {
         $personId = $payload['person_id'] ?? null;
         $targetPk = $payload['target']['pk'] ?? null;
         $changes = $payload['changes'] ?? null;
-        $meta = $payload['meta'] ?? [];
+        $meta = self::sanitizeClientMeta($payload['meta'] ?? []);
 
         if (!is_array($targetPk)) {
             return $this->errorResponse('缺少 target.pk', 422, ['target.pk' => ['required']]);
@@ -137,7 +137,7 @@ class MutationController extends Controller {
         $personId = $payload['person_id'] ?? null;
         $targetPk = $payload['target']['pk'] ?? null;
         $changes = $payload['changes'] ?? null;
-        $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+        $meta = self::sanitizeClientMeta($payload['meta'] ?? []);
 
         if (!is_array($targetPk)) {
             return $this->errorResponse('缺少 target.pk', 422, ['target.pk' => ['required']]);
@@ -377,7 +377,7 @@ class MutationController extends Controller {
         $personId = $payload['person_id'] ?? null;
         $targetPk = $payload['target']['pk'] ?? null;
         $changes = $payload['changes'] ?? [];
-        $meta = $payload['meta'] ?? [];
+        $meta = self::sanitizeClientMeta($payload['meta'] ?? []);
 
         if (!is_array($targetPk)) {
             return $this->errorResponse('缺少 target.pk', 422, ['target.pk' => ['required']]);
@@ -413,7 +413,7 @@ class MutationController extends Controller {
         $mode = strtolower((string) ($payload['mode'] ?? 'direct'));
         $personId = $payload['person_id'] ?? null;
         $targetPk = $payload['target']['pk'] ?? null;
-        $meta = $payload['meta'] ?? [];
+        $meta = self::sanitizeClientMeta($payload['meta'] ?? []);
 
         if (!is_array($targetPk)) {
             return $this->errorResponse('缺少 target.pk', 422, ['target.pk' => ['required']]);
@@ -533,7 +533,7 @@ class MutationController extends Controller {
         $personId = $item['person_id'] ?? null;
         $targetPk = $item['target']['pk'] ?? null;
         $changes = $item['changes'] ?? null;
-        $meta = $item['meta'] ?? $defaults['meta'] ?? [];
+        $meta = self::sanitizeClientMeta($item['meta'] ?? $defaults['meta'] ?? []);
 
         $fail = fn (string $msg, array $errors): array => [
             'index' => $index, 'http_status' => 422, 'ok' => false, 'message' => $msg, 'errors' => $errors,
@@ -607,5 +607,30 @@ class MutationController extends Controller {
         }
 
         return response()->json($body, $status);
+    }
+
+    /**
+     * 剝掉客戶端 meta 裡的**內部鍵**（`__` 前綴）。
+     *
+     * `__approving_operation_id` 是核准流程重放 handler 時用來「排除待審的自己那一筆」的
+     * 內部訊號（見 OperationsProposalController::applyViaMutationHandler()，它直接呼叫
+     * handler、不經本控制器）。若讓客戶端帶進來，眾包使用者只要在 `meta` 裡塞上自己那筆
+     * 待審提案的 id，就能讓待審重複防呆（含 D7 的等價字形查重）直接放行，再送一筆**變體形**
+     * 的重複提案——精確比對的 `hasPendingCreateProposal()` 擋不住不同字形，兩筆依序核准
+     * 就落成兩列語義重複資料。
+     *
+     * @param mixed $meta
+     * @return array<string,mixed>
+     */
+    private static function sanitizeClientMeta($meta): array {
+        if (!is_array($meta)) {
+            return [];
+        }
+
+        return array_filter(
+            $meta,
+            static fn ($key) => !is_string($key) || !str_starts_with($key, '__'),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 }

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -1758,7 +1758,7 @@ class BasicInformationController extends Controller {
             }
 
             // 非阻塞提示：異體字落地替換（嚴格模式），比照既有 flash(..., 'info') 慣例。
-            foreach (CharVariantMapService::buildNotices($storeResult['replaced']) as $notice) {
+            foreach (CharVariantMapService::buildNotices($storeResult['variant_replaced'] ?? []) as $notice) {
                 flash($notice.' @ '.Carbon::now(), 'info');
             }
 

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -11,6 +11,7 @@ use App\Services\CharVariantMapService;
 use App\Support\ColumnFilterExpression;
 use App\Support\ColumnFilterParseException;
 use App\Support\PinyinUmlaut;
+use App\Support\VariantEquivalentLookup;
 use App\Support\VariantReplaceScope;
 use Carbon\Carbon;
 use Illuminate\Contracts\Database\Query\Expression;
@@ -2449,90 +2450,27 @@ class CodesController extends Controller {
     }
 
     /**
-     * 主鍵欄位分成「在替換範圍內的文本欄」與「其餘」。
+     * D7「兩形並存」查重與其輔助方法：實作已抽到 `App\Support\VariantEquivalentLookup`，
+     * 供代碼表 CRUD 與 v2 mutation 的 create 路徑共用——同一個缺口在兩邊都會鑄出語義
+     * 重複列（唯一鍵擋不住不同字形），不能只修一邊。這裡保留薄委派層以維持原呼叫點。
      *
      * @param array<int,string> $keyColumns
-     * @return array{0: array<int,string>, 1: array<int,string>} [替換範圍內的, 其餘的]
+     * @return array{0: array<int,string>, 1: array<int,string>}
      */
     protected function splitKeyColumnsByVariantScope(string $table, array $keyColumns): array {
-        $inScope = [];
-        $fixed = [];
-
-        foreach ($keyColumns as $column) {
-            if (VariantReplaceScope::modeFor($table, $column) === null) {
-                $fixed[] = $column;
-            } else {
-                $inScope[] = $column;
-            }
-        }
-
-        return [$inScope, $fixed];
+        return VariantEquivalentLookup::splitKeyColumns($table, $keyColumns);
     }
 
     /**
-     * D7「兩形並存」的去重：找出**歸一後與本次輸入相同**的既有列。
-     *
-     * D6 不做回溯校正，所以既有列的文本主鍵可能還是任一個變體形；而對照是**多對一**
-     * （多個變體可指向同一參考字），所以「歸一後相同」的字形可能很多。
-     * 只用替換後的值查重會錯過那些列，鑄出語義重複的列——而資料庫唯一鍵擋不住
-     * （不同字形是不同鍵值），**比不替換更糟**。
-     *
-     * 做法：**把不在替換範圍內的主鍵欄固定在 SQL 條件裡，取回那一小群候選列，
-     * 再在 PHP 端把它們的文本主鍵歸一後比對**。這樣是**精確**的（不管對照表是什麼形狀）、
-     * 而且只要**一次查詢**。
-     *
-     * 早期版本改用「列舉所有等價字形再逐一查」，那個做法有兩個缺點：查詢次數是等價字形數
-     * （最壞可達數十次），而且為了避免組合爆炸設的上限本身是**正確性缺口**——超過上限就
-     * 退回只比對正規形，等於完全失去這道去重。
-     *
      * @param array<int,string> $keyColumns
-     * @param array<string,mixed> $after 替換後的資料
+     * @param array<string,mixed> $after
      * @return mixed 既有列（stdClass）或 null
      */
     protected function findExistingRowInEitherVariantForm(string $table, array $keyColumns, array $after) {
-        [$inScope, $fixed] = $this->splitKeyColumnsByVariantScope($table, $keyColumns);
-
-        // 主鍵沒有任何可替換的文本欄 ⇒ 一般查重就夠，零額外成本。
-        if ($inScope === []) {
-            return null;
-        }
-
-        // 全部主鍵欄都可替換 ⇒ 沒有能收斂候選集的 SQL 條件，會變成全表掃描。
-        // 目前沒有這種表（ALTNAME_DATA 是 3 鍵、只有 1 個文本欄可替換），
-        // 真的出現時記 warning 並跳過，不要靜默做全表掃描。
-        if ($fixed === []) {
-            \Illuminate\Support\Facades\Log::warning('D7 去重跳過：主鍵全部在替換範圍內，無法收斂候選集', [
-                'table' => $table,
-                'key_columns' => $keyColumns,
-            ]);
-
-            return null;
-        }
-
-        $query = DB::table($table);
-        foreach ($fixed as $column) {
-            if (!array_key_exists($column, $after)) {
-                return null;
-            }
-            $query->where($column, $after[$column]);
-        }
-
-        foreach ($query->get() as $row) {
-            if ($this->rowMatchesAfterNormalization($table, $inScope, (array) $row, $after)) {
-                return $row;
-            }
-        }
-
-        return null;
+        return VariantEquivalentLookup::findExistingRow($table, $keyColumns, $after);
     }
 
     /**
-     * D7：待審的新增提案裡有沒有「歸一後與本次輸入相同」的一筆。
-     *
-     * `hasActiveCreateProposalConflict()` 是拿 `resource_id` 做完全相等比對，
-     * 所以 S2 之前留下的 pending 提案（帶變體形 resource_id）不會與新提案（帶歸一後
-     * resource_id）衝突 ⇒ 兩筆並存、依序核准就落成兩種字形的兩筆列。
-     *
      * @param array<int,string> $keyColumns
      * @param array<string,mixed> $after
      */
@@ -2542,135 +2480,34 @@ class CodesController extends Controller {
         array $after,
         ?int $excludeOperationId = null
     ): bool {
-        [$inScope] = $this->splitKeyColumnsByVariantScope($table, $keyColumns);
-        if ($inScope === []) {
-            return false;
-        }
+        // 代碼表的 resource_id 是 buildCompositeId() 的位置式 '_._' 串接，用位置式 LIKE 收斂。
+        [$inScope] = VariantEquivalentLookup::splitKeyColumns($table, $keyColumns);
 
-        if (!Schema::hasTable('operations')) {
-            return false;
-        }
-
-        $query = DB::table('operations')
-            ->where('resource', $table)
-            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE);
-        if ($excludeOperationId !== null) {
-            $query->where('id', '!=', $excludeOperationId);
-        }
-
-        // 用「前導的非替換範圍主鍵欄」組出 resource_id 前綴來收斂候選集。
-        // resource_id 是 buildCompositeId() 以 '_._' 串起來的複合主鍵，所以前導欄可以做
-        // 前綴 LIKE，而 operations 上的 (resource, resource_id, op_type) 索引吃得到。
-        // 少了這個條件就會把該表**所有歷史** create proposal（含已核准／已取消）全部撈回來
-        // 反序列化，集合隨歷史無上限成長。
-        if (($pattern = $this->variantProposalResourceIdPattern($keyColumns, $inScope, $after)) !== null) {
-            $query->where('resource_id', 'like', $pattern);
-        }
-
-        // 分批而非一次載入：候選集理論上無上限（**不能用 limit 截斷**——截斷會重現
-        // 「漏抓重複」的正確性缺口）。用 lazyById() 而不是 cursor()：PDO MySQL 預設是
-        // buffered query（config/database.php 沒關掉 MYSQL_ATTR_USE_BUFFERED_QUERY），
-        // cursor() 仍會把整個結果集先讀進 PHP 記憶體；lazyById() 以 id 分頁，
-        // 每批大小固定，記憶體才真的有界。
-        foreach ($query->lazyById(500) as $operation) {
-            $payload = json_decode((string) $operation->resource_data, true);
-            if (!is_array($payload)) {
-                continue;
-            }
-            if (!in_array($payload['__review_status'] ?? null, ['pending', 'rejected'], true)) {
-                continue;
-            }
-            // 其餘主鍵欄必須相同，文本主鍵欄則比對歸一後的值
-            foreach ($keyColumns as $column) {
-                if (in_array($column, $inScope, true)) {
-                    continue;
-                }
-                if ((string) ($payload[$column] ?? '') !== (string) ($after[$column] ?? '')) {
-                    continue 2;
-                }
-            }
-            if ($this->rowMatchesAfterNormalization($table, $inScope, $payload, $after)) {
-                return true;
-            }
-        }
-
-        return false;
+        return VariantEquivalentLookup::hasEquivalentPendingCreateProposal(
+            $table,
+            $keyColumns,
+            $after,
+            $excludeOperationId,
+            VariantEquivalentLookup::proposalResourceIdPattern($keyColumns, $inScope, $after)
+        );
     }
 
     /**
-     * 用「非替換範圍的主鍵欄」組出 `resource_id` 的 LIKE 樣式，把候選集收斂在 SQL 層。
-     *
-     * `resource_id` 是 `buildCompositeId()` 以 `'_._'` 串起的**位置式**序列化，所以可以
-     * 逐位置組樣式：在替換範圍內的欄位放 `%`、其餘放實際值。
-     *
-     * **不能只做「前導前綴」**：production 的 `ALTNAME_DATA` 主鍵順序是
-     * `(c_alt_name_chn, c_alt_name_type_code, c_personid)`——第一欄正是可替換的文字欄，
-     * 前導前綴會直接失效而退回全掃。位置式樣式在任何順序下都能收斂。
-     *
-     * 這個樣式是**寬鬆的預篩**（分隔符裡的 `_` 本身是 LIKE 單字元通配、且值含 `%`／`_`
-     * 時會退成 `%`），只會多撈不會少撈——精確比對在 PHP 端由
-     * `rowMatchesAfterNormalization()` 完成，所以寬鬆是安全的。
-     *
      * @param array<int,string> $keyColumns
-     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<int,string> $inScope
      * @param array<string,mixed> $after
-     * @return string|null null = 無法收斂（所有主鍵欄都是通配），呼叫端就別加這個條件
      */
     protected function variantProposalResourceIdPattern(array $keyColumns, array $inScope, array $after): ?string {
-        $parts = [];
-        $hasLiteral = false;
-
-        foreach ($keyColumns as $column) {
-            if (in_array($column, $inScope, true)) {
-                $parts[] = '%';
-
-                continue;
-            }
-
-            $value = array_key_exists($column, $after) && $after[$column] !== null
-                ? (string) $after[$column]
-                : '';
-
-            // 值本身含 LIKE 通配字元時退成 '%'：跨 driver 的 ESCAPE 語法不一致
-            // （SQLite 需要顯式 ESCAPE），而寬鬆預篩本來就安全。
-            if ($value === '' || strpbrk($value, '%_') !== false) {
-                $parts[] = '%';
-
-                continue;
-            }
-
-            $parts[] = $value;
-            $hasLiteral = true;
-        }
-
-        if (!$hasLiteral) {
-            return null;
-        }
-
-        return implode('_._', $parts);
+        return VariantEquivalentLookup::proposalResourceIdPattern($keyColumns, $inScope, $after);
     }
 
     /**
-     * 候選列的文本主鍵歸一後是否與本次輸入相同。
-     *
-     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<int,string> $inScope
      * @param array<string,mixed> $candidate
-     * @param array<string,mixed> $after 替換後的資料
+     * @param array<string,mixed> $after
      */
     protected function rowMatchesAfterNormalization(string $table, array $inScope, array $candidate, array $after): bool {
-        foreach ($inScope as $column) {
-            $candidateValue = $candidate[$column] ?? null;
-            if (!is_string($candidateValue)) {
-                return false;
-            }
-
-            $normalized = CharVariantMapService::replaceFor($table, $column, $candidateValue)['text'];
-            if ($normalized !== (string) ($after[$column] ?? '')) {
-                return false;
-            }
-        }
-
-        return true;
+        return VariantEquivalentLookup::rowMatchesAfterNormalization($table, $inScope, $candidate, $after);
     }
 
     /**
@@ -2698,6 +2535,10 @@ class CodesController extends Controller {
      * @return string|null null = 通過；非 null = 錯誤訊息
      */
     protected function guardCharVariantMapWrite(string $table, array $data, array $conditions = []): ?string {
+        // ⚠️ 同名但**不同回傳型別**的孿生實作：v2 API 側是
+        // App\Services\Mutations\Concerns\GuardsCharVariantMapWrites::guardCharVariantMapWrite()
+        // （回 ?JsonResponse，給 handler 用）。兩者驗的是同一件事（CharVariantMapService::assertWritable），
+        // 差別只在錯誤呈現方式（這裡回訊息字串供 flash）。改一邊記得改另一邊。
         if (strtolower($table) !== 'char_variant_map') {
             return null;
         }

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -6,6 +6,7 @@ use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
@@ -754,7 +755,20 @@ class OperationsProposalController extends Controller {
             throw new \RuntimeException('資料已存在，無法再次新增。');
         }
 
+        // char_variant_map 走這條通用核准路徑（不在 HANDLER_ROUTED_RESOURCES）：落庫前必須
+        // 驗結構。提交端的守衛（AbstractCodeTableMutationHandler）擋不到**歷史待審提案**，
+        // 也擋不到任何不經該 handler 建立的提案；成環的對照一旦落庫，dropCycleEdges() 會把
+        // 環上兩條邊一起丟掉、只留 Log::error，該組字的落地替換在全站靜默停止。
+        if (strtolower($table) === 'char_variant_map') {
+            CharVariantMapService::assertWritable($data);
+        }
+
         DB::table($table)->insert($data);
+
+        // 落庫後重置快取，否則新對照在該 process 的剩餘生命週期內不生效。
+        if (strtolower($table) === 'char_variant_map') {
+            CharVariantMapService::reset();
+        }
 
         $row = DB::table($table)->where($this->buildKeyConditions($keyColumns, $data))->first();
         if (!$row) {
@@ -794,8 +808,21 @@ class OperationsProposalController extends Controller {
             }
         }
 
+        // char_variant_map 走的是這條通用核准路徑（不在 HANDLER_ROUTED_RESOURCES）：
+        // 落庫前必須驗結構（單一 codepoint、不成環），否則成環的對照核准後會讓
+        // CharVariantMapService::dropCycleEdges() 把環上兩條邊一起丟掉、只留 Log::error，
+        // 該組字的落地替換在全站靜默停止（提案階段的守衛見 AbstractCodeTableMutationHandler）。
+        if (strtolower($table) === 'char_variant_map' && !empty($updatePayload)) {
+            CharVariantMapService::assertWritable($updatePayload, isset($original['id']) ? (int) $original['id'] : null);
+        }
+
         if (!empty($updatePayload)) {
             DB::table($table)->where($conditions)->update($updatePayload);
+        }
+
+        // 落庫後重置對照表快取，否則核准後的對照在該 process 的剩餘生命週期內不生效。
+        if (strtolower($table) === 'char_variant_map') {
+            CharVariantMapService::reset();
         }
 
         $readKeyRow = $this->resolveReadbackKeyRow($keyColumns, $original, $updatePayload);

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -38,6 +38,7 @@ use App\Support\CompositePrimaryKey;
 use App\Support\ExecutionTimeLimit;
 use App\Support\MemoryLimit;
 use App\Support\PinyinUmlaut;
+use App\Support\VariantEquivalentLookup;
 use Carbon\Carbon;
 //修改結束
 
@@ -243,20 +244,44 @@ class BiogMainRepository {
     /**
      * @param $request
      * @param $id
+     * @param array<int,string>|null $variantFields 只對這些欄位做異體字落地替換；null＝整列。
+     *                                              v2 只送「使用者本次實際變更的欄」（見下方註解）。
      */
-    public function updateById($request, $id) {
+    public function updateById($request, $id, ?array $variantFields = null) {
         $data = $request->all();
 
-        // 異體字落地替換（嚴格模式）：先替換姓／名分欄，再組出 c_name_chn，維持
-        // c_name_chn === c_surname_chn.c_mingzi_chn 的既有 invariant（見
-        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
-        $surnameReplaced = CharVariantMapService::replaceStrict((string) $request->c_surname_chn);
-        $mingziReplaced = CharVariantMapService::replaceStrict((string) $request->c_mingzi_chn);
-        $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
-        $data['c_surname_chn'] = $surnameReplaced['text'];
-        $data['c_mingzi_chn'] = $mingziReplaced['text'];
+        // 異體字落地替換：替換範圍由 VariantReplaceScope 按「表.欄位」決定——姓名欄
+        // （c_surname_chn／c_mingzi_chn／c_name_chn）走 strict、其餘文本欄（c_notes／
+        // c_tribe／c_fl_ey_notes／c_fl_ly_notes…）走 lenient。舊碼只手掛兩個姓名欄，
+        // 其他文本欄全漏（見 plan S3）。
+        //
+        // **$variantFields 為什麼必要**：v2 的 $request 是 handler 用「原列 ∪ changes」
+        // 合成的整列，整列替換等於對使用者沒碰過的既有欄做回溯校正（D6 明說不做），
+        // 而且會讓「完全沒改任何欄」的存檔因為某個舊欄被歸一而變成一筆真實 UPDATE，
+        // 連 updated_fields 都對不上。所以 v2 只把「本次實際變更的欄」列進替換範圍，
+        // 與 21 個子資源 handler（只替換 $updateData）語義一致。
+        // legacy Blade 表單路徑傳 null＝整列，那裡的 $request->all() 確實全是使用者提交的值。
+        $variantScope = $variantFields === null
+            ? $data
+            : array_intersect_key($data, array_flip($variantFields));
+        $variantResult = CharVariantMapService::replaceRow($variantScope, 'BIOG_MAIN');
+        $data = array_replace($data, $variantResult['data']);
+        $variantReplaced = $variantResult['replaced'];
 
-        $c_name_chn = $surnameReplaced['text'].$mingziReplaced['text'];
+        // 組出 c_name_chn，維持 c_name_chn === c_surname_chn.c_mingzi_chn 的既有 invariant。
+        // 必須讀**替換後**的 $data，不可回頭讀 $request（那是替換前的原始輸入）。
+        //
+        // **兩個分欄都是空的時候不重組**：v2 的 $request 是「原列 ∪ changes」，沒有明確
+        // 姓氏的歷史人物兩個分欄本來就是 NULL，而 c_name_chn 存著完整姓名。無條件相加
+        // 會把它清成空字串——對這種人物做任何更新（哪怕只改卒年）都會靜默清掉姓名。
+        // store() 早就有等價的 array_key_exists 保護（見該處長註解與
+        // ApiV2CreateBiogMainTest::testDirectBiogMainCreateWithOnlyNameChnDoesNotClearItWhenPartsAreAbsent）。
+        $data['c_surname_chn'] = (string) ($data['c_surname_chn'] ?? '');
+        $data['c_mingzi_chn'] = (string) ($data['c_mingzi_chn'] ?? '');
+        $hasNameParts = $data['c_surname_chn'] !== '' || $data['c_mingzi_chn'] !== '';
+        $c_name_chn = $hasNameParts
+            ? $data['c_surname_chn'].$data['c_mingzi_chn']
+            : (string) ($data['c_name_chn'] ?? '');
         $c_name = trim($request->c_surname.' '.$request->c_mingzi);
         #20230626修改外文全名呈現順序
         #$c_name_proper = $request->c_surname_proper.' '.$request->c_mingzi_proper;
@@ -295,8 +320,11 @@ class BiogMainRepository {
         $hasChanges = $this->hasMeaningfulChanges($data, $ori, ['c_modified_by', 'c_modified_date', 'c_created_by', 'c_created_date']);
 
         if (!$hasChanges) {
+            // 也要帶 variant_replaced：使用者送的字被靜默歸一成與現值相同時，
+            // 光回「未偵測到任何修改內容」毫無線索（呼叫端據此組 notices）。
             return [
                 'no_changes' => true,
+                'variant_replaced' => $variantReplaced,
             ];
         }
 
@@ -367,7 +395,9 @@ class BiogMainRepository {
     public function store(Request $request) {
         $data = $request->all();
 
-        // 異體字落地替換（嚴格模式）。v2 API 的 ALLOWED_FIELDS 允許呼叫端只送
+        // 異體字落地替換：整列一次過（姓名欄 strict、其餘文本欄 lenient，由
+        // VariantReplaceScope 按「表.欄位」決定），再依下述分支組 c_name_chn。
+        // v2 API 的 ALLOWED_FIELDS 允許呼叫端只送
         // c_name_chn（不拆分姓／名，例如無明確姓氏的歷史人物），也允許送
         // c_surname_chn/c_mingzi_chn（此時依「待決事項 2」無條件由分欄重組
         // c_name_chn，不採信客戶端傳來的值，避免分欄與組合欄不同步）。若兩個分欄
@@ -375,17 +405,16 @@ class BiogMainRepository {
         // 送分欄，只能直接替換 c_name_chn 本身，不能無條件拿兩個不存在的分欄相加把
         // c_name_chn 覆寫成空字串（見 tests/Feature/ApiV2CreateBiogMainTest.php
         // 只送 c_name_chn 的既有使用情境）。
+        $variantResult = CharVariantMapService::replaceRow($data, 'BIOG_MAIN');
+        $data = $variantResult['data'];
+        $variantReplaced = $variantResult['replaced'];
+
         if (array_key_exists('c_surname_chn', $data) || array_key_exists('c_mingzi_chn', $data)) {
-            $surnameReplaced = CharVariantMapService::replaceStrict((string) ($data['c_surname_chn'] ?? ''));
-            $mingziReplaced = CharVariantMapService::replaceStrict((string) ($data['c_mingzi_chn'] ?? ''));
-            $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
-            $data['c_surname_chn'] = $surnameReplaced['text'];
-            $data['c_mingzi_chn'] = $mingziReplaced['text'];
-            $data['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];
+            $data['c_surname_chn'] = (string) ($data['c_surname_chn'] ?? '');
+            $data['c_mingzi_chn'] = (string) ($data['c_mingzi_chn'] ?? '');
+            $data['c_name_chn'] = $data['c_surname_chn'].$data['c_mingzi_chn'];
         } else {
-            $nameChnReplaced = CharVariantMapService::replaceStrict((string) ($data['c_name_chn'] ?? ''));
-            $data['c_name_chn'] = $nameChnReplaced['text'];
-            $variantReplaced = $nameChnReplaced['replaced'];
+            $data['c_name_chn'] = (string) ($data['c_name_chn'] ?? '');
         }
 
         $data = (new ToolsRepository())->timestamp($data, true);
@@ -411,7 +440,8 @@ class BiogMainRepository {
                 $operation ? (string) $operation->id : null
             );
 
-            return ['model' => $flight, 'replaced' => $variantReplaced];
+            // key 名與 updateById() 一致（統一為 variant_replaced，見 plan S3）。
+            return ['model' => $flight, 'variant_replaced' => $variantReplaced];
         });
     }
 
@@ -2709,6 +2739,9 @@ class BiogMainRepository {
                     // 多條垃圾鏡像、force 名義成功實際沒清」的不一致；codex MINOR）。
                     $only = $drifted->first();
                     $updateSet = Arr::except($dataMirror, ['c_created_by', 'c_created_date']);
+                    // D7：force 就地收斂也是改鍵（c_text_title 是 PK 成員），同樣要先確認對面
+                    // 沒有另一列歸一後相同但字形不同的關係——唯一鍵擋不住不同字形。
+                    $this->assertMirrorRenameHasNoVariantEquivalentRow('ASSOC_DATA', collect([$only]), $updateSet);
                     $pkWhere = [];
                     foreach (CompositePrimaryKey::SCHEMAS['ASSOC_DATA'] as $col) {
                         $pkWhere[] = [$col, '=', $only->$col];
@@ -2737,6 +2770,9 @@ class BiogMainRepository {
                 $insert['c_created_by'] = \App\Support\AuditActor::currentName();
                 $insert['c_created_date'] = Carbon::now();
             }
+            // D7：補建鏡像列也可能與對面既有的變體形列歸一後相同（唯一鍵擋不住不同字形），
+            // 所以插入前一樣要 preflight；這裡沒有「自己」要排除。
+            $this->assertMirrorRenameHasNoVariantEquivalentRow('ASSOC_DATA', collect([]), $insert);
             DB::table('ASSOC_DATA')->insert($insert);
             $auditLog->write(
                 'ASSOC_DATA',
@@ -2760,6 +2796,13 @@ class BiogMainRepository {
             $this->detectMirrorConflicts('ASSOC_DATA', $mirroredRows, $conflictBaselines, $updateSet, $auditLog);
         }
 
+        // D7「兩形並存」：c_text_title 是 ASSOC_DATA 的 PK 成員，異體字落地替換會讓鏡像列
+        // 一起改鍵。DB 唯一鍵只擋得住**同字形**的碰撞，若對面已存在另一列「歸一後與新鍵相同
+        // 但字形不同」的關係（例如 `愼書` 與 `慬書` 都歸一成 `慎書`），這個 update 不會撞唯一鍵，
+        // 對面就留下兩筆歸一後相同的關係。這裡先擋成乾淨的衝突（整筆交易回滾 → 409）。
+        // 排除本次要更新的那些鏡像列自己（$mirroredRows）。
+        $this->assertMirrorRenameHasNoVariantEquivalentRow('ASSOC_DATA', $mirroredRows, $updateSet);
+
         $query->update($updateSet);
 
         foreach ($mirroredRows as $mirroredRow) {
@@ -2777,6 +2820,79 @@ class BiogMainRepository {
                 $operationId
             );
         }
+    }
+
+    /**
+     * 鏡像列改鍵前，確認對面沒有另一列「異體字歸一後與新主鍵相同」的資料。
+     *
+     * 為什麼 DB 擋不住：不同字形＝不同鍵值，唯一鍵不衝突。而落地替換會把被觸碰的那一列
+     * 歸一，於是對面可能同時留下 `慎書`（剛改的）與 `慬書`（歸一後也是 `慎書`）兩筆語義
+     * 相同的關係。拋 InvalidArgumentException 讓 v2 handler 轉成 409 並回滾整筆
+     * （legacy／核准路徑則冒成「套用失敗」，兩者都比靜默鑄出重複列好）。
+     *
+     * @param \Illuminate\Support\Collection<int,object> $mirroredRows 本次要更新的鏡像列（排除自己）
+     * @param array<string,mixed> $updateSet 鏡像列更新後的欄位值（含替換後的 PK 成員）
+     */
+    public function assertMirrorRenameHasNoVariantEquivalentRow(string $table, $mirroredRows, array $updateSet): void {
+        $keyColumns = CompositePrimaryKey::SCHEMAS[$table] ?? [];
+        if ($keyColumns === []) {
+            return;
+        }
+
+        // 新鍵：鏡像列原值疊上 updateSet（updateSet 未必含全部 PK 欄）。
+        // $mirroredRows 為空＝這是「補建新列」的情境（backfill），此時 $updateSet 本身就是
+        // 完整的新列，沒有「自己」要排除。
+        $excludePks = [];
+        $newPks = [];
+        foreach ($mirroredRows as $row) {
+            $rowArray = (array) $row;
+            $oldPk = array_intersect_key($rowArray, array_flip($keyColumns));
+            $newPk = array_intersect_key(array_replace($rowArray, $updateSet), array_flip($keyColumns));
+            $excludePks[] = $oldPk;
+
+            // 只在**落地替換範圍內的 PK 欄**（此處是 c_text_title）真的變動時才檢查。
+            //
+            // 為什麼不是「任何 PK 欄變動就檢查」：鏡像同步本來就會改寫幾個數值 PK 欄
+            // （c_kin_id／c_assoc_kin_id 會被設成正向那個人的 id），所以「只改對面備註」
+            // 也會讓 PK 變動。若據此檢查，對面早就存在兩形並存的歷史資料（D6 不回溯校正）
+            // 會讓這種合法操作被誤擋成 409——而那個重複是替換上線前就有的，擋它並沒有
+            // 防止任何新的重複產生。異體字造成的收斂只可能來自文本型 PK 欄的變動。
+            [$inScopePkColumns] = VariantEquivalentLookup::splitKeyColumns($table, $keyColumns);
+            foreach ($inScopePkColumns as $column) {
+                if ((string) ($oldPk[$column] ?? '') !== (string) ($newPk[$column] ?? '')) {
+                    $newPks[] = $newPk;
+
+                    break;
+                }
+            }
+        }
+
+        // 有命中鏡像列、但沒有任何一列改鍵 ⇒ 無須檢查（下面的 $newPks === [] 分支是
+        // 「補建新列」專用，不能讓它在這裡誤觸發）。
+        if ($newPks === [] && !$this->isEmptyRowSet($mirroredRows)) {
+            return;
+        }
+
+        if ($newPks === []) {
+            $newPks[] = array_intersect_key($updateSet, array_flip($keyColumns));
+        }
+
+        foreach ($newPks as $newPk) {
+            if (VariantEquivalentLookup::findExistingRow($table, $keyColumns, $newPk, $excludePks) !== null) {
+                throw new \InvalidArgumentException(
+                    '對面的鏡像資料已有一筆異體字歸一後相同的紀錄，請先手動整理後再儲存。'
+                );
+            }
+        }
+    }
+
+    /** 鏡像列集合是否為空（backfill 情境）。Collection 與陣列都要能吃。 */
+    protected function isEmptyRowSet($rows): bool {
+        if ($rows instanceof \Illuminate\Support\Collection) {
+            return $rows->isEmpty();
+        }
+
+        return empty($rows);
     }
 
     /**
@@ -3099,6 +3215,14 @@ class BiogMainRepository {
                     $this->createAssocMirrorBaselines($data_mirror, $data['c_assoc_code'])
                 );
             } else {
+                // D7：反向碼為哨兵 0（無有效反向可定位）時走盲插。此時 c_text_title 已是
+                // 歸一後的字形，若對面已存在同一組固定 PK、書名為歷史變體形的鏡像列，
+                // 這一插就造成兩形並存（唯一鍵擋不住不同字形）。
+                // 只在 $detectConflict（v2／核准路徑）時檢查——legacy direct 明文維持原盲插 parity。
+                if ($detectConflict) {
+                    $this->assertMirrorRenameHasNoVariantEquivalentRow('ASSOC_DATA', collect([]), $data_mirror);
+                }
+
                 DB::table('ASSOC_DATA')->insert($data_mirror);
                 $auditLog->write(
                     'ASSOC_DATA',

--- a/app/Services/Mutations/AbstractCodeTableMutationHandler.php
+++ b/app/Services/Mutations/AbstractCodeTableMutationHandler.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Str;
  * 呼叫端仍須依 MutationController 契約傳 person_id，通常為 0）。
  */
 abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\GuardsCharVariantMapWrites;
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
 
@@ -158,6 +159,11 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
         $operation = null;
         $newArray = [];
 
+        // char_variant_map：落庫前驗結構，並排除自己那一列（單邊改欄時要能 merge 舊值）。
+        if (($guardError = $this->guardCharVariantMapWrite($table, $updateData, isset($pk['id']) ? (int) $pk['id'] : null)) !== null) {
+            return $guardError;
+        }
+
         try {
             DB::transaction(function () use ($table, $pk, $resourceId, $updateData, $originalArray, $comment, $operationId, $personId, &$operation, &$newArray) {
                 $this->whereByPk(DB::table($table), $pk)->update($updateData);
@@ -201,6 +207,8 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
             throw $e;
         }
 
+        $this->resetVariantMapCacheIfNeeded($table);
+
         return response()->json([
             'ok' => true,
             'resource' => $this->resourceName(),
@@ -216,6 +224,13 @@ abstract class AbstractCodeTableMutationHandler extends AbstractMutationHandler 
     }
 
     protected function handleProposal(int $personId, array $pk, string $resourceId, array $updateData, array $originalArray, string $comment): JsonResponse {
+        // char_variant_map：提案階段就擋。核准走的是通用 applyUpdateProposal()（本表不在
+        // HANDLER_ROUTED_RESOURCES），那條路徑不驗結構——讓成環的對照混進待審提案，
+        // 核准時就會直接落庫，之後 dropCycleEdges() 把整組邊丟掉、替換全站靜默停止。
+        if (($guardError = $this->guardCharVariantMapWrite($this->tableName(), $updateData, isset($pk['id']) ? (int) $pk['id'] : null)) !== null) {
+            return $guardError;
+        }
+
         $proposalData = array_merge($originalArray, $updateData, [
             '__proposal_meta' => [
                 'action' => 'update',

--- a/app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php
+++ b/app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php
@@ -7,6 +7,7 @@ use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
 use App\Services\AuditLogService;
 use App\Support\CompositePrimaryKey;
+use App\Support\VariantEquivalentLookup;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -26,7 +27,11 @@ use Illuminate\Support\Str;
  * - 統一 response shape
  */
 abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\AppliesVariantReplacement;
     use \App\Services\Mutations\Concerns\RecordsAiFillSubmission;
+
+    /** 核准提案重放時「自己那一筆」的 operation id（見 handle()）；null = 非核准重放。 */
+    protected ?int $approvingOperationId = null;
 
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
@@ -75,6 +80,23 @@ abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHa
     // ── handle ───────────────────────────────────────────────
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 異體字落地替換的通知一律在此統一掛上：涵蓋成功、409（替換後撞既有 PK）與
+        // 422（替換後無實際變更）三類回應——使用者必須知道「我輸入的字被正規化了」，
+        // 尤其是在被擋下來的時候，否則錯誤訊息看起來毫無道理。
+        $this->resetVariantReplaced();
+        // 核准提案時以 direct/proposal 重放本 handler，待審的那筆提案正是自己；
+        // handleProposal() 的簽章不含 $meta（多個子類覆寫它），所以在這裡先收下來。
+        $this->approvingOperationId = isset($meta['__approving_operation_id'])
+            ? (int) $meta['__approving_operation_id']
+            : null;
+
+        return $this->withVariantNotices(
+            $this->handleAfterVariantReset($resource, $mode, $operation, $personId, $targetPk, $changes, $meta)
+        );
+    }
+
+    /** handle() 的原始流程；異體字通知由 handle() 統一掛上。 */
+    protected function handleAfterVariantReset(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
         // 1. 授權
         $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
         if ($authorizationError) {
@@ -117,14 +139,23 @@ abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHa
             return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
         }
 
+        // 7.5 異體字落地替換（型別驅動；見 Concerns\AppliesVariantReplacement）。
+        // 必須早於 preprocessCreateData()、extractPkFromRow() 與 findExistingRow()：
+        // 文本型 PK 成員替換後的值才會成為實際寫入的 PK，查重也才看到替換後的值。
+        $rowData = $this->applyVariantReplacement($rowData);
+
         // 8. 前處理（子類可覆寫，如 -999 → 0 轉換）
         $rowData = $this->preprocessCreateData($rowData);
 
         // 8.1 從正規化後的 rowData 提取實際 PK（前處理可能改變 key 值）
         $actualPk = $this->extractPkFromRow($rowData);
 
-        // 9. 檢查目標 PK 是否已存在（使用正規化後的 PK）
-        $existing = $this->findExistingRow($actualPk);
+        // 9. 檢查目標 PK 是否已存在（使用正規化後的 PK）。
+        // 第二個條件是 D7「兩形並存」查重：既有列可能存變體形（D6 不做回溯校正），
+        // 只比對替換後的值會讓「原樣重送變體形」鑄出第二列語義重複資料——而唯一鍵
+        // 擋不住（不同字形＝不同鍵值）。落地替換上線前這種輸入是乾淨的 409。
+        $existing = $this->findExistingRow($actualPk)
+            ?: VariantEquivalentLookup::findExistingRow($this->tableName(), $this->keyColumns(), $rowData);
         if ($existing) {
             return $this->errorResponse('目標主鍵已存在', 409, ['target.pk' => ['conflict']]);
         }
@@ -215,6 +246,11 @@ abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHa
                 // 子類在同一交易內的後續處理（例如社會關係/親屬寫互逆鏡像列），保證原子性
                 $this->afterDirectInsert($personId, $actualPk, $rowData, $insertedArray, $operation);
             });
+        } catch (\InvalidArgumentException $e) {
+            // 子類／鏡像同步明確拋出的衝突（例如 D7 等價字形 preflight、Altname 的括號正規化
+            // 撞號）→ 整筆交易已回滾，回 409 而不是漏成 500。對齊
+            // AbstractPersonSubresourceMutationHandler::handleDirect() 的同名 catch。
+            return $this->errorResponse($e->getMessage(), 409, ['target.pk' => ['conflict']]);
         } catch (\Illuminate\Database\QueryException $e) {
             if ($this->isUniqueConstraintViolation($e)) {
                 return $this->errorResponse('目標主鍵已存在', 409, ['target.pk' => ['conflict']]);
@@ -267,8 +303,19 @@ abstract class AbstractPersonSubresourceCreateHandler extends AbstractMutationHa
     protected function handleProposal(int $personId, array $actualPk, array $rowData, string $comment): JsonResponse {
         $resourceId = CompositePrimaryKey::buildStoredResourceId($actualPk);
 
-        // 檢查：相同 resource_id 不得已有待審核的新增提案
-        if ($this->operationRepository->hasPendingCreateProposal($this->tableName(), $resourceId)) {
+        // 檢查：相同 resource_id 不得已有待審核的新增提案。
+        // 第二個條件同樣是 D7 查重：帶變體形 resource_id 的舊提案與帶歸一後 resource_id
+        // 的新提案不會相等 ⇒ 兩筆並存、依序核准就落成兩種字形的兩列。
+        // 核准重放時要排除「自己那一筆」（meta.__approving_operation_id），否則自擋。
+        if ($this->operationRepository->hasPendingCreateProposal($this->tableName(), $resourceId)
+            || VariantEquivalentLookup::hasEquivalentPendingCreateProposal(
+                $this->tableName(),
+                $this->keyColumns(),
+                $rowData,
+                $this->approvingOperationId,
+                null,
+                $personId // 人物子資源的 resource_id 是查詢字串，改用有索引的 operations.c_personid 收斂
+            )) {
             return $this->errorResponse('相同主鍵已有待審核的新增提案', 409, [
                 'target.pk' => ['pending_proposal_exists'],
             ]);

--- a/app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php
+++ b/app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php
@@ -6,6 +6,7 @@ use App\Models\Operation;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Support\CompositePrimaryKey;
+use App\Support\VariantEquivalentLookup;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -27,6 +28,7 @@ use Illuminate\Support\Str;
  */
 abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutationHandler {
     use \App\Services\Mutations\Concerns\RecordsAiFillSubmission;
+    use \App\Services\Mutations\Concerns\AppliesVariantReplacement;
 
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
@@ -75,6 +77,18 @@ abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutation
     // ── handle ───────────────────────────────────────────────
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 異體字落地替換的通知一律在此統一掛上：涵蓋成功、409（替換後撞既有 PK）與
+        // 422（替換後無實際變更）三類回應——使用者必須知道「我輸入的字被正規化了」，
+        // 尤其是在被擋下來的時候，否則錯誤訊息看起來毫無道理。
+        $this->resetVariantReplaced();
+
+        return $this->withVariantNotices(
+            $this->handleAfterVariantReset($resource, $mode, $operation, $personId, $targetPk, $changes, $meta)
+        );
+    }
+
+    /** handle() 的原始流程；異體字通知由 handle() 統一掛上。 */
+    protected function handleAfterVariantReset(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
         // 1. 授權
         $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
         if ($authorizationError) {
@@ -133,6 +147,11 @@ abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutation
             return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
         }
 
+        // 9.5 異體字落地替換（型別驅動；見 Concerns\AppliesVariantReplacement）。
+        // 必須早於 preprocessUpdateData()、hasEffectiveChanges() 與 buildNewPk()：
+        // 「只把變體形改成參考形」不能被當成無變更擋掉，替換後的值也要進新 PK。
+        $updateData = $this->applyVariantReplacement($updateData);
+
         // 10. 前處理（子類可覆寫，如 -999 → 0 轉換）
         $updateData = $this->preprocessUpdateData($updateData);
 
@@ -141,6 +160,16 @@ abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutation
         if (!$this->hasEffectiveChanges($originalArray, $updateData)) {
             return $this->errorResponse('未偵測到任何修改內容', 422, [
                 'changes' => ['no_effective_changes'],
+            ]);
+        }
+
+        // 11.5 D7「兩形並存」查重（改鍵時）。DB 唯一鍵只擋得住**同字形**的碰撞，
+        // 而既有列可能存變體形（D6 不做回溯校正）：把某列的文本型 PK 成員改成
+        // 「歸一後等於另一既有變體形列」的值時，精確比對查不到、唯一鍵也不衝突，
+        // 就會落成兩列語義相同、字形不同的資料。與 create 側同一個缺口。
+        if ($this->findVariantEquivalentPkConflict($targetPk, $updateData, $originalArray) !== null) {
+            return $this->errorResponse('變更後的主鍵與現有記錄重複（異體字歸一後相同）', 409, [
+                'target.pk' => ['conflict'],
             ]);
         }
 
@@ -311,6 +340,59 @@ abstract class AbstractPersonSubresourceMutationHandler extends AbstractMutation
                 'row' => $newArray,
             ],
         ]);
+    }
+
+    /**
+     * 改鍵後的新 PK 是否與**另一**既有列「異體字歸一後相同」。
+     *
+     * 回傳該衝突列，或 null（沒衝突／候選列就是正在編輯的這一列）。
+     * 排除自己是必要的：例如 `BIOG_SOURCE_DATA` 只改 `c_pages` 時，其餘 PK 欄與原列
+     * 完全相同，`VariantEquivalentLookup` 會把原列自己撈回來，誤報 409。
+     *
+     * @param array<string,mixed> $targetPk
+     * @param array<string,mixed> $updateData
+     */
+    protected function findVariantEquivalentPkConflict(array $targetPk, array $updateData, array $originalArray) {
+        $newPk = $this->buildNewPk($targetPk, $updateData);
+
+        // 排除「正在編輯的那一列」交給 lookup 內部處理，**不能**拿回傳值在外面判斷：
+        // 候選集可以有多列同時歸一成同一個值（`愼齋` 與 `慬齋` 都歸一成 `慎齋`），
+        // 外部判斷只看得到第一筆，是自己就誤判成沒衝突，真正衝突的另一列被漏掉。
+        //
+        // 排除用的 PK 取自 $originalArray（**實際命中那一列的值**）而不是 $targetPk：
+        // payload 的 PK 可能帶哨兵別名（sources 的 c_textid=-999 實際落庫是 0），
+        // 拿別名比會把原列自己當成別列而回假 409。
+        $selfPk = array_intersect_key($originalArray, array_flip($this->keyColumns()));
+
+        // **只在真的改鍵時才檢查**。既有資料可能早就有兩列歸一後相同（D6 不做回溯校正），
+        // 此時使用者只改某列的 c_notes 這種非 PK 欄是**合法操作**：它既沒有新增、也沒有
+        // 把任何列改造成語義重複。無條件檢查會把那些歷史資料變成「任何更新都做不了」。
+        if (!$this->pkDiffers($newPk, $selfPk)) {
+            return null;
+        }
+
+        return VariantEquivalentLookup::findExistingRow(
+            $this->tableName(),
+            $this->keyColumns(),
+            $newPk,
+            [$selfPk]
+        );
+    }
+
+    /**
+     * 兩組主鍵值是否不同（逐欄字串比對，與其他 PK 比對處一致）。
+     *
+     * @param array<string,mixed> $left
+     * @param array<string,mixed> $right
+     */
+    protected function pkDiffers(array $left, array $right): bool {
+        foreach ($this->keyColumns() as $column) {
+            if ((string) ($left[$column] ?? '') !== (string) ($right[$column] ?? '')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // ── Proposal Update ──────────────────────────────────────

--- a/app/Services/Mutations/AltnameCreateHandler.php
+++ b/app/Services/Mutations/AltnameCreateHandler.php
@@ -5,7 +5,6 @@ namespace App\Services\Mutations;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\BracketNormalizer;
-use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\PinyinUmlaut;
 use Illuminate\Http\JsonResponse;
@@ -13,14 +12,6 @@ use Illuminate\Support\Facades\Schema;
 
 class AltnameCreateHandler extends AbstractPersonSubresourceCreateHandler {
     protected NameSearchIndexService $nameSearchIndexService;
-
-    /**
-     * 本次 preprocessCreateData() 對 c_alt_name_chn 實際套用的異體字替換
-     * （異體字 => 參考字）。handleDirect()／handleProposal() 併入回應的 notices。
-     *
-     * @var array<string,string>
-     */
-    protected array $variantReplaced = [];
 
     public function __construct(
         OperationRepository $operationRepository,
@@ -79,15 +70,10 @@ class AltnameCreateHandler extends AbstractPersonSubresourceCreateHandler {
         // #71：非 PK 碼欄 c_source 完全幂等（null/''/-999→0），對齊已修的 AltnameMutationHandler。
         $data = $this->normalizeEmptyCodeFields($data, ['c_source']);
 
-        // 異體字落地替換（嚴格模式）。發生在 extractPkFromRow() 之前（見
-        // AbstractPersonSubresourceCreateHandler::handle() 119-122 行），替換後的值
-        // 自然成為新 PK 的一部分（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
-        // 待決事項 3）。
-        if (array_key_exists('c_alt_name_chn', $data)) {
-            $replaced = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn']);
-            $data['c_alt_name_chn'] = $replaced['text'];
-            $this->variantReplaced = $replaced['replaced'];
-        }
+        // 異體字落地替換（c_alt_name_chn 為 strict 模式）已由基底類別的通用掛鉤在
+        // 本方法之前完成，替換紀錄收在 $this->variantReplaced、通知由 handle() 掛上。
+        // 這裡**不要**再自己呼叫 CharVariantMapService：通用掛鉤先跑過，值已是參考形，
+        // 再呼叫一次的 replaced 恆為 []，assign 回去會讓別名替換通知靜默消失。
 
         return $data;
     }
@@ -101,15 +87,7 @@ class AltnameCreateHandler extends AbstractPersonSubresourceCreateHandler {
 
         $this->syncAltnameIndexAfterCreate($rowData);
 
-        return CharVariantMapService::withNotices($response, $this->variantReplaced);
-    }
-
-    protected function handleProposal(int $personId, array $actualPk, array $rowData, string $comment): JsonResponse {
-        $response = parent::handleProposal($personId, $actualPk, $rowData, $comment);
-
-        return $response->getStatusCode() === 200
-            ? CharVariantMapService::withNotices($response, $this->variantReplaced)
-            : $response;
+        return $response;
     }
 
     protected function syncAltnameIndexAfterCreate(array $rowData): void {

--- a/app/Services/Mutations/AltnameMutationHandler.php
+++ b/app/Services/Mutations/AltnameMutationHandler.php
@@ -5,7 +5,6 @@ namespace App\Services\Mutations;
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\BracketNormalizer;
-use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
 use App\Support\PinyinUmlaut;
 use Illuminate\Http\JsonResponse;
@@ -14,14 +13,6 @@ use Illuminate\Support\Facades\Schema;
 
 class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
     protected NameSearchIndexService $nameSearchIndexService;
-
-    /**
-     * 本次 preprocessUpdateData() 對 c_alt_name_chn 實際套用的異體字替換
-     * （異體字 => 參考字）。handleDirect()／handleProposal() 併入回應的 notices。
-     *
-     * @var array<string,string>
-     */
-    protected array $variantReplaced = [];
 
     public function __construct(
         OperationRepository $operationRepository,
@@ -80,17 +71,10 @@ class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
         // sentinel 完全幂等：c_source（legacy 哨兵 0=Unknown）的 null/'' 也→0（normalizeSentinelValues 只做 -999）。
         $data = $this->normalizeEmptyCodeFields($data, ['c_source']);
 
-        // 異體字落地替換（嚴格模式）。發生在 buildNewPk() 之前（見
-        // AbstractPersonSubresourceMutationHandler::handle() 135 行早於 handleDirect()
-        // 內 212 行的 buildNewPk()），替換後的值自然成為新 PK 的一部分，
-        // performUpdate() 的 PK 衝突偵測與 syncAltnameIndexAfterUpdate() 都讀取
-        // 替換後的 updateData（見 docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
-        // 待決事項 3）。
-        if (array_key_exists('c_alt_name_chn', $data)) {
-            $replaced = CharVariantMapService::replaceStrict((string) $data['c_alt_name_chn']);
-            $data['c_alt_name_chn'] = $replaced['text'];
-            $this->variantReplaced = $replaced['replaced'];
-        }
+        // 異體字落地替換（c_alt_name_chn 為 strict 模式）已由基底類別的通用掛鉤在
+        // 本方法之前完成，替換紀錄收在 $this->variantReplaced、通知由 handle() 掛上。
+        // 這裡**不要**再自己呼叫 CharVariantMapService：通用掛鉤先跑過，值已是參考形，
+        // 再呼叫一次的 replaced 恆為 []，assign 回去會讓別名替換通知靜默消失。
 
         return $data;
     }
@@ -134,15 +118,7 @@ class AltnameMutationHandler extends AbstractPersonSubresourceMutationHandler {
             $this->syncAltnameIndexAfterUpdate($originalObject, $updateData, $targetPk);
         }
 
-        return CharVariantMapService::withNotices($response, $this->variantReplaced);
-    }
-
-    protected function handleProposal(int $personId, array $targetPk, array $updateData, array $originalArray, string $comment): JsonResponse {
-        $response = parent::handleProposal($personId, $targetPk, $updateData, $originalArray, $comment);
-
-        return $response->getStatusCode() === 200
-            ? CharVariantMapService::withNotices($response, $this->variantReplaced)
-            : $response;
+        return $response;
     }
 
     /**

--- a/app/Services/Mutations/AssociationCreateHandler.php
+++ b/app/Services/Mutations/AssociationCreateHandler.php
@@ -108,6 +108,12 @@ class AssociationCreateHandler extends AbstractPersonSubresourceCreateHandler {
 
         // 反向碼為哨兵 0：無有效反向可定位／偵測疑似 → 退回 legacy 無條件 insert（parity）。
         if ((int) $reverseAssocCode === 0) {
+            // D7：即使沒有有效反向碼可定位，插入的 c_text_title 已是歸一後字形；
+            // 對面若已有同一組固定 PK、書名為歷史變體形的列，這一插就造成兩形並存
+            // （唯一鍵擋不住不同字形）。拋例外由基底轉 409 並回滾整筆。
+            app(BiogMainRepository::class)
+                ->assertMirrorRenameHasNoVariantEquivalentRow('ASSOC_DATA', collect([]), $mirror);
+
             DB::table('ASSOC_DATA')->insert($mirror);
             $this->auditLogService->write(
                 'ASSOC_DATA',

--- a/app/Services/Mutations/BiogMainCreateHandler.php
+++ b/app/Services/Mutations/BiogMainCreateHandler.php
@@ -155,7 +155,7 @@ class BiogMainCreateHandler extends AbstractMutationHandler {
         }
 
         $flight = $storeResult['model'];
-        $variantReplaced = $storeResult['replaced'];
+        $variantReplaced = $storeResult['variant_replaced'] ?? [];
 
         if ($flight && Schema::hasTable('CBDB__NAME_FTS')) {
             $this->nameSearchIndexService->reindexPerson($flight);

--- a/app/Services/Mutations/BiogMainMutationHandler.php
+++ b/app/Services/Mutations/BiogMainMutationHandler.php
@@ -102,15 +102,20 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
         }
 
         try {
-            $result = $this->biogMainRepository->updateById($proxy, $personId);
+            $result = $this->biogMainRepository->updateById($proxy, $personId, $updatedFields);
         } catch (\Throwable $e) {
             return $this->errorResponse('更新失敗：'.$e->getMessage(), 500);
         }
 
         if (($result['no_changes'] ?? false) === true) {
-            return $this->errorResponse('未偵測到任何修改內容', 422, [
-                'changes' => ['no_effective_changes'],
-            ]);
+            // 使用者輸入被落地替換歸一成與現值相同時，422 也要帶 notices，
+            // 否則「未偵測到任何修改內容」看起來毫無道理（對齊子資源 handler）。
+            return CharVariantMapService::withNotices(
+                $this->errorResponse('未偵測到任何修改內容', 422, [
+                    'changes' => ['no_effective_changes'],
+                ]),
+                $result['variant_replaced'] ?? []
+            );
         }
 
         $updated = BiogMain::find($personId);
@@ -140,7 +145,7 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
     }
 
     protected function handleProposalUpdate(int $personId, array $updatedFields, array $merged, BiogMain $original, array $meta): JsonResponse {
-        ['payload' => $proposalData, 'replaced' => $variantReplaced] = $this->prepareProposalPayload($merged);
+        ['payload' => $proposalData, 'replaced' => $variantReplaced] = $this->prepareProposalPayload($merged, $updatedFields);
         $validator = Validator::make($proposalData, $this->validationRules($original), $this->validationMessages());
         if ($validator->fails()) {
             return $this->errorResponse('參數校驗失敗', 422, $validator->errors()->toArray());
@@ -209,19 +214,34 @@ class BiogMainMutationHandler extends AbstractMutationHandler {
     }
 
     /**
+     * @param array<int,string>|null $variantFields 只對這些欄位做落地替換；null＝整列。
      * @return array{payload: array, replaced: array<string,string>}
      */
-    protected function prepareProposalPayload(array $payload): array {
-        // 異體字落地替換（嚴格模式）：先替換姓／名分欄，再組出 c_name_chn，維持
-        // c_name_chn === c_surname_chn.c_mingzi_chn 的既有 invariant（見
-        // docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md 待決事項 1）。
-        $surnameReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_surname_chn'] ?? ''));
-        $mingziReplaced = CharVariantMapService::replaceStrict((string) ($payload['c_mingzi_chn'] ?? ''));
-        $variantReplaced = CharVariantMapService::mergeReplaced($surnameReplaced['replaced'], $mingziReplaced['replaced']);
-        $payload['c_surname_chn'] = $surnameReplaced['text'];
-        $payload['c_mingzi_chn'] = $mingziReplaced['text'];
+    protected function prepareProposalPayload(array $payload, ?array $variantFields = null): array {
+        // 異體字落地替換（姓名欄 strict、其餘文本欄 lenient，由 VariantReplaceScope
+        // 按「表.欄位」決定）。
+        //
+        // 這裡**不能**只改 BiogMainRepository 就算了：提案 payload 不經 repository，
+        // 若漏掉此處，非姓名文本欄在審核畫面看到的字形會與核准後落庫的不一致。
+        //
+        // $payload 是「原列 ∪ changes」的整列，所以替換範圍要收在「本次實際變更的欄」——
+        // 否則審核者會在 diff 裡看到提案人根本沒改過的欄位被歸一（D6 不做回溯校正）。
+        $variantScope = $variantFields === null
+            ? $payload
+            : array_intersect_key($payload, array_flip($variantFields));
+        $variantResult = CharVariantMapService::replaceRow($variantScope, 'BIOG_MAIN');
+        $payload = array_replace($payload, $variantResult['data']);
+        $variantReplaced = $variantResult['replaced'];
 
-        $payload['c_name_chn'] = $surnameReplaced['text'].$mingziReplaced['text'];
+        // 組 c_name_chn 一律讀**替換後**的 $payload（維持 c_name_chn === 姓.名 的 invariant）；
+        // 兩個分欄都空時不重組，否則沒有明確姓氏的歷史人物（分欄 NULL、c_name_chn 存完整
+        // 姓名）會在任何一次更新提案裡被清成空字串（與 BiogMainRepository::updateById()
+        // 及 store() 的保護一致）。
+        $payload['c_surname_chn'] = (string) ($payload['c_surname_chn'] ?? '');
+        $payload['c_mingzi_chn'] = (string) ($payload['c_mingzi_chn'] ?? '');
+        if ($payload['c_surname_chn'] !== '' || $payload['c_mingzi_chn'] !== '') {
+            $payload['c_name_chn'] = $payload['c_surname_chn'].$payload['c_mingzi_chn'];
+        }
         $payload['c_name'] = trim(($payload['c_surname'] ?? '').' '.($payload['c_mingzi'] ?? ''));
         $payload['c_name_proper'] = trim(($payload['c_mingzi_proper'] ?? '').' '.($payload['c_surname_proper'] ?? ''));
         $payload['c_name_rm'] = trim(($payload['c_mingzi_rm'] ?? '').' '.($payload['c_surname_rm'] ?? ''));

--- a/app/Services/Mutations/CodeTableCreateHandler.php
+++ b/app/Services/Mutations/CodeTableCreateHandler.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Str;
  * person_id 對本表無意義：呼叫端仍須帶（controller 要求），本 handler 僅將其原樣記入 operations.c_personid。
  */
 class CodeTableCreateHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\GuardsCharVariantMapWrites;
     protected array $definitions;
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
@@ -89,6 +90,12 @@ class CodeTableCreateHandler extends AbstractMutationHandler {
         $insertedArray = [];
         $comment = is_string($meta['comment'] ?? null) ? trim($meta['comment']) : '';
 
+        // char_variant_map：落庫前驗結構（單一 codepoint、不成環），否則成環的對照會讓
+        // dropCycleEdges() 靜默丟掉整組邊、該組字的替換在全站停止（見 trait 註解）。
+        if (($guardError = $this->guardCharVariantMapWrite($table, $row)) !== null) {
+            return $guardError;
+        }
+
         try {
             DB::transaction(function () use (&$operation, &$insertedArray, $table, $keyColumn, $explicit, $explicitId, $def, $row, $personId, $operationId, $comment) {
                 $id = $explicit
@@ -138,6 +145,8 @@ class CodeTableCreateHandler extends AbstractMutationHandler {
 
             throw $e;
         }
+
+        $this->resetVariantMapCacheIfNeeded($table);
 
         return response()->json([
             'ok' => true,

--- a/app/Services/Mutations/CodeTableDeleteHandler.php
+++ b/app/Services/Mutations/CodeTableDeleteHandler.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
  * 定義見 config/code_table_writes.php。按單主鍵刪除，走既有授權 + operations + AuditLog（before-image）。
  */
 class CodeTableDeleteHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\GuardsCharVariantMapWrites;
     protected array $definitions;
     protected OperationRepository $operationRepository;
     protected AuditLogService $auditLogService;
@@ -99,6 +100,12 @@ class CodeTableDeleteHandler extends AbstractMutationHandler {
                 $operation ? (string) $operation->id : null
             );
         });
+
+        // 注意：本方法開頭已無條件回 403（碼表刪除停用中），以下都是不可達的既有碼。
+        // 若日後恢復刪除，char_variant_map 刪列後**必須**呼叫
+        // $this->resetVariantMapCacheIfNeeded($table)（trait 已掛好），
+        // 否則被刪掉的對照在該 process 的剩餘生命週期內還會繼續替換。
+        $this->resetVariantMapCacheIfNeeded($table);
 
         return response()->json([
             'ok' => true,

--- a/app/Services/Mutations/Concerns/AppliesVariantReplacement.php
+++ b/app/Services/Mutations/Concerns/AppliesVariantReplacement.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Mutations\Concerns;
+
+use App\Services\CharVariantMapService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * v2 mutation handler 的異體字落地替換掛鉤（見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md S3）。
+ *
+ * 掛鉤點一律在 `preprocess*Data()` 之前、也就是 PK 計算（`extractPkFromRow()`／
+ * `buildNewPk()`）與查重（`findExistingRow()`／`hasEffectiveChanges()`）之前，
+ * 這樣文本型 PK 成員（`ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、
+ * `BIOG_SOURCE_DATA.c_pages`）被替換後的值會自然成為新 PK，查重也看到替換後的值。
+ *
+ * 替換範圍由 `VariantReplaceScope::modeFor()` 按「表.欄位型別」決定：人名／別名欄
+ * strict、其餘文本欄 lenient、未知表與排除欄不替換（fail-closed）。所以子類不需要、
+ * 也**不應該**自己再呼叫 `CharVariantMapService::replace*()`。
+ */
+trait AppliesVariantReplacement {
+    /**
+     * 本次請求已發生的替換（變體字 → 參考字）。
+     *
+     * @var array<string,string|array<int,string>>
+     */
+    protected array $variantReplaced = [];
+
+    /**
+     * 對整列套用落地替換，並把結果**併入**（而非覆寫）`$this->variantReplaced`。
+     *
+     * 為什麼一定要 merge：子類若在自己的 `preprocess*` 或 `afterDirect*` 再補一次
+     * 替換並 assign，會把通用掛鉤收集到的通知靜默吃掉——這正是 S3 修掉的失效模式
+     * （`AltnameCreateHandler` 舊碼 assign 後，通用掛鉤先跑、它的 `replaced` 恆為 []，
+     * 別名替換通知就消失了）。
+     *
+     * @param array<string,mixed> $data
+     * @param string|null $table 目標資料表；省略時取 `$this->tableName()`（基底體系內的
+     *                           子資源都有這個方法，體系外的三個例外 handler 沒有，需明給）
+     * @return array<string,mixed>
+     */
+    protected function applyVariantReplacement(array $data, ?string $table = null): array {
+        $result = CharVariantMapService::replaceRow($data, $table ?? $this->tableName());
+        $this->variantReplaced = CharVariantMapService::mergeReplaced(
+            $this->variantReplaced,
+            $result['replaced']
+        );
+
+        return $result['data'];
+    }
+
+    /**
+     * 重置累積的替換紀錄。
+     *
+     * handler 由容器解析，同一個 process／請求內可能被重複使用（例如批次多筆 mutate），
+     * 不重置會把上一筆的通知帶到下一筆的回應上。
+     */
+    protected function resetVariantReplaced(): void {
+        $this->variantReplaced = [];
+    }
+
+    /** 把 `notices` 掛到回應上（沒有替換時原樣回傳，含 422／409 等錯誤回應）。 */
+    protected function withVariantNotices(JsonResponse $response): JsonResponse {
+        return CharVariantMapService::withNotices($response, $this->variantReplaced);
+    }
+}

--- a/app/Services/Mutations/Concerns/GuardsCharVariantMapWrites.php
+++ b/app/Services/Mutations/Concerns/GuardsCharVariantMapWrites.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services\Mutations\Concerns;
+
+use App\Exceptions\VariantMappingException;
+use App\Services\CharVariantMapService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * `char_variant_map` 經 v2 mutation API 寫入時的結構守衛與快取重置。
+ *
+ * 為什麼非做不可：`config/code_table_mutations.php` 把 `char_variant_map` 登記成可
+ * mutate 的代碼表（`allowed_fields` 含 `c_variant_char`／`c_reference_char`），但
+ * 結構驗證與快取重置原本只掛在 `CodesController`（Codes UI）與 `OperationsController`
+ * （還原）。也就是說用 API 就能繞過去：
+ *
+ * - 新增一筆會**成環**的對照（表裡已有 `峯→峰`，再送 `峰→峯`）→ `resolveMap()` 的
+ *   `dropCycleEdges()` 會把環上**兩條**邊一起丟掉，只留 Log::error ⇒ 這組字的替換在
+ *   全站靜默停止。多字元對照同樣會被靜默丟棄。
+ * - 不重置快取 ⇒ 新對照在該 process 的剩餘生命週期內不生效。
+ *
+ * S3 把落地替換擴到所有人物寫入路徑之後，這個洞的影響面從 Codes UI 擴到全站，所以
+ * 守衛下移到落庫層（handler），不再依賴呼叫端記得檢查。
+ */
+trait GuardsCharVariantMapWrites {
+    /**
+     * @param array<string,mixed> $row 本次要寫入的欄位
+     * @param int|null $excludeId 更新時排除自己那一列（取得要排除的舊邊）
+     * @return JsonResponse|null null = 通過；非 null = 422 錯誤回應
+     */
+    protected function guardCharVariantMapWrite(string $table, array $row, ?int $excludeId = null): ?JsonResponse {
+        if (strtolower($table) !== 'char_variant_map') {
+            return null;
+        }
+
+        try {
+            CharVariantMapService::assertWritable($row, $excludeId);
+        } catch (VariantMappingException $e) {
+            // 只 catch 專屬型別：QueryException 繼承 PDOException 繼承 RuntimeException，
+            // 用 \RuntimeException 會把資料庫錯誤誤判成「驗證失敗」並洩漏原始 SQL。
+            return $this->errorResponse($e->getMessage(), 422, [
+                'changes' => ['invalid_variant_mapping'],
+            ]);
+        }
+
+        return null;
+    }
+
+    /** 落庫成功後重置對照表快取（只有動到 char_variant_map 時）。 */
+    protected function resetVariantMapCacheIfNeeded(string $table): void {
+        if (strtolower($table) === 'char_variant_map') {
+            CharVariantMapService::reset();
+        }
+    }
+}

--- a/app/Services/Mutations/PossessionCreateHandler.php
+++ b/app/Services/Mutations/PossessionCreateHandler.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Facades\DB;
  * 配發 c_possession_record_id 並寫主表 + POSSESSION_ADDR。
  */
 class PossessionCreateHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\AppliesVariantReplacement;
     protected BiogMainRepository $biogMainRepository;
     protected AuditLogService $auditLogService;
     protected OperationRepository $operationRepository;
@@ -69,6 +70,16 @@ class PossessionCreateHandler extends AbstractMutationHandler {
     }
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 異體字落地替換的通知統一在此掛上（成功與 409／422 皆帶）。
+        $this->resetVariantReplaced();
+
+        return $this->withVariantNotices(
+            $this->handleAfterVariantReset($resource, $mode, $operation, $personId, $targetPk, $changes, $meta)
+        );
+    }
+
+    /** handle() 的原始流程；異體字通知由 handle() 統一掛上。 */
+    protected function handleAfterVariantReset(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
         $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
         if ($authorizationError) {
             return $authorizationError;
@@ -91,6 +102,11 @@ class PossessionCreateHandler extends AbstractMutationHandler {
                 $writable[$f] = '0';
             }
         }
+
+        // 異體字落地替換（型別驅動；POSSESSION_DATA 全文本欄走 lenient）。放在白名單化與
+        // 哨兵正規化之後、direct／proposal 分派之前，兩條路徑寫的都是替換後的 $writable。
+        // c_possession_record_id 是數值 surrogate PK，沒有文本型 PK 成員要顧。
+        $writable = $this->applyVariantReplacement($writable, 'POSSESSION_DATA');
 
         $addr = $changes['c_addr_id'] ?? [];
         if (!is_array($addr)) {

--- a/app/Services/Mutations/PostingCreateHandler.php
+++ b/app/Services/Mutations/PostingCreateHandler.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Schema;
  * 輸入契約：target.pk 可為空 {}；欄位走 changes（須含 c_office_id；c_addr 為地址陣列副表）。
  */
 class PostingCreateHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\AppliesVariantReplacement;
     protected BiogMainRepository $biogMainRepository;
     protected AuditLogService $auditLogService;
     protected OperationRepository $operationRepository;
@@ -86,6 +87,16 @@ class PostingCreateHandler extends AbstractMutationHandler {
     }
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 異體字落地替換的通知統一在此掛上（成功與 409／422 皆帶）。
+        $this->resetVariantReplaced();
+
+        return $this->withVariantNotices(
+            $this->handleAfterVariantReset($resource, $mode, $operation, $personId, $targetPk, $changes, $meta)
+        );
+    }
+
+    /** handle() 的原始流程；異體字通知由 handle() 統一掛上。 */
+    protected function handleAfterVariantReset(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
         $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
         if ($authorizationError) {
             return $authorizationError;
@@ -111,6 +122,10 @@ class PostingCreateHandler extends AbstractMutationHandler {
         if ($cs === null || $cs === '' || (int) $cs === -999) {
             $writable['c_source'] = '0';
         }
+
+        // 異體字落地替換（型別驅動；POSTED_TO_OFFICE_DATA 全文本欄走 lenient）。放在白名單化與
+        // 哨兵正規化之後、direct／proposal 分派之前；PK 兩欄皆為數值，無文本型 PK 成員。
+        $writable = $this->applyVariantReplacement($writable, 'POSTED_TO_OFFICE_DATA');
 
         $addr = $changes['c_addr'] ?? [];
         if (!is_array($addr)) {

--- a/app/Services/Mutations/PostingMutationHandler.php
+++ b/app/Services/Mutations/PostingMutationHandler.php
@@ -47,7 +47,11 @@ class PostingMutationHandler extends AbstractPersonSubresourceMutationHandler {
 
         try {
             // 僅改地址（無任何官名欄位變更）：父類會因 changes 空而 422，故獨立處理。
+            // 這條路徑不經 parent::handle()，所以自己重置替換紀錄（它只寫數值 addr id，
+            // 沒有文本欄要替換，但不重置會把上一筆 mutate 的通知帶進來）。
             if ($this->pendingIncomingAddr !== null && $changes === []) {
+                $this->resetVariantReplaced();
+
                 return $mode === 'proposal'
                     ? $this->handleAddressOnlyProposal($personId, $targetPk, $meta)
                     : $this->handleAddressOnlyDirect($personId, $targetPk);
@@ -59,7 +63,11 @@ class PostingMutationHandler extends AbstractPersonSubresourceMutationHandler {
             $errors = $e->errors();
             $msg = collect($errors)->flatten()->first() ?? '地址資料衝突';
 
-            return $this->errorResponse($msg, 409, $errors !== [] ? $errors : ['c_office_id' => ['conflict']]);
+            // 例外會穿過 parent::handle() 裡的 withVariantNotices()，所以這條 409 要自己補
+            // 通知——使用者的字被正規化後才撞到衝突，看不到通知會覺得 409 毫無道理。
+            return $this->withVariantNotices(
+                $this->errorResponse($msg, 409, $errors !== [] ? $errors : ['c_office_id' => ['conflict']])
+            );
         } finally {
             $this->pendingIncomingAddr = null;
         }

--- a/app/Services/Mutations/SourceMutationHandler.php
+++ b/app/Services/Mutations/SourceMutationHandler.php
@@ -4,9 +4,14 @@ namespace App\Services\Mutations;
 
 use App\Repositories\BiogSourceRepository;
 use App\Support\CompositePrimaryKey;
+use App\Support\VariantEquivalentLookup;
 use Illuminate\Http\JsonResponse;
 
 class SourceMutationHandler extends AbstractMutationHandler {
+    use \App\Services\Mutations\Concerns\AppliesVariantReplacement;
+
+    /** BIOG_SOURCE_DATA 的 3 鍵主鍵（第三欄 c_pages 是文本欄，會被落地替換）；權威定義在 CompositePrimaryKey。 */
+    private const KEY_COLUMNS = CompositePrimaryKey::SCHEMAS['BIOG_SOURCE_DATA'];
     protected BiogSourceRepository $biogSourceRepository;
 
     public function __construct(BiogSourceRepository $biogSourceRepository) {
@@ -20,6 +25,16 @@ class SourceMutationHandler extends AbstractMutationHandler {
     }
 
     public function handle(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
+        // 異體字落地替換的通知統一在此掛上（成功與 409／422 皆帶）。
+        $this->resetVariantReplaced();
+
+        return $this->withVariantNotices(
+            $this->handleAfterVariantReset($resource, $mode, $operation, $personId, $targetPk, $changes, $meta)
+        );
+    }
+
+    /** handle() 的原始流程；異體字通知由 handle() 統一掛上。 */
+    protected function handleAfterVariantReset(string $resource, string $mode, string $operation, int $personId, array $targetPk, array $changes, array $meta = []): JsonResponse {
         $authorizationError = $mode === 'proposal' ? $this->authorizeProposal() : $this->authorizeDirect();
         if ($authorizationError) {
             return $authorizationError;
@@ -31,6 +46,20 @@ class SourceMutationHandler extends AbstractMutationHandler {
             return $this->errorResponse('主鍵格式不正確', 422, ['pk' => [$e->getMessage()]]);
         }
 
+        // 異體字落地替換（型別驅動；BIOG_SOURCE_DATA 全文本欄走 lenient，含 PK 第三欄 c_pages）。
+        //
+        // 為什麼要在這裡、而且 create 與 update 對 $targetPk 的處理不同：
+        // - create：$targetPk 就是「要建立的那個 PK」，必須一起替換，否則落庫的 c_pages
+        //   會是變體形、與 $changes 那側正規化的結果不一致。
+        // - update：$targetPk 是**既有列的定位器**，那列可能正存著變體形（D6 不做回溯校正），
+        //   替換它會定位落空 404。所以只替換 $changes——使用者把 c_pages 改成參考形時，
+        //   isReKeyed() 會如實判定為改鍵並走既有的碰撞偵測（D7「觸碰即歸一」）。
+        //   反之若使用者送的變體形替換後恰好等於原 PK，isReKeyed() 判否，不會誤報 409。
+        $changes = $this->applyVariantReplacement($changes, 'BIOG_SOURCE_DATA');
+        if ($operation === 'create') {
+            $targetPk = $this->applyVariantReplacement($targetPk, 'BIOG_SOURCE_DATA');
+        }
+
         $validationErrors = $this->biogSourceRepository->validateMutation($personId, $targetPk, $changes, $operation);
         if ($validationErrors !== []) {
             return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
@@ -38,7 +67,11 @@ class SourceMutationHandler extends AbstractMutationHandler {
 
         if ($operation === 'create') {
             $data = $this->biogSourceRepository->buildCreatePayload($personId, $targetPk, $changes);
-            $existing = $this->biogSourceRepository->findByPk($data);
+            // 第二個條件是 D7「兩形並存」查重：c_pages 是 PK 第三欄且是文本欄，既有列可能
+            // 存變體形（D6 不做回溯校正），只比對替換後的值會讓「原樣重送變體形」鑄出第二列
+            // 語義重複資料，而唯一鍵擋不住（不同字形＝不同鍵值）。
+            $existing = $this->biogSourceRepository->findByPk($data)
+                ?: VariantEquivalentLookup::findExistingRow('BIOG_SOURCE_DATA', self::KEY_COLUMNS, $data);
             if ($existing) {
                 return $this->errorResponse('BIOG_SOURCE_DATA 記錄已存在', 409, [
                     'target.pk' => ['duplicate'],
@@ -50,7 +83,19 @@ class SourceMutationHandler extends AbstractMutationHandler {
                 ? (int) $meta['__approving_operation_id']
                 : null;
 
-            if ($this->biogSourceRepository->hasPendingCreateProposal($data, $approvingOperationId)) {
+            // 同上：帶變體形 resource_id 的舊提案與帶歸一後 resource_id 的新提案不會相等。
+            if ($this->biogSourceRepository->hasPendingCreateProposal($data, $approvingOperationId)
+                || VariantEquivalentLookup::hasEquivalentPendingCreateProposal(
+                    'BIOG_SOURCE_DATA',
+                    self::KEY_COLUMNS,
+                    $data,
+                    $approvingOperationId,
+                    null,
+                    $personId,
+                    // BIOG_SOURCE_DATA 的既有語義：只有 pending 算衝突，被拒絕的提案可重新提交
+                    // （見 BiogSourceRepository::hasPendingCreateProposal()）。
+                    ['pending']
+                )) {
                 return $this->errorResponse('相同主鍵已有待審核提案', 409, [
                     'target.pk' => ['pending_proposal_exists'],
                 ]);
@@ -64,7 +109,10 @@ class SourceMutationHandler extends AbstractMutationHandler {
             $data = $this->biogSourceRepository->buildUpdatePayload($personId, $targetPk, $changes, $existing);
 
             // 改鍵（c_textid/c_pages 變更）碰撞偵測：新主鍵已存在另一列時擋下，避免 UPDATE 覆寫他列。
-            if ($this->biogSourceRepository->isReKeyed($targetPk, $changes) && $this->biogSourceRepository->findByPk($data)) {
+            // 第二個條件是 D7 查重：c_pages 是文本型 PK 欄，既有列可能存變體形，
+            // 精確比對查不到、唯一鍵也不衝突（不同字形＝不同鍵值）⇒ 會落成兩形並存。
+            if (($this->biogSourceRepository->isReKeyed($targetPk, $changes) && $this->biogSourceRepository->findByPk($data))
+                || $this->findVariantEquivalentSourceConflict($existing, $data)) {
                 return $this->errorResponse('變更後的出處主鍵與現有記錄重複', 409, [
                     'target.pk' => ['duplicate'],
                 ]);
@@ -125,6 +173,39 @@ class SourceMutationHandler extends AbstractMutationHandler {
                 'row' => $result['row'],
             ],
         ]);
+    }
+
+    /**
+     * 更新後的 PK 是否與**另一**既有列「異體字歸一後相同」（c_pages 是文本型 PK 欄）。
+     *
+     * 排除自己是必要的：只改非 PK 欄時其餘 PK 欄與原列相同，
+     * `VariantEquivalentLookup` 會把原列自己撈回來，誤報 409。
+     *
+     * @param array<string,mixed>|object $existing 實際命中的既有列（repository 可能回陣列或物件）（**不能**用 $targetPk 比對：payload 的 PK
+     *                          可能帶哨兵別名，例如 c_textid=-999 實際落庫是 0，
+     *                          用別名比會把原列自己誤判成別列而回假 409）
+     * @param array<string,mixed> $data 替換後的完整 payload
+     */
+    private function findVariantEquivalentSourceConflict(array|object $existing, array $data): bool {
+        // 排除自己交給 lookup 內部做：候選集可以有多列同時歸一成同一個值，
+        // 在外面看第一筆是不是自己會漏掉真正衝突的另一列。
+        $selfPk = array_intersect_key((array) $existing, array_flip(self::KEY_COLUMNS));
+
+        // 只在真的改鍵時才檢查：既有資料可能早就有兩列歸一後相同（D6 不回溯校正），
+        // 使用者只改非 PK 欄是合法操作，無條件檢查會把那些列變成完全無法更新。
+        $reKeyed = false;
+        foreach (self::KEY_COLUMNS as $column) {
+            if ((string) ($data[$column] ?? '') !== (string) ($selfPk[$column] ?? '')) {
+                $reKeyed = true;
+
+                break;
+            }
+        }
+        if (!$reKeyed) {
+            return false;
+        }
+
+        return VariantEquivalentLookup::findExistingRow('BIOG_SOURCE_DATA', self::KEY_COLUMNS, $data, [$selfPk]) !== null;
     }
 
     /**

--- a/app/Support/VariantEquivalentLookup.php
+++ b/app/Support/VariantEquivalentLookup.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Operation;
+use App\Services\CharVariantMapService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * D7「兩形並存」查重：既有列可能存**變體形**（D6 不做回溯校正），所以新增時只拿
+ * 「替換後的值」做精確比對是不夠的——會鑄出兩列語義相同、字形不同的資料，而資料庫
+ * 唯一鍵**擋不住**（不同字形＝不同鍵值）。那比完全不替換更糟。
+ *
+ * 例：`ALTNAME_DATA` 已有 `('愼齋', type 4, person)`。使用者再送一次 `愼齋`
+ * → 替換成 `慎齋` → 精確查重找不到 → INSERT ⇒ 同一人有 `愼齋` 與 `慎齋` 兩筆別名。
+ * 在落地替換上線之前，同樣的輸入會被乾淨的 409 擋下。
+ *
+ * 做法：**把不在替換範圍內的主鍵欄固定在 SQL 條件裡，取回那一小群候選列，再在 PHP 端
+ * 把它們的文本主鍵歸一後比對**。這樣是**精確**的（不管對照表是什麼形狀）、而且只要
+ * **一次查詢**。早期版本「列舉所有等價字形再逐一查」有兩個缺點：查詢次數是等價字形數，
+ * 而且為避免組合爆炸設的上限本身就是正確性缺口（超過上限就退回只比正規形）。
+ *
+ * 呼叫端：`CodesController`（代碼表 CRUD 的 5 條寫入路徑）與 v2 mutation 的 create
+ * 路徑（`AbstractPersonSubresourceCreateHandler`、`SourceMutationHandler`）。
+ */
+class VariantEquivalentLookup {
+    /**
+     * 主鍵欄位分成「在替換範圍內的文本欄」與「其餘」。
+     *
+     * @param array<int,string> $keyColumns
+     * @return array{0: array<int,string>, 1: array<int,string>} [替換範圍內的, 其餘的]
+     */
+    public static function splitKeyColumns(string $table, array $keyColumns): array {
+        $inScope = [];
+        $fixed = [];
+
+        foreach ($keyColumns as $column) {
+            if (VariantReplaceScope::modeFor($table, $column) === null) {
+                $fixed[] = $column;
+            } else {
+                $inScope[] = $column;
+            }
+        }
+
+        return [$inScope, $fixed];
+    }
+
+    /**
+     * 找出「歸一後與本次輸入相同」的既有列（可能存的是變體形）。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<string,mixed> $after 替換後的資料
+     * @param array<int,array<string,mixed>> $excludePks 要排除的列（以完整主鍵指定），
+     *        典型用途是改鍵時排除「正在編輯的那一列自己」。
+     *        **排除必須在這裡做、不能由呼叫端拿回傳值判斷**：候選集可以有多列同時歸一成
+     *        同一個值（例如 `愼齋` 與 `慬齋` 都歸一成 `慎齋`），若這裡回傳第一筆、呼叫端
+     *        看到那是自己就當成「沒衝突」，真正衝突的另一列就被漏掉、照樣鑄出兩形並存列。
+     * @return mixed 既有列（stdClass）或 null
+     */
+    public static function findExistingRow(string $table, array $keyColumns, array $after, array $excludePks = []) {
+        [$inScope, $fixed] = self::splitKeyColumns($table, $keyColumns);
+
+        // 主鍵沒有任何可替換的文本欄 ⇒ 一般查重就夠，零額外成本。
+        if ($inScope === []) {
+            return null;
+        }
+
+        // 全部主鍵欄都可替換 ⇒ 沒有能收斂候選集的 SQL 條件，會變成全表掃描。
+        // 目前沒有這種表（ALTNAME_DATA 是 3 鍵、只有 1 個文本欄可替換），
+        // 真的出現時記 warning 並跳過，不要靜默做全表掃描。
+        if ($fixed === []) {
+            Log::warning('D7 去重跳過：主鍵全部在替換範圍內，無法收斂候選集', [
+                'table' => $table,
+                'key_columns' => $keyColumns,
+            ]);
+
+            return null;
+        }
+
+        $query = DB::table($table);
+        foreach ($fixed as $column) {
+            if (!array_key_exists($column, $after)) {
+                return null;
+            }
+            $query->where($column, $after[$column]);
+        }
+
+        foreach ($query->get() as $row) {
+            if (!self::rowMatchesAfterNormalization($table, $inScope, (array) $row, $after)) {
+                continue;
+            }
+            if (self::matchesAnyPk($keyColumns, (array) $row, $excludePks)) {
+                continue; // 是被排除的列（通常就是正在編輯的自己）——繼續找下一個候選
+            }
+
+            return $row;
+        }
+
+        return null;
+    }
+
+    /**
+     * 候選列的主鍵是否等於 $excludePks 裡的任一組。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<string,mixed> $row
+     * @param array<int,array<string,mixed>> $excludePks
+     */
+    private static function matchesAnyPk(array $keyColumns, array $row, array $excludePks): bool {
+        foreach ($excludePks as $pk) {
+            $same = true;
+            foreach ($keyColumns as $column) {
+                if ((string) ($row[$column] ?? '') !== (string) ($pk[$column] ?? '')) {
+                    $same = false;
+
+                    break;
+                }
+            }
+            if ($same) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 待審的新增提案裡有沒有「歸一後與本次輸入相同」的一筆。
+     *
+     * 一般的 `hasPendingCreateProposal()` 是拿 `resource_id` 做完全相等比對，所以帶
+     * 變體形 resource_id 的舊提案不會與帶歸一後 resource_id 的新提案衝突 ⇒ 兩筆並存、
+     * 依序核准就落成兩種字形的兩列。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<string,mixed> $after
+     * @param int|null $excludeOperationId 核准重放時要排除的「自己那一筆」
+     * @param string|null $resourceIdLikePattern 代碼表用：位置式 resource_id 的 LIKE 樣式
+     * @param array<int,string> $conflictingStatuses 哪些 `__review_status` 算衝突。預設
+     *        `['pending','rejected']`（對齊 `OperationRepository::hasPendingCreateProposal()`）；
+     *        `BIOG_SOURCE_DATA` 的既有語義只擋 `pending`（被拒絕的可重新提交），所以那邊要
+     *        明確傳 `['pending']`——否則同一資源會變成「字形相同可重送、只是異體等價不可重送」
+     *        的不一致行為。
+     * @param int|null $personId 人物子資源用：以有索引的 operations.c_personid 收斂候選集。
+     *                            **已知邊界**：舊資料／測試資料的 `operations.c_personid`
+     *                            可能是 0（見 OperationsProposalController 同旨註解），
+     *                            這類舊 pending 提案的變體形重複不會被抓到——精確字形仍由
+     *                            `hasPendingCreateProposal()` 擋住，故接受此邊界。
+     */
+    public static function hasEquivalentPendingCreateProposal(
+        string $table,
+        array $keyColumns,
+        array $after,
+        ?int $excludeOperationId = null,
+        ?string $resourceIdLikePattern = null,
+        ?int $personId = null,
+        array $conflictingStatuses = ['pending', 'rejected']
+    ): bool {
+        [$inScope] = self::splitKeyColumns($table, $keyColumns);
+        if ($inScope === []) {
+            return false;
+        }
+
+        if (!Schema::hasTable('operations')) {
+            return false;
+        }
+
+        $query = DB::table('operations')
+            ->where('resource', $table)
+            ->where('op_type', Operation::TYPE_PROPOSAL_CREATE);
+        if ($excludeOperationId !== null) {
+            $query->where('id', '!=', $excludeOperationId);
+        }
+
+        // 收斂候選集，否則會把該表**所有歷史** create proposal（含已核准／已取消）全部撈
+        // 回來反序列化，集合隨歷史無上限成長。
+        //
+        // 收斂條件由呼叫端給，因為 resource_id 的格式**依表而異**：代碼表是
+        // `CodesController::buildCompositeId()` 的位置式 `'_._'` 串接（可用位置式 LIKE
+        // 樣式，見 proposalResourceIdPattern()），人物子資源是
+        // `CompositePrimaryKey::buildStoredResourceId()` 的 `http_build_query()`
+        // 查詢字串（欄名帶在字串裡、值 percent-encoded，位置式樣式對它無效）。
+        // 後者改用 operations.c_personid 收斂——那是有索引的欄，效果更好。
+        if ($resourceIdLikePattern !== null) {
+            $query->where('resource_id', 'like', $resourceIdLikePattern);
+        }
+        if ($personId !== null) {
+            // 也要涵蓋 c_personid = 0 的歷史／測試資料（見 OperationsProposalController
+            // 同旨註解）。漏抓的後果不只是「少擋一次」：第一筆送出並核准後，第二筆會在
+            // **核准重放**時才被既有資料列的 D7 查重擋下，提案卡在 pending 需人工處理。
+            // payload 的 c_personid 仍會在下面逐欄精確比對，所以不會誤判成別人的提案。
+            $query->where(function ($q) use ($personId) {
+                $q->where('c_personid', $personId)->orWhere('c_personid', 0);
+            });
+        }
+
+        // 分批而非一次載入：候選集理論上無上限（**不能用 limit 截斷**——截斷會重現
+        // 「漏抓重複」的正確性缺口）。用 lazyById() 而不是 cursor()：PDO MySQL 預設是
+        // buffered query（config/database.php 沒關掉 MYSQL_ATTR_USE_BUFFERED_QUERY），
+        // cursor() 仍會把整個結果集先讀進 PHP 記憶體；lazyById() 以 id 分頁，
+        // 每批大小固定，記憶體才真的有界。
+        foreach ($query->lazyById(500) as $operation) {
+            $payload = json_decode((string) $operation->resource_data, true);
+            if (!is_array($payload)) {
+                continue;
+            }
+            if (!in_array($payload['__review_status'] ?? null, $conflictingStatuses, true)) {
+                continue;
+            }
+            // 其餘主鍵欄必須相同，文本主鍵欄則比對歸一後的值
+            foreach ($keyColumns as $column) {
+                if (in_array($column, $inScope, true)) {
+                    continue;
+                }
+                if ((string) ($payload[$column] ?? '') !== (string) ($after[$column] ?? '')) {
+                    continue 2;
+                }
+            }
+            if (self::rowMatchesAfterNormalization($table, $inScope, $payload, $after)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 用「非替換範圍的主鍵欄」組出 `resource_id` 的 LIKE 樣式，把候選集收斂在 SQL 層。
+     *
+     * **只適用代碼表**：`CodesController::buildCompositeId()` 以 `'_._'` 串起的**位置式**
+     * 序列化，所以可以逐位置組樣式：在替換範圍內的欄位放 `%`、其餘放實際值。
+     * （人物子資源的 `resource_id` 是 `http_build_query()` 查詢字串，不是位置式，
+     * 那條路徑改用 `operations.c_personid` 收斂。）
+     *
+     * **不能只做「前導前綴」**：production 的 `ALTNAME_DATA` 主鍵順序是
+     * `(c_alt_name_chn, c_alt_name_type_code, c_personid)`——第一欄正是可替換的文字欄，
+     * 前導前綴會直接失效而退回全掃。位置式樣式在任何順序下都能收斂。
+     *
+     * 這個樣式是**寬鬆的預篩**（分隔符裡的 `_` 本身是 LIKE 單字元通配、且值含 `%`／`_`
+     * 時會退成 `%`），只會多撈不會少撈——精確比對在 PHP 端由
+     * `rowMatchesAfterNormalization()` 完成，所以寬鬆是安全的。
+     *
+     * @param array<int,string> $keyColumns
+     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<string,mixed> $after
+     * @return string|null null = 無法收斂（所有主鍵欄都是通配），呼叫端就別加這個條件
+     */
+    public static function proposalResourceIdPattern(array $keyColumns, array $inScope, array $after): ?string {
+        $parts = [];
+        $hasLiteral = false;
+
+        foreach ($keyColumns as $column) {
+            if (in_array($column, $inScope, true)) {
+                $parts[] = '%';
+
+                continue;
+            }
+
+            $value = array_key_exists($column, $after) && $after[$column] !== null
+                ? (string) $after[$column]
+                : '';
+
+            // 值本身含 LIKE 通配字元時退成 '%'：跨 driver 的 ESCAPE 語法不一致
+            // （SQLite 需要顯式 ESCAPE），而寬鬆預篩本來就安全。
+            if ($value === '' || strpbrk($value, '%_') !== false) {
+                $parts[] = '%';
+
+                continue;
+            }
+
+            $parts[] = $value;
+            $hasLiteral = true;
+        }
+
+        if (!$hasLiteral) {
+            return null;
+        }
+
+        return implode('_._', $parts);
+    }
+
+    /**
+     * 候選列的文本主鍵歸一後是否與本次輸入相同。
+     *
+     * @param array<int,string> $inScope 在替換範圍內的主鍵欄
+     * @param array<string,mixed> $candidate
+     * @param array<string,mixed> $after 替換後的資料
+     */
+    public static function rowMatchesAfterNormalization(string $table, array $inScope, array $candidate, array $after): bool {
+        foreach ($inScope as $column) {
+            $candidateValue = $candidate[$column] ?? null;
+            if (!is_string($candidateValue)) {
+                return false;
+            }
+
+            $normalized = CharVariantMapService::replaceFor($table, $column, $candidateValue)['text'];
+            if ($normalized !== (string) ($after[$column] ?? '')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Support/VariantReplaceScope.php
+++ b/app/Support/VariantReplaceScope.php
@@ -386,13 +386,27 @@ final class VariantReplaceScope {
         try {
             $columns = Schema::getColumns($table);
         } catch (\Throwable $e) {
-            // 表不存在或 driver 不支援：視為沒有文本欄，配合 fail-closed。
+            // **只有「表確實不存在」才降級**（部署未跑 migration、測試建了精簡表集）。
+            // 這個判定是確定性的，快取它安全。
             //
-            // ⚠️ 這個負結果會被 $columnTypes／$modeCache 快取住，所以在 web request 裡
-            // 一次連線抖動就會讓該表的文本欄在**這個 process 的剩餘生命週期**都不被替換
-            // （測試有 TestCase::setUp() 的 reset() 兜著，web 沒有）。因此這裡記 warning，
-            // 讓「整批資料沒被替換」這種靜默失效至少留下痕跡。
-            Log::warning('VariantReplaceScope: 讀取欄位型別失敗，該表本次視為無文本欄', [
+            // 其他 Throwable（連線抖動、暫時性 metadata 鎖、driver 不支援）一律往上拋：
+            // 這裡的負結果會被 $columnTypes／$textColumnCache／$modeCache 三層快取住，
+            // 一次瞬時錯誤就會讓該表在**這個 process 的剩餘生命週期**都不做替換，資料
+            // 靜默留變體形而且沒有任何錯誤回應。長生命週期的 queue worker／artisan
+            // 批次匯入尤其致命。與 CharVariantMapService::loadEdges() 的策略一致。
+            $tableMissing = false;
+
+            try {
+                $tableMissing = !Schema::hasTable($table);
+            } catch (\Throwable) {
+                // hasTable 也失敗 ⇒ 連線本身有問題，不是「表不存在」⇒ 照原例外往上拋。
+            }
+
+            if (!$tableMissing) {
+                throw $e;
+            }
+
+            Log::warning('VariantReplaceScope: 資料表不存在，該表視為無文本欄', [
                 'table' => $table,
                 'error' => $e->getMessage(),
             ]);

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -311,6 +311,90 @@ D3 已內嵌一份已查證的代碼鍵清單，直接進排除常數。本步�
 - v2 回應以 `withNotices()` 帶 `notices`；422／409 也要帶。
 - 測試（`tests/Feature/ApiV2MutateVariantReplacementTest.php`）：`ASSOC_DATA.c_text_title`（PK 成員 + 鏡像撞號回 409）、**`BIOG_SOURCE_DATA.c_pages`**（PK 第三欄）、`EVENTS_DATA.c_event`、`POSSESSION_DATA.c_possession_desc_chn`、`ENTRY_DATA.c_exam_rank`、`STATUS_DATA.c_supplement`、各表 `c_notes`；BIOG_MAIN 姓名 strict 而同列 `c_notes`／`c_tribe` lenient（與上面 `replaceRow` 的決定是同一個原子變更）；**編輯既有變體形列時的 D7「PK 改名」行為**。
 
+#### S3 執行結果補記（review 後追加的四項）
+
+實作時 review 找出四個計畫原本沒列、但必須一起處理的問題，都已在同一步完成：
+
+1. **D7「兩形並存」查重必須同時接到 v2 create 側**（原本只在 S2 為 Codes UI 做）。
+   既有列可能存變體形（D6 不做回溯校正），只比對替換後的值會讓「原樣重送變體形」
+   INSERT 出第二列語義重複資料，而唯一鍵擋不住（不同字形＝不同鍵值）——**比不替換更糟**，
+   而且落地替換上線前這種輸入本來是乾淨的 409。
+   做法：把 `CodesController` 的四個 helper 抽成 `App\Support\VariantEquivalentLookup`
+   （controller 改為薄委派），接到 `AbstractPersonSubresourceCreateHandler` 的既有列查重
+   與待審提案防呆、以及 `SourceMutationHandler` 的 create 兩處。
+   **踩到的陷阱**：`resource_id` 格式依表而異——代碼表是 `buildCompositeId()` 的位置式
+   `'_._'` 串接（可用位置式 LIKE 樣式收斂），人物子資源是
+   `CompositePrimaryKey::buildStoredResourceId()` ＝ `http_build_query()` 查詢字串，
+   位置式樣式對它完全無效（會靜默失去這道查重）。後者改用有索引的 `operations.c_personid`
+   收斂候選集。
+
+2. **BIOG_MAIN 的替換範圍收到「使用者本次實際變更的欄」**。`BiogMainMutationHandler`
+   是唯一在伺服器端把「原列 ∪ changes」合成整列再送進 repository 的資源，整列替換會
+   (a) 回溯改寫使用者沒碰過的既有欄（違反 D6）、(b) 讓 `updated_fields` 與實際落庫不一致，
+   提案審核 diff 出現提案人沒改過的欄、(c) 讓某個舊欄被歸一而把「完全沒改」的存檔變成
+   一筆真實 UPDATE。做法：`updateById()` 與 `prepareProposalPayload()` 各加一個
+   `$variantFields` 參數（null＝整列，legacy Blade 表單路徑用；v2 傳 `$updatedFields`）。
+   這也讓 BIOG_MAIN 與其他 20 個資源（只替換 `$updateData`／`$rowData`）語義一致。
+
+3. **`VariantReplaceScope::loadColumnTypes()` 不再快取瞬時錯誤的負結果**。原本任何
+   `Throwable` 都回 `[]`，而該結果會被 `$columnTypes`／`$textColumnCache`／`$modeCache`
+   三層快取住 ⇒ 一次連線抖動就讓該表在**這個 process 的剩餘生命週期**都不做替換（長生命
+   週期的 queue worker／artisan 批次匯入尤其致命），資料靜默留變體形且沒有錯誤回應。
+   改為：只有 `Schema::hasTable()` 確認「表確實不存在」才降級並快取，其餘一律 rethrow
+   ——與 `CharVariantMapService::loadEdges()` 的策略對齊。
+
+4. **`char_variant_map` 的結構守衛下移到落庫層**。它登記在
+   `config/code_table_mutations.php`，所以 `/api/v2/create`／`/api/v2/mutate` 就能寫，
+   而 `assertWritable()`／`reset()` 原本只掛在 `CodesController` 與 `OperationsController`
+   ⇒ 用 API 新增一筆成環的對照（表裡已有 `峯→峰`，再送 `峰→峯`）會落庫成功，之後
+   `dropCycleEdges()` 把環上兩條邊一起丟掉、只留 `Log::error`，這組字的替換在全站靜默停止。
+   S3 把替換面擴到所有人物寫入路徑後，影響面從 Codes UI 擴到全站。做法：新增
+   `Concerns\GuardsCharVariantMapWrites`，掛在 `CodeTableCreateHandler`、
+   `AbstractCodeTableMutationHandler::handleDirect()`、`CodeTableDeleteHandler`。
+
+第二輪 review 又找出四項，同樣已在本步修完：
+
+5. **D7 查重必須同時接到改鍵（update）側**，不是只有 create。DB 唯一鍵只擋同字形；把某列
+   的文本型 PK 成員改成「歸一後等於另一既有變體形列」的值時，精確比對查不到、唯一鍵也不
+   衝突 ⇒ 一樣落成兩形並存。修在 `AbstractPersonSubresourceMutationHandler::handle()`
+   （分派 direct／proposal 之前，一次涵蓋兩條路）與 `SourceMutationHandler` 的 update 分支。
+   **自我排除必須比對「實際命中那一列的 PK 值」而非 `$targetPk`**：payload 的 PK 可能帶哨兵
+   別名（`sources` 的 `c_textid=-999` 實際落庫是 0），拿別名比會把原列自己誤判成別列而回假 409
+   （`testDirectSourceUpdateSupportsSelect2ZeroTextIdAliasWithoutChangesPersonId` 抓到過一次）。
+
+6. **`meta.__` 內部鍵不可由客戶端帶進來**。`__approving_operation_id` 是核准重放時「排除待審
+   的自己那一筆」的內部訊號（核准端直接呼叫 handler、不經 API 控制器）。原本 API 把 `meta`
+   原樣傳進 handler ⇒ 眾包使用者只要塞上自己那筆待審提案的 id，就能讓待審重複防呆（含 D7
+   等價字形查重）放行，再送一筆變體形的重複提案。修法：`Api\MutationController` 的 5 個入口
+   統一以 `sanitizeClientMeta()` 剝掉 `__` 前綴鍵（同時堵住 `SourceMutationHandler` 既有的同型洞）。
+
+7. **`char_variant_map` 的守衛還要補提案與通用核准兩條路**。它不在
+   `OperationsProposalController::HANDLER_ROUTED_RESOURCES`，核准走通用 `applyUpdateProposal()`
+   的 raw update：提案時不驗、核准時也不驗、且不重置快取。修法：
+   `AbstractCodeTableMutationHandler::handleProposal()` 提交即擋，`applyUpdateProposal()`
+   落庫前 `assertWritable()`、落庫後 `reset()`。
+
+8. **順手修掉一個既有的姓名清空 bug**（develop 上行為相同，但正好在本次重寫的那幾行）：
+   `updateById()`／`prepareProposalPayload()` 原本**無條件** `c_name_chn = 姓 . 名`，而 v2 的
+   payload 是「原列 ∪ changes」⇒ 沒有明確姓氏的歷史人物（兩個分欄 NULL、`c_name_chn` 存完整
+   姓名）只要被更新任何一欄，姓名就被靜默清成空字串。`store()` 早有等價保護，現在三處一致：
+   兩個分欄都空時不重組。
+
+測試 harness 另修三處（`FakeQueryBuilder` 把 `!=` 當等值比較會讓語義完全反過來、
+`FakeSchemaBuilder` 缺 `getColumns()`／`getForeignKeys()`）——都是假 driver 與真實 Laravel API
+的落差，不是生產碼問題；補上後 `personFkColumns()` 那段也不再被 `catch(\Throwable)` 靜默吞掉。
+
+另記兩件**刻意接受**的行為（不修，S9 一併寫進文檔）：
+
+- `ASSOC_DATA.c_text_title` 被替換時，`syncAssocMirrorOnUpdate()` 會把對面鏡像列的同名
+  PK 成員一起改名（定位器用替換前的舊值，不會落空）。這是對既有資料的回溯改寫，與 D6
+  精神有張力，明文記為「觸碰即歸一」的刻意例外。撞既有參考形鏡像列時是乾淨的 409 + 整筆
+  回滾（走基底的 `isUniqueConstraintViolation`），已有回歸測試。
+- 文本型 PK 成員改名後，改名前的 `operations.resource_id`／`audit_log.row_pk` 仍指向舊
+  字形，同一筆資料的歷史被切成兩個身分。這是**任何** PK 改名共有的性質（手動改別名一樣
+  會發生），不是替換引入的新機制；若要處理應該是「改名時遷移舊 resource_id」的獨立工作，
+  不是收窄替換範圍。
+
 ### S4：實體聚合（官職／社會機構）串接（G3）
 
 **這一步的所有精確比對都要按 D7 處理兩形並存。**

--- a/tests/Feature/ApiV2CreateBiogMainTest.php
+++ b/tests/Feature/ApiV2CreateBiogMainTest.php
@@ -159,6 +159,7 @@ class ApiV2CreateBiogMainTest extends TestCase {
             $table->integer('c_dy')->nullable();
             $table->integer('c_death_age')->nullable();
             $table->text('c_notes')->nullable();
+            $table->string('c_tribe')->nullable();
             $table->string('c_created_by')->nullable();
             $table->dateTime('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
@@ -337,6 +338,35 @@ class ApiV2CreateBiogMainTest extends TestCase {
             'c_mingzi_chn' => '清',
             'c_name_chn' => '張清',
         ]);
+    }
+
+    /**
+     * 同一列裡兩套規則並存：姓名欄 strict（`峯` 保留原形），其餘文本欄 lenient（`峯`→`峰`）。
+     *
+     * 這是 plan S3 把三處手掛姓名欄改成整列 `replaceRow('BIOG_MAIN')` 的核心回歸——
+     * 舊碼只替換 c_surname_chn／c_mingzi_chn，c_notes／c_tribe 等文本欄全漏。
+     */
+    #[Test]
+    public function testDirectBiogMainCreateAppliesStrictToNameAndLenientToOtherTextColumns(): void {
+        $this->actingAs($this->makeUser(email: 'create-biog-variant-mixed@example.com'));
+
+        $response = $this->postJson('/api/v2/create', $this->createPayload([
+            'changes' => [
+                'c_surname_chn' => '張',
+                'c_mingzi_chn' => '峯',
+                'c_notes' => '峯下人',
+                'c_tribe' => '峯部',
+            ],
+        ]))->assertOk();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 2000,
+            'c_mingzi_chn' => '峯',      // strict：峯 不替換
+            'c_name_chn' => '張峯',
+            'c_notes' => '峰下人',       // lenient：峯→峰
+            'c_tribe' => '峰部',
+        ]);
+        $this->assertNotEmpty($response->json('notices'), 'lenient 欄發生替換也要回通知');
     }
 
     #[Test]

--- a/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
+++ b/tests/Feature/ApiV2MutateCodeTableCharVariantMapTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -223,6 +225,126 @@ class ApiV2MutateCodeTableCharVariantMapTest extends TestCase {
         ])->assertStatus(409);
 
         $this->assertDatabaseHas('char_variant_map', ['id' => 43, 'c_variant_char' => '靑']);
+    }
+
+    /**
+     * 結構守衛必須掛在**落庫層**（handler），不是只掛在 Codes UI controller：
+     * `char_variant_map` 登記在 config/code_table_mutations.php，用 API 就能寫。
+     *
+     * 成環的對照（表裡已有 `峯→峰`，再送 `峰→峯`）若讓它落庫，`resolveMap()` 的
+     * `dropCycleEdges()` 會把環上**兩條**邊一起丟掉、只留一行 Log::error ⇒ 這組字的
+     * 落地替換在全站靜默停止。S3 之後這個洞的影響面是所有人物寫入路徑。
+     */
+    #[Test]
+    public function testCreateCyclicMappingIsRejectedByApi(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-cycle@example.com'));
+        DB::table('char_variant_map')->insert(['id' => 60, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1]);
+
+        $res = $this->postJson('/api/v2/create', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 61]],
+            'changes' => ['c_variant_char' => '峰', 'c_reference_char' => '峯', 'c_strict_excluded' => 1],
+        ]);
+
+        $res->assertStatus(422);
+        $this->assertSame(1, DB::table('char_variant_map')->count(), '成環的對照不得落庫');
+    }
+
+    /** 多字元對照同樣要在落庫前擋下（會被 resolveMap() 靜默丟棄）。 */
+    #[Test]
+    public function testCreateMultiCodepointMappingIsRejectedByApi(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-multi@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 70]],
+            'changes' => ['c_variant_char' => '甲乙', 'c_reference_char' => '丙', 'c_strict_excluded' => 1],
+        ])->assertStatus(422);
+
+        $this->assertSame(0, DB::table('char_variant_map')->count());
+    }
+
+    /** 更新成環同樣要擋（排除自己那一列後仍成環）。 */
+    #[Test]
+    public function testUpdateIntoCycleIsRejectedByApi(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-cycle-upd@example.com'));
+        DB::table('char_variant_map')->insert([
+            ['id' => 80, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['id' => 81, 'c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 1],
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['id' => 81]],
+            'changes' => ['c_variant_char' => '峰', 'c_reference_char' => '峯'],
+        ])->assertStatus(422);
+
+        $this->assertDatabaseHas('char_variant_map', ['id' => 81, 'c_variant_char' => '靑']);
+    }
+
+    /** 落庫成功後必須重置對照表快取，否則新對照在該 process 的剩餘生命週期內不生效。 */
+    #[Test]
+    public function testCreateResetsVariantMapCacheSoNewMappingTakesEffect(): void {
+        $this->actingAs($this->makeUser(email: 'cvm-reset@example.com'));
+
+        // 先讓服務把（此時為空的）對照表快取起來。
+        $this->assertSame('龴', CharVariantMapService::replaceLenient('龴')['text']);
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'char_variant_map',
+            'person_id' => 0,
+            'target' => ['pk' => ['id' => 90]],
+            'changes' => ['c_variant_char' => '龴', 'c_reference_char' => '甲', 'c_strict_excluded' => 0],
+        ])->assertOk();
+
+        $this->assertSame('甲', CharVariantMapService::replaceLenient('龴')['text'], '新對照應立即生效（快取已重置）');
+    }
+
+    /**
+     * codex round 2：**歷史待審提案**（不經現行 submission guard 建立）核准時，
+     * 通用 applyCreateProposal() 也必須驗結構——否則成環的對照落庫後
+     * dropCycleEdges() 會把整組邊丟掉，該組字的替換全站靜默停止。
+     */
+    #[Test]
+    public function testApprovingLegacyCyclicCreateProposalIsRejected(): void {
+        DB::table('char_variant_map')->insert(['id' => 100, 'c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1]);
+
+        $proposer = $this->makeUser(email: 'cvm-legacy-proposer@example.com');
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => $proposer->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'char_variant_map',
+            'resource_id' => '101',
+            'resource_data' => json_encode([
+                'id' => 101,
+                'c_variant_char' => '峰',
+                'c_reference_char' => '峯',
+                'c_strict_excluded' => 1,
+                '__review_status' => 'pending',
+                '__key_columns' => ['id'],
+                '__proposal_meta' => [
+                    'action' => 'create',
+                    'table' => 'char_variant_map',
+                    'submitted_by' => $proposer->name,
+                    'submitted_by_id' => $proposer->id,
+                ],
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->actingAs($this->makeUser(User::STATUS_ACTIVE, User::ROLE_SUPER_ADMIN, 'cvm-legacy-admin@example.com'));
+        $this->post(route('operations.proposals.approve', $operationId), ['review_comment' => '同意']);
+
+        $this->assertSame(1, DB::table('char_variant_map')->count(), '成環的對照不得因核准而落庫');
+        $this->assertDatabaseMissing('char_variant_map', ['id' => 101]);
     }
 
     #[Test]

--- a/tests/Feature/ApiV2MutateTest.php
+++ b/tests/Feature/ApiV2MutateTest.php
@@ -156,6 +156,8 @@ class ApiV2MutateTest extends TestCase {
             $table->integer('c_dy_intercalary')->default(0);
             $table->integer('c_index_year')->nullable();
             $table->integer('c_death_age')->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_tribe')->nullable();
             $table->string('c_created_by')->nullable();
             $table->dateTime('c_created_date')->nullable();
             $table->string('c_modified_by')->nullable();
@@ -619,6 +621,167 @@ class ApiV2MutateTest extends TestCase {
         $this->assertSame('張清', $payload['c_name_chn']);
         // 提案未核准前，BIOG_MAIN 本身不應變更。
         $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_mingzi_chn' => '忠']);
+    }
+
+    /**
+     * 只替換「使用者本次實際變更的欄」，不對他沒碰過的既有欄做回溯校正（D6）。
+     *
+     * BIOG_MAIN 是唯一在伺服器端把「原列 ∪ changes」合成整列再送進 repository 的資源，
+     * 若整列替換會有三個後果：(1) 回溯改寫使用者沒送的欄；(2) updated_fields 與實際落庫
+     * 不一致，提案審核 diff 會出現提案人沒改過的欄；(3) 某個舊欄被歸一會讓「完全沒改」
+     * 的存檔變成一筆真實 UPDATE。
+     */
+    #[Test]
+    public function testDirectBiogMainUpdateOnlyReplacesVariantsInSubmittedFields() {
+        $this->actingAs($this->makeUser(email: 'biog-scoped-variant@example.com'));
+        // 既有列的 c_notes 存著變體形（D6：既有資料不做回溯校正）。
+        $this->seedBiogMain(['c_notes' => '淸流舊注']);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_death_age' => 61],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('BIOG_MAIN', [
+            'c_personid' => 138841,
+            'c_death_age' => 61,
+            'c_notes' => '淸流舊注', // 使用者沒送 c_notes ⇒ 不得被歸一
+        ]);
+    }
+
+    /** 送出的欄本身有變體字時照樣替換（與上一條互補，確保收窄沒有把機制關掉）。 */
+    #[Test]
+    public function testDirectBiogMainUpdateStillReplacesVariantsInTheFieldUserSubmitted() {
+        $this->actingAs($this->makeUser(email: 'biog-scoped-variant-on@example.com'));
+        $this->seedBiogMain(['c_notes' => '舊注']);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_notes' => '峯下人'],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_notes' => '峰下人']);
+        $this->assertNotEmpty($response->json('notices'));
+    }
+
+    /**
+     * 使用者送的字被歸一成與現值相同 ⇒ 422「未偵測到任何修改內容」，
+     * 這條回應也必須帶 notices，否則訊息看起來毫無道理。
+     */
+    #[Test]
+    public function testDirectBiogMainUpdateNoChangesResponseCarriesVariantNotices() {
+        $this->actingAs($this->makeUser(email: 'biog-nochange-notice@example.com'));
+        $this->seedBiogMain(['c_notes' => '清流']);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_notes' => '淸流'],
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertNotEmpty($response->json('notices'), '422 也要帶異體字通知');
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_notes' => '清流']);
+    }
+
+    /**
+     * 沒有明確姓氏的歷史人物（c_surname_chn／c_mingzi_chn 皆 NULL、c_name_chn 存完整姓名）：
+     * 對他做任何更新都不得把 c_name_chn 清成空字串。
+     *
+     * 舊碼在 updateById()／prepareProposalPayload() 無條件 `c_name_chn = 姓 . 名`，
+     * 而 v2 的 payload 是「原列 ∪ changes」⇒ 兩個 NULL 分欄相加＝''，姓名靜默消失。
+     * store() 早就有等價保護。
+     */
+    #[Test]
+    public function testDirectBiogMainUpdateDoesNotClearNameChnWhenPartsAreNull() {
+        $this->actingAs($this->makeUser(email: 'biog-unsplit-name@example.com'));
+        $this->seedBiogMain([
+            'c_name_chn' => '完顏阿骨打',
+            'c_surname_chn' => null,
+            'c_mingzi_chn' => null,
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_death_age' => 61],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('BIOG_MAIN', ['c_personid' => 138841, 'c_name_chn' => '完顏阿骨打', 'c_death_age' => 61]);
+    }
+
+    /** 提案路徑同理（payload 不經 repository）。 */
+    #[Test]
+    public function testProposalBiogMainUpdateDoesNotClearNameChnWhenPartsAreNull() {
+        $this->actingAs($this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-unsplit-proposal@example.com'));
+        $this->seedBiogMain([
+            'c_name_chn' => '完顏阿骨打',
+            'c_surname_chn' => null,
+            'c_mingzi_chn' => null,
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => ['c_death_age' => 61],
+            'meta' => ['comment' => '只改卒年'],
+        ])->assertOk();
+
+        $operation = DB::table('operations')->where('resource', 'BIOG_MAIN')->first();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('完顏阿骨打', $payload['c_name_chn'], '提案 payload 不得把未分欄的姓名清空');
+    }
+
+    /**
+     * 提案 payload 也必須套用「姓名 strict、其餘文本欄 lenient」——這條路徑不經
+     * BiogMainRepository，而是 BiogMainMutationHandler::prepareProposalPayload()。
+     * 漏掉它會讓審核畫面看到的字形與核准後落庫的不一致（plan S3）。
+     */
+    #[Test]
+    public function testProposalBiogMainUpdateAppliesLenientRuleToNonNameTextColumns() {
+        $user = $this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'biog-proposal-lenient@example.com');
+        $this->actingAs($user);
+        $this->seedBiogMain();
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'basicinformation',
+            'person_id' => 138841,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 138841]],
+            'changes' => [
+                'c_mingzi_chn' => '峯',
+                'c_notes' => '峯下人',
+            ],
+            'meta' => ['comment' => '提案：名用嚴格規則、備註用全量規則'],
+        ])->assertOk();
+
+        $operation = DB::table('operations')
+            ->where('resource', 'BIOG_MAIN')
+            ->where('op_type', Operation::TYPE_PROPOSAL_UPDATE)
+            ->first();
+        $payload = json_decode($operation->resource_data, true);
+
+        $this->assertSame('峯', $payload['c_mingzi_chn'], '名字欄 strict：峯 不替換');
+        $this->assertSame('張峯', $payload['c_name_chn']);
+        $this->assertSame('峰下人', $payload['c_notes'], '備註欄 lenient：峯→峰');
     }
 
     #[Test]

--- a/tests/Feature/ApiV2MutateVariantReplacementTest.php
+++ b/tests/Feature/ApiV2MutateVariantReplacementTest.php
@@ -1,0 +1,1314 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\CompositePrimaryKey;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 異體字落地替換在人物子資源 v2 mutation 全面生效（plan S3）。
+ *
+ * 掛鉤在兩個抽象基底類別（`AbstractPersonSubresourceCreateHandler`／
+ * `AbstractPersonSubresourceMutationHandler`）與體系外三個例外
+ * （`PossessionCreateHandler`／`PostingCreateHandler`／`SourceMutationHandler`）。
+ * 這支測試不逐一列舉 21 個子類，而是抽樣覆蓋三類風險：
+ *
+ * 1. **文本型 PK 成員**被替換（`BIOG_SOURCE_DATA.c_pages`、`ASSOC_DATA.c_text_title`、
+ *    `ALTNAME_DATA.c_alt_name_chn`）——替換必須早於 PK 計算與查重。
+ * 2. **strict／lenient 分流**：只有人名／別名欄用 strict（`峯` 不替換），
+ *    同一列的 `c_notes` 等一般文本欄用 lenient（`峯`→`峰`）。
+ * 3. 一般文本欄（`c_event`／`c_exam_rank`／`c_supplement`／`c_possession_desc_chn`／
+ *    各表 `c_notes`）確實被替換，且回應帶 `notices`。
+ */
+class ApiV2MutateVariantReplacementTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('app.env', 'testing');
+        $this->app['env'] = 'testing';
+        config()->set('prometheus.enabled', false);
+        config()->set('prometheus.storage_adapter', 'memory');
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createUsersTable();
+        $this->createOperationsTable();
+        $this->createAuditLogTable();
+        $this->createCharVariantMapTable();
+        $this->createAltnameTable();
+        $this->createAssociationTable();
+        $this->createAssocCodesTable();
+        $this->createKinshipCodesTable();
+        $this->createEventTable();
+        $this->createEventsAddrTable();
+        $this->createEntryTable();
+        $this->createStatusTable();
+        $this->createPossessionTable();
+        $this->createPossessionAddrTable();
+        $this->createTextCodesTable();
+        $this->createSourceTable();
+        $this->createPostingTable();
+        $this->createPostingAddrTable();
+        $this->createPostingIdTable();
+    }
+
+    protected function tearDown(): void {
+        foreach ([
+            'POSTING_DATA', 'POSTED_TO_ADDR_DATA', 'POSTED_TO_OFFICE_DATA', 'BIOG_SOURCE_DATA', 'TEXT_CODES', 'POSSESSION_ADDR', 'POSSESSION_DATA',
+            'STATUS_DATA', 'ENTRY_DATA', 'EVENTS_ADDR', 'EVENTS_DATA',
+            'KINSHIP_CODES', 'ASSOC_CODES', 'ASSOC_DATA', 'ALTNAME_DATA',
+            'char_variant_map', 'audit_log', 'operations', 'users',
+        ] as $table) {
+            Schema::dropIfExists($table);
+        }
+        parent::tearDown();
+    }
+
+    // ── 1. 文本型 PK 成員 ────────────────────────────────────
+
+    /** BIOG_SOURCE_DATA 的 PK 第三欄就是文本欄 c_pages：替換必須早於查重與落庫。 */
+    #[Test]
+    public function testSourceCreateReplacesVariantInTextPrimaryKeyColumn(): void {
+        $this->actingAs($this->makeUser('src-create@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            'changes' => ['c_notes' => '槀本'],
+        ])->assertOk();
+
+        $this->assertTrue(
+            DB::table('BIOG_SOURCE_DATA')->where('c_pages', '慎一')->where('c_notes', '稿本')->exists(),
+            'PK 成員 c_pages 與一般文本欄 c_notes 都應以參考形落庫'
+        );
+        $this->assertFalse(DB::table('BIOG_SOURCE_DATA')->where('c_pages', '愼一')->exists());
+        $this->assertNotEmpty($response->json('notices'), '回應應帶異體字通知');
+    }
+
+    /** D7「觸碰即歸一」：既有列存的是變體形，更新時把 PK 成員改成參考形＝改鍵。 */
+    #[Test]
+    public function testSourceUpdateRenamesVariantPrimaryKeyToReferenceForm(): void {
+        $this->actingAs($this->makeUser('src-rename@example.com'));
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            'c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一', 'c_notes' => null,
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            // 使用者原樣重送變體形頁碼、只改備註：頁碼會被歸一化成參考形（改鍵）。
+            'changes' => ['c_pages' => '愼一', 'c_notes' => '補注'],
+        ])->assertOk();
+
+        $this->assertTrue(DB::table('BIOG_SOURCE_DATA')->where('c_pages', '慎一')->exists(), 'PK 應改名為參考形');
+        $this->assertFalse(DB::table('BIOG_SOURCE_DATA')->where('c_pages', '愼一')->exists(), '變體形列不應殘留');
+        $this->assertSame(1, DB::table('BIOG_SOURCE_DATA')->count(), '不得複製出第二列');
+    }
+
+    /** 更新時 targetPk 是定位器：既有列存變體形也必須定位得到（不可連 targetPk 一起替換）。 */
+    #[Test]
+    public function testSourceUpdateStillLocatesRowStoredInVariantForm(): void {
+        $this->actingAs($this->makeUser('src-locate@example.com'));
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            'c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一', 'c_notes' => null,
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            'changes' => ['c_notes' => '只改備註'],
+        ])->assertOk();
+
+        $row = DB::table('BIOG_SOURCE_DATA')->first();
+        $this->assertSame('愼一', $row->c_pages, '未送 c_pages 時不做回溯校正（D6）');
+        $this->assertSame('只改備註', $row->c_notes);
+    }
+
+    /** ALTNAME_DATA.c_alt_name_chn 是 PK 成員且走 strict：通用掛鉤接手後通知不可消失。 */
+    #[Test]
+    public function testAltnameCreateKeepsStrictNoticeAfterGenericHookTakesOver(): void {
+        $this->actingAs($this->makeUser('altname-notice@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => [],
+        ])->assertOk();
+
+        $this->assertTrue(DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '慎齋')->exists());
+        $this->assertNotEmpty(
+            $response->json('notices'),
+            '別名替換通知不可因通用掛鉤接手而消失（子類重複呼叫 + assign 的失效模式）'
+        );
+    }
+
+    // ── 2. strict／lenient 分流 ──────────────────────────────
+
+    /** 同一列：別名欄 strict（峯 保留），c_notes lenient（峯→峰）。 */
+    #[Test]
+    public function testAltnameStrictColumnKeepsExcludedVariantWhileNotesIsReplaced(): void {
+        $this->actingAs($this->makeUser('altname-mixed@example.com'));
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '峯生', 'c_alt_name_type_code' => 4]],
+            'changes' => ['c_notes' => '峯字備註'],
+        ])->assertOk();
+
+        $row = DB::table('ALTNAME_DATA')->first();
+        $this->assertSame('峯生', $row->c_alt_name_chn, '人名／別名欄用 strict：峯 不替換');
+        $this->assertSame('峰字備註', $row->c_notes, '一般文本欄用 lenient：峯→峰');
+    }
+
+    // ── 3. 一般文本欄與通知 ─────────────────────────────────
+
+    /** EVENTS_DATA.c_event（longtext）。 */
+    #[Test]
+    public function testEventUpdateReplacesVariantInEventText(): void {
+        $this->actingAs($this->makeUser('event-variant@example.com'));
+        DB::table('EVENTS_DATA')->insert([
+            'c_personid' => 1000, 'c_sequence' => 1, 'c_event_code' => 7, 'c_event' => '舊事',
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'events',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_sequence' => 1, 'c_event_code' => 7]],
+            'changes' => ['c_event' => '登靑雲', 'c_notes' => '峯頂'],
+        ])->assertOk();
+
+        $row = DB::table('EVENTS_DATA')->first();
+        $this->assertSame('登青雲', $row->c_event);
+        $this->assertSame('峰頂', $row->c_notes);
+        $this->assertNotEmpty($response->json('notices'));
+    }
+
+    /** ENTRY_DATA.c_exam_rank。 */
+    #[Test]
+    public function testEntryUpdateReplacesVariantInExamRank(): void {
+        $this->actingAs($this->makeUser('entry-variant@example.com'));
+        DB::table('ENTRY_DATA')->insert([
+            'c_personid' => 1000, 'c_entry_code' => 36, 'c_sequence' => 1, 'c_kin_code' => 0,
+            'c_assoc_code' => 0, 'c_kin_id' => 0, 'c_year' => 0, 'c_assoc_id' => 0,
+            'c_inst_code' => 0, 'c_inst_name_code' => 0, 'c_exam_rank' => '舊名次',
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'entries',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => [
+                'c_personid' => 1000, 'c_entry_code' => 36, 'c_sequence' => 1, 'c_kin_code' => 0,
+                'c_assoc_code' => 0, 'c_kin_id' => 0, 'c_year' => 0, 'c_assoc_id' => 0,
+                'c_inst_code' => 0, 'c_inst_name_code' => 0,
+            ]],
+            'changes' => ['c_exam_rank' => '第一甲頴等'],
+        ])->assertOk();
+
+        $this->assertSame('第一甲穎等', DB::table('ENTRY_DATA')->value('c_exam_rank'));
+    }
+
+    /** STATUS_DATA.c_supplement。 */
+    #[Test]
+    public function testStatusUpdateReplacesVariantInSupplement(): void {
+        $this->actingAs($this->makeUser('status-variant@example.com'));
+        DB::table('STATUS_DATA')->insert([
+            'c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3, 'c_supplement' => '舊補',
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'statuses',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3]],
+            'changes' => ['c_supplement' => '淸流'],
+        ])->assertOk();
+
+        $this->assertSame('清流', DB::table('STATUS_DATA')->value('c_supplement'));
+    }
+
+    /** POSSESSION_DATA：走體系外的 PossessionCreateHandler。 */
+    #[Test]
+    public function testPossessionCreateReplacesVariantInDescription(): void {
+        $this->actingAs($this->makeUser('possession-variant@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'possessions',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => []],
+            'changes' => ['c_possession_desc_chn' => '靑瓷', 'c_notes' => '厰造'],
+        ])->assertOk();
+
+        $row = DB::table('POSSESSION_DATA')->first();
+        $this->assertSame('青瓷', $row->c_possession_desc_chn);
+        $this->assertSame('廠造', $row->c_notes);
+        $this->assertNotEmpty($response->json('notices'));
+    }
+
+    /** 提案模式（proposal）：payload 落在 operations 裡的也必須是替換後的值。 */
+    #[Test]
+    public function testProposalPayloadStoresReplacedText(): void {
+        $this->actingAs($this->makeUser('proposal-variant@example.com', User::ROLE_REGULAR));
+        DB::table('STATUS_DATA')->insert([
+            'c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3, 'c_supplement' => '舊補',
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'statuses',
+            'person_id' => 1000,
+            'mode' => 'proposal',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3]],
+            'changes' => ['c_supplement' => '淸流'],
+        ])->assertOk();
+
+        $payload = json_decode((string) DB::table('operations')->value('resource_data'), true);
+        $this->assertSame('清流', $payload['c_supplement'], '提案 payload 必須存替換後的值，否則審核畫面與落庫不一致');
+    }
+
+    // ── 4. ASSOC_DATA.c_text_title：PK 成員 + 鏡像 ──────────
+
+    /** 正向列改鍵成功時，對面鏡像列的同名 PK 成員一起收斂。 */
+    #[Test]
+    public function testAssociationUpdateReplacesTextTitleAndConvergesMirror(): void {
+        $this->actingAs($this->makeUser('assoc-mirror@example.com'));
+        $this->seedAssociationPair('愼書');
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload('愼書', [
+            'c_text_title' => '愼書',
+            'c_assocship_pair' => 2,
+        ]))->assertOk();
+
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '慎書')->exists(),
+            '正向列的 c_text_title 應改為參考形'
+        );
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 2000)->where('c_text_title', '慎書')->exists(),
+            '對面鏡像列應一起收斂（觸碰即歸一）'
+        );
+        $this->assertSame(2, DB::table('ASSOC_DATA')->count(), '不得產生額外列');
+    }
+
+    /**
+     * 對面已存在參考形鏡像列時，鏡像改鍵會撞唯一鍵——必須是乾淨的 409，
+     * 不可冒成未捕捉的 500，且整筆（含正向列）回滾。
+     */
+    #[Test]
+    public function testAssociationUpdateReturns409WhenMirrorRenameCollides(): void {
+        $this->actingAs($this->makeUser('assoc-mirror-conflict@example.com'));
+        $this->seedAssociationPair('愼書');
+        // 對面那個人已經有一列參考形的同段關係鏡像：鏡像改鍵會撞上它。
+        // c_kin_id／c_assoc_kin_id 必須與鏡像同步後的值一致（afterDirectUpdate 會把它們設成
+        // 正向那個人的 id），否則 9 鍵 PK 不相同、撞不到唯一鍵，測不到要測的東西。
+        $this->insertAssociation(2000, 2, 1000, '慎書', [
+            'c_kin_id' => 1000,
+            'c_assoc_kin_id' => 1000,
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', $this->associationPayload('愼書', [
+            'c_text_title' => '愼書',
+            'c_assocship_pair' => 2,
+        ]));
+
+        $this->assertSame(409, $response->getStatusCode(), '鏡像改鍵撞號應回 409 而非 500');
+        // 注意：errors 的鍵名本身含點（'target.pk'），不能用 json() 的點記法取值。
+        $this->assertSame(['conflict'], $response->json('errors')['target.pk'] ?? null, '應走主鍵衝突分支');
+        $this->assertNotEmpty(
+            $response->json('notices'),
+            '被擋下來的回應也要帶異體字通知，否則使用者看不懂 409 從哪來'
+        );
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '愼書')->exists(),
+            '整筆交易應回滾，正向列維持原值'
+        );
+    }
+
+    // ── 5. D7「兩形並存」查重（替換不可鑄出語義重複列）──────
+
+    /**
+     * 既有列存變體形（D6 不做回溯校正），使用者原樣再送一次同一個變體形：
+     * 必須是乾淨的 409，**不可**因為替換後的值查不到而 INSERT 出第二列。
+     *
+     * 為什麼這條最重要：唯一鍵擋不住（`愼齋` 與 `慎齋` 是兩個不同鍵值），落地替換上線前
+     * 這種輸入本來會被 409 擋下——沒有這道查重，替換反而比不替換更糟。
+     */
+    #[Test]
+    public function testAltnameCreateReturns409WhenExistingRowIsStoredInVariantForm(): void {
+        $this->actingAs($this->makeUser('altname-d7@example.com'));
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4,
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => [],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode(), '既有變體形列應擋下等價字形的新增');
+        $this->assertSame(1, DB::table('ALTNAME_DATA')->count(), '不得鑄出第二列語義重複的別名');
+    }
+
+    /** 同上，PK 第三欄是文本欄的 BIOG_SOURCE_DATA。 */
+    #[Test]
+    public function testSourceCreateReturns409WhenExistingRowIsStoredInVariantForm(): void {
+        $this->actingAs($this->makeUser('src-d7@example.com'));
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            'c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一',
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            'changes' => [],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode());
+        $this->assertSame(1, DB::table('BIOG_SOURCE_DATA')->count());
+    }
+
+    /**
+     * 待審提案側同理：帶變體形 resource_id 的舊提案與帶歸一後 resource_id 的新提案
+     * 不會相等 ⇒ 沒有這道查重就會兩筆並存、依序核准落成兩種字形的兩列。
+     */
+    #[Test]
+    public function testAltnameProposalReturns409WhenPendingProposalIsInVariantForm(): void {
+        $this->actingAs($this->makeUser('altname-d7-proposal@example.com', User::ROLE_REGULAR));
+        DB::table('operations')->insert([
+            'user_id' => 1,
+            'c_personid' => 1000,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'ALTNAME_DATA',
+            // 人物子資源的 resource_id ＝ CompositePrimaryKey::buildStoredResourceId()
+            // ＝ http_build_query()（欄名帶在字串裡、值 percent-encoded），不是代碼表的 '_._' 位置式。
+            'resource_id' => CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => 1000,
+                'c_alt_name_chn' => '愼齋',
+                'c_alt_name_type_code' => 4,
+            ]),
+            'resource_data' => json_encode([
+                'c_personid' => 1000,
+                'c_alt_name_chn' => '愼齋',
+                'c_alt_name_type_code' => 4,
+                '__review_status' => 'pending',
+                '__key_columns' => ['c_alt_name_chn', 'c_alt_name_type_code', 'c_personid'],
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'proposal',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => [],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode(), '等價字形的待審提案應擋下重複提交');
+        $this->assertSame(1, DB::table('operations')->count(), '不得產生第二筆待審提案');
+    }
+
+    /**
+     * 改鍵（update）側的 D7：把某列的文本型 PK 成員改成「歸一後等於另一既有變體形列」
+     * 的值時，DB 唯一鍵擋不住（不同字形＝不同鍵值），必須自己擋成 409。
+     */
+    #[Test]
+    public function testAltnameUpdateReturns409WhenRenameCollidesWithVariantFormRow(): void {
+        $this->actingAs($this->makeUser('altname-d7-update@example.com'));
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4],
+            ['c_personid' => 1000, 'c_alt_name_chn' => '甲號', 'c_alt_name_type_code' => 4],
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '甲號', 'c_alt_name_type_code' => 4]],
+            'changes' => ['c_alt_name_chn' => '慎齋'],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode(), '歸一後與既有變體形列相同 ⇒ 應擋下');
+        $this->assertSame(2, DB::table('ALTNAME_DATA')->count());
+        $this->assertTrue(DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '甲號')->exists(), '應整筆回滾');
+    }
+
+    /** 只改非 PK 欄時不得因為「候選列就是自己」而誤報 409。 */
+    #[Test]
+    public function testAltnameUpdateOfNonKeyFieldIsNotBlockedByItsOwnRow(): void {
+        $this->actingAs($this->makeUser('altname-d7-self@example.com'));
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4, 'c_notes' => '舊',
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => ['c_notes' => '新'],
+        ])->assertOk();
+
+        $this->assertSame('新', DB::table('ALTNAME_DATA')->value('c_notes'));
+    }
+
+    /**
+     * codex round 1：候選集裡「自己」排在真正衝突的另一列**之前**時，不得因為
+     * 「第一筆是自己」就放行。`愼齋` 與 `慬齋` 都歸一成 `慎齋`。
+     */
+    #[Test]
+    public function testAltnameUpdateStillBlocksWhenSelfIsAlsoAnEquivalentCandidate(): void {
+        $this->actingAs($this->makeUser('altname-d7-self-first@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        // 插入順序讓「正在編輯的自己」先被掃到。
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4],
+            ['c_personid' => 1000, 'c_alt_name_chn' => '慬齋', 'c_alt_name_type_code' => 4],
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => ['c_alt_name_chn' => '慎齋'],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode(), '另一列也歸一成 慎齋 ⇒ 必須擋下');
+        $this->assertSame(2, DB::table('ALTNAME_DATA')->count());
+        $this->assertTrue(DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '愼齋')->exists(), '應整筆回滾');
+    }
+
+    /**
+     * codex round 1：鏡像列改鍵時，對面若已有另一列「歸一後相同但字形不同」的關係，
+     * DB 唯一鍵擋不住（不同字形＝不同鍵值），必須自己擋成 409 並回滾。
+     */
+    #[Test]
+    public function testAssociationUpdateBlocksMirrorRenameCollidingWithVariantEquivalentRow(): void {
+        $this->actingAs($this->makeUser('assoc-mirror-d7@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        $this->seedAssociationPair('愼書');
+        // 對面另有一段同對方／同首年的關係，書名是**另一個**變體形，歸一後與新鍵相同。
+        $this->insertAssociation(2000, 2, 1000, '慬書', [
+            'c_kin_id' => 1000,
+            'c_assoc_kin_id' => 1000,
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', $this->associationPayload('愼書', [
+            'c_text_title' => '愼書',
+            'c_assocship_pair' => 2,
+        ]));
+
+        $this->assertSame(409, $response->getStatusCode(), '鏡像改鍵撞等價字形應回 409');
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '愼書')->exists(),
+            '整筆交易應回滾'
+        );
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 2000)->where('c_text_title', '愼書')->exists(),
+            '鏡像列也應維持原值'
+        );
+    }
+
+    // ── 6. 其餘掛鉤點與 422 通知 ─────────────────────────────
+
+    /** POSTED_TO_OFFICE_DATA：走體系外的 PostingCreateHandler。 */
+    #[Test]
+    public function testPostingCreateReplacesVariantInNotes(): void {
+        $this->actingAs($this->makeUser('posting-variant@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'postings',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => []],
+            'changes' => ['c_office_id' => 3000, 'c_notes' => '靑州任'],
+        ])->assertOk();
+
+        $this->assertSame('青州任', DB::table('POSTED_TO_OFFICE_DATA')->value('c_notes'));
+        $this->assertNotEmpty($response->json('notices'));
+    }
+
+    /**
+     * 使用者送的字被歸一成與現值相同 ⇒ 422「未偵測到任何修改內容」。
+     * 這條回應**也要帶 notices**，否則錯誤訊息看起來毫無道理。
+     */
+    #[Test]
+    public function testNoEffectiveChangesResponseStillCarriesVariantNotices(): void {
+        $this->actingAs($this->makeUser('status-422@example.com'));
+        DB::table('STATUS_DATA')->insert([
+            'c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3, 'c_supplement' => '清流',
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'statuses',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_sequence' => 1, 'c_status_code' => 3]],
+            'changes' => ['c_supplement' => '淸流'],
+        ]);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertNotEmpty($response->json('notices'), '422 也要帶異體字通知');
+    }
+
+    /**
+     * codex round 2：鏡像**補建**（backfill）路徑也要做 D7 preflight。
+     * 嚴格定位用舊書名精確比對，所以對面存另一個變體形（`慬書`）時定位落空 → 走補建，
+     * 插入歸一後的 `慎書` 就與 `慬書` 並存（唯一鍵擋不住不同字形）。
+     */
+    #[Test]
+    public function testAssociationMirrorBackfillBlocksVariantEquivalentDuplicate(): void {
+        $this->actingAs($this->makeUser('assoc-backfill-d7@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        // 只有正向列（對面沒有可嚴格定位的鏡像）＋對面另有一列別的變體形。
+        $this->insertAssociation(1000, 1, 2000, '愼書');
+        $this->insertAssociation(2000, 2, 1000, '慬書', ['c_kin_id' => 1000, 'c_assoc_kin_id' => 1000]);
+
+        $response = $this->postJson('/api/v2/mutate', $this->associationPayload('愼書', [
+            'c_text_title' => '愼書',
+            'c_assocship_pair' => 2, // 顯式送配對碼 ⇒ 允許 backfill
+        ]));
+
+        $this->assertSame(409, $response->getStatusCode(), '補建的鏡像列與既有變體形列歸一後相同 ⇒ 應擋下');
+        $this->assertSame(2, DB::table('ASSOC_DATA')->count(), '不得補出第三列');
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '愼書')->exists(),
+            '整筆交易應回滾'
+        );
+    }
+
+    /**
+     * codex round 2：#70 的 force 就地收斂路徑（碼漂移的疑似鏡像列）同樣是改鍵，
+     * 也要做 D7 preflight。
+     */
+    #[Test]
+    public function testAssociationMirrorForceConvergeBlocksVariantEquivalentDuplicate(): void {
+        $this->actingAs($this->makeUser('assoc-force-d7@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        $this->insertAssociation(1000, 1, 2000, '愼書');
+        // 對面的漂移鏡像列（碼 99 不是合法 ASSOC_CODE）＋另一列合法碼但別的變體形書名。
+        $this->insertAssociation(2000, 99, 1000, '愼書', ['c_kin_id' => 1000, 'c_assoc_kin_id' => 1000]);
+        $this->insertAssociation(2000, 2, 1000, '慬書', ['c_kin_id' => 1000, 'c_assoc_kin_id' => 1000]);
+
+        $payload = $this->associationPayload('愼書', [
+            'c_text_title' => '愼書',
+            'c_assocship_pair' => 2,
+        ]);
+        $payload['meta'] = ['force' => true]; // #70：強制收斂漂移鏡像
+
+        $response = $this->postJson('/api/v2/mutate', $payload);
+
+        $this->assertSame(409, $response->getStatusCode(), 'force 收斂後會與既有變體形列歸一後相同 ⇒ 應擋下');
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 2000)->where('c_assoc_code', 99)->where('c_text_title', '愼書')->exists(),
+            '漂移列應維持原值（整筆回滾）'
+        );
+    }
+
+    /**
+     * codex round 2：待審提案的等價查重必須涵蓋 `operations.c_personid = 0` 的歷史資料。
+     * 漏抓的後果不是「少擋一次」——第二筆會在核准重放時才被擋，提案卡在 pending。
+     */
+    #[Test]
+    public function testAltnameProposalDedupCoversLegacyZeroPersonIdOperations(): void {
+        $this->actingAs($this->makeUser('altname-d7-zero@example.com', User::ROLE_REGULAR));
+        DB::table('operations')->insert([
+            'user_id' => 1,
+            'c_personid' => 0, // 歷史／測試資料可能是 0
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => 1000,
+                'c_alt_name_chn' => '愼齋',
+                'c_alt_name_type_code' => 4,
+            ]),
+            'resource_data' => json_encode([
+                'c_personid' => 1000,
+                'c_alt_name_chn' => '愼齋',
+                'c_alt_name_type_code' => 4,
+                '__review_status' => 'pending',
+                '__key_columns' => ['c_alt_name_chn', 'c_alt_name_type_code', 'c_personid'],
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'proposal',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => [],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode());
+        $this->assertSame(1, DB::table('operations')->count());
+    }
+
+    /**
+     * codex round 2：`BIOG_SOURCE_DATA` 的既有語義是「被拒絕的提案可以重新提交」，
+     * 等價字形查重不得把它變成「字形相同可重送、只是異體等價不可重送」的不一致行為。
+     */
+    #[Test]
+    public function testSourceProposalDedupIgnoresRejectedProposalsLikeExactMatchDoes(): void {
+        $this->actingAs($this->makeUser('src-d7-rejected@example.com', User::ROLE_REGULAR));
+        DB::table('operations')->insert([
+            'user_id' => 1,
+            'c_personid' => 1000,
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'BIOG_SOURCE_DATA',
+            'resource_id' => CompositePrimaryKey::buildStoredResourceId([
+                'c_personid' => 1000,
+                'c_textid' => 500,
+                'c_pages' => '愼一',
+            ]),
+            'resource_data' => json_encode([
+                'c_personid' => 1000,
+                'c_textid' => 500,
+                'c_pages' => '愼一',
+                '__review_status' => 'rejected',
+                '__key_columns' => ['c_personid', 'c_textid', 'c_pages'],
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'proposal',
+            'operation' => 'create',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            'changes' => [],
+        ])->assertOk();
+
+        $this->assertSame(2, DB::table('operations')->count(), '被拒絕的提案不應擋住重新提交');
+    }
+
+    /**
+     * codex round 3：既有資料早就有兩列歸一後相同（D6 不做回溯校正）時，
+     * 只改其中一列的**非 PK 欄**是合法操作，不得被 D7 preflight 誤擋成 409。
+     *
+     * 註：這條與下一條在目前實作下有兩道保護——「只在改鍵時才檢查」的閘門，以及
+     * 「未送文本 PK 欄時 $after 仍是原字形、比不到已歸一的候選」。所以把閘門單獨拿掉
+     * 它們仍會綠；留著是為了鎖住使用者可見行為（真正鎖住閘門的是鏡像那條測試）。
+     */
+    #[Test]
+    public function testUpdatingNonKeyFieldIsAllowedEvenWhenTwoVariantFormsAlreadyCoexist(): void {
+        $this->actingAs($this->makeUser('altname-d7-no-false-409@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        // 兩列歸一後都是「慎齋」，是落地替換上線前就存在的歷史資料。
+        DB::table('ALTNAME_DATA')->insert([
+            ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4, 'c_notes' => '舊'],
+            ['c_personid' => 1000, 'c_alt_name_chn' => '慬齋', 'c_alt_name_type_code' => 4, 'c_notes' => '舊'],
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'altnames',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_alt_name_chn' => '愼齋', 'c_alt_name_type_code' => 4]],
+            'changes' => ['c_notes' => '新'],
+        ])->assertOk();
+
+        $this->assertSame('新', DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '愼齋')->value('c_notes'));
+        $this->assertSame('舊', DB::table('ALTNAME_DATA')->where('c_alt_name_chn', '慬齋')->value('c_notes'));
+    }
+
+    /** 同上，BIOG_SOURCE_DATA（PK 第三欄是文本欄）。 */
+    #[Test]
+    public function testSourceUpdatingNonKeyFieldIsAllowedWhenTwoVariantFormsAlreadyCoexist(): void {
+        $this->actingAs($this->makeUser('src-d7-no-false-409@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一'],
+            ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '慬一'],
+        ]);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'sources',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_personid' => 1000, 'c_textid' => 500, 'c_pages' => '愼一']],
+            'changes' => ['c_notes' => '只改備註'],
+        ])->assertOk();
+
+        $this->assertSame('只改備註', DB::table('BIOG_SOURCE_DATA')->where('c_pages', '愼一')->value('c_notes'));
+    }
+
+    /** 鏡像側同理：對面早有兩形並存時，只改正向列的非 PK 欄不得被誤擋。 */
+    #[Test]
+    public function testAssociationNonKeyUpdateIsAllowedWhenMirrorSideHasCoexistingVariantForms(): void {
+        $this->actingAs($this->makeUser('assoc-d7-no-false-409@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        // 正向與鏡像的書名都已是參考形（改備註不會改鍵），但對面另有一列變體形。
+        $this->seedAssociationPair('慎書');
+        $this->insertAssociation(2000, 2, 1000, '慬書', ['c_kin_id' => 1000, 'c_assoc_kin_id' => 1000]);
+
+        $this->postJson('/api/v2/mutate', $this->associationPayload('慎書', [
+            'c_notes' => '只改備註',
+            'c_assocship_pair' => 2,
+        ]))->assertOk();
+
+        $this->assertSame(
+            '只改備註',
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->value('c_notes')
+        );
+    }
+
+    /**
+     * codex round 4：反向關係碼為哨兵 0（無有效反向可定位）時走的是「盲插鏡像」分支。
+     * 插入的 c_text_title 已是歸一後字形，對面若已有同一組固定 PK、書名為歷史變體形的列，
+     * 這一插就造成兩形並存（唯一鍵擋不住不同字形），必須擋成 409 並回滾。
+     */
+    #[Test]
+    public function testAssociationCreateWithZeroReversePairBlocksVariantEquivalentMirror(): void {
+        $this->actingAs($this->makeUser('assoc-zero-pair-d7@example.com'));
+        DB::table('char_variant_map')->insert([
+            'c_variant_char' => '慬', 'c_reference_char' => '慎', 'c_strict_excluded' => 0,
+        ]);
+        CharVariantMapService::reset();
+
+        // 關係碼 7 沒有反向配對碼（c_assoc_pair 為 null ⇒ 哨兵 0）。
+        DB::table('ASSOC_CODES')->insert(['c_assoc_code' => 7, 'c_assoc_pair' => null, 'c_assoc_pair2' => null]);
+        // 對面已有一列：固定 PK 與即將插入的鏡像相同，只有書名是另一個變體形。
+        $this->insertAssociation(2000, 0, 1000, '慬書', ['c_kin_id' => 1000, 'c_assoc_kin_id' => 1000]);
+
+        $response = $this->postJson('/api/v2/mutate', [
+            'resource' => 'associations',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'create',
+            'target' => ['pk' => [
+                'c_personid' => 1000,
+                'c_assoc_code' => 7,
+                'c_assoc_id' => 2000,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => '愼書',
+                'c_assoc_first_year' => 1060,
+            ]],
+            'changes' => ['c_source' => 10],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode(), '盲插鏡像撞等價字形應回 409');
+        $this->assertSame(1, DB::table('ASSOC_DATA')->count(), '整筆交易應回滾（正向列也不留）');
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────
+
+    protected function makeUser(string $email, int $role = User::ROLE_SUPER_ADMIN): User {
+        return User::forceCreate([
+            'name' => 'tester',
+            'email' => $email,
+            'confirmation_token' => 'token-123',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => $role,
+        ]);
+    }
+
+    protected function insertAssociation(int $personId, int $assocCode, int $assocId, string $title, array $overrides = []): void {
+        DB::table('ASSOC_DATA')->insert(array_replace([
+            'c_personid' => $personId,
+            'c_assoc_code' => $assocCode,
+            'c_assoc_id' => $assocId,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => $title,
+            'c_assoc_first_year' => 1060,
+            'c_source' => 10,
+        ], $overrides));
+    }
+
+    /** 1000 --1--> 2000 的正向列，與 2000 --2--> 1000 的鏡像列。 */
+    protected function seedAssociationPair(string $title): void {
+        $this->insertAssociation(1000, 1, 2000, $title);
+        $this->insertAssociation(2000, 2, 1000, $title);
+    }
+
+    protected function associationPayload(string $pkTitle, array $changes): array {
+        return [
+            'resource' => 'associations',
+            'person_id' => 1000,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => [
+                'c_personid' => 1000,
+                'c_assoc_code' => 1,
+                'c_assoc_id' => 2000,
+                'c_kin_code' => 0,
+                'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0,
+                'c_assoc_kin_id' => 0,
+                'c_text_title' => $pkTitle,
+                'c_assoc_first_year' => 1060,
+            ]],
+            'changes' => $changes,
+        ];
+    }
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php
+     * 相同的 7 筆種子資料（`峯` 是唯一 strict 排除的一筆）。
+     */
+    protected function createCharVariantMapTable(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '愼', 'c_reference_char' => '慎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '槀', 'c_reference_char' => '稿', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+            ['c_variant_char' => '靑', 'c_reference_char' => '青', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '頴', 'c_reference_char' => '穎', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+            ['c_variant_char' => '厰', 'c_reference_char' => '廠', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+    }
+
+    protected function createUsersTable(): void {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function createOperationsTable(): void {
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    protected function createAuditLogTable(): void {
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+    }
+
+    protected function createAltnameTable(): void {
+        Schema::create('ALTNAME_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->string('c_alt_name_chn', 255)->default('');
+            $table->integer('c_alt_name_type_code')->default(0);
+            $table->string('c_alt_name', 255)->nullable();
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->integer('c_sequence')->default(0);
+            $table->string('c_alt_name_pinyin', 255)->nullable();
+            $table->string('c_alt_name_pinyin2', 255)->nullable();
+            $table->string('c_alt_name_pinyin3', 255)->nullable();
+            $table->string('c_alt_name_role', 50)->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+            $table->primary(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code']);
+        });
+    }
+
+    protected function createAssociationTable(): void {
+        Schema::create('ASSOC_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code')->default(0);
+            $table->integer('c_assoc_id')->default(0);
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_assoc_kin_code')->default(0);
+            $table->integer('c_assoc_kin_id')->default(0);
+            $table->string('c_text_title', 255)->default('');
+            $table->integer('c_assoc_first_year')->default(0);
+            $table->integer('c_assoc_last_year')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->text('c_supplement')->nullable();
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_assoc_count')->default(0);
+            $table->integer('c_topic_code')->nullable();
+            $table->integer('c_occasion_code')->nullable();
+            $table->integer('c_tertiary_personid')->nullable();
+            $table->text('c_tertiary_type_notes')->nullable();
+            $table->integer('c_assoc_claimer_id')->nullable();
+            $table->integer('c_addr_id')->nullable();
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+            $table->primary([
+                'c_personid', 'c_assoc_code', 'c_assoc_id',
+                'c_kin_code', 'c_kin_id', 'c_assoc_kin_code',
+                'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year',
+            ]);
+        });
+    }
+
+    protected function createAssocCodesTable(): void {
+        Schema::create('ASSOC_CODES', function (Blueprint $table) {
+            $table->integer('c_assoc_code')->primary();
+            $table->integer('c_assoc_pair')->nullable();
+            $table->integer('c_assoc_pair2')->nullable();
+        });
+        DB::table('ASSOC_CODES')->insert([
+            ['c_assoc_code' => 1, 'c_assoc_pair' => 2, 'c_assoc_pair2' => null],
+            ['c_assoc_code' => 2, 'c_assoc_pair' => 1, 'c_assoc_pair2' => null],
+        ]);
+    }
+
+    protected function createKinshipCodesTable(): void {
+        Schema::create('KINSHIP_CODES', function (Blueprint $table) {
+            $table->integer('c_kincode')->primary();
+            $table->integer('c_kin_pair1')->nullable();
+            $table->integer('c_kin_pair2')->nullable();
+        });
+        DB::table('KINSHIP_CODES')->insert([
+            ['c_kincode' => 0, 'c_kin_pair1' => null, 'c_kin_pair2' => null],
+        ]);
+    }
+
+    protected function createEventTable(): void {
+        Schema::create('EVENTS_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_event_code')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->integer('c_year')->nullable();
+            $table->integer('c_month')->nullable();
+            $table->integer('c_day')->nullable();
+            $table->integer('c_day_ganzhi')->nullable();
+            $table->integer('c_nh_code')->nullable();
+            $table->integer('c_nh_year')->nullable();
+            $table->integer('c_yr_range')->nullable();
+            $table->integer('c_intercalary')->default(0);
+            $table->integer('c_addr_id')->nullable();
+            $table->longText('c_event')->nullable();
+            $table->string('c_role', 255)->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->primary(['c_personid', 'c_sequence', 'c_event_code']);
+        });
+    }
+
+    protected function createEventsAddrTable(): void {
+        Schema::create('EVENTS_ADDR', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_event_code')->default(0);
+            $table->integer('c_addr_id')->default(0);
+            $table->primary(['c_personid', 'c_sequence', 'c_event_code', 'c_addr_id']);
+        });
+    }
+
+    protected function createEntryTable(): void {
+        Schema::create('ENTRY_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_entry_code')->default(0);
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_assoc_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_year')->default(0);
+            $table->integer('c_assoc_id')->default(0);
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->integer('c_entry_addr_id')->nullable();
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->integer('c_entry_nh_id')->nullable();
+            $table->integer('c_entry_nh_year')->nullable();
+            $table->integer('c_entry_range')->nullable();
+            $table->string('c_exam_rank', 255)->nullable();
+            $table->integer('c_attempt_count')->nullable();
+            $table->string('c_exam_field', 255)->nullable();
+            $table->integer('c_parental_status_code')->nullable();
+            $table->integer('c_age')->nullable();
+            $table->string('c_posting_notes', 255)->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+            $table->primary([
+                'c_personid', 'c_entry_code', 'c_sequence', 'c_kin_code',
+                'c_assoc_code', 'c_kin_id', 'c_year', 'c_assoc_id',
+                'c_inst_code', 'c_inst_name_code',
+            ]);
+        });
+    }
+
+    protected function createStatusTable(): void {
+        Schema::create('STATUS_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_status_code')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->text('c_supplement')->nullable();
+            $table->integer('c_firstyear')->nullable();
+            $table->integer('c_fy_nh_code')->nullable();
+            $table->integer('c_fy_nh_year')->nullable();
+            $table->integer('c_fy_range')->nullable();
+            $table->integer('c_lastyear')->nullable();
+            $table->integer('c_ly_nh_code')->nullable();
+            $table->integer('c_ly_nh_year')->nullable();
+            $table->integer('c_ly_range')->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+            $table->primary(['c_personid', 'c_sequence', 'c_status_code']);
+        });
+    }
+
+    protected function createPossessionTable(): void {
+        Schema::create('POSSESSION_DATA', function (Blueprint $table) {
+            $table->integer('c_possession_record_id');
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->integer('c_possession_act_code')->default(0);
+            $table->string('c_possession_desc', 255)->nullable();
+            $table->string('c_possession_desc_chn', 255)->nullable();
+            $table->string('c_quantity', 255)->nullable();
+            $table->integer('c_measure_code')->default(0);
+            $table->integer('c_possession_yr')->nullable();
+            $table->integer('c_possession_nh_code')->nullable();
+            $table->integer('c_possession_nh_yr')->nullable();
+            $table->integer('c_possession_yr_range')->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->primary('c_possession_record_id');
+        });
+    }
+
+    protected function createPossessionAddrTable(): void {
+        Schema::create('POSSESSION_ADDR', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_possession_record_id');
+            $table->integer('c_addr_id')->default(0);
+            $table->primary(['c_possession_record_id', 'c_addr_id']);
+        });
+    }
+
+    protected function createPostingTable(): void {
+        Schema::create('POSTED_TO_OFFICE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_office_id')->default(0);
+            $table->integer('c_posting_id');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_source')->default(0);
+            $table->string('c_pages', 255)->nullable();
+            $table->text('c_notes')->nullable();
+            $table->text('c_supplement')->nullable();
+            $table->integer('c_firstyear')->nullable();
+            $table->integer('c_fy_nh_code')->nullable();
+            $table->integer('c_fy_nh_year')->nullable();
+            $table->integer('c_fy_range')->nullable();
+            $table->integer('c_fy_intercalary')->default(0);
+            $table->integer('c_fy_month')->nullable();
+            $table->integer('c_fy_day')->nullable();
+            $table->integer('c_fy_day_gz')->nullable();
+            $table->integer('c_lastyear')->nullable();
+            $table->integer('c_ly_nh_code')->nullable();
+            $table->integer('c_ly_nh_year')->nullable();
+            $table->integer('c_ly_range')->nullable();
+            $table->integer('c_ly_intercalary')->default(0);
+            $table->integer('c_ly_month')->nullable();
+            $table->integer('c_ly_day')->nullable();
+            $table->integer('c_ly_day_gz')->nullable();
+            $table->integer('c_appt_code')->default(0);
+            $table->integer('c_assume_office_code')->nullable();
+            $table->integer('c_dy')->nullable();
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->integer('c_office_category_id')->nullable();
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+            $table->primary(['c_office_id', 'c_posting_id']);
+        });
+    }
+
+    /** officeStoreById 由 POSTING_DATA 配發 c_posting_id（max+1）。 */
+    protected function createPostingIdTable(): void {
+        Schema::create('POSTING_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_posting_id')->primary();
+            // officeStoreById 經 ToolsRepository::timestamp 蓋建檔稽核欄，缺欄會 500。
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+        });
+    }
+
+    protected function createPostingAddrTable(): void {
+        Schema::create('POSTED_TO_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid')->default(0);
+            $table->integer('c_posting_id')->default(0);
+            $table->integer('c_office_id')->default(0);
+            $table->integer('c_addr_id')->default(0);
+            $table->string('c_created_by', 255)->nullable();
+            $table->string('c_created_date', 255)->nullable();
+            $table->string('c_modified_by', 255)->nullable();
+            $table->string('c_modified_date', 255)->nullable();
+        });
+    }
+
+    protected function createTextCodesTable(): void {
+        Schema::create('TEXT_CODES', function (Blueprint $table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title')->nullable();
+            $table->string('c_title_chn')->nullable();
+        });
+        DB::table('TEXT_CODES')->insert([
+            ['c_textid' => 0, 'c_title' => 'n/a', 'c_title_chn' => '未詳'],
+            ['c_textid' => 500, 'c_title' => 'Book A', 'c_title_chn' => '甲書'],
+        ]);
+    }
+
+    protected function createSourceTable(): void {
+        Schema::create('BIOG_SOURCE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_textid')->default(0);
+            $table->string('c_pages', 255)->default('');
+            $table->longText('c_notes')->nullable();
+            $table->smallInteger('c_main_source')->nullable();
+            $table->smallInteger('c_self_bio')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+            $table->primary(['c_personid', 'c_textid', 'c_pages']);
+        });
+    }
+}

--- a/tests/Feature/CodesControllerTest.php
+++ b/tests/Feature/CodesControllerTest.php
@@ -1695,8 +1695,35 @@ class FakeSchemaBuilder {
         return array_key_exists($table, $this->schemaColumns);
     }
 
+    /**
+     * `VariantReplaceScope` 以 `Schema::getColumns()` 的 type_name 判斷哪些欄是文本型。
+     *
+     * 假 driver 一律回 varchar：這些代碼表欄位在真實庫都是 varchar／text。落地替換在本
+     * harness 下實際仍是 no-op（沒有 char_variant_map 表，服務會降級不替換），所以這個
+     * 方法只是讓型別查詢不炸——**不能**靠 loadColumnTypes() 吞掉 Error 來達成：那個
+     * catch 已收窄成「只有表確實不存在才降級」，否則一次瞬時錯誤會讓整個 process 之後
+     * 都不替換（見 plan S3 補記第 3 點）。
+     */
+    public function getColumns($table) {
+        return array_map(
+            static fn ($name) => ['name' => $name, 'type_name' => 'varchar'],
+            $this->getColumnListing($table)
+        );
+    }
+
     public function getIndexes($table) {
         return $this->schemaIndexes[$table] ?? [];
+    }
+
+    /**
+     * `CodesController::personFkColumns()` 用 `Schema::getForeignKeys()` 找指向 BIOG_MAIN
+     * 的欄位（人物選擇器與 -999 哨兵正規化靠它）。缺這個方法時該處的
+     * `catch (\Throwable)` 會吞掉 Error 並回 []，於是那段邏輯在本 harness 下**從未被驗證**，
+     * 每個寫入請求還會多噴一次 testing.ERROR。假 driver 沒有外鍵資訊，回空陣列即可
+     * ——需要驗證 FK 行為的測試應自己覆寫這個回傳值。
+     */
+    public function getForeignKeys($table) {
+        return [];
     }
 }
 
@@ -1822,6 +1849,14 @@ class FakeQueryBuilder {
         }, $this->applyConditions()));
     }
 
+    /**
+     * D7 兩形並存查重掃待審提案時用 lazyById() 分批（見 VariantEquivalentLookup）。
+     * 假 driver 的資料集本來就在記憶體裡，直接回 get() 的結果即可（語義上等價於單一批次）。
+     */
+    public function lazyById($chunkSize = 1000, $column = 'id', $alias = null) {
+        return $this->get();
+    }
+
     public function orderBy($column, $direction = 'asc') {
         $normalizedDir = strtolower((string) $direction) === 'desc' ? 'desc' : 'asc';
         $this->manager->recordedOrderBys[] = [(string) $column, $normalizedDir];
@@ -1941,6 +1976,13 @@ class FakeQueryBuilder {
             $needle = trim((string) $expected, '%');
 
             return stripos((string) $value, $needle) !== false;
+        }
+
+        // '!=' 必須明確處理：落到最後的等值比較會讓語義**反過來**（原本要排除的那列
+        // 變成唯一命中的列）。D7 兩形並存查重就是用 where('id','!=',$excludeId) 排除
+        // 「核准重放時自己那一筆」，靜默當成等值會讓它自擋。
+        if (in_array($condition['operator'], ['!=', '<>'], true)) {
+            return (string) $value !== (string) $expected;
         }
 
         if ($condition['operator'] === '<') {


### PR DESCRIPTION
## 這一步做了什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S3**：異體字落地替換從「手掛少數姓名欄」改為由 `VariantReplaceScope` 按「表.欄位型別」決定的整列替換，涵蓋 21 個人物子資源 v2 handler、體系外三個例外 handler 與 BIOG_MAIN 三處寫入。

- 通用掛鉤（新 `Concerns\AppliesVariantReplacement`）插在兩個抽象基底類別的 `handle()` 內，早於 `preprocess`、PK 計算與查重 ⇒ 文本型 PK 成員（`ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、`BIOG_SOURCE_DATA.c_pages`）替換後的值成為實際落庫的 PK。`notices` 由 `handle()` 統一掛上，成功與 409／422 都帶。
- 移除 Altname 子類重複的 `replaceStrict()` + assign（會讓別名替換通知靜默消失），基底改用 merge。
- BIOG_MAIN 改為整列 `replaceRow()`（`c_notes`／`c_tribe` 等原本全漏），但 v2 路徑把範圍收窄到「使用者本次實際變更的欄」——它的 payload 是「原列 ∪ changes」，整列替換等於回溯改寫使用者沒碰過的欄（D6 明說不做）。

## Review 過程中補上的防護（都不在原計畫的 S3 清單裡）

| 問題 | 為什麼嚴重 |
|---|---|
| v2 create／改鍵缺 **D7 兩形並存查重** | 既有列可能存變體形（D6 不回溯校正），只比對替換後的值會鑄出兩列語義相同、字形不同的資料，而**唯一鍵擋不住**——比完全不替換更糟。抽成 `App\Support\VariantEquivalentLookup` 並接到 create、改鍵、以及 `ASSOC_DATA` 鏡像同步的三條寫入分支與反向碼哨兵 0 的盲插 |
| `VariantReplaceScope::loadColumnTypes()` 快取瞬時錯誤 | 一次連線抖動就讓該表在整個 process 的剩餘生命週期都不替換，資料靜默留變體形。改為只有「表確實不存在」才降級 |
| `char_variant_map` 的守衛只在 Codes UI | 用 API 或核准歷史提案就能寫入成環的對照，之後 `dropCycleEdges()` 把整組邊丟掉、該組字的替換全站靜默停止。守衛下移到落庫層（含通用核准的 create／update） |
| `meta.__approving_operation_id` 客戶端可控 | 眾包使用者塞上自己那筆待審提案的 id 就能關掉待審重複防呆。API 入口統一剝掉 `__` 前綴鍵 |
| 姓名清空（既有 bug） | 沒有明確姓氏的歷史人物（分欄 NULL、`c_name_chn` 存完整姓名）更新任何一欄都會被靜默清空。三處寫入現在一致 |

查重**只在真的改鍵時**執行——否則歷史上就已兩形並存的資料會變成任何更新都做不了（假 409）。

## 驗證

- `./vendor/bin/phpunit` 全綠：**2886 tests / 15299 assertions**
- `php-cs-fixer`（清 cache、dist config）：0 fixes
- 新測試檔 `tests/Feature/ApiV2MutateVariantReplacementTest.php`（29 條）＋ 既有測試檔補強；每一條都以「把機制中和掉會紅」逐一驗證過鑑別力，唯二例外在測試註解裡明寫（有第二道保護擋著）
- Review：2 組 review agent 兩輪 ＋ codex 五輪，最後一輪回「沒有需修正的實質問題」

🤖 Generated with [Claude Code](https://claude.com/claude-code)