### PR TITLE
異體字落地替換 S6：提案核准的直接寫庫分支，並補上核准端的兩形並存守衛

### DIFF
--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -8,6 +8,7 @@ use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
+use App\Support\VariantEquivalentLookup;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -742,7 +743,30 @@ class OperationsProposalController extends Controller {
         return $row ? $this->convertRowToArray($row) : null;
     }
 
+    /**
+     * 提案核准時對 payload 做異體字落地替換（型別驅動，範圍由 VariantReplaceScope 決定）。
+     *
+     * payload 到此**已由 `sanitizePayload()` 收斂成純欄位**（`__` 前綴的內部鍵與非欄位鍵都
+     * 已被剃掉），所以這裡處理的就是資料欄。`replaceRow()` 的型別閘門與
+     * `EXCLUDED_COLUMNS_ANY_TABLE`（稽核欄）是第二層保險——**不要**因為看到這段而以為
+     * 可以把呼叫點往上搬到 `sanitizePayload()` 之前。char_variant_map 整表排除，不受影響。
+     *
+     * @param array<string,mixed> $data
+     * @return array<string,mixed>
+     */
+    protected function replaceVariantsForApproval(string $table, array $data): array {
+        return CharVariantMapService::replaceRow($data, $table)['data'];
+    }
+
     protected function applyCreateProposal(string $table, array $data, array $keyColumns): array {
+        // 異體字落地替換：**掛在方法最上方、buildKeyConditions() 之前**，不是「insert 之前」。
+        // 下方 :753 的重複檢查也用 $data 組主鍵條件，若替換晚於它，就會出現「查重用替換前
+        // 的值、落庫用替換後的值」的錯位（§1.3 明文禁止的形狀）。
+        //
+        // 這是**雙保險**：提案建立端（S2／S3／S5）存進 payload 的已是替換後值，本步是對
+        // 歷史遺留 payload（那些在落地替換上線前送出的提案）補網；依 D8 重複套用是幂等的。
+        $data = $this->replaceVariantsForApproval($table, $data);
+
         $data = $this->assignAutoKeyIfNeeded($table, $keyColumns, $data);
         $data = $this->enforceAuditFieldsForCreate($table, $data);
 
@@ -753,6 +777,14 @@ class OperationsProposalController extends Controller {
         $existing = DB::table($table)->where($this->buildKeyConditions($keyColumns, $data))->first();
         if ($existing) {
             throw new \RuntimeException('資料已存在，無法再次新增。');
+        }
+
+        // D7「兩形並存」：上面是替換後值的**精確**比對，擋不住「歸一後相同但字形不同」的
+        // 既有列（那是兩個不同的鍵值，唯一鍵也不會衝突）。今天走這條分支的表其文本型 PK
+        // 成員都在排除清單內，所以 findExistingRow() 會在 $inScope === [] 直接 return null
+        // ＝零額外查詢；掛著是為了日後任何文本型 PK 的表落到這條分支時不會靜默分裂。
+        if (VariantEquivalentLookup::findExistingRow($table, $keyColumns, $data) !== null) {
+            throw new \RuntimeException('已存在異體字歸一後相同的紀錄（字形不同），無法再次新增。');
         }
 
         // char_variant_map 走這條通用核准路徑（不在 HANDLER_ROUTED_RESOURCES）：落庫前必須
@@ -788,6 +820,10 @@ class OperationsProposalController extends Controller {
             throw new \RuntimeException('缺少原始資料，無法更新。');
         }
 
+        // 異體字落地替換：同樣掛在最上方。$conditions 用 $original（既有列的實際值）定位，
+        // 不受替換影響；而 buildUpdatePayload() 與改鍵碰撞偵測都讀 $data，必須看到替換後的值。
+        $data = $this->replaceVariantsForApproval($table, $data);
+
         $data = $this->enforceAuditFieldsForUpdate($table, $data, $original);
         $conditions = $this->buildKeyConditions($keyColumns, $original);
 
@@ -805,6 +841,12 @@ class OperationsProposalController extends Controller {
             $newKeyRow = $this->resolveReadbackKeyRow($keyColumns, $original, $updatePayload);
             if (DB::table($table)->where($this->buildKeyConditions($keyColumns, $newKeyRow))->exists()) {
                 throw new \RuntimeException('變更後的主鍵與現有記錄重複，無法核准此改鍵提案。');
+            }
+
+            // D7：同上，精確比對擋不住等價字形。排除自己（改鍵前那一列）交給 lookup 內部。
+            $selfPk = array_intersect_key($original, array_flip($keyColumns));
+            if (VariantEquivalentLookup::findExistingRow($table, $keyColumns, $newKeyRow, [$selfPk]) !== null) {
+                throw new \RuntimeException('變更後的主鍵與現有記錄異體字歸一後相同，無法核准此改鍵提案。');
             }
         }
 
@@ -858,8 +900,32 @@ class OperationsProposalController extends Controller {
         $conditions = $this->buildKeyConditions($keyColumns, $original);
 
         $row = DB::table($table)->where($conditions)->first();
+
         if (!$row) {
-            // 目標列已不存在：視為冪等成功，回傳原始資料以利稽核紀錄
+            // 刻意**不替換** $original（delete 的定位器就該是歷史快照當時的字形）。但自本階段
+            // 起，文本型 PK 成員（ASSOC_DATA.c_text_title、ALTNAME_DATA.c_alt_name_chn）**真的會**
+            // 被核准改寫，於是「待審的 delete 提案指向舊字形、目標列已被另一筆核准改名」從理論
+            // 變成常態。若直接當成冪等成功，approve() 會照樣寫一筆 DELETE 稽核並標記 approved，
+            // 而資料列還在——稽核鏈記錄了一件沒發生的事。所以先用歸一後的 PK 再探一次。
+            $normalizedOriginal = CharVariantMapService::replaceRow($original, $table)['data'];
+            $normalizedConditions = $this->buildKeyConditions($keyColumns, $normalizedOriginal);
+
+            if ($normalizedConditions !== $conditions) {
+                $row = DB::table($table)->where($normalizedConditions)->first();
+                if ($row) {
+                    $conditions = $normalizedConditions;
+                }
+            }
+        }
+
+        if (!$row) {
+            // 兩種字形都找不到：維持既有的冪等成功語義（目標列可能已被正常刪除），
+            // 但留下痕跡——否則「提案已過期」與「真的刪掉了」在稽核上長得一模一樣。
+            Log::warning('核准刪除提案時目標列已不存在（含異體字歸一後再探一次），視為冪等成功', [
+                'table' => $table,
+                'key_columns' => $keyColumns,
+            ]);
+
             return $original;
         }
 
@@ -1105,22 +1171,34 @@ class OperationsProposalController extends Controller {
             $type = Operation::TYPE_UPDATE;
         }
 
-        // delete 後 appliedRow 為被刪列（= original），以原始 PK 建立 resource_id
-        $resourceIdRow = $type === Operation::TYPE_DELETE ? $original : $appliedRow;
+        // delete 後 appliedRow 為**實際被刪除的那一列**。多數情況它與 $original 相同，
+        // 但當提案指向舊字形、目標列已被異體字歸一改名時，applyDeleteProposal() 會以歸一後的
+        // PK 再探一次並刪掉那一列 ⇒ 兩者字形不同。此時 resource_id 必須跟著實際刪除的列，
+        // 否則同一筆 DELETE 的 resource_id（舊字形）與 resource_data／audit row_pk（新字形）
+        // 互相矛盾，還原時也會指向一個不存在的鍵。
+        $resourceIdRow = $appliedRow;
+        if ($type === Operation::TYPE_DELETE) {
+            $hasKeys = $keyColumns !== [] && !array_diff($keyColumns, array_keys($appliedRow));
+            $resourceIdRow = $hasKeys ? $appliedRow : $original;
+        }
         $resourceId = $this->buildCompositeId($keyColumns, $resourceIdRow);
 
         // 對於 BiogMain 相關提案，使用實際的 c_personid；對於 Codes 提案使用 0
         $personId = $proposal->c_personid ?? 0;
 
         if ($type === Operation::TYPE_DELETE) {
+            // 快照也要用**實際刪除的那一列**，與上面的 resource_id 同源。三者（resource_id、
+            // resource_data／resource_original、audit row_pk）必須是同一個字形，否則
+            // 「還原這筆刪除」會以舊字形重建一列不存在過的資料。
+            // $resourceIdRow 已在上方決定（appliedRow 含齊主鍵時用它，否則回退 original）。
             return $this->operationRepository->store(
                 Auth::id(),
                 $personId,
                 Operation::TYPE_DELETE,
                 $proposal->resource,
                 $resourceId,
-                $original,
-                $original
+                $resourceIdRow,
+                $resourceIdRow
             );
         }
 

--- a/app/Repositories/BiogMainRepository.php
+++ b/app/Repositories/BiogMainRepository.php
@@ -1496,6 +1496,15 @@ class BiogMainRepository {
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
+        // 異體字落地替換（型別驅動）。提案核准走這條路（applyKinshipProposal／
+        // applyAssocProposal 不重放 v2 handler，直接呼叫本方法），所以 S3 的基底掛鉤覆蓋不到。
+        // legacy Blade 路徑共用本方法（flag=new 下已被 LegacyBladeFormGate 下架），共用同一份
+        // 替換語義本來就是想要的。掛在哨兵正規化之後、timestamp() 與任何 PK 計算之前；
+        // 稽核欄由排除清單擋住。
+        // KIN_DATA 的主鍵三欄都是數值，替換不會改鍵（不涉 D7）。
+        $data = CharVariantMapService::replaceRow($data, 'KIN_DATA')['data'];
+        // 零額外查詢的守衛（$inScope === [] 直接 return null）；掛著防日後主鍵變動時漏掉。
+        $this->assertNoVariantEquivalentRow('KIN_DATA', $data, [array_intersect_key((array) $row, array_flip(CompositePrimaryKey::SCHEMAS['KIN_DATA']))]);
         $data = (new ToolsRepository())->timestamp($data);
 
         $ori_data = $data;
@@ -1570,6 +1579,15 @@ class BiogMainRepository {
         $data['c_kin_code'] = $data['c_kin_code'] == -999 ? '0' : $data['c_kin_code'];
         $data['c_kin_id'] = $data['c_kin_id'] == -999 ? '0' : $data['c_kin_id'];
         $data['c_source'] = $data['c_source'] == -999 ? '0' : $data['c_source'];
+        // 異體字落地替換（型別驅動）。提案核准走這條路（applyKinshipProposal／
+        // applyAssocProposal 不重放 v2 handler，直接呼叫本方法），所以 S3 的基底掛鉤覆蓋不到。
+        // legacy Blade 路徑共用本方法（flag=new 下已被 LegacyBladeFormGate 下架），共用同一份
+        // 替換語義本來就是想要的。掛在哨兵正規化之後、timestamp() 與任何 PK 計算之前；
+        // 稽核欄由排除清單擋住。
+        // KIN_DATA 的主鍵三欄都是數值，替換不會改鍵（不涉 D7）。
+        $data = CharVariantMapService::replaceRow($data, 'KIN_DATA')['data'];
+        // KIN_DATA 主鍵三欄全數值 ⇒ 這道守衛零額外查詢；掛著是為了日後主鍵若變動不會漏。
+        $this->assertNoVariantEquivalentRow('KIN_DATA', $data);
         $data = (new ToolsRepository())->timestamp($data, true);
 
         $ori_Data = $data;
@@ -2445,6 +2463,25 @@ class BiogMainRepository {
         $old_c_assocship_pair2 = $old_c_assocship_pair['c_assoc_pair2'] ?? null;
 
         $data = Arr::except($data, ['_method', '_token', 'action', '__proposal_comment', 'c_assocship_pair', 'c_kinship_pair', 'c_assoc_kinship_pair', 'ai_fill_log_id']);
+        // 異體字落地替換（型別驅動）。提案核准走這條路（applyKinshipProposal／
+        // applyAssocProposal 不重放 v2 handler，直接呼叫本方法），所以 S3 的基底掛鉤覆蓋不到。
+        // legacy Blade 路徑共用本方法（flag=new 下已被 LegacyBladeFormGate 下架），共用同一份
+        // 替換語義本來就是想要的。掛在哨兵正規化之後、timestamp() 與任何 PK 計算之前；
+        // 稽核欄由排除清單擋住。
+        // 只替換 $data（要寫入的值）。定位既有列用的是 $id 解析出來的舊 PK，**不可替換**：
+        // 既有列可能存變體形（D6 不做回溯校正），替換定位器會讓 update 落空。
+        $data = CharVariantMapService::replaceRow($data, 'ASSOC_DATA')['data'];
+        // D7（改鍵時）：排除自己交給 lookup 內部；並且**只在真的改鍵時檢查**——既有資料
+        // 可能早就兩形並存，使用者只改 c_notes 是合法操作，無條件檢查會讓那些列永遠改不了。
+        $selfPk = array_intersect_key((array) $row, array_flip(CompositePrimaryKey::SCHEMAS['ASSOC_DATA']));
+        $newPk = array_intersect_key(array_replace($selfPk, $data), array_flip(CompositePrimaryKey::SCHEMAS['ASSOC_DATA']));
+        foreach (CompositePrimaryKey::SCHEMAS['ASSOC_DATA'] as $pkColumn) {
+            if ((string) ($newPk[$pkColumn] ?? '') !== (string) ($selfPk[$pkColumn] ?? '')) {
+                $this->assertNoVariantEquivalentRow('ASSOC_DATA', $newPk, [$selfPk]);
+
+                break;
+            }
+        }
         $data = (new ToolsRepository())->timestamp($data);
 
         $ori_data = $data;
@@ -2886,6 +2923,34 @@ class BiogMainRepository {
         }
     }
 
+    /**
+     * D7「兩形並存」守衛：核准／legacy 寫入路徑用（v2 側由 handler 的掛鉤負責）。
+     *
+     * 為什麼非做不可：`ASSOC_DATA.c_text_title` 是主鍵成員且在替換範圍內，所以替換等於改鍵。
+     * 既有列可能存變體形（D6 不做回溯校正），此時「原樣重送同一個變體形」在替換之後 PK 值
+     * 就不同了 ⇒ insert 成功、唯一鍵擋不住 ⇒ 同一組關係出現兩列語義相同、字形不同的資料。
+     * **在本步之前，同一筆輸入是乾淨的 1062**（approve() 有專屬 QueryException catch 回滾 +
+     * 友善提示），所以少了這道守衛就是把「乾淨拒絕」換成「靜默鑄出重複列」——比不替換更糟。
+     *
+     * KIN_DATA 三個主鍵欄都是數值 ⇒ `findExistingRow()` 的 `$inScope === []` 分支直接
+     * return null，零額外查詢；仍然掛上是為了日後主鍵若變動不會漏。
+     *
+     * @param array<string,mixed> $data 替換後、即將落庫的資料
+     * @param array<int,array<string,mixed>> $excludePks 要排除的列（改鍵時排除自己）
+     */
+    protected function assertNoVariantEquivalentRow(string $table, array $data, array $excludePks = []): void {
+        $keyColumns = CompositePrimaryKey::SCHEMAS[$table] ?? [];
+        if ($keyColumns === []) {
+            return;
+        }
+
+        if (VariantEquivalentLookup::findExistingRow($table, $keyColumns, $data, $excludePks) !== null) {
+            throw new \RuntimeException(
+                '已存在異體字歸一後相同的紀錄（字形不同），無法寫入；請先手動整理後再試。'
+            );
+        }
+    }
+
     /** 鏡像列集合是否為空（backfill 情境）。Collection 與陣列都要能吃。 */
     protected function isEmptyRowSet($rows): bool {
         if ($rows instanceof \Illuminate\Support\Collection) {
@@ -3146,6 +3211,18 @@ class BiogMainRepository {
         if ($data['c_assoc_first_year'] == '') {  #這個判斷式只會將「社會關係始年」為空白時，填充為-9999，如果使用者填寫0，會維持0的值而不更動。
             $data['c_assoc_first_year'] = '-9999';
         }
+        // 異體字落地替換（型別驅動）。提案核准走這條路（applyKinshipProposal／
+        // applyAssocProposal 不重放 v2 handler，直接呼叫本方法），所以 S3 的基底掛鉤覆蓋不到。
+        // legacy Blade 路徑共用本方法（flag=new 下已被 LegacyBladeFormGate 下架），共用同一份
+        // 替換語義本來就是想要的。掛在哨兵正規化之後、timestamp() 與任何 PK 計算之前；
+        // 稽核欄由排除清單擋住。
+        // ⚠️ ASSOC_DATA.c_text_title 是主鍵成員，替換等於改鍵——必須在下方 insert 與
+        // resource_id 組裝之前替換，兩者才看到同一個值（否則 operations 的 resource_id
+        // 會指向一個不存在的字形）。
+        $data = CharVariantMapService::replaceRow($data, 'ASSOC_DATA')['data'];
+        // D7：替換把 c_text_title（PK 成員）改成參考形之後，必須確認沒有「歸一後相同但
+        // 字形不同」的既有列，否則就是靜默鑄出重複列（見 assertNoVariantEquivalentRow）。
+        $this->assertNoVariantEquivalentRow('ASSOC_DATA', $data);
         $data = (new ToolsRepository())->timestamp($data, true);
 
         $ori_Data = $data;

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -518,6 +518,41 @@ validate 與 service，所以替換與標籤歸一自動生效；已補
 - **`char_variant_map` 的 guard**：`applyCreateProposal()`／`applyUpdateProposal()` 落庫前呼叫 `assertWritable()`，成功後 `CharVariantMapService::reset()`——該表**不在** `HANDLER_ROUTED_RESOURCES`，所以它的提案核准就是走這兩條。
 - **`OperationsController::restore()` 不做內容替換**（S1 只在它掛 `assertWritable()` 結構驗證，兩者不同）。本步測試含「restore 後歷史字形原樣保留」的負向斷言，鎖住這個刻意的不對稱。
 
+#### S6 執行結果補記
+
+計畫列的兩項在前面步驟已完成：`char_variant_map` 在通用核准路徑的 guard ＋ 清快取（**S3** 做的），
+實體聚合提案核准（**S4** 覆蓋，且已有回歸鎖）。本步真正新增的是四件事，以及 review 找出的五項。
+
+1. 通用分支 `applyCreateProposal()`／`applyUpdateProposal()` 的替換掛在**方法最上方、
+   `buildKeyConditions()` 之前**（計畫已強調不可寫成「落庫前」）。價值是對**歷史遺留 payload**
+   補網——提案建立端在 S2／S3／S5 已替換過。
+2. 親屬／社會關係的四個 repository 寫入方法（`kinshipStoreById`／`kinshipUpdateById`／
+   `assocStoreById`／`assocPerformUpdate`）各自掛鉤：核准不重放 v2 handler，S3 覆蓋不到。
+   `assocUpdateById` 只替換 `$data`，定位器（`$row`／`$id` 解析出的舊 PK）不動。
+3. **新增 D7 守衛 `assertNoVariantEquivalentRow()`（review 抓到的 HIGH）**：
+   `ASSOC_DATA.c_text_title` 是主鍵成員，替換等於改鍵。既有列可能存變體形，於是「原樣重送同一
+   變體形」在替換後 PK 值就不同了 ⇒ insert 成功、唯一鍵擋不住 ⇒ 靜默鑄出兩形並存的重複列。
+   **在加上替換之前，同一筆輸入是乾淨的 1062**（`approve()` 有專屬 QueryException catch 回滾），
+   所以少了守衛等於把「乾淨拒絕」換成「靜默重複」。update 側排除自己（交給 lookup 內部）
+   且**只在真的改鍵時檢查**（否則歷史上就已兩形並存的列會變成永遠改不了）。KIN_DATA 也掛——
+   三個主鍵欄全數值 ⇒ `$inScope === []` 直接 return null ＝零額外查詢，防日後主鍵變動時漏掉。
+   通用分支也接上同一個 lookup，理由相同（今天零成本，但把日後的缺口永久封掉）。
+4. **`applyDeleteProposal()` 的過期提案**：本階段起文本型 PK 真的會被核准改寫，於是「待審 delete
+   提案指向舊字形、目標列已被另一筆核准改名」從理論變成常態。直接當成冪等成功會讓 `approve()`
+   寫下一筆 DELETE 稽核並標記 approved，**而資料列還在**——稽核鏈記錄了一件沒發生的事。
+   改為：先用歸一後的 PK 再探一次；兩種字形都找不到才維持冪等並記 warning。
+   連帶修好 `logFinalOperation()`：DELETE 的 `resource_id` **與兩份快照**都改用實際刪除的那一列，
+   否則 resource_id（新字形）、resource_data（舊字形）、audit row_pk（新字形）三者互相矛盾，
+   還原時會以舊字形重建一列不存在過的資料。
+5. **restore 不做內容替換**（負向斷言，含正向對照）：restore 的語義是「恢復成歷史快照當時的
+   樣子」，順手歸一就不是還原而是改寫歷史。S1 只在 restore 掛了 `char_variant_map` 的**結構**
+   驗證（`assertWritable`），與內容替換是兩件不同的事。負向測試自己先斷言「替換機制在本環境
+   是活的」，否則機制整體死掉時它會假綠。
+
+驗證覆蓋：通用分支 create／update、親屬與社會關係的 create 與 update（assoc 那條斷言落庫列、
+`operations.resource_id`、`audit_log.row_pk`、**鏡像列**四處同一字形）、D7 守衛擋下重複列且提案
+維持 `pending`、非改鍵不被誤擋、delete 的兩形探測與三處字形一致、restore 原樣保留。
+
 ### S7：眾包回填、v1 端點、複製與修復工具（G6–G9）
 
 - `CrowdsourcingController::confirm():202` 落庫前套 `replaceRow()`，寫入點：`BiogMain::create` `:238`、`OfficeCode::create` `:250`、`OfficeCodeTypeRel::create` `:263`、`OfficeTypeTree::create` `:273`（`c_office_type_desc_chn` 是中文欄）、`$biog->update($data)` **五處**（`:293`／`:303`／`:313`／`:322`／`:340`）。

--- a/tests/Feature/OperationsAltnameRestoreTest.php
+++ b/tests/Feature/OperationsAltnameRestoreTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
 use App\Support\CompositePrimaryKey;
+use App\Support\VariantReplaceScope;
 use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -60,11 +62,14 @@ class OperationsAltnameRestoreTest extends TestCase {
             $table->integer('c_alt_name_type_code');
             $table->string('c_alt_name')->nullable();
             $table->string('c_alt_name_chn');
+            // 真實 ALTNAME_DATA 有 c_notes；異體字還原測試需要一個一般文本欄。
+            $table->text('c_notes')->nullable();
             $table->primary(['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code']);
         });
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('ALTNAME_DATA');
         Schema::dropIfExists('operations');
         Schema::dropIfExists('users');
@@ -541,5 +546,80 @@ class OperationsAltnameRestoreTest extends TestCase {
         $this->assertNotNull($row);
         $this->assertSame('Version 1', $row->c_alt_name);
         $this->assertEquals(1, $row->c_sequence);
+    }
+
+    /**
+     * plan S6 的負向斷言：**restore 不做內容替換**。
+     *
+     * 這是刻意的不對稱。restore 的語義是「把資料恢復成歷史快照當時的樣子」——若順手把
+     * 快照裡的變體形歸一，那就不是還原而是改寫歷史（而且會讓「還原後再比對快照」永遠不一致）。
+     * S1 只在 restore 掛了 `char_variant_map` 的**結構**驗證（assertWritable），與內容替換是
+     * 兩件不同的事。
+     */
+    #[Test]
+    public function test_restore_does_not_normalize_historical_variant_forms(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+
+        // 正向對照：先證明替換機制在本測試環境**是活的**。少了這行，若對照表沒載進來
+        // （建表失敗／範圍誤判／快取殘留），下面的「原樣保留」斷言會因為機制整體死掉而
+        // 假綠——負向測試必須自己證明它測的東西存在。
+        $this->assertSame('清', CharVariantMapService::replaceFor('ALTNAME_DATA', 'c_notes', '淸')['text']);
+
+        $this->actingAsAdmin();
+
+        DB::table('ALTNAME_DATA')->insert([
+            'c_personid' => 321,
+            'c_sequence' => 2,
+            'c_alt_name_type_code' => 10,
+            'c_alt_name' => 'New Name',
+            'c_alt_name_chn' => '張三',
+        ]);
+
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_personid' => 321,
+            'c_alt_name_chn' => '張三',
+            'c_alt_name_type_code' => 10,
+        ]);
+
+        // 歷史快照的備註帶變體形「淸」——還原後必須原樣保留。
+        $operation = Operation::create([
+            'user_id' => 1,
+            'c_personid' => 321,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode([
+                'c_personid' => 321, 'c_sequence' => 2, 'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10, 'c_alt_name' => 'New Name',
+            ], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode([
+                'c_personid' => 321, 'c_sequence' => 1, 'c_alt_name_chn' => '張三',
+                'c_alt_name_type_code' => 10, 'c_alt_name' => 'Old Name',
+                'c_notes' => '淸代舊注',
+            ], JSON_UNESCAPED_UNICODE),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $this->post("/operations/{$operation->id}/restore")->assertRedirect();
+
+        $row = DB::table('ALTNAME_DATA')->where('c_personid', 321)->first();
+        $this->assertSame('淸代舊注', $row->c_notes, 'restore 必須原樣還原歷史字形，不可順手歸一');
+        $this->assertSame('Old Name', $row->c_alt_name);
+
+        Schema::dropIfExists('char_variant_map');
     }
 }

--- a/tests/Feature/OperationsProposalControllerTest.php
+++ b/tests/Feature/OperationsProposalControllerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -219,6 +221,7 @@ class OperationsProposalControllerTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('char_variant_map');
         Schema::dropIfExists('KINSHIP_CODES');
         Schema::dropIfExists('KIN_DATA');
         Schema::dropIfExists('ASSOC_CODES');
@@ -1421,5 +1424,461 @@ class OperationsProposalControllerTest extends TestCase {
         $this->assertDatabaseHas('KIN_DATA', ['c_personid' => 2000, 'c_kin_id' => 1000, 'c_kin_code' => 101]);
         $this->assertSame(2, DB::table('KIN_DATA')->count(), '回滾：正反向皆不得半刪');
         $this->assertSame(0, DB::table('operations')->where('resource', 'KIN_DATA')->where('op_type', Operation::TYPE_DELETE)->count(), '不得寫入 final delete operation');
+    }
+    // ── 異體字落地替換：提案核准端（plan S6）────────────────
+
+    /**
+     * 最小 char_variant_map 種子（「淸→清」）。本檔其餘測試不建這張表，走
+     * CharVariantMapService 的「表不存在就降級」路徑、行為不變。
+     */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    /**
+     * 通用核准分支（applyCreateProposal）：**歷史遺留 payload** 的補網。
+     *
+     * 提案建立端（S2／S3／S5）存進 payload 的已是替換後值，所以這條測試刻意手造一筆
+     * 「落地替換上線前送出」的提案（payload 裡還是變體形），核准時必須替換後才落庫。
+     * TEXT_CODES 不在 HANDLER_ROUTED_RESOURCES，所以走的正是這條通用分支。
+     */
+    #[Test]
+    public function testApproveCreateProposalReplacesVariantsInLegacyPayload(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeAdmin());
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'TEXT_CODES',
+            'resource_id' => '90001',
+            'resource_data' => [
+                'c_textid' => 90001,
+                'c_title' => '淸嘉錄',
+                '__key_columns' => ['c_textid'],
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'create', 'submitted_by' => 'tester'],
+            ],
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $this->assertSame('清嘉錄', DB::table('TEXT_CODES')->where('c_textid', 90001)->value('c_title'));
+    }
+
+    /** 通用核准分支（applyUpdateProposal）同理。 */
+    #[Test]
+    public function testApproveUpdateProposalReplacesVariantsInLegacyPayload(): void {
+        $this->seedCharVariantMap();
+        DB::table('TEXT_CODES')->insert(['c_textid' => 90002, 'c_title' => '舊名']);
+        $this->actingAs($this->makeAdmin());
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'TEXT_CODES',
+            'resource_id' => '90002',
+            'resource_data' => [
+                'c_textid' => 90002,
+                'c_title' => '淸嘉錄',
+                '__key_columns' => ['c_textid'],
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'update', 'submitted_by' => 'tester'],
+            ],
+            'resource_original' => ['c_textid' => 90002, 'c_title' => '舊名'],
+        ]);
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $this->assertSame('清嘉錄', DB::table('TEXT_CODES')->where('c_textid', 90002)->value('c_title'));
+    }
+
+    /**
+     * 親屬提案核准不重放 v2 handler（直接呼叫 BiogMainRepository::kinshipStoreById），
+     * 所以 S3 的基底掛鉤覆蓋不到，必須在 repository 那層獨立掛。
+     */
+    #[Test]
+    public function testApproveKinshipCreateProposalReplacesVariants(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeAdmin());
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'KIN_DATA',
+            'resource_id' => '1000-2000-100',
+            'resource_data' => [
+                'c_personid' => 1000, 'c_kin_id' => 2000, 'c_kin_code' => 100,
+                'c_source' => 10, 'c_notes' => '淸代族譜',
+                'c_kinship_pair' => 0,
+                '__key_columns' => ['c_personid', 'c_kin_id', 'c_kin_code'],
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'create', 'submitted_by' => 'tester'],
+            ],
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $this->assertSame(
+            '清代族譜',
+            DB::table('KIN_DATA')->where(['c_personid' => 1000, 'c_kin_id' => 2000, 'c_kin_code' => 100])->value('c_notes')
+        );
+    }
+
+    /**
+     * 社會關係提案核准同理，而且 `c_text_title` 是**主鍵成員**——替換等於改鍵，
+     * 所以落庫的列與 operations 的 resource_id 必須看到同一個字形。
+     */
+    #[Test]
+    public function testApproveAssocCreateProposalReplacesVariantsInPrimaryKeyMember(): void {
+        $this->seedCharVariantMap();
+        $this->actingAs($this->makeAdmin());
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => '1000-1-2000-0-0-0-0-淸書-1060',
+            'resource_data' => [
+                'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000,
+                'c_kin_code' => 0, 'c_kin_id' => 0, 'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0,
+                'c_text_title' => '淸書', 'c_assoc_first_year' => 1060, 'c_source' => 10,
+                'c_assocship_pair' => 0, 'c_kinship_pair' => 0, 'c_assoc_kinship_pair' => 0,
+                '__key_columns' => [
+                    'c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id',
+                    'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year',
+                ],
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'create', 'submitted_by' => 'tester'],
+            ],
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '清書')->exists(),
+            'PK 成員應以參考形落庫'
+        );
+        $this->assertFalse(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '淸書')->exists()
+        );
+
+        // 落庫後寫的 operation（TYPE_CREATE）其 resource_id 必須用替換後的字形，
+        // 否則還原／稽核會指向一個不存在的列。
+        $created = DB::table('operations')
+            ->where('resource', 'ASSOC_DATA')
+            ->where('op_type', Operation::TYPE_CREATE)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($created);
+        // resource_id 是 http_build_query()（值 percent-encoded），先解碼再比字形。
+        $decodedResourceId = urldecode((string) $created->resource_id);
+        $this->assertStringContainsString('清書', $decodedResourceId);
+        $this->assertStringNotContainsString('淸書', $decodedResourceId);
+    }
+
+    /**
+     * review：`assocPerformUpdate` 的替換也要測（原本只測了 create）。
+     *
+     * 這條同時斷言 plan 要求的「四處看到同一個字形」：落庫列、`operations.resource_id`、
+     * `audit_log.row_pk`、**以及鏡像列**（鏡像是 `$data_mirror = $data` 直接繼承替換值，
+     * 是重構時最容易失手的地方）。
+     */
+    #[Test]
+    public function testApproveAssocUpdateProposalReplacesVariantsEverywhere(): void {
+        $this->seedCharVariantMap();
+
+        // 正向列與鏡像列都存舊書名。
+        DB::table('ASSOC_DATA')->insert([
+            ['c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '舊書', 'c_assoc_first_year' => 1060, 'c_source' => 10],
+            ['c_personid' => 2000, 'c_assoc_code' => 2, 'c_assoc_id' => 1000, 'c_kin_code' => 0, 'c_kin_id' => 1000,
+                'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 1000, 'c_text_title' => '舊書', 'c_assoc_first_year' => 1060, 'c_source' => 10],
+        ]);
+
+        $this->actingAs($this->makeAdmin());
+
+        $fwdPk = [
+            'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '舊書', 'c_assoc_first_year' => 1060,
+        ];
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => '1000-1-2000-0-0-0-0-舊書-1060',
+            'resource_data' => array_merge($fwdPk, [
+                'c_text_title' => '淸書', // 改書名，字形是變體形
+                'c_source' => 10,
+                'c_assocship_pair' => 2, 'c_kinship_pair' => 0, 'c_assoc_kinship_pair' => 0,
+                '__key_columns' => array_keys($fwdPk),
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'update', 'submitted_by' => 'tester'],
+            ]),
+            'resource_original' => array_merge($fwdPk, ['c_source' => 10]),
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation), ['review_comment' => '核准'])
+            ->assertRedirect();
+
+        // 1) 落庫列
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '清書')->exists(),
+            '正向列應以參考形落庫'
+        );
+        $this->assertFalse(DB::table('ASSOC_DATA')->where('c_text_title', '淸書')->exists(), '不得留下變體形');
+
+        // 2) 鏡像列
+        $this->assertTrue(
+            DB::table('ASSOC_DATA')->where('c_personid', 2000)->where('c_text_title', '清書')->exists(),
+            '鏡像列也要看到同一個字形'
+        );
+
+        // 3) operations.resource_id（percent-encoded，需先解碼）
+        $updated = DB::table('operations')
+            ->where('resource', 'ASSOC_DATA')
+            ->where('op_type', Operation::TYPE_UPDATE)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($updated);
+        $this->assertStringContainsString('清書', urldecode((string) $updated->resource_id));
+
+        // 4) audit_log.row_pk
+        $audit = DB::table('audit_log')
+            ->where('table_name', 'ASSOC_DATA')
+            ->where('operation', 'UPDATE')
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($audit);
+        $this->assertStringContainsString('清書', (string) $audit->row_pk);
+        $this->assertStringNotContainsString('淸書', (string) $audit->row_pk);
+    }
+
+    /** review：`kinshipUpdateById` 的替換也要測。 */
+    #[Test]
+    public function testApproveKinshipUpdateProposalReplacesVariants(): void {
+        $this->seedCharVariantMap();
+        // 親屬更新要求對面鏡像存在（否則 kinshipUpdateById 回 err、核准中止），
+        // 比照既有的 testApproveKinUpdateProposalSucceedsWhenMirrorInSync 建雙邊。
+        DB::table('KIN_DATA')->insert([
+            ['c_personid' => 1000, 'c_kin_id' => 2000, 'c_kin_code' => 100,
+                'c_source' => 10, 'c_notes' => '舊注', 'c_autogen_notes' => 'auto-x'],
+            ['c_personid' => 2000, 'c_kin_id' => 1000, 'c_kin_code' => 101,
+                'c_source' => 10, 'c_notes' => '舊注', 'c_autogen_notes' => 'auto-x'],
+        ]);
+        $this->actingAs($this->makeAdmin());
+
+        $fwdPk = ['c_personid' => 1000, 'c_kin_id' => 2000, 'c_kin_code' => 100];
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'KIN_DATA',
+            'resource_id' => '1000-2000-100',
+            'resource_data' => array_merge($fwdPk, [
+                'c_source' => 10, 'c_notes' => '淸代族譜', 'c_autogen_notes' => 'auto-x',
+                'c_kinship_pair' => 101,
+                '__key_columns' => array_keys($fwdPk),
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'update', 'submitted_by' => 'tester'],
+            ]),
+            'resource_original' => array_merge($fwdPk, ['c_source' => 10, 'c_notes' => '舊注', 'c_autogen_notes' => 'auto-x']),
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation), ['review_comment' => '核准'])
+            ->assertRedirect();
+
+        $this->assertSame(
+            '清代族譜',
+            DB::table('KIN_DATA')->where($fwdPk)->value('c_notes')
+        );
+        $this->assertSame(
+            '清代族譜',
+            DB::table('KIN_DATA')->where(['c_personid' => 2000, 'c_kin_id' => 1000, 'c_kin_code' => 101])->value('c_notes'),
+            '鏡像列也要看到替換後的值'
+        );
+    }
+
+    /**
+     * review（HIGH）：核准時替換把 `c_text_title` 改成參考形之後，若已有一列「歸一後相同
+     * 但字形不同」的資料，必須擋下——**不可靜默鑄出兩形並存的重複列**。
+     *
+     * 在這道守衛之前，同一筆輸入是乾淨的 1062（approve() 有專屬 QueryException catch）；
+     * 加了替換卻不加守衛，就是把「乾淨拒絕」換成「靜默重複」。
+     */
+    #[Test]
+    public function testApproveAssocCreateProposalBlocksVariantEquivalentDuplicate(): void {
+        $this->seedCharVariantMap();
+        // 既有列存變體形（D6 不做回溯校正）。
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '淸書', 'c_assoc_first_year' => 1060, 'c_source' => 10,
+        ]);
+        $this->actingAs($this->makeAdmin());
+
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_CREATE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => '1000-1-2000-0-0-0-0-清書-1060',
+            'resource_data' => [
+                'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000,
+                'c_kin_code' => 0, 'c_kin_id' => 0, 'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0,
+                'c_text_title' => '清書', 'c_assoc_first_year' => 1060, 'c_source' => 10,
+                'c_assocship_pair' => 0, 'c_kinship_pair' => 0, 'c_assoc_kinship_pair' => 0,
+                '__key_columns' => [
+                    'c_personid', 'c_assoc_code', 'c_assoc_id', 'c_kin_code', 'c_kin_id',
+                    'c_assoc_kin_code', 'c_assoc_kin_id', 'c_text_title', 'c_assoc_first_year',
+                ],
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'create', 'submitted_by' => 'tester'],
+            ],
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation))->assertRedirect();
+
+        $this->assertSame(1, DB::table('ASSOC_DATA')->count(), '不得鑄出第二列語義重複的關係');
+        $this->assertSame('淸書', DB::table('ASSOC_DATA')->value('c_text_title'), '既有列不變（整筆回滾）');
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('pending', $payload['__review_status'] ?? null, '核准應失敗、提案維持 pending（不是被標成 rejected）');
+    }
+
+    /**
+     * codex：delete 提案的兩形探測——目標列已被另一筆核准改名成參考形時，
+     * 舊字形的定位器落空，必須用歸一後的 PK 再探一次並真的刪掉；
+     * 不可當成「冪等成功」而寫下一筆沒發生的 DELETE 稽核。
+     */
+    #[Test]
+    public function testApproveDeleteProposalFindsRowRenamedByVariantNormalization(): void {
+        $this->seedCharVariantMap();
+
+        // 現況：列已是**參考形**（被另一筆核准歸一過）。
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '清書', 'c_assoc_first_year' => 1060, 'c_source' => 10,
+        ]);
+        $this->actingAs($this->makeAdmin());
+
+        // 待審的 delete 提案仍指向**舊字形**。
+        $oldPk = [
+            'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '淸書', 'c_assoc_first_year' => 1060,
+        ];
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_DELETE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => '1000-1-2000-0-0-0-0-淸書-1060',
+            'resource_data' => array_merge($oldPk, [
+                '__key_columns' => array_keys($oldPk),
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'delete', 'submitted_by' => 'tester'],
+            ]),
+            'resource_original' => array_merge($oldPk, ['c_source' => 10]),
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation), ['review_comment' => '核准'])
+            ->assertRedirect();
+
+        $this->assertSame(0, DB::table('ASSOC_DATA')->count(), '歸一後的那一列才是目標，必須真的被刪除');
+
+        // codex：最終 DELETE operation 的 resource_id 必須跟著**實際刪除的列**（參考形），
+        // 否則同一筆稽核的 resource_id（舊字形）與 resource_data／audit row_pk（新字形）互相矛盾。
+        $deleted = DB::table('operations')
+            ->where('resource', 'ASSOC_DATA')
+            ->where('op_type', Operation::TYPE_DELETE)
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($deleted);
+        $this->assertStringContainsString('清書', urldecode((string) $deleted->resource_id));
+        $this->assertStringNotContainsString('淸書', urldecode((string) $deleted->resource_id));
+
+        // 快照（resource_data／resource_original）與 audit row_pk 也必須是同一個字形，
+        // 否則「還原這筆刪除」會以舊字形重建一列不存在過的資料。
+        $deletedPayload = json_decode((string) $deleted->resource_data, true);
+        $this->assertSame('清書', $deletedPayload['c_text_title'] ?? null);
+        $deletedOriginal = json_decode((string) $deleted->resource_original, true);
+        $this->assertSame('清書', $deletedOriginal['c_text_title'] ?? null);
+
+        $auditDelete = DB::table('audit_log')
+            ->where('table_name', 'ASSOC_DATA')
+            ->where('operation', 'DELETE')
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($auditDelete);
+        $this->assertStringContainsString('清書', (string) $auditDelete->row_pk);
+        $this->assertStringNotContainsString('淸書', (string) $auditDelete->row_pk);
+    }
+
+    /**
+     * codex：D7 守衛在 update 側必須排除自己、且**只在真的改鍵時**檢查——
+     * 既有資料可能早就兩形並存，只改 c_notes 是合法操作，不可被擋成「永遠改不了」。
+     */
+    #[Test]
+    public function testApproveAssocUpdateOfNonKeyFieldIsNotBlockedByCoexistingVariantForms(): void {
+        $this->seedCharVariantMap();
+
+        // 兩列**只有 c_text_title 的字形不同**、歸一後相同——這才是「歷史上就已兩形並存」，
+        // 也才是無條件檢查會誤擋的形狀（其餘 PK 欄都相同，所以互為等價候選）。
+        DB::table('ASSOC_DATA')->insert([
+            ['c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '清書', 'c_assoc_first_year' => 1060, 'c_source' => 10],
+            ['c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+                'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '淸書', 'c_assoc_first_year' => 1060, 'c_source' => 10],
+        ]);
+        $this->actingAs($this->makeAdmin());
+
+        $fwdPk = [
+            'c_personid' => 1000, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '清書', 'c_assoc_first_year' => 1060,
+        ];
+        $operation = $this->proposalOperation([
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'ASSOC_DATA',
+            'resource_id' => '1000-1-2000-0-0-0-0-清書-1060',
+            'resource_data' => array_merge($fwdPk, [
+                'c_source' => 10, 'c_notes' => '只改備註',
+                'c_assocship_pair' => 0, 'c_kinship_pair' => 0, 'c_assoc_kinship_pair' => 0,
+                '__key_columns' => array_keys($fwdPk),
+                '__review_status' => 'pending',
+                '__proposal_meta' => ['action' => 'update', 'submitted_by' => 'tester'],
+            ]),
+            'resource_original' => array_merge($fwdPk, ['c_source' => 10]),
+        ]);
+        $operation->c_personid = 1000;
+        $operation->save();
+
+        $this->post(route('operations.proposals.approve', $operation), ['review_comment' => '核准'])
+            ->assertRedirect();
+
+        $operation->refresh();
+        $payload = json_decode($operation->resource_data, true);
+        $this->assertSame('approved', $payload['__review_status'] ?? null, '沒有改鍵 ⇒ 不該被 D7 擋下');
+        $this->assertSame(
+            '只改備註',
+            DB::table('ASSOC_DATA')->where('c_personid', 1000)->where('c_text_title', '清書')->value('c_notes')
+        );
+        $this->assertNull(
+            DB::table('ASSOC_DATA')->where('c_text_title', '淸書')->value('c_notes'),
+            '另一形那列不該被動到'
+        );
     }
 }


### PR DESCRIPTION
## 這一步做了什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S6**：提案核准的直接寫庫分支。

計畫列的兩項在前面步驟已完成（`char_variant_map` 的 guard ＋ 清快取在 **S3**、實體聚合核准在 **S4**），本步新增：

- **通用分支**（`applyCreateProposal`／`applyUpdateProposal`）的替換掛在**方法最上方、`buildKeyConditions()` 之前**——不是「落庫前」，否則會重演「查重用替換前值、落庫用替換後值」的錯位。價值是對**歷史遺留 payload** 補網。
- **親屬／社會關係**核准不重放 v2 handler、直接呼叫 `BiogMainRepository` 的四個寫入方法，S3 的基底掛鉤覆蓋不到，四處各自補掛（`assocUpdateById` 只替換 `$data`，定位器不動）。
- **restore 刻意不做內容替換**的負向斷言（含正向對照，避免機制整體死掉時假綠）。

## Review 抓到的 HIGH：核准端必須自己做 D7 守衛

`ASSOC_DATA.c_text_title` 是主鍵成員，替換等於改鍵。既有列可能存變體形（D6 不做回溯校正），於是「原樣重送同一變體形」在替換後 PK 值就不同了 ⇒ insert 成功、唯一鍵擋不住 ⇒ **靜默鑄出兩列語義相同、字形不同的資料**。

關鍵在於：**加上替換之前，同一筆輸入是乾淨的 1062**（`approve()` 有專屬 `QueryException` catch 回滾 + 友善提示）。所以只加替換不加守衛，等於把「乾淨拒絕」換成「靜默重複」——正是 `VariantEquivalentLookup` 檔頭寫的「比完全不替換更糟」。

新增 `assertNoVariantEquivalentRow()`：update 側排除自己（交給 lookup 內部）且**只在真的改鍵時檢查**（否則歷史上就已兩形並存的列會變成永遠改不了）；`KIN_DATA` 與通用分支也接上（主鍵無可替換文本欄時零額外查詢），把日後的缺口永久封掉。

## 連帶修好的過期 delete 提案

本階段起文本型 PK 真的會被核准改寫，「待審 delete 提案指向舊字形、目標列已被另一筆核准改名」從理論變成常態。原本直接當成冪等成功，會讓 `approve()` 寫下一筆 DELETE 稽核並標記 approved，**而資料列還在**。

- `applyDeleteProposal()`：先用歸一後的 PK 再探一次；兩種字形都找不到才維持冪等並記 warning。
- `logFinalOperation()`：DELETE 的 `resource_id` **與兩份快照**都改用實際刪除的那一列——否則 `resource_id`（新字形）、`resource_data`（舊字形）、`audit_log.row_pk`（新字形）三者互相矛盾，還原那筆刪除會以舊字形重建一列不存在過的資料。

## 驗證

- `./vendor/bin/phpunit` 全綠：**2931 tests / 15464 assertions**；`php-cs-fixer` 0 fixes
- 新測試：通用分支 create／update 的歷史 payload 補網、親屬與社會關係的 create 與 update（assoc 那條斷言落庫列／`operations.resource_id`／`audit_log.row_pk`／**鏡像列**四處同一字形）、D7 守衛擋下重複列且提案維持 `pending`、非改鍵不被誤擋、delete 的兩形探測與三處字形一致、restore 原樣保留
- 每條都以「把機制中和掉會紅」驗證；其中一條第一版寫錯（第二列在多個 PK 欄都不同 ⇒ 互不是等價候選、無條件版本照樣綠），已修成正確形狀並重新測量
- Review：review agent 一輪（6 項發現，含上述 HIGH）＋ codex 四輪，最後回「沒有需修正的實質問題」

🤖 Generated with [Claude Code](https://claude.com/claude-code)