### PR TITLE
異體字落地替換 S4：官職／社會機構聚合串接，標籤對照表兩側歸一

### DIFF
--- a/app/Http/Controllers/AdminBatchLoadOfficesController.php
+++ b/app/Http/Controllers/AdminBatchLoadOfficesController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\CharVariantMapService;
 use App\Services\Import\OfficeImportService;
+use App\Support\VariantLabelMap;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -101,7 +103,10 @@ class AdminBatchLoadOfficesController extends Controller {
                 $results[] = [
                     'line' => $row['line'],
                     'office_id' => $created['office_id'],
-                    'name' => $row['name'],
+                    // 顯示**實際落庫**的職名（可能已做異體字替換），不是使用者原輸入，
+                    // 否則結果頁與資料庫不一致。變更明細另外列在 variant_replacements。
+                    'name' => $created['name'] ?? $row['name'],
+                    'variant_replacements' => CharVariantMapService::flattenReplaced($created['variant_replaced'] ?? []),
                     'pinyin' => $created['pinyin'],
                     'translation' => $row['translation'],
                     'dynasty_label' => $row['dynasty_label'],
@@ -152,7 +157,11 @@ class AdminBatchLoadOfficesController extends Controller {
 
             $name = trim($parts[0]);
             $translation = trim($parts[1]);
-            $dynastyLabel = trim($parts[2]);
+            // 標籤在此就歸一：validateDynasties() 與交易內的 $dynastyMap[$row['dynasty_label']]
+            // （無檢查陣列存取）吃的都是這個值。只在驗證階段歸一會讓後者拋
+            // "Undefined array key" 而不是乾淨的逐列錯誤。
+            $dynastyLabelRaw = trim($parts[2]);
+            $dynastyLabel = VariantLabelMap::normalizeLabel($dynastyLabelRaw, 'DYNASTIES', 'c_dynasty_chn');
             $typeId = trim($parts[3]);
             $department = trim($parts[4]);
             $sourceId = trim($parts[5]);
@@ -185,6 +194,9 @@ class AdminBatchLoadOfficesController extends Controller {
                 'name' => $name,
                 'translation' => $translation,
                 'dynasty_label' => $dynastyLabel,
+                // 保留使用者原輸入供錯誤訊息使用：查表用歸一後的值，但訊息裡要顯示他真的
+                // 打了什麼（顯示歸一後的字會讓人一頭霧水——他從沒打過那個字）。
+                'dynasty_label_raw' => $dynastyLabelRaw,
                 'type_id' => $typeId,
                 'department' => $department,
                 'source_id' => (int) $sourceId,
@@ -204,13 +216,16 @@ class AdminBatchLoadOfficesController extends Controller {
      * @return array<string,int>
      */
     protected function getDynastyMap(): array {
-        return DB::table('DYNASTIES')
+        // 鍵已做異體字歸一（見 App\Support\VariantLabelMap）：D6 不回溯校正，既有 DYNASTIES
+        // 列若字面是「淸」就永遠是「淸」，只歸一表格裡的標籤查不到它。兩側都歸一，
+        // 「表格寫淸／代碼表寫清」與反方向才都命中。碰撞取最小碼並記 warning。
+        $pairs = DB::table('DYNASTIES')
             ->orderBy('c_dy')
-            ->pluck('c_dy', 'c_dynasty_chn')
-            ->mapWithKeys(function ($code, $label) {
-                return [trim((string) $label) => (int) $code];
-            })
-            ->toArray();
+            ->get(['c_dy', 'c_dynasty_chn'])
+            ->map(fn ($row) => [(string) ($row->c_dynasty_chn ?? ''), (int) $row->c_dy])
+            ->all();
+
+        return VariantLabelMap::build($pairs, 'DYNASTIES', 'c_dynasty_chn')[0];
     }
 
     /**
@@ -224,7 +239,8 @@ class AdminBatchLoadOfficesController extends Controller {
         $errors = [];
         foreach ($rows as $row) {
             if (!array_key_exists($row['dynasty_label'], $dynastyMap)) {
-                $errors[] = "第 {$row['line']} 行找不到朝代「{$row['dynasty_label']}」對應的代碼";
+                $label = $row['dynasty_label_raw'] ?? $row['dynasty_label'];
+                $errors[] = "第 {$row['line']} 行找不到朝代「{$label}」對應的代碼";
             }
         }
 

--- a/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
+++ b/app/Http/Controllers/AdminBatchLoadSocialInstitutesController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\CharVariantMapService;
 use App\Services\Import\SocialInstituteImportService;
+use App\Support\VariantLabelMap;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -106,7 +108,10 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
 
                 $results[] = [
                     'line' => $row['line'],
-                    'name' => $row['name'],
+                    // 顯示**實際生效**的機構名：新建時是歸一後的參考形，複用既有碼時是既有列
+                    // 的原字面（刻意不歸一，見 SocialInstituteImportService::resolveNameCode()）。
+                    'name' => $created['name'] ?? $row['name'],
+                    'variant_replacements' => CharVariantMapService::flattenReplaced($created['variant_replaced'] ?? []),
                     'name_code' => $created['name_code'],
                     'name_pinyin' => $created['name_pinyin'],
                     'name_created' => $created['name_created'],
@@ -162,8 +167,13 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
             }
 
             $name = trim($parts[0]);
-            $typeLabel = trim($parts[1]);
-            $dynastyLabel = trim($parts[2]);
+            // 標籤在此就歸一：validateLookups() 與交易內 $typeMap[...]／$dynastyMap[...]
+            // （無檢查陣列存取）吃的都是這個值。只在驗證階段歸一會讓後者拋
+            // "Undefined array key" 而不是乾淨的逐列錯誤。
+            $typeLabelRaw = trim($parts[1]);
+            $dynastyLabelRaw = trim($parts[2]);
+            $typeLabel = VariantLabelMap::normalizeLabel($typeLabelRaw, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_hz');
+            $dynastyLabel = VariantLabelMap::normalizeLabel($dynastyLabelRaw, 'DYNASTIES', 'c_dynasty_chn');
             $addrId = trim($parts[4]);
             $sourceId = trim($parts[5]);
 
@@ -200,6 +210,9 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
                 'name' => $name,
                 'type_label' => $typeLabel,
                 'dynasty_label' => $dynastyLabel,
+                // 保留使用者原輸入供錯誤訊息使用（查表用歸一後的值）。
+                'type_label_raw' => $typeLabelRaw,
+                'dynasty_label_raw' => $dynastyLabelRaw,
                 'addr_id' => (int) $addrId,
                 'source_id' => (int) $sourceId,
             ];
@@ -218,28 +231,24 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
      * @return array<string,int>
      */
     protected function getTypeMap(): array {
+        // 鍵已做異體字歸一（見 App\Support\VariantLabelMap）；碰撞取最小碼並記 warning。
         $records = DB::table('SOCIAL_INSTITUTION_TYPES')
             ->select('c_inst_type_code', 'c_inst_type_hz', 'c_inst_type_py')
             ->orderBy('c_inst_type_code')
             ->get();
 
-        $map = [];
-
+        $hzPairs = [];
+        $pyPairs = [];
         foreach ($records as $record) {
             $code = (int) $record->c_inst_type_code;
-            $hz = trim((string) ($record->c_inst_type_hz ?? ''));
-            $py = trim((string) ($record->c_inst_type_py ?? ''));
-
-            if ($hz !== '') {
-                $map[$hz] = $code;
-            }
-
-            if ($py !== '') {
-                $map[$py] = $code;
-            }
+            $hzPairs[] = [(string) ($record->c_inst_type_hz ?? ''), $code];
+            $pyPairs[] = [(string) ($record->c_inst_type_py ?? ''), $code];
         }
 
-        return $map;
+        [$hzMap] = VariantLabelMap::build($hzPairs, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_hz');
+        [$pyMap] = VariantLabelMap::build($pyPairs, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_py');
+
+        return $hzMap + $pyMap; // 漢字鍵優先
     }
 
     /**
@@ -248,13 +257,14 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
      * @return array<string,int>
      */
     protected function getDynastyMap(): array {
-        return DB::table('DYNASTIES')
+        // 鍵已做異體字歸一（見 App\Support\VariantLabelMap）；碰撞取最小碼並記 warning。
+        $pairs = DB::table('DYNASTIES')
             ->orderBy('c_dy')
-            ->pluck('c_dy', 'c_dynasty_chn')
-            ->mapWithKeys(function ($code, $label) {
-                return [trim((string) $label) => (int) $code];
-            })
-            ->toArray();
+            ->get(['c_dy', 'c_dynasty_chn'])
+            ->map(fn ($row) => [(string) ($row->c_dynasty_chn ?? ''), (int) $row->c_dy])
+            ->all();
+
+        return VariantLabelMap::build($pairs, 'DYNASTIES', 'c_dynasty_chn')[0];
     }
 
     /**
@@ -270,11 +280,13 @@ class AdminBatchLoadSocialInstitutesController extends Controller {
 
         foreach ($rows as $row) {
             if (!array_key_exists($row['type_label'], $typeMap)) {
-                $errors[] = "第 {$row['line']} 行找不到類型「{$row['type_label']}」對應的代碼";
+                $typeLabelForMessage = $row['type_label_raw'] ?? $row['type_label'];
+                $errors[] = "第 {$row['line']} 行找不到類型「{$typeLabelForMessage}」對應的代碼";
             }
 
             if (!array_key_exists($row['dynasty_label'], $dynastyMap)) {
-                $errors[] = "第 {$row['line']} 行找不到朝代「{$row['dynasty_label']}」對應的代碼";
+                $dynastyLabelForMessage = $row['dynasty_label_raw'] ?? $row['dynasty_label'];
+                $errors[] = "第 {$row['line']} 行找不到朝代「{$dynastyLabelForMessage}」對應的代碼";
             }
         }
 

--- a/app/Services/Import/Concerns/SharesImportHelpers.php
+++ b/app/Services/Import/Concerns/SharesImportHelpers.php
@@ -6,6 +6,7 @@ use App\Models\Operation;
 use App\Services\PinyinDictionary;
 use App\Support\CompositePrimaryKey;
 use App\Support\PinyinUmlaut;
+use App\Support\VariantLabelMap;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -17,13 +18,49 @@ use Illuminate\Support\Facades\DB;
  * 使用端須以建構子注入 $operationRepository（OperationRepository）與 $auditLogService（AuditLogService）。
  */
 trait SharesImportHelpers {
-    /** 朝代名→代碼對照。 */
+    /**
+     * dynastyMapAndCodes() 的 per-instance memo（見該方法註解）。
+     *
+     * @var array{0: array<string,int>, 1: array<int,int>}|null
+     */
+    protected ?array $dynastyMapMemo = null;
+
+    /**
+     * 朝代名→代碼對照。**鍵已做異體字歸一**（見 App\Support\VariantLabelMap 的長註解）：
+     * D6 不做回溯校正，既有 DYNASTIES 列的字面若是「淸」就永遠是「淸」，所以只歸一
+     * 傳入標籤查不到它；兩側都歸一才讓「表格寫淸／代碼表寫清」與反方向都命中。
+     *
+     * 歸一後鍵碰撞時取**最小**代碼（不是既有 last-wins 的最大者）並記 warning；
+     * 白名單檢查請改用 dynastyCodes()，否則會漏掉被碰撞吃掉的那個合法代碼。
+     */
     public function dynastyMap(): array {
-        return DB::table('DYNASTIES')
+        return $this->dynastyMapAndCodes()[0];
+    }
+
+    /** 全部合法朝代代碼（含標籤歸一後被碰撞吃掉的那些）。 */
+    public function dynastyCodes(): array {
+        return $this->dynastyMapAndCodes()[1];
+    }
+
+    /**
+     * @return array{0: array<string,int>, 1: array<int,int>}
+     *
+     * per-instance memo：dynastyMap() 與 dynastyCodes() 各自呼叫本方法，而單一 v2 請求
+     * 會同時用到兩者（驗證 + 白名單）⇒ 不 memo 就是每次一條 query、一次 build、
+     * 以及**重複的碰撞 warning**。同一請求內代碼表不會變，memo 安全。
+     */
+    protected function dynastyMapAndCodes(): array {
+        if ($this->dynastyMapMemo !== null) {
+            return $this->dynastyMapMemo;
+        }
+
+        $pairs = DB::table('DYNASTIES')
             ->orderBy('c_dy')
-            ->pluck('c_dy', 'c_dynasty_chn')
-            ->mapWithKeys(fn ($code, $label) => [trim((string) $label) => (int) $code])
-            ->toArray();
+            ->get(['c_dy', 'c_dynasty_chn'])
+            ->map(fn ($row) => [(string) ($row->c_dynasty_chn ?? ''), (int) $row->c_dy])
+            ->all();
+
+        return $this->dynastyMapMemo = VariantLabelMap::build($pairs, 'DYNASTIES', 'c_dynasty_chn');
     }
 
     /** 校驗來源 TEXT_ID 存在於 TEXT_CODES；回傳缺失的 id。 */

--- a/app/Services/Import/OfficeImportService.php
+++ b/app/Services/Import/OfficeImportService.php
@@ -4,6 +4,7 @@ namespace App\Services\Import;
 
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Services\CharVariantMapService;
 use App\Services\Import\Concerns\SharesImportHelpers;
 use Illuminate\Support\Facades\DB;
 
@@ -31,6 +32,14 @@ use Illuminate\Support\Facades\DB;
  */
 class OfficeImportService implements EntityAggregateService {
     use SharesImportHelpers;
+
+    /**
+     * 上一次 officeColumns() 實際套用的異體字替換（變體字 → 參考字）。
+     * 供批次匯入結果頁組 variant_replacements（比照書名匯入）。
+     *
+     * @var array<string,string|array<int,string>>
+     */
+    protected array $lastVariantReplaced = [];
 
     public function __construct(
         protected OperationRepository $operationRepository,
@@ -98,8 +107,30 @@ class OfficeImportService implements EntityAggregateService {
      * @param array{name:string,name_alt?:?string,translation?:?string,translation_alt?:?string,pinyin?:?string,pinyin_alt?:?string,dynasty_code:int,source_id:int,pages?:?string,notes?:?string} $input
      */
     protected function officeColumns(array $input): array {
-        $name = (string) $input['name'];
-        $nameAlt = (isset($input['name_alt']) && trim((string) $input['name_alt']) !== '') ? (string) $input['name_alt'] : null;
+        // 異體字落地替換。**必須早於 buildPinyin()**：拼音是從中文逐字派生的，而
+        // `pinyin.c_chn` 被排除在替換範圍外、異體字保有自己的讀音，所以先替換才會拿到
+        // 參考字的讀音——這正是想要的結果。
+        //
+        // 這裡用 replaceFor() 而不是 replaceRow()：$input 的鍵是輸入欄名（name／name_alt／
+        // notes／pages），不是 OFFICE_CODES 的欄位名，replaceRow() 會全部判成非文本欄而跳過。
+        $variantReplaced = [];
+        $replace = function (?string $value, string $column) use (&$variantReplaced): ?string {
+            if ($value === null || $value === '') {
+                return $value;
+            }
+            $result = CharVariantMapService::replaceFor('OFFICE_CODES', $column, $value);
+            $variantReplaced = CharVariantMapService::mergeReplaced($variantReplaced, $result['replaced']);
+
+            return $result['text'];
+        };
+
+        $name = (string) $replace((string) $input['name'], 'c_office_chn');
+        $nameAlt = (isset($input['name_alt']) && trim((string) $input['name_alt']) !== '')
+            ? $replace((string) $input['name_alt'], 'c_office_chn_alt')
+            : null;
+        $input['notes'] = $replace(isset($input['notes']) ? (string) $input['notes'] : null, 'c_notes');
+        $input['pages'] = $replace(isset($input['pages']) ? (string) $input['pages'] : null, 'c_pages');
+        $this->lastVariantReplaced = $variantReplaced;
 
         $pinyin = (isset($input['pinyin']) && trim((string) $input['pinyin']) !== '')
             ? (string) $input['pinyin']
@@ -155,6 +186,9 @@ class OfficeImportService implements EntityAggregateService {
             'type_ids' => $typeIds,
             'operation_id_office' => $officeOp?->id,
             'operation_id_rel' => $relOps[0]?->id ?? null,
+            // 實際落庫的中文名（可能已被異體字替換），與本次替換紀錄。
+            'name' => (string) $columns['c_office_chn'],
+            'variant_replaced' => $this->lastVariantReplaced,
         ];
     }
 
@@ -207,6 +241,9 @@ class OfficeImportService implements EntityAggregateService {
             'types_added' => $toAdd,
             'types_removed' => $toRemove,
             'operation_id_office' => $officeOp?->id,
+            // 與 create() 對稱：實際落庫的職名與本次替換紀錄（供呼叫端組 notices）。
+            'name' => (string) $after['c_office_chn'],
+            'variant_replaced' => $this->lastVariantReplaced,
         ];
     }
 

--- a/app/Services/Import/SocialInstituteImportService.php
+++ b/app/Services/Import/SocialInstituteImportService.php
@@ -4,7 +4,9 @@ namespace App\Services\Import;
 
 use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
+use App\Services\CharVariantMapService;
 use App\Services\Import\Concerns\SharesImportHelpers;
+use App\Support\VariantLabelMap;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -42,33 +44,78 @@ use Illuminate\Support\Facades\DB;
 class SocialInstituteImportService implements EntityAggregateService {
     use SharesImportHelpers;
 
+    /**
+     * 上一次寫入實際套用的異體字替換（變體字 → 參考字）。供批次匯入結果頁組
+     * variant_replacements（比照書名匯入）。
+     *
+     * @var array<string,string|array<int,string>>
+     */
+    protected array $lastVariantReplaced = [];
+
     public function __construct(
         protected OperationRepository $operationRepository,
         protected AuditLogService $auditLogService
     ) {
     }
 
-    /** 機構類型（中文名或拼音）→代碼對照。 */
+    /**
+     * typeMapAndCodes() 的 per-instance memo（見該方法註解）。
+     *
+     * @var array{0: array<string,int>, 1: array<int,int>}|null
+     */
+    protected ?array $typeMapMemo = null;
+
+    /**
+     * 機構類型（中文名或拼音）→代碼對照。**鍵已做異體字歸一**（見 VariantLabelMap）。
+     * 拼音鍵的歸一是恆等映射（對照表的鍵都是漢字），列入只是讓兩種鍵走同一條路。
+     *
+     * 白名單檢查請改用 typeCodes()：歸一後鍵碰撞時 map 只留最小碼，
+     * 拿 map 的值當白名單會讓另一個**完全合法**的代碼開始被判 invalid。
+     */
     public function typeMap(): array {
+        return $this->typeMapAndCodes()[0];
+    }
+
+    /** 全部合法機構類型代碼（含標籤歸一後被碰撞吃掉的那些）。 */
+    public function typeCodes(): array {
+        return $this->typeMapAndCodes()[1];
+    }
+
+    /**
+     * @return array{0: array<string,int>, 1: array<int,int>}
+     *
+     * per-instance memo：同一請求會同時用到 typeMap() 與 typeCodes()，不 memo 就會重複
+     * 查詢、重複 build、重複記碰撞 warning（見 SharesImportHelpers::dynastyMapAndCodes()）。
+     */
+    protected function typeMapAndCodes(): array {
+        if ($this->typeMapMemo !== null) {
+            return $this->typeMapMemo;
+        }
+
         $records = DB::table('SOCIAL_INSTITUTION_TYPES')
             ->select('c_inst_type_code', 'c_inst_type_hz', 'c_inst_type_py')
             ->orderBy('c_inst_type_code')
             ->get();
 
-        $map = [];
+        $hzPairs = [];
+        $pyPairs = [];
         foreach ($records as $record) {
             $code = (int) $record->c_inst_type_code;
-            $hz = trim((string) ($record->c_inst_type_hz ?? ''));
-            $py = trim((string) ($record->c_inst_type_py ?? ''));
-            if ($hz !== '') {
-                $map[$hz] = $code;
-            }
-            if ($py !== '') {
-                $map[$py] = $code;
-            }
+            $hzPairs[] = [(string) ($record->c_inst_type_hz ?? ''), $code];
+            $pyPairs[] = [(string) ($record->c_inst_type_py ?? ''), $code];
         }
 
-        return $map;
+        [$hzMap, $hzCodes] = VariantLabelMap::build($hzPairs, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_hz');
+        [$pyMap, $pyCodes] = VariantLabelMap::build($pyPairs, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_py');
+
+        // 白名單取**兩份的聯集**：schema 允許 c_inst_type_hz／c_inst_type_py 任一為 null，
+        // 舊 typeMap() 也是任一有值就收。只取 hz 那份會讓「只有拼音名」的合法類型碼
+        // 在 v2 的 type_code 驗證被錯判成 invalid（422）。
+        $codes = array_values(array_unique(array_merge($hzCodes, $pyCodes)));
+
+        // 漢字鍵優先（與舊碼「hz 先寫、py 後寫」的 last-wins 相反，但只有在同一字串
+        // 同時是某型的漢字名與另一型的拼音時才有差別，實務上不存在；明確取漢字優先）。
+        return $this->typeMapMemo = [$hzMap + $pyMap, $codes];
     }
 
     /** 校驗地址 ID 存在於 ADDR_CODES；回傳缺失的 id。 */
@@ -163,24 +210,100 @@ class SocialInstituteImportService implements EntityAggregateService {
      *
      * @return array{name_code:int,name_created:bool,name_pinyin:string,operation_id:?int}
      */
+    /**
+     * 這個名稱會解析到哪一個既有 name code（**唯讀**：不配號、不建列、不上鎖）。
+     *
+     * 供改名護欄判斷「這次儲存會不會真的換掉 c_inst_name_code」。
+     * 護欄不能只比字串：異體字歸一後字串相等不代表 code 不變（反方向——輸入參考形而
+     * 既有列是另一個變體形——resolveNameCode() 仍會新建一個 code，那正是護欄要擋的
+     * 「既存引用失配」）。
+     */
+    public function findExistingNameCode(string $name): ?int {
+        $row = $this->locateNameRow($name, false);
+
+        return $row === null ? null : (int) $row->c_inst_name_code;
+    }
+
+    /**
+     * 以「原輸入優先、落空才擴成兩形」定位既有 NAME_CODES 列。
+     *
+     * @param bool $lock 是否 lockForUpdate（寫入路徑要、唯讀探測不要）
+     */
+    protected function locateNameRow(string $name, bool $lock = true): ?object {
+        $referenceName = CharVariantMapService::replaceFor('SOCIAL_INSTITUTION_NAME_CODES', 'c_inst_name_hz', $name)['text'];
+        $candidates = array_values(array_unique([$name, $referenceName]));
+
+        $locate = function (array $names) use ($lock) {
+            $query = DB::table('SOCIAL_INSTITUTION_NAME_CODES')
+                ->whereIn('c_inst_name_hz', $names)
+                ->orderBy('c_inst_name_code');
+            if ($lock) {
+                $query->lockForUpdate();
+            }
+
+            return $query->first();
+        };
+
+        return $locate([$name]) ?: ($candidates === [$name] ? null : $locate($candidates));
+    }
+
     protected function resolveNameCode(string $name, int $actorPersonId): array {
+        // 異體字：**兩形都要探**（替換前的原輸入 + 替換後的參考形）。
+        //
+        // 只拿替換後的值查會製造新的分裂：既有列字面是「淸…」在 D6 之下永不改寫，
+        // 把匯入值正規化成「清…」會讓精確比對**錯過它本來會命中的那一列**，於是鑄出
+        // 第二個 name code——比不替換更糟。
+        //
+        // 由此產生一個**刻意的不對稱**：兩形都在時複用既有的變體形列，該列的
+        // c_inst_name_hz 仍是「淸…」、永不歸一，與 D7 第二類「觸碰即歸一」的語義相反。
+        // 這是為了不製造重複碼而接受的取捨（見 plan S4）。
+        $nameReplacement = CharVariantMapService::replaceFor('SOCIAL_INSTITUTION_NAME_CODES', 'c_inst_name_hz', $name);
+        $referenceName = $nameReplacement['text'];
+        $candidates = array_values(array_unique([$name, $referenceName]));
+
         // lockForUpdate 防兩個同新名的並發請求同時判定「不存在」而各建一列同碼 NAME_CODES；
         // MariaDB 生效，SQLite（測試）grammar 編譯為 no-op。
-        $existing = DB::table('SOCIAL_INSTITUTION_NAME_CODES')
-            ->where('c_inst_name_hz', $name)
-            ->orderBy('c_inst_name_code')
-            ->lockForUpdate()
-            ->first();
+        //
+        // ⚠️ 這道去重是**單向**的，明文記錄其邊界：只涵蓋「輸入是變體形、既有列是參考形」。
+        // 反方向（輸入參考形、既有列是**另一個**變體形）無法用精確比對命中——那需要列舉
+        // 輸入的所有「前像」（會組合爆炸，plan 明確否決）或在表上加一個歸一後的影子欄。
+        // 該情境會像 S4 之前一樣新建一個名稱碼；不是本步造成的回歸，但也沒被本步修好。
+        //
+        // **先精確探原輸入、落空才擴成兩形**：庫裡可能同時有兩形（D6 不自動合併），
+        // 若直接 whereIn + 最小碼優先，輸入「清溪書院」時會被字面不同的「淸溪書院」
+        // （較小的碼）搶走，機構被掛到另一個既有名稱碼上。精確字面優先才符合直覺，
+        // 且兩形都在時的選擇仍是確定的（orderBy c_inst_name_code ＝最小碼優先）。
+        $existing = $this->locateNameRow($name);
 
         if ($existing) {
+            $existingName = (string) ($existing->c_inst_name_hz ?? $name);
+
+            // 命中的既有列必然是「輸入本身」或「輸入的參考形」之一（候選集就這兩個值）。
+            // 後者代表真的發生了字元替換（輸入變體形 → 用既有的參考形列），記進 replaced
+            // 讓使用者看到「淸→清」；否則字面完全相同、什麼都沒變。
+            if ($existingName !== $name) {
+                $this->lastVariantReplaced = CharVariantMapService::mergeReplaced(
+                    $this->lastVariantReplaced,
+                    $nameReplacement['replaced']
+                );
+            }
+
             return [
                 'name_code' => (int) $existing->c_inst_name_code,
                 'name_created' => false,
                 'name_pinyin' => (string) ($existing->c_inst_name_py ?? ''),
                 'operation_id' => null,
+                // 複用既有列：回傳它的**原字面**（可能是變體形，刻意不歸一）。
+                'name_hz' => $existingName,
             ];
         }
 
+        // 新建：這一筆是真的把使用者輸入歸一後落庫，所以替換紀錄要進 notices／結果頁。
+        $this->lastVariantReplaced = CharVariantMapService::mergeReplaced($this->lastVariantReplaced, $nameReplacement['replaced']);
+
+        // 新建時用**參考形**（拼音也從參考形派生：pinyin.c_chn 被排除在替換範圍外、
+        // 異體字保有自己讀音，所以要先替換才拿到參考字的讀音）。
+        $name = $referenceName;
         $nameCode = $this->allocateNextId('SOCIAL_INSTITUTION_NAME_CODES', 'c_inst_name_code');
         $namePinyin = $this->buildPinyin($name);
         $payload = [
@@ -196,7 +319,24 @@ class SocialInstituteImportService implements EntityAggregateService {
             'name_created' => true,
             'name_pinyin' => $namePinyin,
             'operation_id' => $op?->id,
+            'name_hz' => $name, // 新建：參考形
         ];
+    }
+
+    /**
+     * SOCIAL_INSTITUTION_ADDR 的文本欄落地替換（lenient），並把紀錄併進本次累積器。
+     *
+     * @param mixed $value
+     */
+    protected function replaceAddrText($value, string $column): ?string {
+        if ($value === null || $value === '') {
+            return $value === '' ? '' : null;
+        }
+
+        $result = CharVariantMapService::replaceFor('SOCIAL_INSTITUTION_ADDR', $column, (string) $value);
+        $this->lastVariantReplaced = CharVariantMapService::mergeReplaced($this->lastVariantReplaced, $result['replaced']);
+
+        return $result['text'];
     }
 
     /**
@@ -209,7 +349,17 @@ class SocialInstituteImportService implements EntityAggregateService {
      */
     protected function codeColumns(array $input): array {
         $int = fn ($v) => (isset($v) && $v !== '' && $v !== null) ? (int) $v : null;
-        $str = fn ($v) => (isset($v) && $v !== '' && $v !== null) ? (string) $v : null;
+        // 文本欄同樣過落地替換（lenient）。用 replaceFor() 而非 replaceRow()：$input 的鍵是
+        // 輸入欄名（pages／notes），不是 SOCIAL_INSTITUTION_CODES 的欄位名。
+        $str = function ($v, string $column) {
+            if (!isset($v) || $v === '' || $v === null) {
+                return null;
+            }
+            $result = CharVariantMapService::replaceFor('SOCIAL_INSTITUTION_CODES', $column, (string) $v);
+            $this->lastVariantReplaced = CharVariantMapService::mergeReplaced($this->lastVariantReplaced, $result['replaced']);
+
+            return $result['text'];
+        };
 
         return [
             'c_inst_type_code' => (int) $input['type_code'],
@@ -227,8 +377,8 @@ class SocialInstituteImportService implements EntityAggregateService {
             'c_inst_end_dy' => $int($input['end_dy'] ?? null),
             'c_inst_last_known_year' => $int($input['last_known_year'] ?? null),
             'c_source' => (int) $input['source_id'],
-            'c_pages' => $str($input['pages'] ?? null),
-            'c_notes' => $str($input['notes'] ?? null),
+            'c_pages' => $str($input['pages'] ?? null, 'c_pages'),
+            'c_notes' => $str($input['notes'] ?? null, 'c_notes'),
         ];
     }
 
@@ -242,6 +392,9 @@ class SocialInstituteImportService implements EntityAggregateService {
      * }
      */
     public function create(array $input, int $actorPersonId = 0): array {
+        // 批次匯入是同一個 service 實例逐列呼叫；不重置會把上一列的替換紀錄
+        // 帶到下一列的結果頁（本累積器由 codeColumns()／resolveNameCode() 以 merge 寫入）。
+        $this->lastVariantReplaced = [];
         $name = $input['name'];
 
         // 名稱去重：同名已存在則複用碼、不新增 NAME_CODES（見 resolveNameCode）。
@@ -293,6 +446,10 @@ class SocialInstituteImportService implements EntityAggregateService {
             'operation_id_name' => $resolved['operation_id'],
             'operation_id_code' => $codeOp?->id,
             'operation_id_addr' => $addrOp?->id,
+            // 實際生效的機構名（複用既有碼時是既有列的字面——**刻意不歸一**，見 resolveNameCode()）
+            // 與本次替換紀錄。
+            'name' => $resolved['name_hz'],
+            'variant_replaced' => $this->lastVariantReplaced,
         ];
     }
 
@@ -311,6 +468,9 @@ class SocialInstituteImportService implements EntityAggregateService {
      * @return array{inst_code:int,name_code:int,name_changed:bool,addr_added:int,addr_removed:int,operation_id_code:?int}
      */
     public function update(int $instCode, array $input, int $actorPersonId = 0): array {
+        // 批次匯入是同一個 service 實例逐列呼叫；不重置會把上一列的替換紀錄
+        // 帶到下一列的結果頁（本累積器由 codeColumns()／resolveNameCode() 以 merge 寫入）。
+        $this->lastVariantReplaced = [];
         $before = (array) DB::table('SOCIAL_INSTITUTION_CODES')->where('c_inst_code', $instCode)->lockForUpdate()->first();
         $oldNameCode = (int) $before['c_inst_name_code'];
 
@@ -391,8 +551,10 @@ class SocialInstituteImportService implements EntityAggregateService {
             'inst_xcoord' => $r['xcoord'],
             'inst_ycoord' => $r['ycoord'],
             'c_source' => $r['source_id'],
-            'c_pages' => $r['pages'],
-            'c_notes' => $r['notes'],
+            // 這兩欄同樣在落地替換範圍內（SOCIAL_INSTITUTION_ADDR 是已知表、兩欄都是文本型）。
+            // 漏掉會讓同一次 update 裡機構層的 c_notes 被歸一、地址列的 c_notes 原樣入庫。
+            'c_pages' => $this->replaceAddrText($r['pages'], 'c_pages'),
+            'c_notes' => $this->replaceAddrText($r['notes'], 'c_notes'),
         ];
         // reconcileRowSet：同鍵改非鍵值（起訖年、來源、頁碼、備註）、僅增刪差異。
         $result = $this->reconcileRowSet(
@@ -409,6 +571,10 @@ class SocialInstituteImportService implements EntityAggregateService {
             'inst_code' => $instCode,
             'name_code' => $nameCode,
             'name_changed' => $nameChanged,
+            // 與 create() 對稱：實際生效的名稱字面（複用既有碼時是既有列的原字面）
+            // 與本次替換紀錄（供呼叫端組 notices／結果頁）。
+            'name' => $resolved['name_hz'],
+            'variant_replaced' => $this->lastVariantReplaced,
             'addr_added' => $result['added'],
             'addr_removed' => $result['removed'],
             'operation_id_code' => $codeOp?->id,

--- a/app/Services/Mutations/Concerns/ResolvesOfficeAggregateInput.php
+++ b/app/Services/Mutations/Concerns/ResolvesOfficeAggregateInput.php
@@ -3,6 +3,7 @@
 namespace App\Services\Mutations\Concerns;
 
 use App\Services\Import\OfficeImportService;
+use App\Support\VariantLabelMap;
 
 /**
  * 「官職實體」聚合寫入的共用輸入解析與欄位校驗，供 create／update handler 共用，
@@ -55,11 +56,13 @@ trait ResolvesOfficeAggregateInput {
 
         // 朝代：給碼（dynasty_code/c_dy）優先；否則以朝代名（dynasty_label）解析。
         $dynastyMap = $service->dynastyMap();
+        $dynastyCodes = $service->dynastyCodes();
         $dynastyCode = $this->scalarOrNull($changes['dynasty_code'] ?? $changes['c_dy'] ?? null);
         $dynastyLabelError = false;
         if (($dynastyCode === null || $dynastyCode === '') && isset($changes['dynasty_label'])) {
             $label = trim((string) ($this->scalarOrNull($changes['dynasty_label']) ?? ''));
-            $dynastyCode = $dynastyMap[$label] ?? null;
+            // map 的鍵已歸一，傳入標籤也要歸一，兩個方向才都命中（見 VariantLabelMap）。
+            $dynastyCode = VariantLabelMap::lookup($dynastyMap, $label, 'DYNASTIES', 'c_dynasty_chn');
             if ($dynastyCode === null) {
                 $dynastyLabelError = true;
             }
@@ -74,7 +77,9 @@ trait ResolvesOfficeAggregateInput {
         if ($name === '') {
             $errors['name'] = ['required'];
         }
-        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyMap, true)) {
+        // 白名單用 dynastyCodes() 而不是 map 的值：標籤歸一後鍵碰撞時 map 只留最小碼，
+        // 拿 map 當白名單會讓另一個完全合法的 c_dy 開始被判 invalid。
+        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyCodes, true)) {
             $errors['dynasty'] = ['invalid'];
         }
         if ($typeIds === []) {

--- a/app/Services/Mutations/Concerns/ResolvesSocialInstituteAggregateInput.php
+++ b/app/Services/Mutations/Concerns/ResolvesSocialInstituteAggregateInput.php
@@ -25,15 +25,17 @@ trait ResolvesSocialInstituteAggregateInput {
             $errors['name'] = ['required'];
         }
 
-        $typeMap = $service->typeMap();
+        // 白名單一律用 *Codes()：標籤歸一後鍵碰撞時 map 只留最小碼，
+        // 拿 map 的值當白名單會讓另一個完全合法的代碼開始被判 invalid。
+        $dynastyCodes = $service->dynastyCodes();
+
         $typeCode = $this->scalarOrNull($changes['type_code'] ?? $changes['c_inst_type_code'] ?? null);
-        if ($typeCode === null || $typeCode === '' || !in_array((int) $typeCode, $typeMap, true)) {
+        if ($typeCode === null || $typeCode === '' || !in_array((int) $typeCode, $service->typeCodes(), true)) {
             $errors['type'] = ['invalid'];
         }
 
-        $dynastyMap = $service->dynastyMap();
         $dynastyCode = $this->scalarOrNull($changes['dynasty_code'] ?? $changes['c_inst_begin_dy'] ?? null);
-        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyMap, true)) {
+        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyCodes, true)) {
             $errors['dynasty'] = ['invalid'];
         }
 
@@ -90,7 +92,7 @@ trait ResolvesSocialInstituteAggregateInput {
         // 參照表存在性（僅對給值欄）：朝代／年號／year range 皆為 CASCADE 外鍵目標，寫入不存在
         // 的碼會直接 FK 失敗，這裡先以 422 擋下並給欄位級錯誤。
         foreach (['floruit_dy', 'end_dy'] as $k) {
-            if ($input[$k] !== null && !in_array($input[$k], $dynastyMap, true)) {
+            if ($input[$k] !== null && !in_array((int) $input[$k], $dynastyCodes, true)) {
                 $errors[$k] = ['invalid'];
             }
         }

--- a/app/Services/Mutations/EntityAggregate/AbstractEntityAggregateHandler.php
+++ b/app/Services/Mutations/EntityAggregate/AbstractEntityAggregateHandler.php
@@ -4,6 +4,7 @@ namespace App\Services\Mutations\EntityAggregate;
 
 use App\Models\Operation;
 use App\Repositories\OperationRepository;
+use App\Services\CharVariantMapService;
 use App\Services\Mutations\AbstractMutationHandler;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
@@ -117,12 +118,31 @@ abstract class AbstractEntityAggregateHandler extends AbstractMutationHandler {
      * @param array<string, mixed> $result
      */
     protected function envelope(string $resource, string $operation, array $result): JsonResponse {
-        return response()->json([
+        // 異體字落地替換的通知：definition 的 result() 以內部鍵 __variant_replaced 帶上來，
+        // 這裡剝掉它並掛成回應層的 notices（對齊人物子資源 handler）。
+        // 沒有這一步，v2／React 使用者的字被靜默改寫而毫無提示——批次匯入使用者反而看得到。
+        $replaced = $result['__variant_replaced'] ?? [];
+        // __notices：不是「字元替換」但仍需告知使用者的訊息（例如名稱被併入既有的另一個
+        // 字形——那個方向不是正規化，記成 replaced 會謊稱「已正規化」且箭頭反向）。
+        $extraNotices = $result['__notices'] ?? [];
+        unset($result['__variant_replaced'], $result['__notices']);
+
+        $payload = [
             'ok' => true,
             'resource' => $resource,
             'mode' => 'direct',
             'operation' => $operation,
             'result' => $result,
-        ]);
+        ];
+
+        $notices = array_merge(
+            CharVariantMapService::buildNotices(is_array($replaced) ? $replaced : []),
+            array_values(array_filter(is_array($extraNotices) ? $extraNotices : [], 'is_string'))
+        );
+        if ($notices !== []) {
+            $payload['notices'] = $notices;
+        }
+
+        return response()->json($payload);
     }
 }

--- a/app/Services/Mutations/EntityAggregate/OfficeAggregateDefinition.php
+++ b/app/Services/Mutations/EntityAggregate/OfficeAggregateDefinition.php
@@ -68,9 +68,12 @@ class OfficeAggregateDefinition extends AbstractEntityAggregateDefinition {
                 'pk' => ['c_office_id' => $serviceResult['office_id']],
                 'status' => 'created',
                 'operation_id' => $serviceResult['operation_id_office'],
+                // 回應必須回**落庫值**：異體字替換發生在 service 內，回 $input['name'] 會讓
+                // 前端畫面與資料庫不一致（而且使用者不知道字被改過）。
+                '__variant_replaced' => $serviceResult['variant_replaced'] ?? [],
                 'row' => [
                     'c_office_id' => $serviceResult['office_id'],
-                    'c_office_chn' => $input['name'],
+                    'c_office_chn' => $serviceResult['name'] ?? $input['name'],
                     'c_office_pinyin' => $serviceResult['pinyin'],
                     'type_ids' => $serviceResult['type_ids'],
                 ],
@@ -84,9 +87,10 @@ class OfficeAggregateDefinition extends AbstractEntityAggregateDefinition {
                 'operation_id' => $serviceResult['operation_id_office'],
                 'types_added' => $serviceResult['types_added'],
                 'types_removed' => $serviceResult['types_removed'],
+                '__variant_replaced' => $serviceResult['variant_replaced'] ?? [],
                 'row' => [
                     'c_office_id' => $id,
-                    'c_office_chn' => $input['name'],
+                    'c_office_chn' => $serviceResult['name'] ?? $input['name'],
                     'c_office_pinyin' => $serviceResult['pinyin'],
                     'type_ids' => $serviceResult['type_ids'],
                 ],

--- a/app/Services/Mutations/EntityAggregate/SocialInstitutionAggregateDefinition.php
+++ b/app/Services/Mutations/EntityAggregate/SocialInstitutionAggregateDefinition.php
@@ -5,6 +5,7 @@ namespace App\Services\Mutations\EntityAggregate;
 use App\Services\Import\EntityAggregateService;
 use App\Services\Import\SocialInstituteImportService;
 use App\Services\Mutations\Concerns\ResolvesSocialInstituteAggregateInput;
+use App\Support\VariantLabelMap;
 
 /**
  * 「社會機構實體」的聚合定義（resource=social-institution）：收斂原 SocialInstituteImportHandler／
@@ -63,20 +64,23 @@ class SocialInstitutionAggregateDefinition extends AbstractEntityAggregateDefini
         $sourceId = $this->scalarOrNull($changes['source_id'] ?? $changes['c_source'] ?? null);
 
         $typeMap = $this->instService->typeMap();
+        $typeCodes = $this->instService->typeCodes();
         $typeCode = $this->scalarOrNull($changes['type_code'] ?? $changes['c_inst_type_code'] ?? null);
         if (($typeCode === null || $typeCode === '') && isset($changes['type_label'])) {
             $label = trim((string) ($this->scalarOrNull($changes['type_label']) ?? ''));
-            $typeCode = $typeMap[$label] ?? null;
+            // map 的鍵已歸一，傳入標籤也要歸一（見 VariantLabelMap）。
+            $typeCode = VariantLabelMap::lookup($typeMap, $label, 'SOCIAL_INSTITUTION_TYPES', 'c_inst_type_hz');
             if ($typeCode === null) {
                 return [['type_label' => ['not_found']], []];
             }
         }
 
         $dynastyMap = $this->instService->dynastyMap();
+        $dynastyCodes = $this->instService->dynastyCodes();
         $dynastyCode = $this->scalarOrNull($changes['dynasty_code'] ?? $changes['c_inst_begin_dy'] ?? null);
         if (($dynastyCode === null || $dynastyCode === '') && isset($changes['dynasty_label'])) {
             $label = trim((string) ($this->scalarOrNull($changes['dynasty_label']) ?? ''));
-            $dynastyCode = $dynastyMap[$label] ?? null;
+            $dynastyCode = VariantLabelMap::lookup($dynastyMap, $label, 'DYNASTIES', 'c_dynasty_chn');
             if ($dynastyCode === null) {
                 return [['dynasty_label' => ['not_found']], []];
             }
@@ -86,10 +90,10 @@ class SocialInstitutionAggregateDefinition extends AbstractEntityAggregateDefini
         if ($name === '') {
             $errors['name'] = ['required'];
         }
-        if ($typeCode === null || $typeCode === '' || !in_array((int) $typeCode, $typeMap, true)) {
+        if ($typeCode === null || $typeCode === '' || !in_array((int) $typeCode, $typeCodes, true)) {
             $errors['type'] = ['invalid'];
         }
-        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyMap, true)) {
+        if ($dynastyCode === null || $dynastyCode === '' || !in_array((int) $dynastyCode, $dynastyCodes, true)) {
             $errors['dynasty'] = ['invalid'];
         }
         if ($addrId === null || $addrId === '' || !ctype_digit((string) $addrId)) {
@@ -115,8 +119,34 @@ class SocialInstitutionAggregateDefinition extends AbstractEntityAggregateDefini
         ]];
     }
 
+    /**
+     * 這次儲存會不會換掉 c_inst_name_code（唯讀探測，不配號也不建列）。
+     *
+     * @param array<string,mixed> $input
+     * @param array<string,mixed> $existing
+     */
+    protected function nameCodeWouldChange(array $input, array $existing): bool {
+        $name = (string) ($input['name'] ?? '');
+        if ($name === '') {
+            return false;
+        }
+
+        $resolved = $this->instService->findExistingNameCode($name);
+
+        // 解析不到既有列 ⇒ 儲存時會新建一個 code ⇒ 就是改名。
+        return $resolved === null || $resolved !== (int) ($existing['name_code'] ?? 0);
+    }
+
     public function guardWrite(string $operation, ?int $id, array $input, ?array $existing): ?array {
-        if ($operation === 'update' && $existing !== null && ($input['name'] ?? null) !== ($existing['name'] ?? null)) {
+        // 護欄要問的是「這次儲存會不會真的換掉 c_inst_name_code」，所以直接問 resolver，
+        // 不做字串比對：
+        //  - 純字串相等會把「只換字形」（resolveNameCode 兩形都探 ⇒ 同一個 code）誤報成
+        //    rename_blocked_while_referenced（409），那其實是 no-op；
+        //  - 反過來，只比「歸一後字串」又會漏掉反方向——輸入參考形而既有列是另一個變體形時，
+        //    歸一後兩邊看起來相同，但 resolveNameCode() 會**新建**一個 code，那正是護欄
+        //    要擋的「既存引用失配」。
+        if ($operation === 'update' && $existing !== null
+            && $this->nameCodeWouldChange($input, $existing)) {
             // 改名護欄：名稱改變且仍被人物資料引用時擋下（其餘欄位可正常修改）。
             $refCount = $this->instService->referenceCount((int) $id);
             if ($refCount > 0) {
@@ -149,10 +179,13 @@ class SocialInstitutionAggregateDefinition extends AbstractEntityAggregateDefini
                 'status' => 'created',
                 'operation_id' => $serviceResult['operation_id_code'],
                 'name_created' => $serviceResult['name_created'],
+                // 回應必須回**實際生效**的名稱：新建時是歸一後的參考形，複用既有碼時是既有
+                // 列的原字面（刻意不歸一）。回 $input['name'] 會與資料庫不一致。
+                '__variant_replaced' => $serviceResult['variant_replaced'] ?? [],
                 'row' => [
                     'c_inst_code' => $serviceResult['inst_code'],
                     'c_inst_name_code' => $serviceResult['name_code'],
-                    'c_inst_name_hz' => $input['name'],
+                    'c_inst_name_hz' => $serviceResult['name'] ?? $input['name'],
                     'c_inst_name_py' => $serviceResult['name_pinyin'],
                     'c_inst_type_code' => (int) $input['type_code'],
                     'c_inst_addr_id' => (int) $input['addr_id'],
@@ -168,10 +201,11 @@ class SocialInstitutionAggregateDefinition extends AbstractEntityAggregateDefini
                 'name_changed' => $serviceResult['name_changed'],
                 'addr_added' => $serviceResult['addr_added'],
                 'addr_removed' => $serviceResult['addr_removed'],
+                '__variant_replaced' => $serviceResult['variant_replaced'] ?? [],
                 'row' => [
                     'c_inst_code' => $id,
                     'c_inst_name_code' => $serviceResult['name_code'],
-                    'c_inst_name_hz' => $input['name'],
+                    'c_inst_name_hz' => $serviceResult['name'] ?? $input['name'],
                     'c_inst_type_code' => $input['type_code'],
                 ],
             ];

--- a/app/Services/PostingAutofillService.php
+++ b/app/Services/PostingAutofillService.php
@@ -844,9 +844,17 @@ class PostingAutofillService {
      */
     protected function fuzzyMatchOffice(string $officeName, ?int $dynastyCode = null, ?string $adminType = null): ?array {
         // ========== Step 1: 精確匹配 c_office_chn ==========
+        // 異體字：S4 之後新寫入的 OFFICE_CODES.c_office_chn 是歸一後的參考形，而 LLM 從
+        // 文本抽出的官名可能是變體形 ⇒ 純精確比對會落空、退成 Step 3 的模糊匹配（match_type
+        // 由 exact 降成 fuzzy）或整個失敗。把參考形一併納入候選；原輸入仍優先。
+        $reference = CharVariantMapService::replaceFor('OFFICE_CODES', 'c_office_chn', $officeName)['text'];
+        $exactNames = $reference === $officeName ? [$officeName] : [$officeName, $reference];
+
         $query = DB::table('OFFICE_CODES')
             ->select('c_office_id as id', 'c_office_chn as text')
-            ->where('c_office_chn', '=', $officeName);
+            ->whereIn('c_office_chn', $exactNames)
+            // 原輸入的字面優先（同時命中兩形時不要隨機挑）。
+            ->orderByRaw('CASE WHEN c_office_chn = ? THEN 0 ELSE 1 END', [$officeName]);
 
         if ($dynastyCode !== null) {
             $query->where('c_dy', '=', $dynastyCode);
@@ -1451,17 +1459,40 @@ class PostingAutofillService {
      * @return int|null 解析出的 c_nianhao_id；無法確定時回傳 null
      */
     protected function resolveNianhaoId(string $name, ?int $dynasty, ?int $yearHint): ?int {
-        $query = DB::table('NIAN_HAO')->where('c_nianhao_chn', $name);
-        if ($dynasty !== null) {
-            $query->where('c_dy', $dynasty);
-        }
-        $candidates = $query->get(['c_nianhao_id', 'c_firstyear', 'c_lastyear']);
+        // 異體字：**先精確探原輸入、落空才擴成兩形**。
+        //
+        // 不能一開始就 whereIn 兩形：庫裡若同時有變體形與參考形兩列（D6 不自動合併），
+        // 候選會從 1 筆變 2 筆，而本方法在「候選 >1 且無法用年份消歧」時是直接回 null
+        // （改由呼叫端轉 suggested）⇒ 原本 exact 命中的年號會靜默降級成「無法確定」。
+        // 先精確、落空才擴，既修好「代碼表寫另一形」的情況，也不動原本會命中的路徑。
+        $reference = CharVariantMapService::replaceFor('NIAN_HAO', 'c_nianhao_chn', $name)['text'];
+        $nameSets = $reference === $name ? [[$name]] : [[$name], [$name, $reference]];
 
-        if ($candidates->isEmpty() && $dynasty !== null) {
-            // 按朝代過濾找不到時，退而不限朝代重試（沿用既有行為）。
-            $candidates = DB::table('NIAN_HAO')
-                ->where('c_nianhao_chn', $name)
-                ->get(['c_nianhao_id', 'c_firstyear', 'c_lastyear']);
+        // 探測順序：**先把所有名稱候選在指定朝代內試完，全落空才放寬朝代**。
+        //
+        // 不能在每一輪名稱候選裡就先做「不限朝代」的 fallback：那會讓「原字形在別的朝代有一筆、
+        // 參考形在指定朝代有一筆」的情況回傳**別的朝代**那一筆，而指定朝代明明有等價形可用。
+        // 朝代條件比字形條件更該被尊重。
+        $probe = function (array $names, bool $withDynasty) use ($dynasty) {
+            $query = DB::table('NIAN_HAO')->whereIn('c_nianhao_chn', $names);
+            if ($withDynasty && $dynasty !== null) {
+                $query->where('c_dy', $dynasty);
+            }
+
+            return $query->get(['c_nianhao_id', 'c_firstyear', 'c_lastyear']);
+        };
+
+        $candidates = collect();
+        foreach ([true, false] as $withDynasty) {
+            if (!$withDynasty && $dynasty === null) {
+                break; // 沒有朝代條件時第二輪與第一輪相同，不必重跑
+            }
+            foreach ($nameSets as $names) {
+                $candidates = $probe($names, $withDynasty);
+                if ($candidates->isNotEmpty()) {
+                    break 2;
+                }
+            }
         }
 
         if ($candidates->count() === 1) {

--- a/app/Support/VariantLabelMap.php
+++ b/app/Support/VariantLabelMap.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Support;
+
+use App\Services\CharVariantMapService;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 「標籤 → 代碼」對照表的異體字歸一（見 docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md S4）。
+ *
+ * 為什麼**兩側都要**歸一：
+ * - 只歸一傳入標籤不夠。D6 不做回溯校正，既有 `DYNASTIES` 列的字面若是「淸」就永遠是
+ *   「淸」；而使用者輸入「清」本來就是參考字、替換後不變 ⇒ 照樣查不到。
+ * - 只歸一代碼表那側也不夠：使用者輸入「淸」而代碼表寫「清」時同樣落空。
+ * 所以 map 的鍵在記憶體內歸一（不改資料庫）、查表前也把傳入標籤歸一，兩個方向才都命中。
+ *
+ * **鍵碰撞的處理是這個類別存在的主要理由**：這些 map 的值同時被當成「合法代碼白名單」
+ * （`in_array((int) $code, $map, true)`）。歸一後若兩列的鍵塌成一個，被丟掉那個
+ * `c_dy`／`c_inst_type_code` 就會從白名單消失，**一個完全合法的代碼開始被判 invalid**。
+ * 所以 `build()` 回傳兩份東西：
+ *   1. `label => code` 的純量 map（碰撞時**確定性取最小碼**並記 warning）——呼叫端形狀不變；
+ *   2. **扁平的合法代碼集合**——白名單檢查改讀它，不再因為鍵碰撞而漏掉合法碼。
+ *
+ * 注意：不能沿用「`mapWithKeys` + `orderBy` asc 的 last-wins」，那是取**最大**者，與這裡
+ * 明訂的「取最小」相反。
+ */
+class VariantLabelMap {
+    /**
+     * 從 (標籤, 代碼) 序對建出歸一後的 map 與合法代碼集合。
+     *
+     * 刻意接受 (標籤, 代碼) 序對而不是既有的 keyed map：keyed map 早在 `pluck()` 那一步
+     * 就把「字面完全相同的標籤」塌掉了，用它建 `allCodes` 會連那種情況都漏掉代碼。
+     *
+     * @param iterable<int,array{0: mixed, 1: mixed}> $pairs [標籤, 代碼]
+     * @param string $table 標籤欄所屬的表（決定替換模式）
+     * @param string $column 標籤欄
+     * @return array{0: array<string,int>, 1: array<int,int>} [歸一標籤 => 最小代碼, 全部合法代碼]
+     */
+    public static function build(iterable $pairs, string $table, string $column): array {
+        $map = [];
+        $allCodes = [];
+
+        $rawLabels = [];
+
+        foreach ($pairs as $pair) {
+            $label = trim((string) ($pair[0] ?? ''));
+            $code = (int) ($pair[1] ?? 0);
+
+            // 標籤為空的列**不進白名單**：白名單的用途只是「不要因為歸一造成的鍵碰撞而
+            // 漏掉合法代碼」，而碰撞的雙方都必然有標籤。把無標籤列（含 c_dy 為 NULL 被折成
+            // 0 的佔位列）也算進去，等於放寬了原本「map 的值」那組白名單，會讓
+            // dynasty_code=0／佔位碼從被擋變成通過。
+            if ($label === '') {
+                continue;
+            }
+
+            $key = self::normalizeLabel($label, $table, $column);
+            if ($key === '') {
+                continue;
+            }
+
+            $allCodes[$code] = true;
+
+            if (!array_key_exists($key, $map)) {
+                $map[$key] = $code;
+                $rawLabels[$key] = $label;
+
+                continue;
+            }
+
+            if ($map[$key] === $code) {
+                continue;
+            }
+
+            // 只有「原始標籤互不相同」才是歸一造成的碰撞，值得 warning。字面完全相同的
+            // 重複標籤是既有資料問題、舊碼一直靜默 last-wins，不該因為這次改動開始刷 log。
+            if (($rawLabels[$key] ?? null) !== $label) {
+                Log::warning('標籤歸一後碰撞，取最小代碼', [
+                    'table' => $table,
+                    'column' => $column,
+                    'normalized_label' => $key,
+                    'codes' => [$map[$key], $code],
+                ]);
+            }
+
+            $map[$key] = min($map[$key], $code);
+            if ($map[$key] === $code) {
+                $rawLabels[$key] = $label;
+            }
+        }
+
+        return [$map, array_values(array_map('intval', array_keys($allCodes)))];
+    }
+
+    /** 查表前把傳入標籤做同樣的歸一（`trim` 後替換，與 `build()` 的鍵一致）。 */
+    public static function normalizeLabel(string $label, string $table, string $column): string {
+        return trim(CharVariantMapService::replaceFor($table, $column, trim($label))['text']);
+    }
+
+    /**
+     * 以歸一後的標籤查 map。
+     *
+     * @param array<string,int> $map 由 `build()` 產生（鍵已歸一）
+     */
+    public static function lookup(array $map, string $label, string $table, string $column): ?int {
+        $key = self::normalizeLabel($label, $table, $column);
+
+        return $map[$key] ?? null;
+    }
+}

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -417,6 +417,61 @@ D3 已內嵌一份已查證的代碼鍵清單，直接進排除常數。本步�
 - 批次匯入結果頁補 `variant_replacements`，比照書名匯入。
 - 測試：`AdminBatchLoadOfficesTest`／`AdminBatchLoadSocialInstitutesTest` 補——(a) 表格寫「淸」、代碼表「清」→ 成功；(b) 表格寫「清」、代碼表「淸」→ 成功（前一版會漏的方向）；(c) 代碼表同時有兩形 → 有 warning 且**兩個代碼都仍可用**；(d) **既有 name code 是「淸…」、匯入「淸…」→ 複用既有碼、不新建，且該列名稱文本保持「淸…」原形**（鎖住上面那個刻意的不對稱）；(e) 兩列分別寫「淸」「清」的同一機構名 → 收斂到同一個碼。
 
+#### S4 執行結果補記
+
+計畫列的項目都做了（`VariantLabelMap` 兩側歸一 + 碰撞取最小碼 + 扁平白名單、5 個 map builder、
+5 個 lookup site、`officeColumns()` 早於 `buildPinyin()`、`resolveNameCode()` 兩形都探、
+批次結果頁 `variant_replacements`）。review 另外找出九項計畫沒列到的問題，一併修在本步：
+
+1. **v2／React 路徑回傳的是使用者原輸入、且完全沒有 notices**。`OfficeAggregateDefinition`／
+   `SocialInstitutionAggregateDefinition` 的 `result()` 用 `$input['name']` 組回應 ⇒ DB 寫參考形、
+   回應回變體形，React 編輯器儲存後畫面與資料庫不一致，使用者也不知道字被改過（批次匯入使用者
+   反而看得到提示）。改為回 `$serviceResult['name']`，並以內部鍵 `__variant_replaced` 讓
+   `AbstractEntityAggregateHandler::envelope()` 掛上 notices。
+2. **`SOCIAL_INSTITUTION_ADDR.c_pages`／`c_notes` 漏替換**：同一次 update 裡機構層的 `c_notes`
+   被歸一、地址列的原樣入庫。這兩欄同樣是已知表的文本欄，本來就在範圍內。
+3. **`VariantReplaceScope`／白名單語義不可順手放寬**：`allCodes` 只收「有標籤」的列。原本連
+   無標籤列（含 `c_dy` 為 NULL 被折成 0 的佔位列）也收，等於讓 `dynasty_code=0` 從被擋變成通過。
+4. **碰撞 warning 只在「原始標籤互不相同」時記**：否則庫裡本來就有的重複字面（舊碼一直靜默
+   last-wins）會開始每次建 map 就刷一行。另外 `dynastyMapAndCodes()`／`typeMapAndCodes()` 加
+   per-instance memo——同一請求會同時用到 `*Map()` 與 `*Codes()`，不 memo 就是重複查詢、重複
+   build、重複 warning。
+5. **`typeCodes()` 要取 hz／py 兩份的聯集**：schema 允許 `c_inst_type_hz` 為 null（只有拼音名），
+   舊 `typeMap()` 也是任一有值就收；只取 hz 那份會讓這種列的合法 `type_code` 被判 invalid（422）。
+6. **`resolveNameCode()` 改成「先精確探原輸入、落空才擴成兩形」**：直接 `whereIn` + 最小碼優先，
+   會讓輸入「清溪書院」時被字面不同的「淸溪書院」（較小的碼）搶走，機構掛到另一個既有名稱碼上。
+7. **`resolveNianhaoId()`／`fuzzyMatchOffice()` 同理，而且朝代條件優先於字形條件**：直接
+   `whereIn` 兩形會讓候選從 1 筆變 2 筆而觸發「無法消歧就回 null」的靜默降級；而「每輪名稱候選
+   就先做不限朝代 fallback」會回別朝代的原字形、忽略指定朝代的等價形。正確順序是：先把所有
+   名稱候選在**指定朝代內**試完，全落空才放寬朝代。
+8. **改名護欄要問 resolver，不能比字串**：`SocialInstitutionAggregateDefinition::guardWrite()`
+   原本比 `$input['name']` 與 `$existing['name']`。純字串相等會把「只換字形」（兩形都探 ⇒ 同一個
+   code）誤報成 409；只比「歸一後字串」又會漏掉反方向（輸入參考形、既有列是另一個變體形 ⇒ 歸一後
+   看起來相同，但會**新建** code ⇒ 正是護欄要擋的既存引用失配）。改用唯讀的
+   `SocialInstituteImportService::findExistingNameCode()` 判斷「這次儲存會不會換掉 name_code」。
+9. **替換紀錄不得跨列殘留**：`SocialInstituteImportService` 的累積器是 merge 寫入，而批次匯入是
+   同一個 service 實例逐列呼叫 ⇒ 第二列的結果頁會顯示第一列的替換。`create()`／`update()` 進入
+   時重置，並補回歸測試。
+10. 批次匯入的錯誤訊息改用保留下來的**原始標籤**（`*_label_raw`）：查表用歸一後的值，但訊息裡
+    顯示歸一後的字會讓使用者一頭霧水（他從沒打過那個字）。
+
+**明文記錄的已知邊界**（不是本步造成的回歸，也沒被本步修好）：
+`resolveNameCode()` 的去重是**單向**的，只涵蓋「輸入變體形、既有列參考形」。反方向（輸入參考形、
+既有列是**另一個**變體形）無法用精確比對命中——那需要列舉輸入的所有「前像」（組合爆炸，本計畫
+D7 已明確否決該做法）或在表上加一個歸一後的影子欄。該情境會像 S4 之前一樣新建一個名稱碼；
+測試 `testReferenceFormInputDoesNotMergeIntoExistingVariantRow` 把這個行為釘死，避免被誤以為
+已解決。真正的修法（影子欄或一次性資料合併）屬獨立工作。
+
+另一個刻意的不對稱（計畫本來就寫明）：兩形都在時複用既有的變體形列，該列的 `c_inst_name_hz`
+永不歸一，與 D7 第二類「觸碰即歸一」相反——為了不製造重複碼而接受的取捨，由測試
+`test_existing_variant_form_name_code_is_reused_and_not_normalized` 鎖住。
+
+提案核准重放（`approveEntityAggregateProposal` → 以 direct 重放同一 handler）走的是同一條
+validate 與 service，所以替換與標籤歸一自動生效；已補
+`testApprovingProposalAppliesVariantReplacementAndLabelNormalization` 作回歸鎖。順帶記錄：
+提案存的是**原始 changes**、替換發生在核准當下（§4.5「存意圖」），所以中間若有人改了
+`char_variant_map`／`DYNASTIES`，提交時與核准時的結果會不同——這是既有設計，不是缺陷。
+
 ### S5：token API 代碼表 create／update（G4）
 
 - `CodeTableCreateHandler`：目前無前處理掛鉤點，在 `:86 array_intersect_key` 之後、`:101` 落庫之前插入（抽出 protected 掛鉤方法）。`:99` 的 `ToolsRepository::timestamp()` 蓋稽核欄，掛在其前即可（稽核欄本來也在排除清單）。

--- a/resources/js/inertia/Pages/Admin/BatchLoadOffices/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadOffices/Index.tsx
@@ -7,10 +7,17 @@ import { LineNumberedTextarea } from '../../../components/ui/LineNumberedTextare
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 
+interface VariantReplacement {
+    from: string;
+    to: string;
+}
+
 interface ResultRow {
     line: number;
     office_id: number | string;
     name: string;
+    /** 本列實際套用的異體字替換（後端 flattenReplaced 的結果）。 */
+    variant_replacements?: VariantReplacement[];
     translation: string;
     pinyin: string;
     dynasty_label: string | null;
@@ -84,7 +91,16 @@ export default function BatchLoadOffices() {
                                     <tr key={`${r.line}-${r.office_id}`} className="border-t border-border">
                                         <td className="px-3 py-1.5">{r.line}</td>
                                         <td className="px-3 py-1.5">{r.office_id}</td>
-                                        <td className="px-3 py-1.5">{r.name}</td>
+                                        <td className="px-3 py-1.5">
+                                            <div>{r.name}</div>
+                                            {r.variant_replacements && r.variant_replacements.length > 0 && (
+                                                <div className="text-xs text-muted-foreground">
+                                                    {t('batch_variant_replaced_hint', {
+                                                        pairs: r.variant_replacements.map((v) => `${v.from}→${v.to}`).join('、'),
+                                                    })}
+                                                </div>
+                                            )}
+                                        </td>
                                         <td className="px-3 py-1.5">{r.translation}</td>
                                         <td className="px-3 py-1.5">{r.pinyin}</td>
                                         <td className="px-3 py-1.5">{r.dynasty_label} / {r.dynasty_code}</td>

--- a/resources/js/inertia/Pages/Admin/BatchLoadSocialInstitutes/Index.tsx
+++ b/resources/js/inertia/Pages/Admin/BatchLoadSocialInstitutes/Index.tsx
@@ -7,9 +7,16 @@ import { LineNumberedTextarea } from '../../../components/ui/LineNumberedTextare
 import { useTranslation } from '../../../hooks/useTranslation';
 import type { SharedProps } from '../../../types/page';
 
+interface VariantReplacement {
+    from: string;
+    to: string;
+}
+
 interface ResultRow {
     line: number;
     name: string;
+    /** 本列實際套用的異體字替換（後端 flattenReplaced 的結果）。 */
+    variant_replacements?: VariantReplacement[];
     name_code: string | number | null;
     name_pinyin: string | null;
     name_created: boolean;
@@ -88,7 +95,16 @@ export default function BatchLoadSocialInstitutes() {
                                     {results.map((r) => (
                                         <tr key={`${r.line}-${r.inst_code}`} className="border-t border-border">
                                             <td className="px-3 py-1.5">{r.line}</td>
-                                            <td className="px-3 py-1.5">{r.name}</td>
+                                            <td className="px-3 py-1.5">
+                                                <div>{r.name}</div>
+                                                {r.variant_replacements && r.variant_replacements.length > 0 && (
+                                                    <div className="text-xs text-muted-foreground">
+                                                        {t('batch_variant_replaced_hint', {
+                                                            pairs: r.variant_replacements.map((v) => `${v.from}→${v.to}`).join('、'),
+                                                        })}
+                                                    </div>
+                                                )}
+                                            </td>
                                             <td className="px-3 py-1.5">{r.name_code}</td>
                                             <td className="px-3 py-1.5">{r.name_pinyin}</td>
                                             <td className="px-3 py-1.5">{r.name_created ? t('batch_yes') : t('batch_no')}</td>

--- a/tests/Feature/AdminBatchLoadOfficesTest.php
+++ b/tests/Feature/AdminBatchLoadOfficesTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -112,6 +114,8 @@ class AdminBatchLoadOfficesTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        // char_variant_map 的清理放在這裡而不是各測試方法尾：斷言失敗時方法尾不會執行。
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('pinyin');
         Schema::dropIfExists('operations');
@@ -231,5 +235,95 @@ class AdminBatchLoadOfficesTest extends TestCase {
         $response->assertSessionHas('batch_errors');
 
         $this->assertSame(0, DB::table('OFFICE_CODES')->count());
+    }
+    // ── 異體字落地替換（plan S4）────────────────────────────
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php 同源的
+     * 最小種子（只要「淸→清」）。其餘測試不建這張表，所以它們走
+     * CharVariantMapService 的「表不存在就降級」路徑、行為不變。
+     */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    protected function seedOfficeLookups(string $dynastyLabel = '清'): void {
+        DB::table('DYNASTIES')->insert(['c_dy' => 20, 'c_dynasty_chn' => $dynastyLabel]);
+        DB::table('OFFICE_TYPE_TREE')->insert([
+            'c_office_type_node_id' => '200501', 'c_office_type_desc_chn' => '宗人府',
+        ]);
+        DB::table('TEXT_CODES')->insert(['c_textid' => 4763]);
+    }
+
+    /** (a) 表格寫變體形「淸」、代碼表寫參考形「清」→ 應成功。 */
+    #[Test]
+    public function test_dynasty_label_in_variant_form_matches_reference_form_code_row(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedOfficeLookups('清');
+
+        $this->post(route('admin.batch-load-offices.store'), [
+            'entries' => "宗人府供事\tClerk\t淸\t200501\t宗人府\t4763",
+        ])->assertRedirect(route('admin.batch-load-offices'));
+
+        $this->assertDatabaseHas('OFFICE_CODES', ['c_office_id' => 1, 'c_dy' => 20]);
+    }
+
+    /**
+     * (b) 表格寫參考形「清」、代碼表寫變體形「淸」→ 也要成功。
+     * 只歸一傳入標籤修不到這個方向（輸入本來就是參考字），必須連 map 的鍵一起歸一。
+     */
+    #[Test]
+    public function test_dynasty_label_in_reference_form_matches_variant_form_code_row(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedOfficeLookups('淸');
+
+        $this->post(route('admin.batch-load-offices.store'), [
+            'entries' => "宗人府供事\tClerk\t清\t200501\t宗人府\t4763",
+        ])->assertRedirect(route('admin.batch-load-offices'));
+
+        $this->assertDatabaseHas('OFFICE_CODES', ['c_office_id' => 1, 'c_dy' => 20]);
+    }
+
+    /**
+     * 職名本身的異體字要落地替換，而且**必須早於拼音派生**——拼音是逐字查
+     * `pinyin.c_chn`（該表被排除在替換範圍外、異體字保有自己讀音），先替換才會拿到
+     * 參考字的讀音，中文欄與拼音欄才不會各說各話。結果頁另外顯示替換明細。
+     */
+    #[Test]
+    public function test_office_name_variant_is_replaced_before_pinyin_derivation(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedOfficeLookups('清');
+
+        $this->post(route('admin.batch-load-offices.store'), [
+            'entries' => "淸吏司\tClerk\t清\t200501\t宗人府\t4763",
+        ])->assertRedirect(route('admin.batch-load-offices'));
+
+        $record = DB::table('OFFICE_CODES')->first();
+        $this->assertSame('清吏司', $record->c_office_chn, '職名應以參考形落庫');
+        $this->assertSame('qing li si', $record->c_office_pinyin, '拼音應由參考形派生');
+
+        // 結果頁的 props 帶落庫後的職名與替換明細（比照書名匯入）。斷言直接讀 flash 資料
+        // 而不是 assertSee：Inertia 把 props JSON 化時會把非 ASCII escape 成 \\uXXXX，
+        // assertSee 對「淸」這種字元會落空。
+        $results = session('batch_results');
+        $this->assertIsArray($results);
+        $this->assertSame('清吏司', $results[0]['name']);
+        $this->assertSame([['from' => '淸', 'to' => '清']], $results[0]['variant_replacements']);
     }
 }

--- a/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
+++ b/tests/Feature/AdminBatchLoadSocialInstitutesTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -123,6 +125,8 @@ class AdminBatchLoadSocialInstitutesTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        // char_variant_map 的清理放在這裡而不是各測試方法尾：斷言失敗時方法尾不會執行。
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('audit_log');
         Schema::dropIfExists('pinyin');
         Schema::dropIfExists('operations');
@@ -309,5 +313,156 @@ class AdminBatchLoadSocialInstitutesTest extends TestCase {
         $response->assertSessionHas('batch_errors');
 
         $this->assertSame(0, DB::table('SOCIAL_INSTITUTION_CODES')->count());
+    }
+    // ── 異體字落地替換（plan S4）────────────────────────────
+
+    /**
+     * 與 database/migrations/2026_07_15_000000_create_char_variant_map_table.php 同源的
+     * 最小種子（只要「淸→清」這一組）。本測試檔其餘測試不建這張表，所以那些測試在
+     * CharVariantMapService 的「表不存在就降級」路徑下完全不做替換、行為不變。
+     */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    protected function seedInstituteLookups(string $dynastyLabel = '清'): void {
+        DB::table('SOCIAL_INSTITUTION_TYPES')->insert([
+            'c_inst_type_code' => 10, 'c_inst_type_hz' => '書院', 'c_inst_type_py' => 'shuyuan',
+        ]);
+        DB::table('DYNASTIES')->insert(['c_dy' => 40, 'c_dynasty_chn' => $dynastyLabel]);
+        DB::table('ADDR_CODES')->insert(['c_addr_id' => 7793]);
+        DB::table('TEXT_CODES')->insert(['c_textid' => 4763]);
+    }
+
+    /** (a) 表格寫變體形「淸」、代碼表寫參考形「清」→ 應成功。 */
+    #[Test]
+    public function test_dynasty_label_in_variant_form_matches_reference_form_code_row(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('清');
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "南浦書院\t書院\t淸\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 1, 'c_inst_begin_dy' => 40]);
+    }
+
+    /**
+     * (b) 表格寫參考形「清」、代碼表寫變體形「淸」→ 也要成功。
+     *
+     * 這個方向只靠「歸一傳入標籤」是修不到的：使用者輸入本來就是參考字、替換後不變，
+     * 而既有代碼表列在 D6 之下永不歸一。必須連 map 的鍵一起歸一。
+     */
+    #[Test]
+    public function test_dynasty_label_in_reference_form_matches_variant_form_code_row(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('淸');
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "南浦書院\t書院\t清\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 1, 'c_inst_begin_dy' => 40]);
+    }
+
+    /**
+     * (d) 既有 name code 是變體形「淸…」、匯入同樣的「淸…」→ 複用既有碼、不新建，
+     * 且該列的名稱文本**保持變體形**。
+     *
+     * 這鎖住 plan S4 明文記錄的刻意不對稱：為了不製造重複碼而複用既有列，
+     * 代價是該列永不歸一（與 D7「觸碰即歸一」相反）。
+     */
+    #[Test]
+    public function test_existing_variant_form_name_code_is_reused_and_not_normalized(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('清');
+        DB::table('SOCIAL_INSTITUTION_NAME_CODES')->insert([
+            'c_inst_name_code' => 500, 'c_inst_name_hz' => '淸溪書院', 'c_inst_name_py' => 'qing xi shu yuan',
+        ]);
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "淸溪書院\t書院\t清\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $this->assertSame(1, DB::table('SOCIAL_INSTITUTION_NAME_CODES')->count(), '不得新建第二個 name code');
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_NAME_CODES', [
+            'c_inst_name_code' => 500,
+            'c_inst_name_hz' => '淸溪書院', // 刻意不歸一
+        ]);
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_name_code' => 500]);
+    }
+
+    /**
+     * (d′) 既有 name code 是參考形、匯入變體形 → 同樣複用，不新建。
+     * 這是「只替換傳入值」會漏的反方向。
+     */
+    #[Test]
+    public function test_variant_form_import_reuses_existing_reference_form_name_code(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('清');
+        DB::table('SOCIAL_INSTITUTION_NAME_CODES')->insert([
+            'c_inst_name_code' => 500, 'c_inst_name_hz' => '清溪書院', 'c_inst_name_py' => 'qing xi shu yuan',
+        ]);
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "淸溪書院\t書院\t清\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $this->assertSame(1, DB::table('SOCIAL_INSTITUTION_NAME_CODES')->count());
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_name_code' => 500]);
+    }
+
+    /** (e) 同一批裡兩列分別寫「淸」「清」的同一機構名 → 收斂到同一個 name code。 */
+    #[Test]
+    public function test_two_rows_with_different_variant_forms_converge_to_one_name_code(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('清');
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "淸溪書院\t書院\t清\t浦城\t7793\t4763\n清溪書院\t書院\t清\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $this->assertSame(1, DB::table('SOCIAL_INSTITUTION_NAME_CODES')->count(), '兩列應收斂到同一個 name code');
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_NAME_CODES', ['c_inst_name_hz' => '清溪書院']);
+        $this->assertSame(2, DB::table('SOCIAL_INSTITUTION_CODES')->count(), '機構列仍是兩筆');
+    }
+
+    /**
+     * 替換紀錄不得跨列殘留：批次匯入是同一個 service 實例逐列呼叫，而
+     * lastVariantReplaced 是以 merge 累積的。第一列有替換、第二列沒有時，
+     * 第二列的結果頁不能顯示第一列的替換。
+     */
+    #[Test]
+    public function test_variant_replacements_do_not_leak_between_rows(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser());
+        $this->seedInstituteLookups('清');
+
+        $this->post(route('admin.batch-load-social-institutes.store'), [
+            'entries' => "淸溪書院\t書院\t清\t浦城\t7793\t4763\n白鹿洞書院\t書院\t清\t浦城\t7793\t4763",
+        ])->assertRedirect(route('admin.batch-load-social-institutes'));
+
+        $results = session('batch_results');
+        $this->assertIsArray($results);
+        $this->assertSame([['from' => '淸', 'to' => '清']], $results[0]['variant_replacements']);
+        $this->assertSame([], $results[1]['variant_replacements'], '第二列不得帶到第一列的替換紀錄');
     }
 }

--- a/tests/Feature/ApiV2MutateOfficeImportTest.php
+++ b/tests/Feature/ApiV2MutateOfficeImportTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -114,6 +116,8 @@ class ApiV2MutateOfficeImportTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        // char_variant_map 的清理放在這裡而不是各測試方法尾：斷言失敗時方法尾不會執行。
+        Schema::dropIfExists('char_variant_map');
         foreach (['POSTED_TO_OFFICE_DATA', 'pinyin', 'TEXT_CODES', 'DYNASTIES', 'OFFICE_TYPE_TREE', 'OFFICE_CODE_TYPE_REL', 'OFFICE_CODES', 'audit_log', 'operations', 'users'] as $t) {
             Schema::dropIfExists($t);
         }
@@ -438,5 +442,96 @@ class ApiV2MutateOfficeImportTest extends TestCase {
         $this->postJson('/api/v2/create', $this->payload())->assertStatus(403);
         $this->postJson('/api/v2/create', $this->payload(['mode' => 'proposal']))->assertOk();
         $this->assertSame(1, DB::table('operations')->where('op_type', Operation::TYPE_PROPOSAL_CREATE)->count());
+    }
+    // ── 異體字落地替換（plan S4；review 補的 v2／React 覆蓋）──────
+
+    /**
+     * 最小 char_variant_map 種子（「淸→清」）。其餘測試不建這張表，走
+     * CharVariantMapService 的「表不存在就降級」路徑、行為不變。
+     */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    /**
+     * v2／React 路徑：職名、別名、備註、頁碼四欄都要落地替換，**回應要回落庫值並帶
+     * notices**。
+     *
+     * 回 `$input['name']` 是這一步 review 抓到的缺陷：DB 寫參考形、回應回變體形，
+     * React 編輯器儲存後畫面與資料庫不一致，使用者也不知道字被改過（批次匯入使用者
+     * 反而看得到提示）。
+     */
+    #[Test]
+    public function testOfficeCreateReplacesVariantsInAllTextColumnsAndReturnsStoredValues(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser(email: 'office-variant@example.com'));
+
+        $response = $this->postJson('/api/v2/create', $this->payload([
+            'changes' => [
+                'name' => '淸吏司',
+                'name_alt' => '淸吏司別名',
+                'notes' => '淸代備註',
+                'pages' => '淸頁',
+                'dynasty_code' => 15,
+                'type_id' => 'x01',
+                'source_id' => 7596,
+            ],
+        ]))->assertOk();
+
+        $row = DB::table('OFFICE_CODES')->first();
+        $this->assertSame('清吏司', $row->c_office_chn);
+        $this->assertSame('清吏司別名', $row->c_office_chn_alt);
+        $this->assertSame('清代備註', $row->c_notes);
+        $this->assertSame('清頁', $row->c_pages);
+        $this->assertSame('qing li si', $row->c_office_pinyin, '拼音須由參考形派生');
+
+        $this->assertSame('清吏司', $response->json('result.row.c_office_chn'), '回應必須回落庫值');
+        $this->assertNotEmpty($response->json('notices'), '回應必須帶異體字通知');
+
+    }
+
+    /**
+     * 提案核准重放時，異體字替換與標籤歸一同樣生效（核准走
+     * `approveEntityAggregateProposal` → 以 direct 重放同一個 handler ⇒ 同 validate、
+     * 同 service、同替換）。提案存的是**原始 changes**，替換發生在核准當下（§4.5 存意圖）。
+     */
+    #[Test]
+    public function testApprovingProposalAppliesVariantReplacementAndLabelNormalization(): void {
+        $this->seedCharVariantMap();
+        // 代碼表寫變體形，提案的標籤送參考形 ⇒ 需要 map 鍵歸一才對得上。
+        DB::table('DYNASTIES')->insert(['c_dy' => 40, 'c_dynasty_chn' => '淸']);
+        $this->actingAs($this->makeUser(email: 'of-p-variant@example.com'));
+
+        $p = $this->payload(['mode' => 'proposal']);
+        $p['changes']['name'] = '淸吏司';
+        unset($p['changes']['dynasty_code']);
+        $p['changes']['dynasty_label'] = '清';
+        $this->postJson('/api/v2/create', $p)->assertOk();
+
+        // 提案存的是原始輸入（尚未替換）。
+        $operation = Operation::where('resource', 'office')->firstOrFail();
+        $stored = json_decode($operation->resource_data, true);
+        $this->assertSame('淸吏司', $stored['changes']['name'] ?? ($stored['name'] ?? null));
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $row = DB::table('OFFICE_CODES')->where('c_office_chn', '清吏司')->first();
+        $this->assertNotNull($row, '核准落庫時職名應為參考形');
+        $this->assertSame(40, (int) $row->c_dy, '朝代標籤歸一後應對上變體形的代碼表列');
+        $this->assertSame('qing li si', $row->c_office_pinyin);
+
     }
 }

--- a/tests/Feature/ApiV2MutateSocialInstituteEntityTest.php
+++ b/tests/Feature/ApiV2MutateSocialInstituteEntityTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -174,6 +176,8 @@ class ApiV2MutateSocialInstituteEntityTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        // char_variant_map 的清理放在這裡而不是各測試方法尾：斷言失敗時方法尾不會執行。
+        Schema::dropIfExists('char_variant_map');
         foreach ([
             'POSTED_TO_OFFICE_DATA', 'ASSOC_DATA', 'ENTRY_DATA', 'BIOG_INST_DATA', 'pinyin',
             'YEAR_RANGE_CODES', 'NIAN_HAO', 'ADDR_CODES', 'TEXT_CODES', 'DYNASTIES',
@@ -350,5 +354,183 @@ class ApiV2MutateSocialInstituteEntityTest extends TestCase {
             'target' => ['pk' => ['c_inst_code' => 10]],
         ])->assertStatus(409);
         $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 10]);
+    }
+    // ── 異體字：標籤歸一與代碼白名單（plan S4）──────────────
+
+    /**
+     * 最小 char_variant_map 種子（「淸→清」）。其餘測試不建這張表，走
+     * CharVariantMapService 的「表不存在就降級」路徑、行為不變。
+     */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    /**
+     * (c) 代碼表同時有兩形（「淸」40 與「清」41）時，標籤歸一會讓兩列的鍵塌成一個
+     * ——但**兩個代碼都必須仍然可用**。
+     *
+     * 這是把白名單從 `in_array(..., $map)` 改成 `in_array(..., $service->dynastyCodes())`
+     * 的理由：拿 map 的值當白名單時，被碰撞吃掉的 41 會開始被判 dynasty invalid，
+     * 而它是一個完全合法的 c_dy。
+     */
+    #[Test]
+    public function testBothCodesStayValidWhenTwoDynastyLabelsNormalizeToTheSameKey(): void {
+        $this->seedCharVariantMap();
+        DB::table('DYNASTIES')->insert([
+            ['c_dy' => 40, 'c_dynasty_chn' => '淸'],
+            ['c_dy' => 41, 'c_dynasty_chn' => '清'],
+        ]);
+        $this->actingAs($this->makeUser('si-variant-whitelist@example.com'));
+
+        // 被碰撞「吃掉」的那個碼（41，因為 map 只留最小的 40）仍須被接受。
+        $this->postJson('/api/v2/mutate', $this->updatePayload(['dynasty_code' => 41]))
+            ->assertOk();
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 10, 'c_inst_begin_dy' => 41]);
+
+        // 另一個（40）當然也要能用。
+        $this->postJson('/api/v2/mutate', $this->updatePayload(['dynasty_code' => 40]))
+            ->assertOk();
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 10, 'c_inst_begin_dy' => 40]);
+
+    }
+
+    /**
+     * 機構層與**地址列**的文本欄都要替換，回應回落庫值並帶 notices。
+     *
+     * 地址列的 c_pages／c_notes 是 review 抓到的缺口：同一次 update 裡機構層的 c_notes
+     * 被歸一、地址列的 c_notes 原樣入庫（SOCIAL_INSTITUTION_ADDR 同樣是已知表、兩欄都是
+     * 文本型，本來就在替換範圍內）。
+     */
+    #[Test]
+    public function testUpdateReplacesVariantsInInstitutionAndAddressTextColumns(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeUser('si-variant-text@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', $this->updatePayload([
+            'notes' => '淸代重修',
+            'pages' => '淸卷一',
+            'addresses' => [[
+                'addr_id' => 101,
+                'notes' => '淸址備註',
+                'pages' => '淸址頁',
+            ]],
+        ]))->assertOk();
+
+        $code = DB::table('SOCIAL_INSTITUTION_CODES')->where('c_inst_code', 10)->first();
+        $this->assertSame('清代重修', $code->c_notes);
+        $this->assertSame('清卷一', $code->c_pages);
+
+        $addr = DB::table('SOCIAL_INSTITUTION_ADDR')->where('c_inst_code', 10)->first();
+        $this->assertSame('清址備註', $addr->c_notes, '地址列的備註也必須歸一');
+        $this->assertSame('清址頁', $addr->c_pages);
+
+        $this->assertNotEmpty($response->json('notices'), '回應必須帶異體字通知');
+    }
+
+    /**
+     * 「只換了字形」的改名在 resolveNameCode() 兩形都探之下其實是 no-op，
+     * 不得被改名護欄誤報成 409（該機構仍被人物資料引用）。
+     */
+    #[Test]
+    public function testVariantOnlyRenameIsNotBlockedByReferenceGuard(): void {
+        $this->seedCharVariantMap();
+        // 既有名稱是參考形，且被人物資料引用。
+        DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_code', 5)
+            ->update(['c_inst_name_hz' => '清溪書院']);
+        DB::table('BIOG_INST_DATA')->insert(['c_personid' => 1, 'c_inst_code' => 10, 'c_inst_name_code' => 5]);
+        $this->actingAs($this->makeUser('si-variant-rename@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', $this->updatePayload([
+            'name' => '淸溪書院', // 只是字形不同 ⇒ 解析到同一個 name_code
+            'notes' => '改備註',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode(), '只換字形不算改名，不該被引用護欄擋下');
+        $this->assertSame(5, (int) DB::table('SOCIAL_INSTITUTION_CODES')->where('c_inst_code', 10)->value('c_inst_name_code'));
+        $this->assertSame('清溪書院', DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_code', 5)->value('c_inst_name_hz'), '既有列不歸一也不被改寫');
+        $this->assertSame('清溪書院', $response->json('result.row.c_inst_name_hz'), '回應要回實際生效的名稱');
+    }
+
+    /**
+     * codex：`typeCodes()` 必須是 hz／py 兩份的**聯集**。schema 允許 c_inst_type_hz 為
+     * null（只有拼音名），舊 typeMap() 也是任一有值就收；只取 hz 那份會讓這種列的
+     * 合法 type_code 在白名單驗證被錯判 invalid（422）。
+     */
+    #[Test]
+    public function testTypeCodeWithOnlyPinyinLabelStaysValid(): void {
+        DB::table('SOCIAL_INSTITUTION_TYPES')->insert([
+            'c_inst_type_code' => 9, 'c_inst_type_hz' => null, 'c_inst_type_py' => 'shuyuan-only',
+        ]);
+        $this->actingAs($this->makeUser('si-py-only@example.com'));
+
+        $this->postJson('/api/v2/mutate', $this->updatePayload(['type_code' => 9]))->assertOk();
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_code' => 10, 'c_inst_type_code' => 9]);
+    }
+
+    /**
+     * 去重是**單向**的，這條把邊界釘死：輸入參考形而既有列是**另一個**變體形時，
+     * 精確比對命中不了（反方向需要列舉輸入的所有前像，plan 明確否決），
+     * 所以會像 S4 之前一樣新建一個名稱碼。
+     *
+     * 這不是本步造成的回歸（S4 之前同樣新建），但也沒被本步修好——寫成測試是為了讓
+     * 這個已知缺口有明文、不會被誤以為已解決。真正的修法是加一個歸一後的影子欄或
+     * 做一次性資料合併，屬獨立工作。
+     */
+    #[Test]
+    public function testReferenceFormInputDoesNotMergeIntoExistingVariantRow(): void {
+        $this->seedCharVariantMap();
+        DB::table('SOCIAL_INSTITUTION_NAME_CODES')->insert([
+            'c_inst_name_code' => 7, 'c_inst_name_hz' => '淸溪書院', 'c_inst_name_py' => 'qing xi shu yuan',
+        ]);
+        $this->actingAs($this->makeUser('si-reverse-direction@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', $this->updatePayload([
+            'name' => '清溪書院', // 參考形；既有列是變體形
+        ]))->assertOk();
+
+        $newCode = (int) DB::table('SOCIAL_INSTITUTION_CODES')->where('c_inst_code', 10)->value('c_inst_name_code');
+        $this->assertNotSame(7, $newCode, '反方向不會併入既有變體形列（已知邊界）');
+        $this->assertSame('清溪書院', DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_code', $newCode)->value('c_inst_name_hz'));
+        // 沒有發生字元替換（輸入本來就是參考形）⇒ 不該有異體字通知。
+        $this->assertNull($response->json('notices'));
+    }
+
+    /**
+     * codex round 2：改名護欄要問「這次儲存會不會真的換掉 c_inst_name_code」，
+     * 不能只比歸一後的字串。
+     *
+     * 反方向（輸入參考形、既有列是另一個變體形）歸一後兩邊字串看起來相同，但
+     * resolveNameCode() 會**新建**一個 code ⇒ 對被引用的機構就是既存引用失配，
+     * 必須照樣回 409。
+     */
+    #[Test]
+    public function testReferenceFormInputIsStillBlockedWhenInstitutionIsReferenced(): void {
+        $this->seedCharVariantMap();
+        DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_code', 5)
+            ->update(['c_inst_name_hz' => '淸溪書院']); // 既有名稱是變體形
+        DB::table('BIOG_INST_DATA')->insert(['c_personid' => 1, 'c_inst_code' => 10, 'c_inst_name_code' => 5]);
+        $this->actingAs($this->makeUser('si-reverse-guard@example.com'));
+
+        $response = $this->postJson('/api/v2/mutate', $this->updatePayload([
+            'name' => '清溪書院', // 參考形：歸一後與既有列「看起來相同」，但會新建 code
+        ]));
+
+        $this->assertSame(409, $response->getStatusCode(), '會換掉 name_code ⇒ 仍須被引用護欄擋下');
+        $this->assertSame(5, (int) DB::table('SOCIAL_INSTITUTION_CODES')->where('c_inst_code', 10)->value('c_inst_name_code'));
+        $this->assertSame(1, DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_hz', '淸溪書院')->count());
+        $this->assertSame(0, DB::table('SOCIAL_INSTITUTION_NAME_CODES')->where('c_inst_name_hz', '清溪書院')->count(), '不得新建名稱列');
     }
 }

--- a/tests/Feature/ApiV2MutateSocialInstituteImportTest.php
+++ b/tests/Feature/ApiV2MutateSocialInstituteImportTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -119,6 +121,8 @@ class ApiV2MutateSocialInstituteImportTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        // char_variant_map 的清理放在這裡而不是各測試方法尾：斷言失敗時方法尾不會執行。
+        Schema::dropIfExists('char_variant_map');
         foreach ([
             'pinyin', 'TEXT_CODES', 'ADDR_CODES', 'DYNASTIES', 'SOCIAL_INSTITUTION_TYPES',
             'SOCIAL_INSTITUTION_ADDR', 'SOCIAL_INSTITUTION_CODES', 'SOCIAL_INSTITUTION_NAME_CODES',
@@ -240,5 +244,42 @@ class ApiV2MutateSocialInstituteImportTest extends TestCase {
         $p['changes']['dynasty_label'] = '宋';
         $this->postJson('/api/v2/create', $p)->assertOk();
         $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_type_code' => 3, 'c_inst_begin_dy' => 15]);
+    }
+
+    /**
+     * 異體字（plan S4）：以**標籤**指定朝代／類型時，兩個方向都要命中——
+     * 表格／payload 寫變體形而代碼表寫參考形，或反過來。
+     *
+     * 反方向（payload 參考形、代碼表變體形）只靠「歸一傳入標籤」是修不到的：
+     * 輸入本來就是參考字、替換後不變，而既有代碼表列在 D6 之下永不歸一。
+     * 必須連 map 的鍵一起歸一。
+     */
+    #[Test]
+    public function testDynastyLabelMatchesAcrossVariantForms(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+
+        // 代碼表寫**變體形**，payload 送**參考形**。
+        DB::table('DYNASTIES')->insert(['c_dy' => 40, 'c_dynasty_chn' => '淸']);
+        $this->actingAs($this->makeUser(email: 'si-label-variant@example.com'));
+
+        $p = $this->payload();
+        unset($p['changes']['dynasty_code']);
+        $p['changes']['dynasty_label'] = '清';
+        $this->postJson('/api/v2/create', $p)->assertOk();
+        $this->assertDatabaseHas('SOCIAL_INSTITUTION_CODES', ['c_inst_begin_dy' => 40]);
+
     }
 }

--- a/tests/Feature/PostingAutofillOfficeMatchTest.php
+++ b/tests/Feature/PostingAutofillOfficeMatchTest.php
@@ -107,4 +107,79 @@ class PostingAutofillOfficeMatchTest extends TestCase {
         }
         $this->assertTrue(true);
     }
+    // ── 異體字（plan S4）：AI 錄入的兩處精確比對 ────────────
+
+    /** 呼叫 protected resolveNianhaoId。 */
+    protected function resolveNianhao(string $name, ?int $dynasty, ?int $yearHint): ?int {
+        $service = app(PostingAutofillService::class);
+        $ref = new ReflectionClass($service);
+        $method = $ref->getMethod('resolveNianhaoId');
+        $method->setAccessible(true);
+        $id = $method->invoke($service, $name, $dynasty, $yearHint);
+
+        return $id === null ? null : (int) $id;
+    }
+
+    /**
+     * 官名精確比對要涵蓋參考形：S4 之後新寫入的 OFFICE_CODES.c_office_chn 是歸一後的
+     * 參考形，而 LLM 從文本抽出的官名可能是變體形。落空會退成模糊匹配
+     * （match_type 由 exact 降成 fuzzy）或整個失敗。
+     */
+    public function test_variant_form_office_name_still_matches_exactly() {
+        DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 90001, 'c_dy' => 20, 'c_office_chn' => '清吏司', 'c_office_chn_alt' => null,
+        ]);
+
+        $result = $this->matchOffice('淸吏司', 20, null);
+
+        $this->assertNotNull($result);
+        $this->assertSame(90001, (int) $result['id']);
+        $this->assertSame('exact', $result['match_type'], '應維持 exact，不可降級成 fuzzy');
+    }
+
+    /** 原輸入的字面優先：兩形都在時不可隨機挑。 */
+    public function test_office_exact_match_prefers_the_submitted_form() {
+        DB::table('OFFICE_CODES')->insert([
+            ['c_office_id' => 90002, 'c_dy' => 20, 'c_office_chn' => '清吏司', 'c_office_chn_alt' => null],
+            ['c_office_id' => 90003, 'c_dy' => 20, 'c_office_chn' => '淸吏司', 'c_office_chn_alt' => null],
+        ]);
+
+        $this->assertSame(90003, (int) $this->matchOffice('淸吏司', 20, null)['id']);
+        $this->assertSame(90002, (int) $this->matchOffice('清吏司', 20, null)['id']);
+    }
+
+    /** 年號：變體形輸入要能對上參考形的代碼表列。 */
+    public function test_variant_form_nianhao_resolves_to_reference_form_row() {
+        DB::table('NIAN_HAO')->insert([
+            'c_nianhao_id' => 9101, 'c_dy' => 20, 'c_nianhao_chn' => '清和', 'c_firstyear' => 1700, 'c_lastyear' => 1710,
+        ]);
+
+        $this->assertSame(9101, $this->resolveNianhao('淸和', 20, null));
+    }
+
+    /**
+     * codex round 2：**朝代條件優先於字形條件**。
+     *
+     * 原字形在別的朝代有一筆、參考形在指定朝代有一筆時，必須回指定朝代那一筆——
+     * 不可在第一輪名稱候選就做「不限朝代」的 fallback 而回了別的朝代。
+     */
+    public function test_nianhao_prefers_reference_form_within_requested_dynasty_over_other_dynasty() {
+        DB::table('NIAN_HAO')->insert([
+            // 原字形，但在別的朝代
+            ['c_nianhao_id' => 9201, 'c_dy' => 19, 'c_nianhao_chn' => '淸和', 'c_firstyear' => 1400, 'c_lastyear' => 1410],
+            // 參考形，在指定的朝代
+            ['c_nianhao_id' => 9202, 'c_dy' => 20, 'c_nianhao_chn' => '清和', 'c_firstyear' => 1700, 'c_lastyear' => 1710],
+        ]);
+
+        $this->assertSame(9202, $this->resolveNianhao('淸和', 20, null), '指定朝代內的等價形優先於別朝代的原字形');
+    }
+
+    /** 指定朝代完全落空時，才放寬朝代（沿用既有行為）。 */
+    public function test_nianhao_falls_back_across_dynasties_only_when_requested_dynasty_has_none() {
+        DB::table('NIAN_HAO')->insert([
+            'c_nianhao_id' => 9301, 'c_dy' => 19, 'c_nianhao_chn' => '淸和', 'c_firstyear' => 1400, 'c_lastyear' => 1410,
+        ]);
+
+        $this->assertSame(9301, $this->resolveNianhao('淸和', 20, null));
+    }
 }

--- a/tests/Unit/VariantLabelMapTest.php
+++ b/tests/Unit/VariantLabelMapTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CharVariantMapService;
+use App\Support\VariantLabelMap;
+use App\Support\VariantReplaceScope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 「標籤 → 代碼」對照表的異體字歸一（plan S4）。
+ *
+ * 重點在**鍵碰撞**：這些 map 的值同時被當成合法代碼白名單，歸一後若兩列的鍵塌成一個，
+ * 被丟掉那個代碼就會從白名單消失、一個完全合法的代碼開始被判 invalid。
+ */
+class VariantLabelMapTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('DYNASTIES', function (Blueprint $table) {
+            $table->integer('c_dy')->primary();
+            $table->string('c_dynasty_chn')->nullable();
+        });
+
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    protected function tearDown(): void {
+        Schema::dropIfExists('char_variant_map');
+        Schema::dropIfExists('DYNASTIES');
+        parent::tearDown();
+    }
+
+    /** 鍵歸一：代碼表寫變體形時，用參考形也查得到。 */
+    #[Test]
+    public function testKeysAreNormalizedSoReferenceFormLookupHitsVariantFormRow(): void {
+        [$map, $codes] = VariantLabelMap::build([['淸', 40]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame(['清' => 40], $map, '鍵應存成參考形');
+        $this->assertSame([40], $codes);
+        $this->assertSame(40, VariantLabelMap::lookup($map, '清', 'DYNASTIES', 'c_dynasty_chn'));
+        $this->assertSame(40, VariantLabelMap::lookup($map, '淸', 'DYNASTIES', 'c_dynasty_chn'), '傳入變體形也要命中');
+    }
+
+    /**
+     * 鍵碰撞：取**最小**碼（不是既有 last-wins 的最大者），且**兩個代碼都留在白名單裡**。
+     * 後者是這個類別存在的主要理由——否則一個完全合法的代碼會開始被判 invalid。
+     */
+    #[Test]
+    public function testCollisionKeepsMinimumCodeInMapAndBothCodesInWhitelist(): void {
+        [$map, $codes] = VariantLabelMap::build([['淸', 40], ['清', 41]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame(['清' => 40], $map, '碰撞取最小碼');
+        sort($codes);
+        $this->assertSame([40, 41], $codes, '兩個代碼都必須留在白名單');
+    }
+
+    /** 順序相反也要得到同樣的結果（「取最小」不能依賴輸入順序）。 */
+    #[Test]
+    public function testCollisionResultIsIndependentOfRowOrder(): void {
+        [$mapA] = VariantLabelMap::build([['淸', 40], ['清', 41]], 'DYNASTIES', 'c_dynasty_chn');
+        [$mapB] = VariantLabelMap::build([['清', 41], ['淸', 40]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame($mapA, $mapB);
+    }
+
+    /**
+     * 空標籤的列既不進 map、**也不進白名單**。
+     *
+     * 白名單的用途只是「不要因為歸一造成的鍵碰撞而漏掉合法代碼」，碰撞雙方都必然有標籤。
+     * 把無標籤列（含 c_dy 為 NULL 被折成 0 的佔位列）也算進去，等於把原本「map 的值」
+     * 那組白名單悄悄放寬，讓 dynasty_code=0／佔位碼從被擋變成通過。
+     */
+    #[Test]
+    public function testRowsWithEmptyLabelDoNotWidenTheWhitelist(): void {
+        [$map, $codes] = VariantLabelMap::build([['', 99], ['清', 40]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame(['清' => 40], $map);
+        $this->assertSame([40], $codes, '無標籤列的代碼不得混進白名單');
+    }
+
+    /** 字面完全相同的重複標籤不算「歸一造成的碰撞」，不該刷 warning（但仍取最小碼）。 */
+    #[Test]
+    public function testDuplicateIdenticalLabelsDoNotLogCollisionWarning(): void {
+        \Illuminate\Support\Facades\Log::spy();
+
+        [$map] = VariantLabelMap::build([['清', 41], ['清', 40]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame(['清' => 40], $map);
+        \Illuminate\Support\Facades\Log::shouldNotHaveReceived('warning');
+    }
+
+    /** 歸一造成的碰撞才記 warning（碰撞是唯一的可觀測性）。 */
+    #[Test]
+    public function testNormalizationCollisionLogsWarning(): void {
+        \Illuminate\Support\Facades\Log::spy();
+
+        VariantLabelMap::build([['淸', 40], ['清', 41]], 'DYNASTIES', 'c_dynasty_chn');
+
+        \Illuminate\Support\Facades\Log::shouldHaveReceived('warning')->once();
+    }
+
+    /** 對照表不存在時（部署未跑 migration）歸一是恆等映射，不可炸也不可清空 map。 */
+    #[Test]
+    public function testDegradesToIdentityWhenMappingTableIsMissing(): void {
+        Schema::dropIfExists('char_variant_map');
+        CharVariantMapService::reset();
+
+        [$map, $codes] = VariantLabelMap::build([['淸', 40]], 'DYNASTIES', 'c_dynasty_chn');
+
+        $this->assertSame(['淸' => 40], $map);
+        $this->assertSame([40], $codes);
+    }
+}


### PR DESCRIPTION
## 這一步做了什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S4**：實體聚合（官職／社會機構）串接。

**核心是「標籤→代碼」對照表要兩側都歸一**（新 `App\Support\VariantLabelMap`）。只歸一傳入標籤不夠——D6 不做回溯校正，既有代碼表列的字面若是「淸」就永遠是「淸」，而使用者輸入「清」本來就是參考字、替換後不變，照樣查不到。兩側都歸一，「表格寫淸／代碼表寫清」與反方向才都命中。

**鍵碰撞是這個類別存在的主要理由**：這些 map 的值同時被當成合法代碼白名單（`in_array((int) $code, $map, true)`）。歸一後若兩列的鍵塌成一個，被丟掉那個 `c_dy`／`c_inst_type_code` 就會從白名單消失，**一個完全合法的代碼開始被判 invalid**。所以 `build()` 回傳「`label => code` 純量 map（碰撞取最小碼＋warning）」與「扁平的合法代碼集合」兩份，5 處白名單檢查全改讀後者。

其餘：`officeColumns()` 的四個文本欄在 `buildPinyin()` **之前**替換（拼音逐字查 `pinyin.c_chn`，該表被排除、異體字保有自己讀音）；`resolveNameCode()`／`resolveNianhaoId()`／`fuzzyMatchOffice()` 改成「先精確探原輸入、落空才擴成兩形」；批次匯入結果頁顯示落庫後的名稱與替換明細。

## Review 過程中修掉的、計畫沒列到的問題

| 問題 | 為什麼嚴重 |
|---|---|
| v2／React 回應回的是**使用者原輸入**、且完全沒有 notices | DB 寫參考形、回應回變體形 ⇒ React 編輯器儲存後畫面與資料庫不一致，使用者也不知道字被改過（批次匯入使用者反而看得到提示） |
| `SOCIAL_INSTITUTION_ADDR.c_pages`／`c_notes` 漏替換 | 同一次 update 裡機構層的 `c_notes` 被歸一、地址列的原樣入庫 |
| 白名單被順手放寬 | `allCodes` 原本連無標籤列（含 `c_dy` 為 NULL 折成 0 的佔位列）也收 ⇒ `dynasty_code=0` 從被擋變成通過 |
| `typeCodes()` 只取漢字名那份 | schema 允許 `c_inst_type_hz` 為 null；只有拼音名的列其合法 `type_code` 被判 invalid（422） |
| 直接 `whereIn` 兩形的兩個副作用 | 最小碼優先會讓字面完全相同的命中被另一個字形搶走；候選從 1 筆變 2 筆會觸發年號「無法消歧就回 null」的靜默降級 |
| 年號查表把字形條件排在朝代之前 | 「原字形在別朝代、參考形在指定朝代」時會回**別的朝代** |
| 改名護欄比字串而不是問 resolver | 純字串相等把「只換字形」誤報 409；只比歸一後字串又漏掉反方向（會新建 code ⇒ 既存引用失配） |
| 替換紀錄跨列殘留 | 批次匯入是同一個 service 實例逐列呼叫，累積器是 merge 寫入 ⇒ 第二列顯示第一列的替換 |
| 碰撞 warning 無節流、builder 無 memo | 既有重複字面會每次建 map 就刷 log；單一請求會重複查詢／build 2～6 次 |
| 錯誤訊息顯示歸一後的標籤 | 使用者從沒打過那個字，除錯體驗變差（改用保留的 `*_label_raw`） |

## 明文記錄的已知邊界

`resolveNameCode()` 的去重是**單向**的：只涵蓋「輸入變體形、既有列參考形」。反方向（輸入參考形、既有列是**另一個**變體形）無法用精確比對命中——需要列舉輸入的所有前像（組合爆炸，計畫 D7 已否決）或在表上加歸一後的影子欄。該情境會像 S4 之前一樣新建一個名稱碼（**不是本步造成的回歸**），已由 `testReferenceFormInputDoesNotMergeIntoExistingVariantRow` 把行為釘死，避免被誤以為已解決。

另一個計畫本來就寫明的刻意不對稱：兩形都在時複用既有的變體形列，該列的 `c_inst_name_hz` 永不歸一（與 D7「觸碰即歸一」相反），為了不製造重複碼而接受。

## 驗證

- `./vendor/bin/phpunit` 全綠：**2916 tests / 15399 assertions**
- `php-cs-fixer`（清 cache、dist config）0 fixes；`npm run build` 通過；`tsc` 錯誤數與改動前相同（21 個既有錯誤，都不在本次檔案）
- 新測試涵蓋計畫要求的 (a)–(e) 五個情境 ＋ v2 聚合／提案核准重放／跨列不殘留／白名單聯集／朝代優先等；每條都以「把機制中和掉會紅」逐一驗證過鑑別力
- Review：review agent 一輪（11 項發現）＋ codex 三輪，最後一輪回「沒有需修正的實質問題」

🤖 Generated with [Claude Code](https://claude.com/claude-code)