### PR TITLE
異體字落地替換 S7：眾包回填、v1 端點、複製與修復工具

### DIFF
--- a/app/Http/Controllers/Api/OperationsController.php
+++ b/app/Http/Controllers/Api/OperationsController.php
@@ -10,7 +10,9 @@ use App\Models\OfficeTypeTree;
 use App\Models\Operation;
 use App\Models\User;
 use App\Repositories\BiogMainRepository;
+use App\Services\CharVariantMapService;
 use App\Services\SecurityAuditLogger;
+use App\Support\VariantReplaceScope;
 use Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -55,6 +57,46 @@ class OperationsController extends Controller {
         return $x;
     }
 
+    /**
+     * 對客戶端送來的 JSON payload 套異體字落地替換（v1 token API 仍在服役）。
+     *
+     * 幾個刻意的選擇：
+     * - **先過 fail-closed**：`$resource` 由客戶端任意給、無白名單，未知表一律原樣存入
+     *   （`VariantReplaceScope::modeFor()` 內部也會 fail-closed，這裡先擋是為了連 decode 都省）。
+     * - **decode 失敗就原樣存入**：維持現況語義（壞 JSON 原樣存、到 `CrowdsourcingController::confirm()`
+     *   才爆），不可變成字串 `"null"`，也不可在此當場拋錯而改變既有 API 行為。
+     * - re-encode 用 `JSON_UNESCAPED_UNICODE`：中文以原字元存，比較與人工檢視都直覺；
+     *   代價是既存位元內容（鍵序／escaping）可能與客戶端原字串不同，這是可接受的。
+     *
+     * @param mixed $json 客戶端送來的原始 JSON 字串
+     */
+    private function replaceVariantsInJsonPayload($json, ?string $resource): string {
+        $raw = (string) $json;
+
+        // **只有與註冊表拼法完全相同時才替換**，刻意與下游的分派保持對稱：
+        // `CrowdsourcingController::confirm()` 的 switch 與 `update_operations()` 的
+        // `$y == "BIOG_MAIN"` 都是精確比對，所以 `" biog_main "` 這種鬆散寫法根本不會被寫入
+        // 任何表。若這裡放行它去替換，就會出現「payload 被改寫、卻永遠不會落庫」的不對稱，
+        // 而且等於讓未驗證的外部字串進到 schema 查詢（那條路徑的空結果會被快取住，
+        // 讓該表在這個 process 之後都不替換——S1 註解警告過的靜默失效）。
+        $canonical = $resource === null || $resource === ''
+            ? null
+            : VariantReplaceScope::canonicalTableName($resource);
+        if ($canonical === null || $canonical !== $resource) {
+            return $raw;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return $raw;
+        }
+
+        $replaced = CharVariantMapService::replaceRow($decoded, $canonical)['data'];
+        $encoded = json_encode($replaced, JSON_UNESCAPED_UNICODE);
+
+        return $encoded === false ? $raw : $encoded;
+    }
+
     public function add_operations($keyword) {
         $user = $this->resolveActiveUserByToken($keyword['token'] ?? null);
         if (!$user) {
@@ -72,7 +114,7 @@ class OperationsController extends Controller {
 
         $operation = new Operation();
         $operation->resource = $y;
-        $operation->resource_data = $x;
+        $operation->resource_data = $this->replaceVariantsInJsonPayload($x, $y);
         $operation->user_id = $token; //這邊要規劃由token取值.
         $operation->crowdsourcing_status = 2;
         $operation->op_type = 1;
@@ -140,7 +182,9 @@ class OperationsController extends Controller {
         $operation->resource = $y;
         $operation->c_personid = $c_personid;
         $operation->resource_id = $resource_id;
-        $operation->resource_data = $x;
+        $operation->resource_data = $this->replaceVariantsInJsonPayload($x, $y);
+        // resource_original 是**歷史快照**（更新前的既有列），刻意不替換——那是「當時實際
+        // 長什麼樣」的事實，改寫它等於偽造紀錄（與 restore 不做內容替換同一個道理）。
         $operation->resource_original = $ori;
         $operation->user_id = $token; //這邊要規劃由token取值.
         $operation->crowdsourcing_status = 2;

--- a/app/Http/Controllers/BasicInformationController.php
+++ b/app/Http/Controllers/BasicInformationController.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
@@ -1976,6 +1977,10 @@ class BasicInformationController extends Controller {
         $data['c_personid'] = $new_id;
         $data = $this->toolRepository->timestamp($data, true); //建檔資訊
         $data['c_modified_by'] = $data['c_modified_date'] = '';
+        // 異體字落地替換：這是「複製既有列」而非新錄入，但既然要複製出**一列新資料**，
+        // 就該複製成正規化後的字形（否則另存出來的人物永遠帶著舊字形，而且新列不受
+        // D6「不回溯校正」保護的理由——它不是既有資料）。
+        $data = CharVariantMapService::replaceRow($data, 'BIOG_MAIN')['data'];
         $flight = null;
         DB::transaction(function () use (&$flight, $data, $new_id) {
             $flight = BiogMain::create($data);
@@ -2003,6 +2008,43 @@ class BasicInformationController extends Controller {
     }
 
     //20240701新增Duplicate Collateral Info功能
+    /**
+     * 複製工具用的「歸一後主鍵」去重器。
+     *
+     * 為什麼需要：`Duplicate_Collateral_Info()` 逐列複製子表，而異體字替換會把「同一人底下
+     * 只差字形的兩列」（例如 `c_pages` = `淸一` 與 `清一`、或 `c_text_title` 同理）壓成**同一個
+     * 主鍵**。第二次 insert 就撞唯一鍵、整個 DB::transaction 回滾 ⇒ 複製功能對這些人物永久
+     * 失敗，而且沒有可行動的訊息（AGENTS.md §1.1 要求撞鍵轉友好報錯）。
+     *
+     * 這裡改成「保留第一列、跳過後續等價列並記 warning」：複製本來就是便利功能，
+     * 少一列語義重複的資料比整個功能失敗好，而原始資料完全不動（D6）。
+     *
+     * @param array<string,mixed> $row 替換後的列
+     * @param array<string,bool> $seen 呼叫端持有的已見主鍵集（by reference）
+     */
+    protected function shouldSkipDuplicateAfterVariantReplacement(string $table, array $row, array &$seen): bool {
+        $keyColumns = CompositePrimaryKey::SCHEMAS[$table] ?? [];
+        if ($keyColumns === []) {
+            return false;
+        }
+
+        $fingerprint = [];
+        foreach ($keyColumns as $column) {
+            $fingerprint[] = (string) ($row[$column] ?? '');
+        }
+        $fingerprint = $table.'|'.implode('|', $fingerprint);
+
+        if (isset($seen[$fingerprint])) {
+            Log::warning('複製時跳過異體字歸一後重複的列', ['table' => $table, 'fingerprint' => $fingerprint]);
+
+            return true;
+        }
+
+        $seen[$fingerprint] = true;
+
+        return false;
+    }
+
     public function Duplicate_Collateral_Info($id) {
         if (!Auth::check()) {
             flash('請登入後編輯 @ '.Carbon::now(), 'error');
@@ -2018,11 +2060,17 @@ class BasicInformationController extends Controller {
         $flight = null;
         $new_id = BiogMain::max('c_personid') + 1;
 
-        DB::transaction(function () use (&$flight, $id, $new_id, $auditLogService) {
+        // 替換後可能把「只差字形的兩列」壓成同一個主鍵，逐表記錄已見主鍵以便跳過（見
+        // shouldSkipDuplicateAfterVariantReplacement()）。
+        $seenKeys = [];
+
+        DB::transaction(function () use (&$flight, $id, $new_id, $auditLogService, &$seenKeys) {
             $data = BiogMain::find($id)->toArray();
             $data['c_personid'] = $new_id;
             $data = $this->toolRepository->timestamp($data, true); //建檔資訊
             $data['c_modified_by'] = $data['c_modified_date'] = '';
+            // 異體字落地替換（同 saveas()：複製出的是新列，要複製成正規化後的字形）。
+            $data = CharVariantMapService::replaceRow($data, 'BIOG_MAIN')['data'];
 
             $flight = BiogMain::create($data);
             $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_MAIN', $new_id, $data);
@@ -2052,6 +2100,13 @@ class BasicInformationController extends Controller {
                 $addr_data['c_personid'] = $new_id;
                 $addr_data = Arr::except($addr_data, ['_token']);
                 $addr_data = $this->toolRepository->timestamp($addr_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $addr_data = CharVariantMapService::replaceRow($addr_data, 'BIOG_ADDR_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('BIOG_ADDR_DATA', $addr_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('BIOG_ADDR_DATA')->insert($addr_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_ADDR_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $addr_data['c_personid'],
@@ -2085,6 +2140,13 @@ class BasicInformationController extends Controller {
                 $source_data = (array)$source_data;
                 $source_data['c_personid'] = $new_id;
                 $source_data = Arr::except($source_data, ['_token']);
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $source_data = CharVariantMapService::replaceRow($source_data, 'BIOG_SOURCE_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('BIOG_SOURCE_DATA', $source_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('BIOG_SOURCE_DATA')->insert($source_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_SOURCE_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $source_data['c_personid'],
@@ -2116,6 +2178,13 @@ class BasicInformationController extends Controller {
                 $kin_data = (array)$kin_data;
                 $kin_data['c_personid'] = $new_id;
                 $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $kin_data = CharVariantMapService::replaceRow($kin_data, 'KIN_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('KIN_DATA', $kin_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('KIN_DATA')->insert($kin_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $kin_data['c_personid'],
@@ -2147,6 +2216,13 @@ class BasicInformationController extends Controller {
                 $kin_pair_id = $kin_data['c_personid'];
                 $kin_data['c_kin_id'] = $new_id;
                 $kin_data = $this->toolRepository->timestamp($kin_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $kin_data = CharVariantMapService::replaceRow($kin_data, 'KIN_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('KIN_DATA', $kin_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('KIN_DATA')->insert($kin_data);
                 $operation = $this->operationRepository->store(Auth::id(), $kin_pair_id, 1, 'KIN_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $kin_data['c_personid'],
@@ -2184,6 +2260,13 @@ class BasicInformationController extends Controller {
                 $assoc_data['c_tertiary_personid'] = 0;
                 $assoc_data['c_tertiary_type_notes'] = null;
                 $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $assoc_data = CharVariantMapService::replaceRow($assoc_data, 'ASSOC_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('ASSOC_DATA', $assoc_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('ASSOC_DATA')->insert($assoc_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $assoc_data['c_personid'],
@@ -2233,6 +2316,13 @@ class BasicInformationController extends Controller {
                 $assoc_data['c_tertiary_personid'] = 0;
                 $assoc_data['c_tertiary_type_notes'] = null;
                 $assoc_data = $this->toolRepository->timestamp($assoc_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $assoc_data = CharVariantMapService::replaceRow($assoc_data, 'ASSOC_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('ASSOC_DATA', $assoc_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('ASSOC_DATA')->insert($assoc_data);
                 $operation = $this->operationRepository->store(Auth::id(), $assoc_pair_id, 1, 'ASSOC_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $assoc_data['c_personid'],
@@ -2277,6 +2367,13 @@ class BasicInformationController extends Controller {
                 $inst_data['c_personid'] = $new_id;
                 $inst_data = Arr::except($inst_data, ['_token']);
                 $inst_data = $this->toolRepository->timestamp($inst_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $inst_data = CharVariantMapService::replaceRow($inst_data, 'BIOG_INST_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('BIOG_INST_DATA', $inst_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('BIOG_INST_DATA')->insert($inst_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'BIOG_INST_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $inst_data['c_personid'],
@@ -2311,6 +2408,13 @@ class BasicInformationController extends Controller {
                 $status_data['c_personid'] = $new_id;
                 $status_data = Arr::except($status_data, ['_token']);
                 $status_data = $this->toolRepository->timestamp($status_data, true); //建檔資訊
+                // 異體字落地替換：複製出的是**新列**，要複製成正規化後的字形；且必須早於下面
+                // operations／audit 的 resource_id 與 row_pk 組裝（BIOG_SOURCE_DATA 的 c_pages、
+                // ASSOC_DATA 的 c_text_title 都是文本型主鍵成員，三者必須看到同一個字形）。
+                $status_data = CharVariantMapService::replaceRow($status_data, 'STATUS_DATA')['data'];
+                if ($this->shouldSkipDuplicateAfterVariantReplacement('STATUS_DATA', $status_data, $seenKeys)) {
+                    continue;
+                }
                 DB::table('STATUS_DATA')->insert($status_data);
                 $operation = $this->operationRepository->store(Auth::id(), $new_id, 1, 'STATUS_DATA', CompositePrimaryKey::buildStoredResourceId([
                     'c_personid' => $status_data['c_personid'],

--- a/app/Http/Controllers/CrowdsourcingController.php
+++ b/app/Http/Controllers/CrowdsourcingController.php
@@ -10,7 +10,9 @@ use App\Models\Operation;
 use App\Repositories\BiogMainRepository;
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
+use App\Services\CharVariantMapService;
 use App\Support\CompositePrimaryKey;
+use App\Support\VariantReplaceScope;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
@@ -222,6 +224,28 @@ class CrowdsourcingController extends Controller {
         $pId = $data[0]['resource_id'];
         $data = $data[0]['resource_data'];
         $data = json_decode($data, true);
+
+        // 異體字落地替換（型別驅動）。眾包回填是**歷史 payload 的最後一道**：提交端可能早於
+        // 落地替換上線（v1 端點的舊提案），所以這裡必須自己替換一次；依 D8 重複套用是幂等的。
+        //
+        // 掛在這裡（decode 之後、進 switch 之前）一次覆蓋全部會寫入的分支——它們的目標表都是
+        // $resource（新增 4：BIOG_MAIN／OFFICE_CODES／OFFICE_CODE_TYPE_REL／OFFICE_TYPE_TREE；
+        // 更新與 BIOG_MAIN 刪除共 5 處 $biog->update()）。$resource 由 operations 列帶來、
+        // 未知表由 VariantReplaceScope 的 fail-closed 擋掉（原樣不動）。
+        //
+        // **$originalData 保留未替換的 payload**：op_type=4 的三個 OFFICE_* 分支只做
+        // $biog->delete()、完全不寫 $data，卻仍把它存進 operations 當快照。那份快照是
+        // restoreDelete() 重建被刪列的依據，替換它等於「還原出一列從未存在過的字形」，
+        // 也違反「快照＝當時實際發生什麼」的原則（v1 的 resource_original 同理不替換）。
+        $originalData = $data;
+        // 同 v1 端點：只有與註冊表拼法**完全相同**時才替換，與下面 switch 的精確比對對稱
+        // （鬆散寫法會落到 default、根本不寫入，替換它只會製造「改了卻沒落庫」的不對稱），
+        // 同時避免把不精確的字串送進 schema 查詢而毒化型別快取。
+        $canonicalResource = VariantReplaceScope::canonicalTableName((string) $resource);
+        if (is_array($data) && $canonicalResource !== null && $canonicalResource === (string) $resource) {
+            $data = CharVariantMapService::replaceRow($data, $canonicalResource)['data'];
+        }
+
         $updated_at = Carbon::now()->format('YmdHis');
 
         //資料對應處理
@@ -348,7 +372,8 @@ class CrowdsourcingController extends Controller {
                     $ori = json_decode($biog);
                     $biog->delete();
                     DB::table('operations')->where('id', $id)->update(['crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at]);
-                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $data, $ori);
+                    // 本分支不寫 $data，只刪列；快照用**未替換**的 payload（見上方 $originalData 註解）。
+                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $originalData, $ori);
                     flash('Delete success @ '.Carbon::now(), 'success');
 
                     break;
@@ -358,7 +383,7 @@ class CrowdsourcingController extends Controller {
                     $ori = json_decode($biog);
                     $biog->delete();
                     DB::table('operations')->where('id', $id)->update(['crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at]);
-                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $data, $ori);
+                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $originalData, $ori); // 同上：不寫 $data，快照不替換
                     flash('Update success @ '.Carbon::now(), 'success');
 
                     break;
@@ -367,7 +392,7 @@ class CrowdsourcingController extends Controller {
                     $ori = json_decode($biog);
                     $biog->delete();
                     DB::table('operations')->where('id', $id)->update(['crowdsourcing_status' => 1, 'rate' => $rate, 'updated_at' => $updated_at]);
-                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $data, $ori);
+                    $this->operationRepository->store(Auth::id(), 0, 4, $resource, $pId, $originalData, $ori); // 同上：不寫 $data，快照不替換
                     flash('Delete success @ '.Carbon::now(), 'success');
 
                     break;

--- a/app/Http/Controllers/UnidirectionalRelationshipRepairController.php
+++ b/app/Http/Controllers/UnidirectionalRelationshipRepairController.php
@@ -4,9 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Repositories\OperationRepository;
 use App\Repositories\ToolsRepository;
+use App\Services\CharVariantMapService;
 use App\Services\RelationshipMirrorService;
+use App\Support\CompositePrimaryKey;
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -186,6 +189,24 @@ class UnidirectionalRelationshipRepairController extends Controller {
             // 創建反向關係記錄
             $newRelation = $this->buildReverseRelation($type, $relation, $params);
             $newRelation = $this->toolsRepository->timestamp($newRelation, true);
+            // 異體字落地替換：只替換**非主鍵欄**（c_notes／c_pages 等內容欄），主鍵成員一律不動。
+            //
+            // 為什麼主鍵成員必須排除（review 抓到的資料完整性問題）：`ASSOC_DATA.c_text_title`
+            // 既是主鍵成員、也是鏡像的**定位鍵**（RelationshipMirrorService::locateOppositeEdges()
+            // 與 reverseRelationExists() 都拿正向列的原字形做精確比對）。若只把補建的鏡像歸一：
+            //   1. 缺邊偵測仍以正向列的變體形去找 ⇒ 找不到新鏡像 ⇒ 這對關係永遠被報成單向；
+            //   2. 使用者再按一次修復，`reverseRelationExists()` 同樣找不到 ⇒ 再插一次同樣的列
+            //      ⇒ 撞唯一鍵 1062、整筆回滾，修復工具失去幂等；
+            //   3. 對面若已有另一個變體形的鏡像，兩者 PK 不同又都歸一成同一形 ⇒ 靜默鑄出重複列。
+            // 這個工具的職責是「補一條與正向列成對的反向邊」，所以鏡像必須與正向列同形。
+            // 真正的收斂發生在使用者下次**經編輯器觸碰**這段關係時（S3 的「觸碰即歸一」會把
+            // 正向與鏡像一起改名，且該路徑有 D7 守衛）。
+            $keyColumns = CompositePrimaryKey::SCHEMAS[(string) $config['table']] ?? [];
+            $replaceableColumns = Arr::except($newRelation, $keyColumns);
+            $newRelation = array_replace(
+                $newRelation,
+                CharVariantMapService::replaceRow($replaceableColumns, (string) $config['table'])['data']
+            );
 
             DB::table($config['table'])->insert($newRelation);
 

--- a/app/Support/VariantReplaceScope.php
+++ b/app/Support/VariantReplaceScope.php
@@ -295,7 +295,10 @@ final class VariantReplaceScope {
         }
 
         if (!array_key_exists($t, self::$columnTypes)) {
-            self::$columnTypes[$t] = self::loadColumnTypes($table);
+            // 用 canonical 名查 schema：快取鍵是正規化名，但查詢必須用註冊表的原始拼法，
+            // 否則「BIOG_MAIN 」（尾空白）這種外部字串會查到空結果並被快取住，
+            // 讓該表在這個 process 之後都不替換（S1 註解警告過的靜默失效模式）。
+            self::$columnTypes[$t] = self::loadColumnTypes(self::canonicalTableName($table) ?? $table);
         }
 
         if (!array_key_exists($t, self::$textColumnCache)) {
@@ -325,6 +328,21 @@ final class VariantReplaceScope {
         }
 
         return isset(self::$knownTables[self::normalize($table)]);
+    }
+
+    /**
+     * 把（可能來自外部、大小寫／空白不精確的）表名換成註冊表裡的原始拼法。
+     *
+     * 未知表回 null——呼叫端據此走 fail-closed，也避免把未驗證字串送進 Schema 查詢。
+     */
+    public static function canonicalTableName(string $table): ?string {
+        if (self::$knownTables === null) {
+            self::$knownTables = self::loadKnownTables();
+        }
+
+        $canonical = self::$knownTables[self::normalize($table)] ?? null;
+
+        return is_string($canonical) ? $canonical : null;
     }
 
     /** 清快取。**必須在 TestCase::setUp() 呼叫**——測試自建的合成表在不同檔案有不同欄位集。 */
@@ -365,10 +383,14 @@ final class VariantReplaceScope {
             }
         }
 
+        // 值存**註冊表裡的原始拼法**（不是 true）：外部字串（例如 v1 token API 的 resource）
+        // 可能帶大小寫差異或前後空白，正規化後雖然通得過 isKnownDataTable()，但拿原字串去查
+        // schema 會查不到欄位、而那個空結果會被三層快取記住 ⇒ 該表在這個 process 之後都不
+        // 替換。所以要能把外部字串換成 canonical 名再去查 schema。
         $set = [];
         foreach ($names as $name) {
             if ($name !== '') {
-                $set[self::normalize($name)] = true;
+                $set[self::normalize($name)] = $name;
             }
         }
 

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -561,6 +561,39 @@ validate 與 service，所以替換與標籤歸一自動生效；已補
 - `UnidirectionalRelationshipRepairController::executeRepair()`（insert `:190`）：建鏡像列時逐字複製 `c_text_title`／`c_notes`，落庫前套。
 - 測試：v1 端點提交含「淸」的人物提案 → payload 已替換；經 `confirm()` 回填後 `BIOG_MAIN` 為「清」；另補「提案 payload 未替換（模擬歷史資料）→ 回填時仍替換」鎖住雙保險。
 
+#### S7 執行結果補記
+
+四個區塊都串上了，但 review 找出**兩個「修一半比不修更糟」的形狀**，以及三項邊界問題：
+
+1. **修復工具只能替換非主鍵欄**（HIGH）。`ASSOC_DATA.c_text_title` 既是主鍵成員、也是鏡像的
+   **定位鍵**（`RelationshipMirrorService::reverseRelationExists()`／`locateOppositeEdges()` 都拿
+   正向列的原字形做精確比對）。只把補建的鏡像歸一會造成：(a) 缺邊偵測仍以正向列的變體形去找
+   ⇒ 找不到新鏡像 ⇒ 這對關係永遠被報成單向、修復按鈕修不掉；(b) 再按一次修復同樣找不到 ⇒
+   再插一次同樣的列 ⇒ 撞唯一鍵、整筆回滾，工具失去幂等；(c) 對面若已有另一個變體形的鏡像，
+   兩者 PK 不同又都歸一成同一形 ⇒ 靜默鑄出重複列。
+   所以修復路徑排除主鍵成員（`c_notes`／`c_pages` 等內容欄照樣歸一），鏡像與正向列保持同形；
+   真正的收斂留給「使用者下次經編輯器觸碰這段關係」（S3 的觸碰即歸一，那條路有 D7 守衛）。
+2. **`confirm()` 的替換不可溢出到「只刪不寫」的分支**。`op_type=4` 的三個 `OFFICE_*` 分支只做
+   `$biog->delete()`、完全不寫 `$data`，卻仍把它存成 operations 快照——而那份快照是
+   `restoreDelete()` 重建被刪列的依據。替換它等於「還原出一列從未存在過的字形」，也違反
+   「快照＝當時實際發生什麼」（v1 的 `resource_original` 同理不替換）。改為保留未替換的
+   `$originalData` 給這三個分支。
+3. **`VariantReplaceScope` 的型別快取毒化**（S1 註解自己警告過的失效模式，S7 是第一個把
+   **未驗證外部字串**送進來的呼叫點）。`isKnownDataTable()` 大小寫／空白不敏感，但
+   `textColumns()` 以正規化名當快取鍵、卻用原始字串查 schema ⇒ `" BIOG_MAIN "` 會查到空欄位集
+   並被三層快取記住，該表在這個 process 之後都不替換。修法：`loadKnownTables()` 改存 canonical
+   拼法、新增 `canonicalTableName()`、`textColumns()` 一律用 canonical 名查 schema。
+   **但兩個外部入口（v1／confirm）刻意收斂成「表名必須與註冊表拼法完全相同才替換」**——
+   下游分派本來就是精確比對，把 canonical 名套進分派等於放寬未驗證字串能觸發寫入的範圍。
+4. **複製工具的歸一撞鍵**：`Duplicate_Collateral_Info()` 逐列複製時，替換會把「同一人底下只差
+   字形的兩列」壓成同一個主鍵，第二次 insert 撞唯一鍵讓整個複製交易回滾 ⇒ 該功能對這些人物
+   永久失敗且沒有可行動訊息（違反 §1.1「撞鍵轉友好報錯」）。改為保留第一列、跳過等價列並記
+   warning。
+5. 已知且刻意接受：v1「payload 已替換 vs `resource_original` 未替換」會讓審核頁的 diff 出現
+   使用者沒動過的欄位（含變體字的 `c_notes` 等）——這是掛鉤在提交端的必然結果，S9 的 CHANGELOG
+   會記一句。另外 re-encode 除了鍵序／escaping，理論上還會把 `{}` 變 `[]`；所有現有消費者都是
+   decode 後使用，assoc 模式下不可見，判定無實害。
+
 ### S8：把「新增文本錄入必須掛落地替換」寫成常規
 
 **硬性關卡，不得因時間壓力跳過。** 本階段價值有一半在「以後不會再漏」——第二階段之所以漏掉 19 個 handler，正是因為當時沒有任何機制會在漏掉時發出聲音。

--- a/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
+++ b/tests/Feature/UnidirectionalRelationshipRepairControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -65,6 +67,7 @@ class UnidirectionalRelationshipRepairControllerTest extends TestCase {
     }
 
     protected function tearDown(): void {
+        Schema::dropIfExists('char_variant_map');
         // 按照依赖关系顺序删除表（先删除有外键约束的表）
         Schema::dropIfExists('operations');
         Schema::dropIfExists('audit_log');
@@ -1347,5 +1350,84 @@ class UnidirectionalRelationshipRepairControllerTest extends TestCase {
                 && ($rowPk['c_assoc_id'] ?? null) == $person1->c_personid
                 && ($rowPk['c_assoc_code'] ?? null) == 5;
         }));
+    }
+
+    /**
+     * 異體字落地替換（plan S7）：修復工具**不可**替換主鍵／定位鍵成員。
+     *
+     * `ASSOC_DATA.c_text_title` 既是主鍵成員也是鏡像定位鍵（`reverseRelationExists()` 與
+     * `locateOppositeEdges()` 都拿正向列的原字形做精確比對）。若把補建的鏡像歸一：
+     *   1. 缺邊偵測仍以正向列的變體形去找 ⇒ 找不到新鏡像 ⇒ 永遠被報成單向；
+     *   2. 再按一次修復同樣找不到 ⇒ 再插一次同樣的列 ⇒ 撞唯一鍵、整筆回滾（失去幂等）。
+     * 所以鏡像的 c_text_title 必須與正向列同形，而 c_notes 這類**非鍵**內容欄照樣歸一。
+     */
+    #[Test]
+    public function assoc_repair_keeps_key_glyph_paired_but_normalizes_content_columns() {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+
+        $person1 = $this->createTestPerson();
+        $person2 = $this->createTestPerson();
+
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => $person1->c_personid,
+            'c_assoc_id' => $person2->c_personid,
+            'c_assoc_code' => 4,
+            'c_kin_code' => 0,
+            'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0,
+            'c_assoc_kin_id' => 0,
+            'c_text_title' => '淸文獻',
+            'c_assoc_first_year' => 1000,
+            'c_inst_code' => 0,
+            'c_inst_name_code' => 0,
+            'c_source' => 200,
+            'c_pages' => '20-25',
+            'c_notes' => '淸代備註',
+        ]);
+
+        $payload = [
+            'c_personid' => $person1->c_personid,
+            'c_assoc_id' => $person2->c_personid,
+            'c_assoc_code' => 4,
+            'new_c_assoc_code' => 5,
+        ];
+
+        $this->actingAs($this->adminUser)
+            ->postJson(route('admin.unidirectional-relationship-repair.assoc'), $payload)
+            ->assertStatus(200);
+
+        $mirror = DB::table('ASSOC_DATA')
+            ->where('c_personid', $person2->c_personid)
+            ->where('c_assoc_id', $person1->c_personid)
+            ->first();
+        $this->assertNotNull($mirror, '應補建反向關係');
+        $this->assertSame('淸文獻', $mirror->c_text_title, '主鍵／定位鍵成員必須與正向列同形');
+        $this->assertSame('清代備註', $mirror->c_notes, '非鍵內容欄照樣歸一');
+
+        // 幂等：再按一次修復要得到「反向關係已存在」的乾淨 400，而不是撞唯一鍵回滾。
+        $this->actingAs($this->adminUser)
+            ->postJson(route('admin.unidirectional-relationship-repair.assoc'), $payload)
+            ->assertStatus(400);
+
+        $this->assertSame(
+            2,
+            DB::table('ASSOC_DATA')->count(),
+            '不得插出第三列（正向 + 鏡像共 2 列）'
+        );
+
+        Schema::dropIfExists('char_variant_map');
     }
 }

--- a/tests/Feature/VariantReplaceCrowdsourcingAndV1Test.php
+++ b/tests/Feature/VariantReplaceCrowdsourcingAndV1Test.php
@@ -1,0 +1,666 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\CharVariantMapService;
+use App\Support\VariantReplaceScope;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 異體字落地替換：眾包回填與 v1 token API（plan S7）。
+ *
+ * 這兩條路的共同點是「payload 可能早於落地替換上線」，所以**提交端與回填端都要替換**
+ * （依 D8 幂等）。v1 端點另有兩個必須守住的邊界：未知 resource 原樣存入（fail-closed）、
+ * 壞 JSON 原樣存入（維持現況語義，不可變成字串 "null" 也不可當場拋錯）。
+ */
+class VariantReplaceCrowdsourcingAndV1Test extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->integer('rate')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+
+        Schema::create('BIOG_MAIN', function (Blueprint $table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name_chn')->nullable();
+            $table->string('c_name')->nullable();
+            $table->string('c_surname_chn')->nullable();
+            $table->string('c_mingzi_chn')->nullable();
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->dateTime('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->dateTime('c_modified_date')->nullable();
+        });
+
+        Schema::create('OFFICE_CODES', function (Blueprint $table) {
+            $table->integer('c_office_id')->primary();
+            $table->string('c_office_chn')->nullable();
+            $table->string('c_office_pinyin')->nullable();
+            $table->text('c_notes')->nullable();
+        });
+
+        $this->seedCharVariantMap();
+    }
+
+    protected function tearDown(): void {
+        foreach ($this->extraTables as $extra) {
+            Schema::dropIfExists($extra);
+        }
+
+        foreach ([
+            'char_variant_map', 'STATUS_DATA', 'BIOG_INST_DATA', 'ASSOC_DATA', 'KIN_DATA',
+            'BIOG_SOURCE_DATA', 'BIOG_ADDR_DATA', 'OFFICE_CODES', 'BIOG_MAIN', 'audit_log', 'operations', 'users',
+        ] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    /** 與 migration 同源的最小種子（「淸→清」）。 */
+    protected function seedCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10);
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(1);
+            $table->string('c_notes', 255)->nullable();
+            $table->timestamps();
+            $table->unique('c_variant_char', 'char_variant_map_c_variant_char_unique');
+        });
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+        CharVariantMapService::reset();
+        VariantReplaceScope::reset();
+    }
+
+    protected function makeCrowdUser(string $token = 'LONG-LIVED-TOKEN'): User {
+        return User::forceCreate([
+            'name' => '眾包使用者',
+            'email' => 'crowd-variant@example.com',
+            'password' => bcrypt('secret'),
+            'confirmation_token' => $token,
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_CROWDSOURCING,
+        ]);
+    }
+
+    // ── v1 token API：提交端 ────────────────────────────────
+
+    /** 提交端就替換：payload 存進 operations 時已是參考形。 */
+    #[Test]
+    public function testV1AddReplacesVariantsInSubmittedPayload(): void {
+        $this->makeCrowdUser();
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'BIOG_MAIN',
+            'json' => json_encode(['c_name_chn' => '淸河', 'c_notes' => '淸人'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $payload = json_decode((string) DB::table('operations')->value('resource_data'), true);
+        $this->assertSame('清河', $payload['c_name_chn']);
+        $this->assertSame('清人', $payload['c_notes']);
+    }
+
+    /** 未知 resource（客戶端可任意給、無白名單）⇒ fail-closed，原樣存入。 */
+    #[Test]
+    public function testV1AddLeavesUnknownResourcePayloadUntouched(): void {
+        $this->makeCrowdUser();
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'NOT_A_CBDB_TABLE',
+            'json' => json_encode(['whatever' => '淸河'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $payload = json_decode((string) DB::table('operations')->value('resource_data'), true);
+        $this->assertSame('淸河', $payload['whatever'], '未知表一律不替換（fail-closed）');
+    }
+
+    /**
+     * 壞 JSON ⇒ 原樣存入。
+     *
+     * 現況語義是「原樣存、到 confirm() 才爆」；不可因為加了替換就變成字串 "null"
+     * （那會讓壞資料看起來像合法的 null payload），也不可在此當場拋錯改變 API 行為。
+     */
+    #[Test]
+    public function testV1AddKeepsMalformedJsonAsIs(): void {
+        $this->makeCrowdUser();
+        $broken = '{"c_name_chn": "淸河"';
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'BIOG_MAIN',
+            'json' => $broken,
+        ]);
+
+        $this->assertSame($broken, DB::table('operations')->value('resource_data'));
+    }
+
+    /**
+     * update 端：payload 替換，但 resource_original（歷史快照）**不動**。
+     *
+     * 用 OFFICE_CODES 而非 BIOG_MAIN：後者的 $ori 走 byPersonId()，會 withCount 十幾張
+     * 關聯表，為了驗一件事而建那些表不成比例。OFFICE_CODES 走的是同一段 update_operations
+     * 邏輯（只換 else 分支取 $ori 的方式），足以鎖住「payload 替換／快照不替換」。
+     */
+    #[Test]
+    public function testV1UpdateReplacesPayloadButNotOriginalSnapshot(): void {
+        $this->makeCrowdUser();
+        DB::table('OFFICE_CODES')->insert(['c_office_id' => 8001, 'c_office_chn' => '淸吏司', 'c_notes' => '淸人']);
+
+        $this->post('/api/operations/update', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'OFFICE_CODES',
+            'pId' => 8001,
+            'json' => json_encode(['c_office_id' => 8001, 'c_office_chn' => '淸吏司改'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $operation = DB::table('operations')->latest('id')->first();
+        $this->assertNotNull($operation);
+        $payload = json_decode((string) $operation->resource_data, true);
+        $this->assertSame('清吏司改', $payload['c_office_chn'], 'payload 要替換');
+
+        // 快照由 Eloquent 以預設 escaping 存（非 ASCII 會變成 \uXXXX 轉義），所以先解碼再比字形。
+        $original = json_decode((string) $operation->resource_original, true);
+        $this->assertSame('淸吏司', $original['c_office_chn'] ?? null, '歷史快照必須原樣保留（那是當時的事實）');
+        $this->assertSame('淸人', $original['c_notes'] ?? null);
+    }
+
+    // ── 眾包回填（confirm）────────────────────────────────
+
+    /** 回填端也替換：模擬**歷史遺留 payload**（提交早於落地替換上線）。 */
+    #[Test]
+    public function testConfirmReplacesVariantsInLegacyPayload(): void {
+        $admin = User::forceCreate([
+            'name' => '審核者',
+            'email' => 'confirm-variant@example.com',
+            'confirmation_token' => 'tok',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+        $this->actingAs($admin);
+
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'c_personid' => 0,
+            'op_type' => 1,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => '',
+            // 未替換的歷史 payload
+            'resource_data' => json_encode(['c_name_chn' => '淸河', 'c_notes' => '淸人'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 2,
+            'rate' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->get("/crowdsourcing/{$operationId}/confirm");
+
+        $row = DB::table('BIOG_MAIN')->first();
+        $this->assertNotNull($row, '回填應建立人物列');
+        $this->assertSame('清河', $row->c_name_chn, '回填時必須替換（雙保險的第二層）');
+        $this->assertSame('清人', $row->c_notes);
+    }
+
+    /** 未知 resource 的回填同樣 fail-closed（不替換、也不該炸）。 */
+    #[Test]
+    public function testConfirmLeavesUnknownResourceUntouched(): void {
+        $admin = User::forceCreate([
+            'name' => '審核者',
+            'email' => 'confirm-unknown@example.com',
+            'confirmation_token' => 'tok2',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+        $this->actingAs($admin);
+
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'c_personid' => 0,
+            'op_type' => 1,
+            'resource' => 'NOT_A_CBDB_TABLE',
+            'resource_id' => '',
+            'resource_data' => json_encode(['whatever' => '淸河'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 2,
+            'rate' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // 斷言重導（而不是只看 DB）：未知 resource 若讓替換拋錯，Laravel 會渲染成 500，
+        // 沒有這行的話後面的斷言照樣成立、測試變成空轉。
+        $this->get("/crowdsourcing/{$operationId}/confirm")->assertRedirect();
+
+        // 未知 resource 在 switch 裡沒有分支 ⇒ 不落庫；重點是不能因為替換而拋錯。
+        $this->assertSame(0, DB::table('BIOG_MAIN')->count());
+        $this->assertSame(
+            '淸河',
+            json_decode((string) DB::table('operations')->where('id', $operationId)->value('resource_data'), true)['whatever']
+        );
+    }
+    // ── 複製工具（saveas／Duplicate_Collateral_Info）──────────
+
+    /**
+     * `saveas()` 複製出的是**新列**，要複製成正規化後的字形。
+     *
+     * 這兩條路由（`routes/web.php:161-162`）**沒有掛 `legacy.form`**，不受 migration flag 影響、
+     * 現在就是活的，而且沒有 React 替代品——所以不能當成 legacy 略過。
+     */
+    #[Test]
+    public function testSaveAsCopiesNormalizedGlyphs(): void {
+        $editor = User::forceCreate([
+            'name' => '編輯者',
+            'email' => 'saveas-variant@example.com',
+            'confirmation_token' => 'tok-saveas',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+        $this->actingAs($editor);
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 9001,
+            'c_name_chn' => '淸河',
+            'c_surname_chn' => '淸',
+            'c_mingzi_chn' => '河',
+            'c_notes' => '淸人所記',
+        ]);
+
+        $this->get('/basicinformation/9001/saveas');
+
+        $copy = DB::table('BIOG_MAIN')->where('c_personid', '!=', 9001)->first();
+        $this->assertNotNull($copy, '應另存出一列新人物');
+        $this->assertSame('清河', $copy->c_name_chn, '複製出的新列要用參考形');
+        $this->assertSame('清', $copy->c_surname_chn);
+        $this->assertSame('清人所記', $copy->c_notes);
+
+        // 原列不動（D6：既有資料不做回溯校正）。
+        $this->assertSame('淸河', DB::table('BIOG_MAIN')->where('c_personid', 9001)->value('c_name_chn'));
+    }
+
+    /**
+     * `Duplicate_Collateral_Info()` 連帶複製 8 張子表，每一列都是**新列**，要用參考形。
+     *
+     * 這條測試特別鎖住**順序**：`BIOG_SOURCE_DATA.c_pages` 與 `ASSOC_DATA.c_text_title`
+     * 都是文本型主鍵成員，替換必須早於 `operations.resource_id` 與 `audit_log.row_pk` 的組裝，
+     * 三者才會看到同一個字形（同 S6 的教訓）。
+     */
+    #[Test]
+    public function testDuplicateCollateralInfoCopiesNormalizedGlyphsIncludingTextPrimaryKeys(): void {
+        $this->createCollateralTables();
+
+        $editor = User::forceCreate([
+            'name' => '編輯者',
+            'email' => 'dup-variant@example.com',
+            'confirmation_token' => 'tok-dup',
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+        $this->actingAs($editor);
+
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 9100, 'c_name_chn' => '淸河', 'c_notes' => '淸人']);
+        // 同一人底下兩列**只差字形**：歸一後 PK 相同。沒有去重的話第二次 insert 撞唯一鍵，
+        // 整個複製交易回滾 ⇒ 複製功能對這種人物永久失敗且沒有可行動訊息。
+        DB::table('BIOG_SOURCE_DATA')->insert([
+            ['c_personid' => 9100, 'c_textid' => 500, 'c_pages' => '淸一', 'c_notes' => '淸注'],
+            ['c_personid' => 9100, 'c_textid' => 500, 'c_pages' => '清一', 'c_notes' => '參考形那列'],
+        ]);
+        DB::table('ASSOC_DATA')->insert([
+            'c_personid' => 9100, 'c_assoc_code' => 1, 'c_assoc_id' => 2000, 'c_kin_code' => 0, 'c_kin_id' => 0,
+            'c_assoc_kin_code' => 0, 'c_assoc_kin_id' => 0, 'c_text_title' => '淸書', 'c_assoc_first_year' => 1060,
+        ]);
+
+        $this->get('/basicinformation/9100/Duplicate_Collateral_Info');
+
+        $newId = (int) DB::table('BIOG_MAIN')->where('c_personid', '!=', 9100)->value('c_personid');
+        $this->assertGreaterThan(0, $newId, '應複製出一列新人物');
+
+        // 文本型主鍵成員要以參考形落庫，而且兩列歸一後撞同一 PK ⇒ 只保留第一列（不整批失敗）。
+        $copiedSources = DB::table('BIOG_SOURCE_DATA')->where('c_personid', $newId)->get();
+        $this->assertCount(1, $copiedSources, '歸一後重複的列應被跳過，而不是讓整個複製回滾');
+        $this->assertSame('清一', $copiedSources[0]->c_pages);
+        $this->assertSame('清注', $copiedSources[0]->c_notes, '保留的是第一列');
+        $this->assertSame('清書', DB::table('ASSOC_DATA')->where('c_personid', $newId)->value('c_text_title'));
+
+        // operations 的 resource_id 必須跟落庫值同字形（否則還原／稽核指向不存在的鍵）。
+        $sourceOp = DB::table('operations')
+            ->where('resource', 'BIOG_SOURCE_DATA')
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($sourceOp);
+        $this->assertStringContainsString('清一', urldecode((string) $sourceOp->resource_id));
+        $this->assertStringNotContainsString('淸一', urldecode((string) $sourceOp->resource_id));
+
+        // audit_log 的 row_pk 同理。
+        $sourceAudit = DB::table('audit_log')->where('table_name', 'BIOG_SOURCE_DATA')->latest('id')->first();
+        $this->assertNotNull($sourceAudit);
+        $this->assertStringContainsString('清一', (string) $sourceAudit->row_pk);
+        $this->assertStringNotContainsString('淸一', (string) $sourceAudit->row_pk);
+
+        // 原列不動（D6）：兩種字形都還在。
+        $this->assertSame(2, DB::table('BIOG_SOURCE_DATA')->where('c_personid', 9100)->count());
+        $this->assertTrue(DB::table('BIOG_SOURCE_DATA')->where('c_personid', 9100)->where('c_pages', '淸一')->exists());
+    }
+
+    /**
+     * `confirm()` 的 update 分支會用 `BiogMainRepository::byPersonId()` 取 $ori，
+     * 那個查詢對十幾張關聯表做 withCount，所以這些表必須存在（可為空、只要 join 欄）。
+     */
+    protected function createPersonCountDependencies(): void {
+        $pairs = [
+            'TEXT_CODES' => ['c_textid'],
+            'BIOG_TEXT_DATA' => ['c_personid', 'c_textid'],
+            'BIOG_ADDR_DATA' => ['c_personid'],
+            'ALTNAME_CODES' => ['c_name_type_code'],
+            'ALTNAME_DATA' => ['c_personid', 'c_alt_name_type_code'],
+            'POSTED_TO_OFFICE_DATA' => ['c_personid', 'c_office_id'],
+            'ENTRY_CODES' => ['c_entry_code'],
+            'ENTRY_DATA' => ['c_personid', 'c_entry_code'],
+            'STATUS_CODES' => ['c_status_code'],
+            'STATUS_DATA' => ['c_personid', 'c_status_code'],
+            'KINSHIP_CODES' => ['c_kincode'],
+            'KIN_DATA' => ['c_personid', 'c_kin_code'],
+            'ASSOC_CODES' => ['c_assoc_code'],
+            'ASSOC_DATA' => ['c_personid', 'c_assoc_code'],
+            'POSSESSION_ACT_CODES' => ['c_possession_act_code'],
+            'POSSESSION_DATA' => ['c_personid', 'c_possession_act_code'],
+            'BIOG_INST_CODES' => ['c_bi_role_code'],
+            'BIOG_INST_DATA' => ['c_personid', 'c_bi_role_code'],
+            'EVENT_CODES' => ['c_event_code'],
+            'EVENTS_DATA' => ['c_personid', 'c_event_code'],
+            'BIOG_SOURCE_DATA' => ['c_personid', 'c_textid'],
+        ];
+
+        foreach ($pairs as $table => $columns) {
+            if (Schema::hasTable($table)) {
+                continue;
+            }
+            Schema::create($table, function (Blueprint $blueprint) use ($columns) {
+                foreach ($columns as $column) {
+                    $blueprint->integer($column)->default(0);
+                }
+            });
+            $this->extraTables[] = $table;
+        }
+    }
+
+    /** @var array<int,string> 由 createPersonCountDependencies() 建的表，tearDown 要清掉。 */
+    protected array $extraTables = [];
+
+    /** Duplicate_Collateral_Info() 會無條件查全部 8 張子表，所以要全部存在（可為空）。 */
+    protected function createCollateralTables(): void {
+        Schema::create('BIOG_ADDR_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_addr_id')->default(0);
+            $table->integer('c_addr_type')->default(0);
+            $table->integer('c_sequence')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+        Schema::create('BIOG_SOURCE_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_textid')->default(0);
+            $table->string('c_pages')->default('');
+            $table->text('c_notes')->nullable();
+            // **真實複合主鍵**：少了它，「歸一後兩列撞同一 PK」根本不會發生，
+            // 去重機制的測試就變成空轉（review 抓到）。
+            $table->primary(['c_personid', 'c_textid', 'c_pages']);
+        });
+        Schema::create('KIN_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_kin_code')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+        Schema::create('ASSOC_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_assoc_code')->default(0);
+            $table->integer('c_assoc_id')->default(0);
+            $table->integer('c_kin_code')->default(0);
+            $table->integer('c_kin_id')->default(0);
+            $table->integer('c_assoc_kin_code')->default(0);
+            $table->integer('c_assoc_kin_id')->default(0);
+            $table->string('c_text_title')->default('');
+            $table->integer('c_assoc_first_year')->default(0);
+            $table->text('c_notes')->nullable();
+            // 第二個 ASSOC 迴圈（三方關係）會補這兩欄。
+            $table->integer('c_tertiary_personid')->nullable();
+            $table->text('c_tertiary_type_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+        Schema::create('BIOG_INST_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_inst_code')->default(0);
+            $table->integer('c_inst_name_code')->default(0);
+            $table->integer('c_bi_role_code')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+        Schema::create('STATUS_DATA', function (Blueprint $table) {
+            $table->integer('c_personid');
+            $table->integer('c_sequence')->default(0);
+            $table->integer('c_status_code')->default(0);
+            $table->text('c_notes')->nullable();
+            $table->text('c_supplement')->nullable();
+            $table->string('c_created_by')->nullable();
+            $table->string('c_created_date')->nullable();
+            $table->string('c_modified_by')->nullable();
+            $table->string('c_modified_date')->nullable();
+        });
+    }
+    // ── review round 2 補的覆蓋 ─────────────────────────────
+
+    /**
+     * confirm() 的 **update 分支**（九個寫入點裡最常走的一半）落庫字形。
+     */
+    #[Test]
+    public function testConfirmUpdateBranchReplacesVariants(): void {
+        $this->createPersonCountDependencies();
+        $this->actingAs($this->makeApprover('confirm-update@example.com'));
+        DB::table('BIOG_MAIN')->insert(['c_personid' => 7100, 'c_name_chn' => '舊名', 'c_notes' => '舊注']);
+
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'c_personid' => 7100,
+            'op_type' => 3,
+            'resource' => 'BIOG_MAIN',
+            'resource_id' => '7100',
+            'resource_data' => json_encode(['c_personid' => 7100, 'c_name_chn' => '淸河', 'c_notes' => '淸人'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 2,
+            'rate' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->get("/crowdsourcing/{$operationId}/confirm");
+
+        $row = DB::table('BIOG_MAIN')->where('c_personid', 7100)->first();
+        $this->assertSame('清河', $row->c_name_chn);
+        $this->assertSame('清人', $row->c_notes);
+    }
+
+    /**
+     * confirm() 的 **delete-only 分支不寫 $data**，卻仍把它存成 operations 快照。
+     * 那份快照是 restoreDelete() 重建被刪列的依據 ⇒ **不可替換**，否則還原會產生一列
+     * 從未存在過的字形（與「快照＝當時實際發生什麼」的原則相違）。
+     */
+    #[Test]
+    public function testConfirmDeleteBranchKeepsSnapshotUnreplaced(): void {
+        $this->actingAs($this->makeApprover('confirm-delete@example.com'));
+        DB::table('OFFICE_CODES')->insert(['c_office_id' => 8100, 'c_office_chn' => '淸吏司']);
+
+        $operationId = DB::table('operations')->insertGetId([
+            'user_id' => 1,
+            'c_personid' => 0,
+            'op_type' => 4,
+            'resource' => 'OFFICE_CODES',
+            'resource_id' => '8100',
+            'resource_data' => json_encode(['c_office_id' => 8100, 'c_office_chn' => '淸吏司'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 2,
+            'rate' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->get("/crowdsourcing/{$operationId}/confirm");
+
+        $this->assertSame(0, DB::table('OFFICE_CODES')->count(), '該列應被刪除');
+
+        $deleteOp = DB::table('operations')->where('op_type', 4)->where('resource', 'OFFICE_CODES')->latest('id')->first();
+        $this->assertNotNull($deleteOp);
+        $snapshot = json_decode((string) $deleteOp->resource_data, true);
+        $this->assertSame('淸吏司', $snapshot['c_office_chn'] ?? null, '刪除快照必須保留當時的字形');
+    }
+
+    /**
+     * v1 的 payload 以 `JSON_UNESCAPED_UNICODE` re-encode（中文存原字元）。
+     * 拿掉那個 flag 這條會紅——先前所有測試都先 json_decode 再比，測不到這件事。
+     */
+    #[Test]
+    public function testV1PayloadIsStoredWithUnescapedUnicode(): void {
+        $this->makeCrowdUser();
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'BIOG_MAIN',
+            'json' => json_encode(['c_name_chn' => '淸河'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $raw = (string) DB::table('operations')->value('resource_data');
+        $this->assertStringContainsString('清河', $raw, '應以原字元存（JSON_UNESCAPED_UNICODE）');
+        $this->assertStringNotContainsString('\\u6e05', $raw);
+    }
+
+    /**
+     * strict／lenient 在同一列並存：`c_surname_chn`／`c_mingzi_chn`／`c_name_chn` 是人名欄
+     * （strict：`峯` 不替換），同列的 `c_notes` 走全量規則（`峯`→`峰`）。
+     */
+    #[Test]
+    public function testV1AddAppliesStrictToNameColumnsAndLenientToNotes(): void {
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '峯', 'c_reference_char' => '峰', 'c_strict_excluded' => 1],
+        ]);
+        CharVariantMapService::reset();
+        $this->makeCrowdUser();
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'BIOG_MAIN',
+            'json' => json_encode([
+                'c_surname_chn' => '峯',
+                'c_name_chn' => '峯生',
+                'c_notes' => '峯下人',
+            ], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $payload = json_decode((string) DB::table('operations')->value('resource_data'), true);
+        $this->assertSame('峯', $payload['c_surname_chn'], '人名欄用 strict：峯 不替換');
+        $this->assertSame('峯生', $payload['c_name_chn']);
+        $this->assertSame('峰下人', $payload['c_notes'], '一般文本欄用 lenient：峯→峰');
+    }
+
+    /**
+     * 鬆散寫法的表名（前後空白／大小寫不同）**不替換**——刻意與下游分派對稱。
+     *
+     * `confirm()` 的 switch 與 `update_operations()` 的 `$y == "BIOG_MAIN"` 都是精確比對，
+     * 所以 `" biog_main "` 根本不會被寫入任何表；若在提交端替換它，就會出現「payload 被
+     * 改寫、卻永遠不會落庫」的不對稱，而且等於讓未驗證字串進到 schema 查詢（空結果會被
+     * 快取住，讓該表在這個 process 之後都不替換）。
+     */
+    #[Test]
+    public function testV1AddDoesNotReplaceWhenResourceNameIsNotExactRegistrySpelling(): void {
+        $this->makeCrowdUser();
+
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => ' biog_main ',
+            'json' => json_encode(['c_name_chn' => '淸河'], JSON_UNESCAPED_UNICODE),
+        ]);
+
+        $payload = json_decode((string) DB::table('operations')->value('resource_data'), true);
+        $this->assertSame('淸河', $payload['c_name_chn'], '非精確表名不替換（與分派對稱）');
+
+        // 型別快取沒有被毒化：緊接著用**精確**表名提交仍正常替換。
+        $this->post('/api/operations/add', [
+            'token' => 'LONG-LIVED-TOKEN',
+            'resource' => 'BIOG_MAIN',
+            'json' => json_encode(['c_name_chn' => '淸河'], JSON_UNESCAPED_UNICODE),
+        ]);
+        $second = json_decode((string) DB::table('operations')->latest('id')->value('resource_data'), true);
+        $this->assertSame('清河', $second['c_name_chn']);
+    }
+
+    protected function makeApprover(string $email): User {
+        return User::forceCreate([
+            'name' => '審核者',
+            'email' => $email,
+            'confirmation_token' => 'tok-'.md5($email),
+            'is_active' => User::STATUS_ACTIVE,
+            'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+}


### PR DESCRIPTION
## 這一步做了什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S7**：四個計畫列出的區塊都串上落地替換——眾包回填（`confirm()` 的九個寫入點）、v1 token API（`add`／`update`，仍在服役）、複製工具（`saveas()` ＋ `Duplicate_Collateral_Info()` 的 9 處寫入）、單向關係修復工具。

## review 找出兩個「只做替換反而更糟」的形狀

**1. 修復工具（HIGH）**：`ASSOC_DATA.c_text_title` 既是主鍵成員、也是鏡像的**定位鍵**（`reverseRelationExists()`／`locateOppositeEdges()` 都拿正向列的原字形做精確比對）。只把補建的鏡像歸一會導致：

- 缺邊偵測仍以正向列的變體形去找 ⇒ 找不到新鏡像 ⇒ 這對關係**永遠被報成單向**，修復按鈕修不掉；
- 再按一次修復同樣找不到 ⇒ 再插一次同樣的列 ⇒ 撞唯一鍵、整筆回滾，**工具失去幂等**；
- 對面若已有另一個變體形的鏡像，兩者 PK 不同又都歸一成同一形 ⇒ 靜默鑄出重複列。

改為**只替換非主鍵欄**，鏡像與正向列保持同形；真正的收斂留給使用者下次經編輯器觸碰這段關係（S3 的「觸碰即歸一」，那條路有 D7 守衛）。

**2. `confirm()` 的替換溢出到「只刪不寫」的分支**：`op_type=4` 的三個 `OFFICE_*` 分支只做 `delete()`、完全不寫 `$data`，卻仍把它存成 operations 快照——而那份快照是 `restoreDelete()` 重建被刪列的依據。替換它等於「還原出一列從未存在過的字形」。改為保留未替換的 `$originalData` 給這三個分支。

## 另外修掉的三項

| 問題 | 說明 |
|---|---|
| **型別快取毒化** | `isKnownDataTable()` 大小寫／空白不敏感，但 `textColumns()` 以正規化名當快取鍵卻用原始字串查 schema ⇒ `" BIOG_MAIN "` 查到空欄位集並被三層快取記住，該表在這個 process 之後都不替換（S1 註解自己警告過的失效模式，S7 是第一個把**未驗證外部字串**送進來的呼叫點）。修法：`canonicalTableName()` ＋ `textColumns()` 一律用 canonical 名查 |
| **兩個外部入口刻意收斂** | v1／`confirm()` 要求「表名與註冊表拼法完全相同」才替換。下游分派本來就是精確比對，把 canonical 名套進分派等於**放寬未驗證字串能觸發寫入的範圍**——那是安全面的擴大，不是修 bug |
| **複製工具的歸一撞鍵** | 替換會把「同一人底下只差字形的兩列」壓成同一主鍵，第二次 insert 撞唯一鍵讓整個複製交易回滾 ⇒ 該功能對這些人物永久失敗且無可行動訊息（違反 §1.1）。改為保留第一列、跳過等價列並記 warning |

## 驗證

- `./vendor/bin/phpunit` 全綠：**2945 tests / 15514 assertions**；`php-cs-fixer` 0 fixes
- 新測試 14 條：v1 的提交端替換／未知表不替換／壞 JSON 原樣／payload 替換但快照不替換／raw JSON 是原字元（鎖 `JSON_UNESCAPED_UNICODE`）／strict 與 lenient 同列並存／非精確表名不替換且不毒化快取；`confirm()` 的 create 與 update 分支替換、delete 分支快照不替換、未知表不炸；`saveas()`；`Duplicate_Collateral_Info()`（文本型主鍵成員、`resource_id`／`row_pk` 同字形、**真實複合主鍵下的歸一撞鍵去重**）；修復工具的鍵字形配對與幂等
- 每條都以「把機制中和掉會紅」驗證；其中兩條第一版是空轉（合成表沒建複合主鍵、未知表測試沒斷言重導），已修正
- Review：review agent 一輪（6 項發現，含上述 HIGH）＋ codex 兩輪，最後回「沒有需修正的實質問題」

🤖 Generated with [Claude Code](https://claude.com/claude-code)