### PR TITLE
把「新增文本錄入必須掛異體字落地替換」寫成常規並機械化把關（S8）

### DIFF
--- a/.claude/skills/database-schema.md
+++ b/.claude/skills/database-schema.md
@@ -407,3 +407,22 @@ php artisan tinker
 - `database/migrations/` - 所有數據庫結構定義
 - `docs/DATABASE_SCHEMA.md` - 由 `php artisan cbdb:generate-schema-docs` 自動生成的 schema 總覽（MySQL + SQLite）
 - `docs/SCHEMA_DOCS_GENERATION.md` - schema 文件生成指令的完整使用說明
+
+## 新增欄位／表格時：異體字落地替換的範圍
+
+替換範圍是**型別驅動**的（見 `app/Support/VariantReplaceScope.php`），所以：
+
+- **新增任何文本型欄位（varchar／char／text 系列）＝自動進入替換範圍**，不需要註冊。
+  這是刻意的（避免「漏掉某欄」的清單維護），但也意味著：**若那一欄語義上必須保留原始字形，
+  必須主動加進排除清單**。
+- **新增對照／映射性質的表**（內容就是字形本身、或作為跨表查表鍵）**必須加進
+  `VariantReplaceScope::EXCLUDED_TABLES`**——否則它會被自己的規則改寫（`char_variant_map`
+  就是這個理由被整表排除）。
+- 常見要排除的欄位型態：稽核署名、URL／識別碼、跨表 join 或查表鍵（替換會打斷關聯）、
+  拉丁人名與拼音欄、唯讀派生索引、紀錄類表（`operations`／`audit_log` 的快照是審計事實）。
+- 新增表若沒登記在 `config/codes.php`／`CompositePrimaryKey::SCHEMAS`／
+  `config/code_table_writes.php`／`config/code_table_mutations.php` 之一，會被 fail-closed
+  當成未知表而**完全不替換**——`tests/Feature/VariantReplaceRegistryDriftTest.php` 會在有
+  未分類的表時變紅，順著它的訊息把新表歸類。
+
+規則全文見 AGENTS.md §1.3。

--- a/.claude/skills/mutation-api-record-editing.md
+++ b/.claude/skills/mutation-api-record-editing.md
@@ -120,6 +120,60 @@ CBDB prod 的維基／維基數據關聯存在 **`BIOG_SOURCE_DATA`**（不是 `
 
 參考實作：`cbdb-dbs/d1_build_*/round3/sync_zhwiki_sources.py`（dry-run 預設、`--only`/`--limit`/`--offset` 分批、`--operator`、`--renote`、429 退避、結果 CSV 存 operation_id）。流程總覽見 `docs/ZHWIKI_SOURCE_SYNC.md`。
 
+## 新增／修改寫入路徑：異體字落地替換（必掛）
+
+見 AGENTS.md §1.3。這裡是**實作步驟**與踩過的坑。
+
+### 掛哪個 hook
+
+| 情況 | 做法 |
+| ------ | ------ |
+| 繼承 `AbstractPersonSubresourceCreateHandler`／`AbstractPersonSubresourceMutationHandler`／`AbstractCodeTableMutationHandler` | **什麼都不用做**，基底的 `handle()` 已掛 `Concerns\AppliesVariantReplacement` |
+| 不繼承上述基底（例如自己組 payload 的聚合 handler、repository 方法、controller） | 自己 `use Concerns\AppliesVariantReplacement`，在**落庫前**呼叫 `$data = $this->applyVariantReplacement($data)`；沒有 `tableName()` 的類別要顯式傳表名 `applyVariantReplacement($data, $table)`（省略會 fallback 到不存在的方法而 **runtime fatal**，不是靜態錯誤） |
+| 不是 handler（controller／service／repository） | 直接 `CharVariantMapService::replaceRow($data, $table)['data']`；單值用 `replaceFor($table, $column, $value)['text']`（`$input` 的鍵是「輸入欄名」而不是資料表欄名時，`replaceRow()` 會全部判成非文本欄而跳過——這種情況一定要用 `replaceFor()` 逐欄呼叫） |
+
+### 掛鉤位置（順序錯了就是 bug）
+
+必須早於：**PK 計算 → 查重／去重鍵查詢 → 拼音派生 → `operations.resource_id`／`audit_log.row_pk` 組裝**。
+
+- 早於 PK 計算：`ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、`BIOG_SOURCE_DATA.c_pages`
+  都是**文本型 PK 成員**，替換等於改鍵。
+- 早於變更偵測：否則「送變體形、現值已是參考形」會被判成有變更而寫一次無意義的 UPDATE。
+- 早於拼音派生：拼音逐字查 `pinyin.c_chn`（**該欄**在 `EXCLUDED_COLUMNS`——不是整張 `pinyin` 表——所以異體字保有自己的讀音），先替換才會拿到
+  參考字的讀音，中文欄與拼音欄才不會各說各話。
+- 早於 `resource_id`／`row_pk`：否則同一筆稽核的 id 與內容字形矛盾，還原時會重建一列從未存在
+  過的資料。
+
+### 通知（notices）怎麼接
+
+- handler 內：`replaced` 由 trait 收在 `$this->variantReplaced`，回應用 `withVariantNotices($response)`
+  掛上（**成功、409、422 都要掛**——被擋下來時使用者才知道「我輸入的字被正規化了」）。
+- 非 handler：`CharVariantMapService::buildNotices($replaced)` 取字串陣列；批次頁用
+  `flattenReplaced()` 取 `[{from,to}]`。
+- ⚠️ **不要自己 implode `replaced`**：衝突時值會是 list（同一變體在 strict 與 lenient 欄的閉包
+  終點可以不同），直接字串串接會拋 "Array to string conversion"。
+- ⚠️ **子類不要再呼叫一次 `replace*()`**：通用掛鉤先跑過、值已是參考形，再呼叫一次的 `replaced`
+  恆為 `[]`；若又 assign 回 `$this->variantReplaced`，**通知會靜默消失**（S3 修掉的失效模式）。
+  基底一律用 `mergeReplaced()` 而非 assign。
+- 累積器記得重置：同一個 service／handler 實例在批次中逐列被呼叫，不重置會把上一列的通知帶到
+  下一列（S4 修過一次）。
+
+### 測試該斷言什麼
+
+1. **落庫值**是參考形（不只看回應）。
+2. **回應回落庫值**，而不是使用者原輸入（S4 抓到的缺陷：DB 寫參考形、回應回變體形，
+   前端畫面與資料庫不一致）。
+3. **notices 存在**；失敗回應（409／422）也要有。
+4. **同一列 strict／lenient 並存**：姓名欄的 `峯` 不替換、同列 `c_notes` 的 `峯`→`峰`。
+   （種子只放 `淸→清` 是測不出模式分流的——它的 `c_strict_excluded = 0`。）
+5. **兩形並存查重**：既有列是變體形、新增參考形 ⇒ 409 而不是鑄出第二列；改鍵同理；
+   而「只改非 PK 欄」在歷史上就已兩形並存時**不可**被誤擋。
+6. **提案 payload** 存的是替換後的值，且核准落庫與 payload 一致。
+7. 負向：`restore`／「只刪不寫」的快照**不替換**（並在同一支測試裡加一句正向對照，
+   例如 `assertSame('清', CharVariantMapService::replaceFor($t, $c, '淸')['text'])`，
+   否則機制整體死掉時負向斷言會假綠）。
+8. 鑑別力：把掛鉤中和掉（改成 `return $data;`）跑一次，確認**真的會紅**。
+
 ## 相關檔案
 
 - `app/Http/Controllers/Api/MutationController.php`（store／create／delete／get）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,64 @@
 - 提案 payload／operation 快照裡的稽核欄是「審計事實」可保留；但任何寫入路徑（handler 重放、
   通用核准、restore）落庫前必須剔除或覆蓋，不可原樣回寫。
 
+### 1.3 文本寫入一律經異體字落地替換
+- 任何**會把文本寫進資料庫**的新路徑，落庫前必須經過
+  [CharVariantMapService](./app/Services/CharVariantMapService.php) 的
+  `replaceRow($data, $table)`（整列）或 `replaceFor($table, $column, $value)`（單值）。
+- **範圍由欄位型別決定**（見 [VariantReplaceScope](./app/Support/VariantReplaceScope.php)）：
+  呼叫端**不需**自己判斷「這欄有沒有中文」，也**不要**自己維護欄位清單。未知表 fail-closed
+  （一律不替換），所以 `$table` 要傳**目標資料表**、永遠不要傳 `operations`。
+- **模式不由呼叫端選，預設是寬鬆（全量規則）**。strict 是逐欄位的例外（人名／別名欄），
+  **不要假設「人物相關的表就該用 strict」**——同一列裡姓名欄 strict、`c_notes` lenient 是刻意的。
+- **掛鉤位置是硬性要求**：必須早於 **PK 計算、查重／去重鍵查詢、拼音派生、以及
+  `operations.resource_id`／`audit_log.row_pk` 的組裝**。否則會出現「查重用替換前的值、
+  落庫用替換後的值」，或稽核鏈指向一個不存在的鍵。
+  已知的文本型 PK 成員：`ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、
+  `BIOG_SOURCE_DATA.c_pages`；已知去重鍵：`SOCIAL_INSTITUTION_NAME_CODES.c_inst_name_hz`；
+  已知標籤→代碼鍵：`DYNASTIES.c_dynasty_chn`、`SOCIAL_INSTITUTION_TYPES.c_inst_type_hz`／`_py`、
+  `NIAN_HAO.c_nianhao_chn`；已知由中文派生：`OFFICE_CODES`／`TEXT_CODES`／機構名的拼音欄。
+- **精確比對必須處理「兩形並存」**：既有列在 D6 之下保留變體形、新列是參考形，所以查重／
+  去重／重用查詢要**兩形都探**（或走
+  [VariantEquivalentLookup](./app/Support/VariantEquivalentLookup.php)）。少了這道，替換會
+  **製造**新的重複列，而唯一鍵擋不住（不同字形＝不同鍵值）——**那比完全不替換更糟**。
+  改鍵時要排除「正在編輯的那一列自己」，而且**只在真的改鍵時檢查**（否則歷史上就已兩形並存的
+  資料會變成任何更新都做不了）。
+- **繼承既有基底類別就自動生效**（`AbstractPersonSubresourceCreateHandler`／
+  `AbstractPersonSubresourceMutationHandler`／`AbstractCodeTableMutationHandler` 都掛了
+  `Concerns\AppliesVariantReplacement`，且在 `handle()` 裡實際呼叫）；只有**不繼承**的新寫入
+  路徑才需要自己掛。兩個常被忽略的邊界：
+  - 繼承了基底、但**額外**自己寫副表／鏡像／聚合列的 handler，那些額外寫入**不在**基底掛鉤的
+    覆蓋範圍內，要自己再掛一次（傳該副表的表名）。
+  - `applyVariantReplacement($data)` 省略表名時取 `$this->tableName()`；**沒有那個方法的
+    handler 必須顯式傳表名**，否則是 runtime fatal 而非靜態錯誤。
+  機械化把關見 `tests/Unit/VariantReplaceHookCoverageTest.php`：繞過基底又沒登記例外時它會紅；
+  清冊分成三本，**已經掛上 trait 的類別不可列進 EXEMPT／EXEMPT_DELEGATES**：
+  「確實不需要掛」（`EXEMPT`，每筆要寫理由）、「寫入委派給下層」（`EXEMPT_DELEGATES`，要指名
+  下層檔案與掛鉤數、會被機械檢查）、「繼承基底但自己另有寫入」（`SUBCLASS_EXTRA_WRITES`，
+  只認**寫在自己檔案裡**的額外寫入；委派給下層方法的鏡像同步偵測不到，要人工判斷）。
+  該測試同時逐檔記數鎖住 handler 體系之外的掛鉤點（controller／repository／import service），
+  掛鉤變少也會紅。**但它不是全庫掃描**：在 `app/Services/Mutations` 以外新開一個檔案直接落庫，
+  只有 code review 擋得住。
+- **替換發生了就要讓使用者知道**：handler 內用 `withVariantNotices()` 把通知掛上回應，
+  **成功、409、422 都要掛**——被擋下來時使用者更需要知道「我輸入的字被正規化了」。
+  累積器在每次 `handle()` 開頭重置；基底一律用 `mergeReplaced()` 而非 assign（直接 assign 會把
+  上游收集到的通知靜默吃掉）。
+- **不該替換的地方一律不掛**（見 `VariantReplaceScope` 的三組排除清單）：
+  - 本身做文本替換／字形對照的表（`char_variant_map` 自己替換自己等於自我吞噬）；
+  - 語義上必須保留原字的欄位：稽核署名、URL、跨表 join／查表鍵、拉丁人名與拼音欄、
+    唯讀派生索引（`CBDB__NAME_FTS`）、以及**紀錄類**表（`operations`／`audit_log`：
+    快照的語義是「當時實際發生什麼」，改寫等於偽造紀錄）。
+  - **新增任何對照／映射性質的表，或任何需保留原始字形的欄位時，必須同步加進排除清單。**
+  - 同理：`restore`（還原歷史快照）與「只刪不寫」的分支**不做內容替換**；
+    鏡像的**定位鍵**不可單邊歸一（會讓偵測永遠找不到、修復工具失去幂等）。
+- **新增對照時要評估搜尋端**：該字的新舊資料會互相搜不到，需評估姓名搜尋與
+  `CBDB__NAME_FTS` 的建索引。**不要去改 `VariantCharNormalizer`**——它做的是拼音派生，
+  與落地替換是兩件事。
+- 「不要再改舊 Blade」的**例外**：資料完整性規則（§1.1／§1.2／§1.3）適用於所有**仍在服役**的
+  寫入路徑，不分新舊（例如 `saveas()`／`Duplicate_Collateral_Info()`／v1 token API／
+  眾包回填都還活著）。只有已被閘門下架**且**有替代品的路徑才豁免。
+- 背景與逐步執行紀錄：[docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md](./docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md)。
+
 ### 2. 複合主鍵
 - Laravel Eloquent 不支援複合主鍵。
 - 複合主鍵表請使用 Query Builder，不要建立仰賴 Eloquent 主鍵行為的模型。
@@ -115,6 +173,7 @@ php artisan cbdb:fetch-chgis-map        # 下載 CHGIS 底圖（缺檔才下載�
 - 跑過受影響測試；若改動面大，跑 `./vendor/bin/phpunit`
 - 改了前端資源時，跑 `npm run build`
 - **改了 API（路由／請求回應欄位／授權／錯誤碼／resource 別名或白名單）時，同步更新 `API.md`**（見「文檔維護原則」）
+- **新增或修改「把文本寫進資料庫」的路徑時，確認已掛上異體字落地替換**（§1.3；繼承既有基底類別即自動生效，不繼承的要自己掛；只有「確實不需要掛」或「寫入委派給下層」才登記進 `tests/Unit/VariantReplaceHookCoverageTest.php` 的例外清冊，並跑該測試確認沒紅）
 - commit message 使用繁體中文
 
 ## 高風險區域備忘

--- a/app/Services/Mutations/Concerns/AppliesVariantReplacement.php
+++ b/app/Services/Mutations/Concerns/AppliesVariantReplacement.php
@@ -34,8 +34,12 @@ trait AppliesVariantReplacement {
      * 別名替換通知就消失了）。
      *
      * @param array<string,mixed> $data
-     * @param string|null $table 目標資料表；省略時取 `$this->tableName()`（基底體系內的
-     *                           子資源都有這個方法，體系外的三個例外 handler 沒有，需明給）
+     * @param string|null $table 目標資料表；省略時取 `$this->tableName()`。
+     *                           **沒有 `tableName()` 的 handler 必須顯式傳表名**，否則會
+     *                           runtime fatal（不是靜態錯誤）。目前顯式傳表名的四個：
+     *                           `CodeTableCreateHandler`（表由請求決定）、
+     *                           `PossessionCreateHandler`、`PostingCreateHandler`、
+     *                           `SourceMutationHandler`。
      * @return array<string,mixed>
      */
     protected function applyVariantReplacement(array $data, ?string $table = null): array {

--- a/tests/Unit/VariantReplaceHookCoverageTest.php
+++ b/tests/Unit/VariantReplaceHookCoverageTest.php
@@ -1,0 +1,709 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Mutations\Concerns\AppliesVariantReplacement;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * 機械化把關：**寫文本進資料庫的路徑必須掛上異體字落地替換**（AGENTS.md §1.3）。
+ *
+ * 為什麼需要這支測試：這個 rollout 的第二階段之所以漏掉 19 個 handler，正是因為當時沒有任何
+ * 機制會在漏掉時發出聲音——只要有人新增一個繞過基底類別的寫入路徑，就靜默地少一道替換。
+ *
+ * 五道把關，各自針對一種真實會發生的退化：
+ * 1. **handler 覆蓋**：`app/Services/Mutations` 下**每一個** handler 都必須掛（或繼承）
+ *    `Concerns\AppliesVariantReplacement`，或明文列在例外清冊。
+ *    刻意**不**先判斷「這個 handler 有沒有寫入」——判斷寫入靠的是掃 `->insert(`／`->update(`
+ *    這類慣用法，而現存 8 個非基底 handler 裡有 4 個把寫入委派給 repository／service，
+ *    自己檔案裡一個寫入慣用法都沒有。以「有寫入才要求登記」為前提的話，那 4 個
+ *    ——以及任何新的同型 handler——會直接落在偵測範圍外（fail-open）。改成全體必須交代，
+ *    代價是每個純讀取／純刪除的 handler 一行例外，換來的是 fail-closed。
+ * 2. **掛鉤真的被呼叫**：光有 `use` 不算——基底檔案裡必須真的呼叫 `applyVariantReplacement()`
+ *    等方法。刪掉那一行呼叫比刪掉 `use` 容易得多，後果一樣（21 個子類靜默失去替換）。
+ * 3. **子類的額外寫入**：繼承了掛鉤的基底 ≠ 自己那些額外的副表／鏡像寫入也被覆蓋。
+ *    這類 handler 必須明文登記，新增一個沒登記的就會紅。
+ * 4. **掛鉤點清冊**：S2～S7 的替換掛在 handler 體系**之外**（controller／repository／
+ *    import service），那些檔案各自被點名並**記數**，掛鉤被移除或減少時就會紅。
+ * 5. **例外清冊自身的衛生**：殭屍豁免（已掛鉤卻還列著）、陳舊條目、短名撞名都會紅。
+ *
+ * 刻意不掃「有沒有呼叫 CharVariantMapService」來判斷 handler 合規：那樣會鼓勵在各處手寫替換，
+ * 而本 rollout 的結論恰恰相反——替換集中在少數掛鉤點，呼叫端只要繼承對的基底。
+ *
+ * **偵測邊界（誠實話）**：本測試覆蓋的是 `app/Services/Mutations` **整個目錄**（handler 與
+ * 非 handler 檔案）加上點名的 12 個體系外掛鉤點。它**不是**全庫掃描：
+ * - 在 `app/Services/Mutations` 之外新開一個檔案直接落庫（新 repository／service／controller），
+ *   本測試不會知道。那類新路徑靠 AGENTS.md §1.3 與 code review 把關；若它成為常態掛鉤點，
+ *   請把它加進 `NON_HANDLER_HOOK_SITES`。
+ * - 子類「委派給下層方法」的額外寫入（例如 `syncAssocMirrorOnUpdate()`）也偵測不到——
+ *   `hasOwnWrite()` 只認自己檔案裡的寫入慣用法。那些路徑目前的正確性是**人工判斷**的結果，
+ *   不是本測試證明的，而且理由不只一種：
+ *   - 一般 update 的鏡像 payload 來自基底已替換的陣列；
+ *   - pair-only 鏡像修復（`AssociationMutationHandler::handlePairOnlyMirrorSync()`）**刻意**
+ *     整列複製既有列、只改碼與 id：那裡沒有任何使用者輸入的文本，且鏡像的定位鍵
+ *     （`c_text_title`）**不可單邊歸一**（D6／S7：歸一了偵測就永遠找不到那一對）。
+ *     所以「該路徑寫進去的是變體形」在既有列本來就是變體形時是**正確**行為，不是漏替換。
+ */
+class VariantReplaceHookCoverageTest extends TestCase {
+    /** handler 所在目錄（相對 repo 根）。 */
+    private const HANDLER_DIR = 'app/Services/Mutations';
+
+    /**
+     * 明文例外：**不需要**自己掛替換的 handler，每筆必須寫理由。
+     *
+     * ⚠️ 這裡只能放「確實不需要掛」的：已經掛上（或繼承）trait 的類別**不可**列在這裡——
+     * 那會讓它從此不再被檢查（見 testExemptEntriesAreNotAlreadyHooked）。
+     *
+     * ⚠️ 「目前沒有寫入」不等於「以後也不會有」：這些條目**會替未來加進去的文本寫入背書**，
+     * 所以在其中任一個 handler 裡新增文本寫入時，必須同時把它從這裡移出並掛上替換。
+     *
+     * @var array<string,string>
+     */
+    private const EXEMPT = [
+        // ── 抽象基底：本身不落庫 ─────────────────────────────
+        'AbstractMutationHandler' => '抽象基底，只做授權／驗證／envelope，不落庫',
+        'AbstractEntityAggregateHandler' => '抽象基底，落庫委派給 Import service（見 EXEMPT_DELEGATES 的兩個子類）',
+
+        // ── 刪除：只刪列，不寫任何文本 ─────────────────────────
+        'AbstractPersonSubresourceDeleteHandler' => '刪除路徑不寫文本；快照是審計事實，替換等於偽造紀錄',
+        'AddressDeleteHandler' => '同上（刪除）',
+        'AltnameDeleteHandler' => '同上（刪除）',
+        'AssociationDeleteHandler' => '同上（刪除）；鏡像清理委派給基底與 repository',
+        // ⚠️ 這一筆不是「不寫文本」：軟刪除是 UPDATE，會把 c_name_chn 覆寫成 DELETE_MARKER
+        // 常數（固定字面值、非使用者輸入，所以沒有替換的必要）。哪天它開始寫任何輸入衍生的
+        // 文本，就必須從這裡移出並掛上替換。
+        'BiogMainDeleteHandler' => '軟刪除以 UPDATE 寫入固定的 DELETE_MARKER 常數，非使用者輸入 ⇒ 無需替換',
+        'CodeTableDeleteHandler' => '同上（刪除）；且碼表刪除目前全域停用（回 403）',
+        'EntityAggregateDeleteHandler' => '同上（刪除）',
+        'EntryDeleteHandler' => '同上（刪除）',
+        'EventDeleteHandler' => '同上（刪除）',
+        'KinshipDeleteHandler' => '同上（刪除）；鏡像清理委派給基底與 repository',
+        'MergedPersonDeleteHandler' => '同上（刪除）',
+        'PossessionDeleteHandler' => '同上（刪除）',
+        'PostingDeleteHandler' => '同上（刪除）',
+        'SocialInstitutionDeleteHandler' => '同上（刪除）',
+        'SourceDeleteHandler' => '同上（刪除）',
+        'StatusDeleteHandler' => '同上（刪除）',
+        'TextDeleteHandler' => '同上（刪除）',
+    ];
+
+    /**
+     * 「寫入委派給下層」的 handler ⇒ 下層檔案必須仍然含**足量**的替換呼叫。
+     *
+     * 這不是免檢清單，而是**把檢查轉移到真正落庫的那一層**。純文字理由不夠：下層那一行被
+     * 刪掉時，理由字串還在、測試照樣綠，例外就變成謊言——正是 S8 要防的失效模式。
+     *
+     * 值是「該檔案至少要有幾個替換呼叫」。**記數是必要的**：`BiogMainRepository` 有 8 處掛鉤，
+     * 只斷言「檔案裡有一處」的話，刪掉 `store()` 的那一處仍會被 KIN_DATA 的那處遮住而假綠。
+     *
+     * @var array<string,array<string,int>>
+     */
+    private const EXEMPT_DELEGATES = [
+        'BiogMainCreateHandler' => ['app/Repositories/BiogMainRepository.php' => 8],
+        // direct 走 repository::updateById()、proposal 走本檔的 prepareProposalPayload()，兩處都要有。
+        'BiogMainMutationHandler' => [
+            'app/Repositories/BiogMainRepository.php' => 8,
+            'app/Services/Mutations/BiogMainMutationHandler.php' => 1,
+        ],
+        'EntityAggregateCreateHandler' => [
+            'app/Services/Import/OfficeImportService.php' => 1,
+            'app/Services/Import/SocialInstituteImportService.php' => 4,
+        ],
+        'EntityAggregateUpdateHandler' => [
+            'app/Services/Import/OfficeImportService.php' => 1,
+            'app/Services/Import/SocialInstituteImportService.php' => 4,
+        ],
+    ];
+
+    /**
+     * 繼承了掛鉤基底、但**自己檔案裡另有寫入**的 handler。
+     *
+     * 基底的掛鉤只覆蓋它自己寫出去的那一列；子類額外插入的副表／鏡像列**不在**覆蓋範圍內
+     * （AGENTS.md §1.3 的第一個邊界）。這裡逐筆交代那些額外寫入為什麼安全；新增一個沒登記的
+     * 就會紅，迫使作者去想「我這個額外寫入的值替換過了嗎」。
+     *
+     * 自己顯式呼叫 `applyVariantReplacement()`／`replace*()` 的 handler 不必登記——它本身就是掛鉤點。
+     *
+     * @var array<string,string>
+     */
+    private const SUBCLASS_EXTRA_WRITES = [
+        'AssociationCreateHandler' => '額外插入 ASSOC_DATA 鏡像列，但 $mirror 由基底已替換過的 $inserted 推導，不含未替換文本',
+        'KinshipCreateHandler' => '額外插入 KIN_DATA 鏡像列，同上（$mirror 由已替換的 $inserted 推導）',
+    ];
+
+    /**
+     * handler 體系**之外**的掛鉤點清冊（S2～S7），值為「至少幾處替換呼叫」。
+     *
+     * 這是 S2～S7 成果的唯一機械化鎖：那些路徑不繼承任何已掛鉤的基底，只要有人重構掉其中
+     * 幾行，全套測試不見得會紅。記數讓「掛鉤變少」也會紅，而不只是「一個都不剩」才紅。
+     *
+     * @var array<string,array{hooks:int,why:string}>
+     */
+    private const NON_HANDLER_HOOK_SITES = [
+        'app/Http/Controllers/CodesController.php' => [
+            'hooks' => 6, 'why' => 'S2：代碼表 CRUD 的 5 條寫入路徑 + 共用的 applyVariantReplacement() 本體',
+        ],
+        'app/Repositories/BiogMainRepository.php' => [
+            'hooks' => 8, 'why' => 'S3／S6：BIOG_MAIN 寫入、親屬與社會關係的核准寫入、legacy 別名 store／update 的 strict 替換',
+        ],
+        'app/Services/Import/OfficeImportService.php' => [
+            'hooks' => 1, 'why' => 'S4：官職聚合（早於 buildPinyin）',
+        ],
+        'app/Services/Import/SocialInstituteImportService.php' => [
+            'hooks' => 4, 'why' => 'S4：機構聚合、名稱碼解析（去重鍵）、地址子表',
+        ],
+        'app/Http/Controllers/OperationsProposalController.php' => [
+            'hooks' => 2, 'why' => 'S6：提案核准的通用 create／update 分支',
+        ],
+        'app/Http/Controllers/CrowdsourcingController.php' => [
+            'hooks' => 1, 'why' => 'S7：眾包回填 confirm()（delete-only 分支刻意用未替換的 $originalData 存快照）',
+        ],
+        'app/Http/Controllers/Api/OperationsController.php' => [
+            'hooks' => 1, 'why' => 'S7：v1 token API 的 add／update 共用 replaceVariantsInJsonPayload()',
+        ],
+        'app/Http/Controllers/BasicInformationController.php' => [
+            'hooks' => 10, 'why' => 'S7：saveas()、Duplicate_Collateral_Info() 的 BIOG_MAIN + 8 張子表寫入',
+        ],
+        'app/Http/Controllers/UnidirectionalRelationshipRepairController.php' => [
+            'hooks' => 1, 'why' => 'S7：補建鏡像列（**僅非主鍵欄**——定位鍵單邊歸一會讓偵測永遠找不到）',
+        ],
+        'app/Services/PostingAutofillService.php' => [
+            'hooks' => 2, 'why' => 'S4：年號與官名的兩形查表',
+        ],
+        'app/Http/Controllers/AdminBatchLoadBookTitlesController.php' => [
+            'hooks' => 1, 'why' => '前階段：書名批次匯入（TEXT_CODES.c_title 派生拼音）',
+        ],
+        'app/Http/Controllers/BasicInformationProposalController.php' => [
+            'hooks' => 3, 'why' => '前階段既有：提案 payload 的姓名／別名 strict 替換（不經 repository，本階段未改動但仍是落地點）',
+        ],
+    ];
+
+    /**
+     * `app/Services/Mutations` 下**不以 Handler 結尾**卻自己落庫的檔案，逐筆交代。
+     *
+     * 有人把寫入搬進這類 helper 時，
+     * testNonHandlerFilesInTheMutationsDirectoryDoNotWriteUnaccounted 會紅。
+     *
+     * @var array<string,string>
+     */
+    private const NON_HANDLER_MUTATION_WRITERS = [
+        // 寫的是 ai_fill_logs.user_submitted（紀錄類表，語義是「使用者當時實際送了什麼」⇒ 不替換；
+        // 且 $submitted 本來就是基底替換後的值）。該表不在型別註冊表內，fail-closed 也不會替換。
+        'Concerns/RecordsAiFillSubmission.php' => 'ai_fill_logs 是紀錄類表：只存提交快照，不替換（值本身已是基底替換後的形）',
+    ];
+
+    /**
+     * 判定「有寫入資料庫」用的**方法名**（涵蓋常見的 Laravel 寫入慣用法，不只 insert／update）。
+     *
+     * 比對的是**真正的方法呼叫 token**，不是字串比對（見 codeCalls()）：字串字面值與註解裡
+     * 出現同名不算。過度收錄（例如 `Request::create()` 也算寫入）是刻意的——多一筆登記的
+     * 成本遠低於漏掉一個寫入。
+     *
+     * @var array<int,string>
+     */
+    private const WRITE_METHODS = [
+        'insert', 'insertGetId', 'insertOrIgnore', 'insertUsing', 'upsert',
+        'update', 'updateOrInsert', 'updateOrCreate', 'firstOrCreate', 'createOrFirst',
+        'truncate', 'delete', 'save', 'increment', 'decrement',
+        'create', 'statement', 'unprepared', 'affectingStatement',
+    ];
+
+    /** 替換掛鉤的方法名（`CharVariantMapService::` 靜態呼叫）。 */
+    private const HOOK_STATIC_METHODS = ['replaceRow', 'replaceFor', 'replaceStrict', 'replaceLenient'];
+
+    /** 替換掛鉤的方法名（trait 提供的實例方法）。 */
+    private const HOOK_INSTANCE_METHODS = ['applyVariantReplacement'];
+
+    /**
+     * `app/Services/Mutations` 下的每一個 handler 都必須掛上替換 trait，或列在例外清冊裡。
+     *
+     * **順序很重要**：先看有沒有掛 trait，才看例外清冊。反過來的話，任何例外條目都會讓
+     * 那個類別從此不再被檢查——包含它日後被搬離已掛鉤的繼承鏈時。
+     */
+    #[Test]
+    public function testEveryMutationHandlerHasTheVariantReplacementHookOrAnExplicitExemption(): void {
+        $unhooked = [];
+
+        foreach ($this->allHandlers() as $shortName => $class) {
+            if ($this->usesReplacementTrait($class)) {
+                continue;
+            }
+
+            if (array_key_exists($shortName, self::EXEMPT) || array_key_exists($shortName, self::EXEMPT_DELEGATES)) {
+                continue;
+            }
+
+            $unhooked[] = $shortName;
+        }
+
+        sort($unhooked);
+
+        $this->assertSame(
+            [],
+            $unhooked,
+            "下列 mutation handler 既沒有掛上（或繼承）Concerns\\AppliesVariantReplacement，\n"
+                ."也沒有列在本測試的例外清冊。\n"
+                ."若它會寫文本 ⇒ 掛上替換（見 AGENTS.md §1.3 與 .claude/skills/mutation-api-record-editing.md）；\n"
+                ."若寫入其實委派給下層 ⇒ 加進 EXEMPT_DELEGATES（要指名下層檔案與掛鉤數，會被機械檢查）；\n"
+                ."若確實不需要（只刪列、抽象基底、純讀取）⇒ 加進 EXEMPT 並寫理由。\n"
+                .implode("\n", $unhooked)
+        );
+    }
+
+    /**
+     * 已經掛上 trait 的類別不可出現在例外清冊裡。
+     *
+     * 這種條目是**殭屍豁免**：它讓一個原本受檢的類別從此不再被檢查，日後被搬離繼承鏈時
+     * 不會有任何東西變紅。（第一版就中過一次：`MergedPersonCreateHandler` 其實繼承了已掛鉤
+     * 的基底，卻被我列為「無文本欄」而豁免——而它的 allowedFields() 明明有 c_notes／c_pages。）
+     */
+    #[Test]
+    public function testExemptEntriesAreNotAlreadyHooked(): void {
+        $handlers = $this->allHandlers();
+        $redundant = [];
+
+        foreach (array_merge(array_keys(self::EXEMPT), array_keys(self::EXEMPT_DELEGATES)) as $shortName) {
+            $class = $handlers[$shortName] ?? null;
+            if ($class !== null && $this->usesReplacementTrait($class)) {
+                $redundant[] = $shortName;
+            }
+        }
+
+        sort($redundant);
+
+        $this->assertSame(
+            [],
+            $redundant,
+            '下列 handler 已經掛上（或繼承）替換 trait，不該再列在例外清冊裡'
+                .'——那會讓它從此不再被檢查。請直接從清冊刪除：'.implode(', ', $redundant)
+        );
+    }
+
+    /** 「委派給下層」的例外：下層檔案必須仍然含足量的替換呼叫。 */
+    #[Test]
+    public function testDelegatedExemptionsStillHaveHooksInTheLowerLayer(): void {
+        $broken = [];
+
+        foreach (self::EXEMPT_DELEGATES as $handler => $files) {
+            foreach ($files as $file => $expected) {
+                $actual = $this->countHooks($file);
+                if ($actual === null) {
+                    $broken[] = "{$handler} → {$file}（檔案不存在）";
+
+                    continue;
+                }
+                if ($actual < $expected) {
+                    $broken[] = "{$handler} → {$file}（掛鉤數 {$actual} < 期望 {$expected}）";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $broken,
+            "下列『寫入委派給下層』的例外已經站不住腳：下層檔案的替換呼叫變少或消失了，\n"
+                ."也就是說 handler 沒掛、下層也（部分）沒掛，那個例外現在是謊言。\n"
+                ."若是刻意減少（該路徑下架）⇒ 一併調降清冊裡的期望數並在 PR 說明理由。\n"
+                .implode("\n", $broken)
+        );
+    }
+
+    /**
+     * 三個基底必須掛著 trait **並且真的呼叫它**。
+     *
+     * 只斷言 `use` 是不夠的：把那一行呼叫刪掉（保留 `use`）比刪 `use` 容易得多，
+     * 而後果一樣——21 個子資源 handler 靜默失去替換。註解不算（比對前先去掉註解）。
+     */
+    #[Test]
+    public function testBaseHandlersCarryTheHookAndActuallyCallIt(): void {
+        $bases = [
+            'app/Services/Mutations/AbstractPersonSubresourceCreateHandler.php' => \App\Services\Mutations\AbstractPersonSubresourceCreateHandler::class,
+            'app/Services/Mutations/AbstractPersonSubresourceMutationHandler.php' => \App\Services\Mutations\AbstractPersonSubresourceMutationHandler::class,
+            'app/Services/Mutations/AbstractCodeTableMutationHandler.php' => \App\Services\Mutations\AbstractCodeTableMutationHandler::class,
+        ];
+
+        foreach ($bases as $file => $class) {
+            $this->assertTrue(
+                $this->usesReplacementTrait($class),
+                $class.' 必須掛著 AppliesVariantReplacement：它一被移除，所有繼承它的 handler 都靜默失去替換'
+            );
+
+            $this->assertFileExists(base_path($file));
+
+            $missing = $this->missingInstanceCalls(
+                $file,
+                ['applyVariantReplacement', 'resetVariantReplaced', 'withVariantNotices']
+            );
+
+            $this->assertSame(
+                [],
+                $missing,
+                $file.' 必須真的呼叫 '.implode('／', $missing)
+                    .'（註解與字串字面值都不算）——光有 use 而不呼叫，等於沒有掛鉤'
+            );
+        }
+    }
+
+    /**
+     * 繼承掛鉤基底、但自己另有寫入的 handler 必須明文登記。
+     *
+     * 基底的掛鉤只替換它自己寫的那一列；子類額外插的副表／鏡像列不在覆蓋範圍內。
+     * 新增一個這種 handler 而沒登記時這裡會紅，逼作者交代那些值替換過了沒有。
+     */
+    #[Test]
+    public function testSubclassesWithTheirOwnWritesAreAccountedFor(): void {
+        $unaccounted = [];
+
+        foreach ($this->allHandlers() as $shortName => $class) {
+            // 自己就是掛鉤點的（顯式呼叫）不必登記。
+            if (in_array(AppliesVariantReplacement::class, class_uses($class) ?: [], true)) {
+                continue;
+            }
+            if (!$this->usesReplacementTrait($class)) {
+                continue; // 由 test 1／例外清冊管。
+            }
+            if (!$this->hasOwnWrite($class)) {
+                continue;
+            }
+            if (array_key_exists($shortName, self::SUBCLASS_EXTRA_WRITES)) {
+                continue;
+            }
+
+            $unaccounted[] = $shortName;
+        }
+
+        sort($unaccounted);
+
+        $this->assertSame(
+            [],
+            $unaccounted,
+            "下列 handler 繼承了已掛鉤的基底，但**自己檔案裡另有資料庫寫入**。\n"
+                ."基底的掛鉤只覆蓋它自己寫出去的那一列——你這個額外寫入（副表／鏡像／聚合列）\n"
+                ."不在覆蓋範圍內。請確認那些值已經是替換後的形，然後登記進 SUBCLASS_EXTRA_WRITES\n"
+                ."並寫明為什麼安全（或改成傳該副表表名再呼叫一次 applyVariantReplacement()）。\n"
+                .implode("\n", $unaccounted)
+        );
+    }
+
+    /** handler 體系之外的掛鉤點（S2～S7）必須都還在，而且數量沒少。 */
+    #[Test]
+    public function testNonHandlerHookSitesStillHaveTheirHooks(): void {
+        $broken = [];
+
+        foreach (self::NON_HANDLER_HOOK_SITES as $file => $spec) {
+            $actual = $this->countHooks($file);
+            if ($actual === null) {
+                $broken[] = "{$file}（檔案不存在；{$spec['why']}）";
+
+                continue;
+            }
+            if ($actual < $spec['hooks']) {
+                $broken[] = "{$file}（掛鉤數 {$actual} < 期望 {$spec['hooks']}；{$spec['why']}）";
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $broken,
+            "下列檔案是 handler 體系之外的替換掛鉤點，掛鉤數量變少或檔案不見了。\n"
+                ."若是刻意移除（例如該路徑已下架）⇒ 調降或刪除 NON_HANDLER_HOOK_SITES 的該筆並在 PR 說明理由；\n"
+                ."否則就是重構時漏掉了。\n"
+                .implode("\n", $broken)
+        );
+    }
+
+    /**
+     * **底線斷言**：掃描本身必須真的掃到東西。
+     *
+     * 沒有這條，只要 `allHandlers()` 因為目錄搬移、命名慣例改變或 autoload 問題而回空集合，
+     * 上面的主測試就會**空轉全綠**——正是本 rollout 想避免的「沒有機制在漏掉時發出聲音」。
+     */
+    #[Test]
+    public function testScannerActuallyFindsHandlers(): void {
+        $all = $this->allHandlers();
+
+        $this->assertGreaterThan(40, count($all), 'handler 掃描結果異常少，掃描邏輯可能壞了');
+
+        $hooked = array_filter($all, fn (string $c): bool => $this->usesReplacementTrait($c));
+        $this->assertGreaterThan(20, count($hooked), '掛上替換 trait 的 handler 異常少，trait 偵測可能壞了');
+
+        // 代表性 handler 必須被掃到（改名時這裡會紅，提醒同步更新掃描與清冊）。
+        foreach ([
+            'AbstractPersonSubresourceCreateHandler',
+            'AbstractCodeTableMutationHandler',
+            'CodeTableCreateHandler',
+            'BiogMainDeleteHandler',
+            'EntityAggregateCreateHandler',
+        ] as $expected) {
+            $this->assertArrayHasKey($expected, $all, $expected.' 應被掃到');
+        }
+
+        // 寫入偵測要涵蓋 insert／update 之外的慣用法：BiogMainDeleteHandler 只用 $biog->save()。
+        $this->assertTrue(
+            $this->hasOwnWrite($all['BiogMainDeleteHandler']),
+            'WRITE_PATTERN 應涵蓋 save() 這類非 insert／update 的寫入慣用法'
+        );
+    }
+
+    /** 例外清冊不可有殭屍條目（handler 改名／刪除後要一起清）。 */
+    #[Test]
+    public function testExemptListHasNoStaleEntries(): void {
+        $existing = array_keys($this->allHandlers());
+        $listed = array_merge(
+            array_keys(self::EXEMPT),
+            array_keys(self::EXEMPT_DELEGATES),
+            array_keys(self::SUBCLASS_EXTRA_WRITES)
+        );
+        $stale = array_values(array_diff($listed, $existing));
+        sort($stale);
+
+        $this->assertSame(
+            [],
+            $stale,
+            'EXEMPT／EXEMPT_DELEGATES／SUBCLASS_EXTRA_WRITES 裡有已不存在的 handler（改名或刪除後沒清）：'
+                .implode(', ', $stale)
+        );
+    }
+
+    /**
+     * `app/Services/Mutations` 下**不以 Handler 結尾**的檔案若自己落庫，必須明文交代。
+     *
+     * 沒有這條，把寫入搬進同目錄的一個 helper（`Concerns\FooWriter`、
+     * `EntityAggregate\BarDefinition`）就完全逃出偵測：它不是 handler、也不在點名清冊裡，
+     * 九支測試全綠而它寫的是未替換的文本。
+     */
+    #[Test]
+    public function testNonHandlerFilesInTheMutationsDirectoryDoNotWriteUnaccounted(): void {
+        $root = base_path(self::HANDLER_DIR);
+        $unaccounted = [];
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($root));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = str_replace('\\', '/', substr($file->getPathname(), strlen($root) + 1));
+            if (str_ends_with(basename($relative, '.php'), 'Handler')) {
+                continue; // 由 handler 那幾支測試管。
+            }
+            if (!$this->fileHasWrite($file->getPathname())) {
+                continue;
+            }
+            if (array_key_exists($relative, self::NON_HANDLER_MUTATION_WRITERS)) {
+                continue;
+            }
+
+            $unaccounted[] = $relative;
+        }
+
+        sort($unaccounted);
+
+        $this->assertSame(
+            [],
+            $unaccounted,
+            "下列 app/Services/Mutations 下的非 handler 檔案自己落庫，卻沒有交代異體字替換：\n"
+                ."請確認落庫值已是參考形（掛上替換或由上游保證），然後登記進 NON_HANDLER_MUTATION_WRITERS\n"
+                ."並寫明理由。\n"
+                .implode("\n", $unaccounted)
+        );
+    }
+
+    /**
+     * handler 短名不可撞名。
+     *
+     * `allHandlers()`（與所有清冊）以短名為鍵，`EntityAggregate/` 這樣的子目錄已經存在；
+     * 兩個同名檔案會讓其中一個被覆蓋掉、從此完全不受檢查，而且不會有任何測試變紅。
+     */
+    #[Test]
+    public function testHandlerShortNamesAreUnique(): void {
+        $byShortName = [];
+        foreach ($this->handlerFiles() as $relative) {
+            $byShortName[basename($relative, '.php')][] = $relative;
+        }
+
+        $collisions = array_filter($byShortName, fn (array $files): bool => count($files) > 1);
+
+        $this->assertSame(
+            [],
+            $collisions,
+            '有 handler 短名撞名；本測試（與各例外清冊）以短名為鍵，撞名會讓其中一個靜默不受檢查。'
+                .'請改名，或改成以 FQCN 為鍵。'
+        );
+    }
+
+    /**
+     * `app/Services/Mutations` 下所有 handler 類別（含子目錄；abstract 也算，
+     * 因為基底掛鉤被移除同樣是缺陷）。
+     *
+     * @return array<string,class-string>
+     */
+    private function allHandlers(): array {
+        $handlers = [];
+
+        foreach ($this->handlerFiles() as $relative) {
+            $class = 'App\\Services\\Mutations\\'.str_replace('/', '\\', substr($relative, 0, -4));
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            $handlers[basename($relative, '.php')] = $class;
+        }
+
+        return $handlers;
+    }
+
+    /**
+     * handler 檔案（相對 HANDLER_DIR 的路徑，含子目錄）。
+     *
+     * Concerns／Exceptions 之類的輔助檔不是 handler；只收檔名以 Handler 結尾者。
+     *
+     * @return array<int,string>
+     */
+    private function handlerFiles(): array {
+        $files = [];
+        $root = base_path(self::HANDLER_DIR);
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($root));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = str_replace('\\', '/', substr($file->getPathname(), strlen($root) + 1));
+            if (!str_ends_with(basename($relative, '.php'), 'Handler')) {
+                continue;
+            }
+
+            $files[] = $relative;
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /** 類別自己或任一祖先是否 use 了替換 trait。 */
+    private function usesReplacementTrait(string $class): bool {
+        for ($current = $class; $current !== false; $current = get_parent_class($current)) {
+            if (in_array(AppliesVariantReplacement::class, class_uses($current) ?: [], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** 該類別**自己的檔案**裡是否有資料庫寫入。 */
+    private function hasOwnWrite(string $class): bool {
+        $file = (new ReflectionClass($class))->getFileName();
+        if ($file === false) {
+            return false;
+        }
+
+        return $this->fileHasWrite($file);
+    }
+
+    /** 該檔案裡是否有資料庫寫入（比對真實呼叫 token）。 */
+    private function fileHasWrite(string $absolutePath): bool {
+        foreach ($this->codeCalls($absolutePath) as $call) {
+            if (in_array($call['method'], self::WRITE_METHODS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** 檔案裡的替換呼叫數（檔案不存在回 null）。 */
+    private function countHooks(string $relativePath): ?int {
+        $path = base_path($relativePath);
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $count = 0;
+        foreach ($this->codeCalls($path) as $call) {
+            if ($call['class'] === 'CharVariantMapService' && in_array($call['method'], self::HOOK_STATIC_METHODS, true)) {
+                $count++;
+
+                continue;
+            }
+            if ($call['class'] === null && in_array($call['method'], self::HOOK_INSTANCE_METHODS, true)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * 檔案裡有沒有以 `->name(` 的形式呼叫某個實例方法。
+     *
+     * **必須限定 `->` 形式**：只比對方法名的話，`SomeHelper::applyVariantReplacement()` 這種
+     * 同名靜態呼叫也會讓斷言過關，而真正的 `$this->applyVariantReplacement()` 已經被刪掉了。
+     *
+     * @param array<int,string> $methods
+     * @return array<int,string> 沒被（以實例方法形式）呼叫到的方法名
+     */
+    private function missingInstanceCalls(string $relativePath, array $methods): array {
+        $called = [];
+        foreach ($this->codeCalls(base_path($relativePath)) as $call) {
+            if ($call['class'] === null) {
+                $called[] = $call['method'];
+            }
+        }
+
+        return array_values(array_filter($methods, fn (string $m): bool => !in_array($m, $called, true)));
+    }
+
+    /**
+     * 檔案裡**真正的方法呼叫**清單。
+     *
+     * 為什麼要走 tokenizer 而不是正則／`php_strip_whitespace()`：去註解只擋得住註解，**擋不住
+     * 字串字面值**。有人把真正的掛鉤刪掉、留下 `$x = 'CharVariantMapService::replaceRow(';`
+     * 這種字面值，純文字比對就會照樣算它一次而假綠。token 級比對只認 `Foo::bar(`／`->bar(`
+     * 的呼叫形式，字串與註解都不算。
+     *
+     * @return array<int,array{class:string|null,method:string}> class 為 null 表示 `->method(` 形式
+     */
+    private function codeCalls(string $absolutePath): array {
+        $tokens = array_values(array_filter(
+            token_get_all((string) file_get_contents($absolutePath)),
+            fn ($token): bool => !is_array($token)
+                || !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)
+        ));
+
+        $calls = [];
+        foreach ($tokens as $i => $token) {
+            if (!is_array($token) || $token[0] !== T_STRING) {
+                continue;
+            }
+
+            // 必須真的是呼叫：後面緊接 `(`。
+            $next = $tokens[$i + 1] ?? null;
+            if ($next !== '(') {
+                continue;
+            }
+
+            $prev = $tokens[$i - 1] ?? null;
+            if (is_array($prev) && $prev[0] === T_DOUBLE_COLON) {
+                $classToken = $tokens[$i - 2] ?? null;
+                $calls[] = [
+                    'class' => is_array($classToken) ? $classToken[1] : null,
+                    'method' => $token[1],
+                ];
+
+                continue;
+            }
+
+            if (is_array($prev) && in_array($prev[0], [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR], true)) {
+                $calls[] = ['class' => null, 'method' => $token[1]];
+            }
+        }
+
+        return $calls;
+    }
+}


### PR DESCRIPTION
## 這是什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S8**：把「新增文本錄入必須掛落地替換」寫成常規，並補上會在漏掉時發出聲音的機械化把關。

**沒有行為改動**：只有規則文件、skill、一支新測試，加一處 docblock 修正。

## 為什麼需要

第二階段之所以漏掉 19 個 handler，正是因為當時沒有任何機制會在漏掉時發出聲音。本階段價值的一半在「以後不會再漏」。

## 內容

**規則**
- `AGENTS.md` 新增 §1.3，與 §1.1（外鍵 RESTRICT）／§1.2（稽核欄）並列為資料完整性規則。含兩個常被忽略的邊界：繼承基底但自己另寫副表／鏡像的 handler、沒有 `tableName()` 的 handler 必須顯式傳表名（省略是 runtime fatal 而非靜態錯誤）。
- 「提交前最低檢查」補一行。
- `.claude/skills/mutation-api-record-editing.md`：掛哪個 hook、順序為什麼是硬性要求、通知怎麼接、測試該斷言哪 8 件事（含鑑別力）。
- `.claude/skills/database-schema.md`：新增文本欄自動進入範圍；新增對照／映射表必須加進排除清單。

**機械化把關 `tests/Unit/VariantReplaceHookCoverageTest.php`（10 支測試）**
- 每一個 handler 都必須掛（或繼承）替換 trait，或列在清冊。**刻意不先判斷「有沒有寫入」**——現存 8 個非基底 handler 裡有 4 個把寫入委派給 repository／service，自己檔案裡沒有任何寫入慣用法；以「有寫入才要求登記」為前提會 fail-open。
- 三本清冊都有機械檢查：`EXEMPT`（要寫理由）、`EXEMPT_DELEGATES`（指名下層檔案**與掛鉤數**）、`SUBCLASS_EXTRA_WRITES`。已掛 trait 的類別不可列進前兩本（殭屍豁免會讓它從此不受檢查）。
- 基底不只要 `use`，還要**真的呼叫**三個 trait 方法。
- 逐檔記數鎖住體系外的 12 個掛鉤點，掛鉤變少也會紅。
- 比對走 PHP tokenizer：註解與字串字面值都不算，且只認 `->method(`，同名靜態呼叫無法冒充。
- 目錄內非 handler 檔案若自己落庫也要交代——這條當場抓出 `Concerns/RecordsAiFillSubmission` 寫 `ai_fill_logs`（紀錄類表，確認不替換後登記）。
- 偵測邊界誠實寫在 docblock 與 AGENTS.md：目錄外新開的檔案、以及委派給下層方法的鏡像同步偵測不到。

## 驗證

- 鑑別力逐項實測會紅：中和基底呼叫、拿掉下層掛鉤、掛鉤數減少、字串字面值冒充、同名靜態呼叫冒充、新增未登記 handler、把寫入搬進目錄內 helper、殭屍豁免、未登記的子類額外寫入。
- 全量測試：2955 tests / 15539 assertions 綠。
- `php-cs-fixer` clean（0 of 675）。
- review agent + codex 三輪，HIGH／MEDIUM 全數處理完畢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
