### PR TITLE
異體字落地替換 S9：文件收尾（API／openapi／CHANGELOG／計畫狀態）

### DIFF
--- a/API.md
+++ b/API.md
@@ -1560,6 +1560,9 @@ v2 提案流程上線前的舊機制，仍在線但**建議一律改用 `/api/v2
 
 - 這條通道寫入的是 `operations` 表且 `crowdsourcing_status = 2`，**與 v2 的提案（`op_type` 8／9／10、`__review_status`）是兩套不同的機制**，也不會出現在 `GET /api/v2/operations`（該端點只回 `crowdsourcing_status = 0`）。此處的 `op_type` 1／3／4 與第三章「一般操作」的編碼相同，但語義是「待處理的眾包投稿」，不是已落庫的操作。
 - 它不做欄位白名單、不驗證複合主鍵，寫入 `add`／`update`／`delete` 時也不寫 `audit_log`（只有 `token` 端點會記安全審計）；`json` 是整包字串。
+- **`json` 裡的文本值會先做異體字落地替換才存進 `operations.resource_data`**（與 v2 同一套規則：人名／別名欄 strict、其餘文本欄用全量規則 lenient；`resource` 必須是註冊表內的**精確拼寫**，大小寫或前後空白不符時**整包不替換**）。
+- `resource_original`（`update` 與 `delete` 會寫，`add` 不寫；部分 delete 分支寫 `null`）是**寫入前的既有列快照**，不是使用者送出的內容，且刻意不替換——那是「當時實際長什麼樣」的事實。由於既有資料不做回溯校正，既有列仍保留原字形，因此審核畫面的 diff 會多出「字形被改寫」那幾行，這是預期現象。
+- 眾包核准回填（`confirm()`）**會再替換一次**：舊提案可能早於落地替換上線，所以那裡是最後一道；重複套用是幂等的（對照表以閉包終點儲存），不會二次漂移。
 - token 是**長期有效且無到期機制**的憑證（帳號的 `confirmation_token`），與 14.2 的 Sanctum token 不同，請勿外流。
 - 回應形狀不一致且**狀態碼不可靠**：`add` 成功回 JSON `{"status_code":200,"message":"..."}`，`update`／`delete` 成功回裸字串 `'200'`；權限不足回 `'403'`（HTTP 403），但**參數缺漏回裸字串 `'500'` 而 HTTP 狀態碼其實是 200**——只看狀態碼會把失敗當成功。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 2026-08
 
+### 異體字落地替換擴張到「所有文本型別欄位」（行為擴張，非修 bug）
+
+- **這是行為擴張**：先前只有 BIOG_MAIN 姓名、ALTNAME_DATA 別名、書名批次匯入三處會做落地替換；現在**所有經應用層寫入的文本欄**（含 `c_notes` 這類自由文字）落庫前都會依 `char_variant_map` 把變體字改寫成參考字。使用者送 `淸` 存進去會變成 `清`。
+- **範圍由欄位型別決定，不由呼叫端維護清單**（`app/Support/VariantReplaceScope.php`）：`Schema::getColumns()` 的型別是 char/varchar/text 系列就在範圍內；未知表 **fail-closed**（一律不替換），所以 `$table` 必須傳目標資料表、永遠不要傳 `operations`。預設用**全量規則（lenient）**，人名／別名欄才用 strict（`c_strict_excluded` 那組例外，例如 `峯` 在姓名欄不替換、在 `c_notes` 會）。
+- **不替換的地方**（節錄；完整清單是 `VariantReplaceScope` 的三組排除常數）：字形對照表自身、拼音字典鍵 `pinyin.c_chn`、稽核署名、URL、跨表 join／查表鍵、拉丁人名與拼音欄、派生／唯讀索引（`ADDRESSES`、`CBDB__NAME_FTS`、兩個 view），以及**紀錄與帳號類**表（`operations`／`audit_log`／`users`／`nl_query_logs`／`ai_fill_logs`——快照的語義是「當時實際發生什麼」，改寫等於偽造紀錄）。`restore`（還原歷史快照）與「只刪不寫」的分支同理不做內容替換。
+- **不做既有資料的回溯校正**（D6）：既有列保留原字形。因此**「兩形並存」是常態**，任何做精確比對的地方（查重、去重鍵、標籤→代碼查表、鏡像定位）都必須**兩形都探**（`app/Support/VariantEquivalentLookup.php`）。少了這道，替換會**製造**新的重複列而唯一鍵擋不住（不同字形＝不同鍵值）——**那比完全不替換更糟**，這是整個階段最容易做錯的地方。
+- **文本型主鍵成員替換＝改列身分**：`ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、`BIOG_SOURCE_DATA.c_pages`。因此掛鉤位置是硬性要求——必須早於 PK 計算、查重、拼音派生，以及 `operations.resource_id`／`audit_log.row_pk` 的組裝；否則稽核鏈會指向一個不存在的鍵，還原時會重建一列從未存在過的資料。
+- **搜尋端完全沒有異體字歸一化**（D9，已知落差、列為下一階段候選）：新寫入的資料是參考形、既有資料是變體形，**兩者互相搜不到**。以 `淸`／`清` 為例，用變體形搜不到新資料、用參考形搜不到舊資料；`CBDB__NAME_FTS` 也不對變體字做歸一（它刻意同時保存繁簡兩形，但那是繁簡轉換、與異體字對照是兩件事）。新增對照時要一併評估這件事。
+- 涵蓋的寫入路徑：Codes CRUD（含提案）、13 個人物子資源的 v2 create／update、官職與社會機構聚合匯入、token API 代碼表寫入、**提案核准的直接寫庫分支**、眾包回填 `confirm()`、v1 token API 的 `add`／`update`、`saveas()` 與 `Duplicate_Collateral_Info()`、單向關係修復工具（僅非主鍵欄）；以及**與 v2 共用 `BiogMainRepository` 的 legacy Blade 人物編輯寫入**（BIOG_MAIN／KIN_DATA／ASSOC_DATA／ALTNAME_DATA）與前階段就有的書名批次匯入。年號與官名的**查表**（`PostingAutofillService`）不是寫入，但也改成兩形都探。
+- **v1 token API 的已知現象**：提案的 `resource_data` 存替換後的值，而 `resource_original`（更新前的**既有列**快照，不是使用者送出的內容）刻意不替換——快照的語義是「當時實際長什麼樣」。既有列在 D6 之下保留原字形，所以審核畫面的 diff 會多出「字形被改寫」的那幾行，這是預期現象、不是 bug。眾包核准回填會再替換一次（舊提案可能早於本次上線），依 D8 幂等。
+- **批次匯入與 token API create 之間仍有非字形的行為差異**（欄位白名單、必填檢查），與本階段無關、未一併收斂。
+- `notices`：發生替換時回應會多一個頂層 `notices` 陣列，**成功、409、422 都會帶**——被擋下來時使用者更需要知道「我輸入的字被正規化了」。詳見 `API.md`。
+- **常規化**：`AGENTS.md` §1.3 訂為資料完整性規則，`tests/Unit/VariantReplaceHookCoverageTest.php` 機械化把關（繞過掛鉤又沒登記例外時會紅）。
+- 逐步執行紀錄見 [docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md](./docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md)。
+
 ### LLM 產出的 Markdown 統一改用共用渲染器（Query Playground QA／NL 查詢／NL 查詢日誌／AI 代碼查詢）
 - 起因：`/app/query-playground?mode=qa` 的回答與 `/app/query-playground/nl-query-logs` 的 LLM Response 都是 Markdown，但前者靠 `HistoricalQaPanel.tsx` 裡一個手刻的正則渲染器、後者根本沒渲染。實測手刻版對一段典型回答的輸出：有序清單 `1. ` 原樣輸出（只認 `^[-*] `）、`[文字](網址)` 完全不處理、巢狀清單的子項會**漏到 `<ul>` 外面**變成裸文字，最嚴重的是「`
 

--- a/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_CALL_SITE_WIRING_PLAN.md
@@ -266,7 +266,8 @@ class CharVariantMapService {
 - `VariantCharNormalizer` 類別本身的刪除清理（見前一份文件「不在本次範圍內」，依賴條件已滿足但屬於獨立任務）。
 - `CBDB__TRAD_SIMP_MAP` 繁簡轉換機制（與本表功能層次不同，見前一份文件）。
 - 對既有資料庫裡「已經含有這些異體字」的既有人物/書名記錄做批次回溯更新——本階段只處理「往後新增/修改時」的落地替換，不做歷史資料的批次校正（批次校正若有需要，屬於另一個獨立任務，且需要更謹慎的影響評估，不應該隨這次呼叫點串接一併做）。
-- **本階段只涵蓋 BIOG_MAIN 姓名欄、ALTNAME_DATA 別名欄、TITLE_VARIANT_MAP（書名）三類欄位，未涵蓋其他任意文本錄入入口**（使用者於 goal 執行中途提出、待下一階段評估，本階段刻意不處理）：
+- **本階段只涵蓋 BIOG_MAIN 姓名欄、ALTNAME_DATA 別名欄、TITLE_VARIANT_MAP（書名）三類欄位，未涵蓋其他任意文本錄入入口**（使用者於 goal 執行中途提出、待下一階段評估，本階段刻意不處理）。
+  ✅ **已由第三階段完成**：見 [CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md](./CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md)——範圍改由**欄位型別**推斷（不再逐點手掛也不維護欄位清單），`c_notes` 等自由文字欄依使用者決定一律替換，掛鉤集中在少數基底類別與掛鉤點，並有 `tests/Unit/VariantReplaceHookCoverageTest.php` 機械化把關。以下三小點記錄的是**當時**的狀態：
   - Codes UI（`/codes/{table}`、`/app/codes/{table}`）對「所有」代碼表的「所有」文本欄位——目前落地替換只掛在 `char_variant_map` 本身被查詢的三個特定呼叫點，並未掛在 `CodesController` 通用的 `store()`/`update()` 寫入路徑上，也就是說透過 Codes UI 編輯任何其他代碼表（例如 `TEXT_CODES.c_title`、`OFFICE_CODES.c_office_chn` 等）時，若使用者輸入了這 7 個異體字之一，**不會**被落地替換。
   - 各人物子資源 editor（複合主鍵子資源，如 `BIOG_SOURCE_DATA`／`POSTING_DATA`／`EVENTS_DATA`／`KIN_DATA` 等）中泛用的 `c_notes`／`c_pages` 等自由文字欄位——這些欄位目前完全沒有掛任何落地替換邏輯，使用者若在筆記或頁碼欄位輸入這些異體字，會原樣存入。
   - 下一階段若要處理，需要先盤點：(1) 哪些欄位屬於「應該落地替換」的範疇（人名/書名等有明確歸一化需求的欄位）vs.「不應該替換」的範疇（例如 `c_notes` 這類引用原始文獻用字、逐字抄錄的欄位，替換後可能反而扭曲史料原貌，需要另外評估是否該用寬鬆或嚴格模式、甚至完全不替換）；(2) 是否要在 `CodesController`／各子資源 mutation handler 的通用寫入路徑上加一個「按欄位類型套用替換」的機制，而非像本階段一樣為每個呼叫點個別手動掛鉤（如果欄位範圍擴大到「所有代碼表所有文本欄位」的量級，個別手動掛鉤的作法會難以維護，值得重新評估是否要換一個更通用的機制，例如寫入前置中介層）。

--- a/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
+++ b/docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md
@@ -5,6 +5,54 @@
 >
 > **文件結構約定**：「決策」只寫**規則**；所有要做的事都在「實作步驟」。同一件事不重複兩處。
 
+## 執行狀態：**已完成**（2026-08-21）
+
+S0～S9 全部完成，逐步 rebase merge 進 `develop`（線性歷史）：
+
+| 步驟 | commit | 內容 |
+|---|---|---|
+| S0＋S1 | `a821dea0` | varchar 代碼鍵補充掃描、`VariantReplaceScope`／`replaceRow()`／`replaceFor()`／`assertWritable()` |
+| S2 | `8fe1a8cb` | Codes UI 全表串接（含提案） |
+| S3 | `45e701a8` | 人物子資源與 BIOG_MAIN 全面串接，補上兩形並存查重 |
+| S4 | `d6381042` | 官職／社會機構聚合串接，標籤對照表兩側歸一 |
+| S5 | `fb9b76db` | token API 代碼表 create／update |
+| S6 | `c1ffa4a4` | 提案核准的直接寫庫分支，補上核准端的兩形並存守衛 |
+| S7 | `9f16c24c` | 眾包回填、v1 端點、複製與修復工具 |
+| S8 | `b0dde593` | 規則（`AGENTS.md` §1.3、兩份 skill）與機械化把關測試 |
+| S9 | 本次 | 文件收尾：`API.md`／`docs/openapi/openapi.yaml`／`CHANGELOG.md`／本文件狀態 |
+
+### 與原計畫的偏差（逐條）
+
+- **D7（兩形並存）的份量被嚴重低估**。原計畫把它寫成一條決策；實作中它是**每一步都要重做一次**
+  的工作：v2 create 的查重、mutation 的改鍵偵測、ASSOC 鏡像改名、機構名去重鍵、標籤→代碼查表、
+  提案核准的落庫前檢查，每一處都要嘛兩形都探、要嘛顯式排除。為此抽出
+  `app/Support/VariantEquivalentLookup.php`（原計畫沒有這個檔案）與 `app/Support/VariantLabelMap.php`。
+  多數 review／codex 的 HIGH 都落在這一類：**替換把原本乾淨的 409／1062 變成靜默的重複列**。
+- **「只在真的改鍵時檢查」是後來才明確的**。無條件做兩形並存檢查會讓「歷史上就已兩形並存」的
+  資料變成任何更新都做不了（false 409）。鏡像那一側還要進一步只看**在範圍內**的 PK 欄，
+  因為鏡像同步本來就會重寫數值型的 `c_kin_id`／`c_assoc_kin_id`。
+- **稽核鏈的字形一致性比預期難**。除了「替換要早於 `resource_id`／`row_pk` 組裝」，S6／S7 還發現
+  刪除路徑必須用**實際被刪的那一列**去組 `resource_id` **與兩份快照**——否則同一筆稽核的 id 與
+  內容字形互相矛盾，還原會重建一列從未存在過的資料。
+- **`VariantReplaceScope` 的表名要正規化兩次**。fail-closed 閘門對大小寫／空白不敏感，但查 schema
+  時若用原字串，會把空的欄位集**快取住**、讓該表在整個 process 之後都不替換（靜默失效）。
+  因此補了 `canonicalTableName()`；而在兩個外部入口（v1 token API、眾包回填）**刻意要求精確拼寫**，
+  不做正規化派發——那會擴大未經信任的輸入能寫到的表。
+- **BIOG_MAIN 的替換必須只針對「使用者這次真的改的欄位」**。原計畫的整列 `replaceRow()` 在 v2
+  等於偷偷做 D6 明文排除的回溯校正，因此 `updateById()` 多了 `$variantFields` 參數。
+- **`Duplicate_Collateral_Info()` 需要 per-table 去重**。歸一可能把兩列塌到同一個文本型 PK 上，
+  整份複製會因 1062 全數回滾；改為跳過並 `Log::warning`。
+- **修復工具只替換非主鍵欄**。鏡像的定位鍵單邊歸一會讓偵測永遠找不到那一對、修復失去幂等。
+  同理 pair-only 鏡像修復刻意整列照抄既有列。
+- **通知（notices）的覆蓋面比原計畫大**：成功之外，409／422 也要帶——被擋下來時使用者更需要
+  知道「我輸入的字被正規化了」。基底一律用 `mergeReplaced()`（直接 assign 會把上游通知靜默吃掉）。
+- **S8 的把關做得比原計畫重**。原計畫只要求「列舉 handler + 例外清冊」；實測那樣有四個假綠管道
+  （例外條目短路掉真實檢查、只 `use` 不呼叫、字串字面值冒充掛鉤、把寫入搬進非 handler 檔案），
+  因此改成全體 handler 都要交代、比對走 PHP tokenizer、掛鉤點逐檔**記數**。
+- **不做的維持不做**：D6（回溯校正）、`restore` 的內容替換、D9（搜尋端歸一）、
+  `MergePreviewController` 產生的帶外 SQL、已被閘門下架的 legacy 寫入路徑。
+- **`docs/openapi/openapi.yaml` 原本完全沒有 `notices`**（不只是沒同步這次的擴張），S9 一併補上。
+
 ## 背景與現況
 
 第一階段的目標宣告是把 `TITLE_VARIANT_MAP` 擴充成「所有表的錄入端都能查詢的通用對照」。第二階段採**逐點手掛**，因此目前全庫只有這些生產呼叫：

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -13,6 +13,15 @@ info:
 
     `POST /api/v2/get` is the recommended way to read a single record because it supports
     nested `target.pk` payloads naturally. `GET /api/v2/get` is kept for compatibility.
+
+    Variant-character replacement: every text column is normalized against `char_variant_map`
+    before it is written (name/alias columns use the strict rule set, all other text columns
+    use the full set). When a replacement happened the response carries a top-level `notices`
+    array - on success responses as well as on 409/422 failures. If the replaced column is
+    part of the primary key (e.g. `ALTNAME_DATA.c_alt_name_chn`), `result.pk` in the response
+    is the key that was actually written; do not reuse the submitted value. Other silent
+    rewrites (pinyin `v` normalized to `ü`, bracket normalization, sentinel
+    normalization) produce no `notices`.
 servers:
   - url: /
 tags:
@@ -355,6 +364,8 @@ components:
         result:
           type: object
           additionalProperties: true
+        notices:
+          $ref: '#/components/schemas/Notices'
       additionalProperties: true
     GetSuccessResponse:
       type: object
@@ -402,4 +413,22 @@ components:
                 - type: number
                 - type: boolean
                 - type: 'null'
+        notices:
+          $ref: '#/components/schemas/Notices'
       additionalProperties: true
+    Notices:
+      type: array
+      description: |
+        Human-readable notes about server-side rewrites that the client did not ask for.
+        Present only when a variant-character replacement happened; appears on success
+        responses and on 409/422 failures alike (a "primary key already exists" or
+        "no effective changes" message is confusing without it).
+      items:
+        type: string
+      example:
+        - 異體字：「淸」已正規化為「清」
+      x-note: |
+        One notice covers every column in the request; the message lists the
+        variant/reference pairs that were applied and does not attribute them to
+        individual columns.
+


### PR DESCRIPTION
## 這是什麼

`docs/CHAR_VARIANT_MAP_TEXT_COLUMN_ROLLOUT_PLAN.md` 的 **S9**（最後一步）：文件收尾。**純文件，無程式碼改動。**

## 內容

- **`API.md`**：v1 舊版 operations 通道補三條事實——`json` 的文本值先替換才存進 `resource_data`（`resource` 需**精確拼寫**，否則整包不替換）；`resource_original` 是**寫入前的既有列快照**、刻意不替換（因此審核 diff 會多出「字形被改寫」那幾行，是預期現象）；眾包核准回填**會再替換一次**（舊提案可能早於本次上線，依 D8 幂等）。
- **`docs/openapi/openapi.yaml`**：**原本完全沒有 `notices`**。補 `Notices` schema 並掛到 `MutationSuccessResponse` 與 `ErrorResponse`（成功與 409／422 都會帶），`info.description` 補一段落地替換說明。example 用真實訊息格式，並註明一次請求只有一則通知、不逐欄歸屬。
- **`CHANGELOG.md`**：記一則，**明確標為行為擴張而非修 bug**。含使用者最需要知道的三件事：所有文本欄（含 `c_notes`）都會被改寫；不做回溯校正所以「兩形並存」是常態、精確比對一律要兩形都探；以及 **D9——搜尋端完全沒有歸一，新舊資料互相搜不到**。
- **計畫文件**補「執行狀態」表（S0～S9 的 commit）與**與原計畫的偏差**逐條記錄。
- **第二階段文件**的「未涵蓋其他文本錄入入口」改為指向本階段（已完成），並標明其下三小點記錄的是當時狀態。

## 驗證

- review agent 與 codex 各一輪。修掉的錯誤陳述：`resource_original` 不是「使用者送出的字形」而是既有列快照（且 `add` 不寫、部分 delete 分支寫 `null`）、核准回填其實**會**再替換一次、拼音歸一是 `v`→`ü` 不是 `ue`、通知格式不含欄位名、排除清單與涵蓋路徑清單原本是不完整的列舉卻寫得像完整。
- 全量測試：2955 tests / 15539 assertions 綠。
- openapi.yaml 通過 YAML 與 OpenAPI 3.1 解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
