### PR TITLE
修正操作紀錄「資源」連結對提案一律 404，並補上別名分頁的出處／頁碼／備註欄

### DIFF
--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -855,17 +855,22 @@ class OperationsController extends Controller {
         $showPerPersonResourceButtons = in_array(strtoupper($resourceName), ['KIN_DATA', 'ASSOC_DATA'], true) && $personRowspan > 1;
 
         // 主資源連結（非 per-person 模式）。
+        // 不可直接用 $rawResourceId：提案的 resource_id 是「提案完成後」的主鍵，先於現實寫入，
+        // 拿去開 edit-v2 會 404。見 resolveLinkResourceId()。
         $id = $item->c_personid;
+        $linkResourceId = $this->resolveLinkResourceId($item, is_array($resourceDataParsed) ? $resourceDataParsed : null);
         $resourceSpecificLink = null;
-        if ((int) $id !== 0 && $opType !== 4) {
-            $resourceSpecificLink = CompositePrimaryKey::buildResourceEditUrl($resourceName, $rawResourceId, $id);
+        if ((int) $id !== 0 && $opType !== 4 && $linkResourceId !== null) {
+            $resourceSpecificLink = CompositePrimaryKey::buildResourceEditUrl($resourceName, $linkResourceId, $id);
         }
         $hasPersonLink = (int) $id !== 0 && !empty($biogmain);
         $resourceLink = null;
         if ($hasPersonLink && $resourceSpecificLink) {
             $resourceLink = $resourceSpecificLink;
-        } elseif ($isCodeResource && $opType !== 4) {
-            $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($resourceName, $rawResourceId);
+        } elseif ($isCodeResource && $opType !== 4 && $linkResourceId !== null) {
+            // 同樣用 $linkResourceId：ALTNAME_DATA 這類「既是人物子資源、也在 codes.tables 裡」的表，
+            // 提案在上面的分支被擋掉後會落到這裡，若沿用 $rawResourceId 等於換一條路徑撞同一個 404。
+            $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($resourceName, $linkResourceId);
             // flag-aware：codes flag=new 時開 React 版編輯頁，不要從 React 操作紀錄掉回舊 Blade 頁。
             $resourceLink = code_table_edit_url($resourceName, $codeRouteId);
         }
@@ -1083,6 +1088,73 @@ class OperationsController extends Controller {
         }
 
         return route('codes.proposals.edit', ['table_name' => $resourceName, 'operation' => $item->id], false);
+    }
+
+    /**
+     * 「資源」連結該指向哪一個 resource_id（null＝此刻沒有可指向的實體列，不出連結）。
+     *
+     * operations.resource_id 對提案存的是「提案完成後」的主鍵，是**先於現實**寫進去的：
+     * - create 提案：核准前那一列根本不存在；
+     * - update 提案：只要改到任一主鍵成員（ALTNAME_DATA.c_alt_name_chn、ASSOC_DATA.c_text_title、
+     *   BIOG_SOURCE_DATA.c_pages 這類文本型，或 c_addr_type／c_kin_code 這類代碼型都算），
+     *   resource_id 就是尚不存在的新鍵；
+     * - delete 提案：核准後舊鍵那一列已被刪掉。
+     * 直接拿它開 edit-v2，編輯器以主鍵查不到列就 abort(404)——這是所有複合主鍵子資源共通的問題，
+     * 不限別名。
+     *
+     * 未核准的 update 提案改以 resource_original 的主鍵指向「現存那一列」，與核准路徑
+     * （OperationsProposalController::applyViaMutationHandler() 一律以 original 定位）同一套語義。
+     */
+    protected function resolveLinkResourceId($item, ?array $payload = null): ?string {
+        $rawResourceId = (string) ($item->resource_id ?? '');
+        $opType = (int) ($item->op_type ?? 0);
+
+        $proposalTypes = [
+            Operation::TYPE_PROPOSAL_CREATE,
+            Operation::TYPE_PROPOSAL_UPDATE,
+            Operation::TYPE_PROPOSAL_DELETE,
+        ];
+        if (!in_array($opType, $proposalTypes, true)) {
+            return $rawResourceId;
+        }
+
+        if ($payload === null) {
+            $decoded = json_decode((string) ($item->resource_data ?? ''), true);
+            $payload = is_array($decoded) ? $decoded : [];
+        }
+        $applied = (string) ($payload['__review_status'] ?? 'pending') === 'approved';
+
+        // create：核准後 resource_id 已被 updateProposalStatus() 改指實際建立的列；核准前無實體。
+        if ($opType === Operation::TYPE_PROPOSAL_CREATE) {
+            return $applied ? $rawResourceId : null;
+        }
+
+        // delete：核准前 resource_id 即現存列；核准後該列已刪除。
+        if ($opType === Operation::TYPE_PROPOSAL_DELETE) {
+            return $applied ? null : $rawResourceId;
+        }
+
+        // update：核准後 resource_id（新鍵）即現況；核准前指向原列。
+        if ($applied) {
+            return $rawResourceId;
+        }
+
+        $keyColumns = is_array($payload['__key_columns'] ?? null) ? $payload['__key_columns'] : [];
+        $original = json_decode((string) ($item->resource_original ?? ''), true);
+        if (empty($keyColumns) || !is_array($original)) {
+            return null;
+        }
+
+        $originalPk = [];
+        foreach ($keyColumns as $column) {
+            if (!is_string($column) || !array_key_exists($column, $original)) {
+                // 原始快照缺主鍵欄 → 無從定位；寧可不出連結，也不要送使用者去撞 404。
+                return null;
+            }
+            $originalPk[$column] = $original[$column];
+        }
+
+        return CompositePrimaryKey::buildStoredResourceId($originalPk);
     }
 
     /**
@@ -1849,7 +1921,10 @@ class OperationsController extends Controller {
             return [];
         }
 
-        $allowEditLink = (int) ($item->op_type ?? 0) !== Operation::TYPE_DELETE;
+        // linkResourceId 為 null＝此刻沒有實體列可指（未核准的 create 提案、已核准的 delete 提案），
+        // 連 audit 推導出的 per-person 連結也一併不出——已核准的刪除提案有 audit 卻沒有列。
+        $linkResourceId = $this->resolveLinkResourceId($item);
+        $allowEditLink = (int) ($item->op_type ?? 0) !== Operation::TYPE_DELETE && $linkResourceId !== null;
         $targets = [];
         $auditLogs = is_array($item->audit_logs ?? null) ? $item->audit_logs : [];
         foreach ($auditLogs as $audit) {
@@ -1886,8 +1961,10 @@ class OperationsController extends Controller {
             ];
         }
 
+        // 提案沒有 audit_logs（尚未落庫），會落到這個回退分支；resource_id 是「提案完成後」的
+        // 主鍵，未核准時指向不存在的列 ⇒ 與主資源連結同一個 404，這裡套同一套解析。
         $primaryId = $item->c_personid ?? null;
-        $primaryResourceId = trim((string) ($item->resource_id ?? ''));
+        $primaryResourceId = trim((string) ($linkResourceId ?? ''));
         if (is_numeric($primaryId) && (int) $primaryId > 0 && $primaryResourceId !== '') {
             $primaryId = (int) $primaryId;
             if (!isset($targets[$primaryId])) {

--- a/app/Http/Controllers/OperationsProposalController.php
+++ b/app/Http/Controllers/OperationsProposalController.php
@@ -8,6 +8,7 @@ use App\Repositories\OperationRepository;
 use App\Services\AuditLogService;
 use App\Services\CharVariantMapService;
 use App\Services\NameSearchIndexService;
+use App\Support\CompositePrimaryKey;
 use App\Support\VariantEquivalentLookup;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
@@ -1181,7 +1182,7 @@ class OperationsProposalController extends Controller {
             $hasKeys = $keyColumns !== [] && !array_diff($keyColumns, array_keys($appliedRow));
             $resourceIdRow = $hasKeys ? $appliedRow : $original;
         }
-        $resourceId = $this->buildCompositeId($keyColumns, $resourceIdRow);
+        $resourceId = $this->buildCompositeId($keyColumns, $resourceIdRow, $proposal->resource);
 
         // 對於 BiogMain 相關提案，使用實際的 c_personid；對於 Codes 提案使用 0
         $personId = $proposal->c_personid ?? 0;
@@ -1249,15 +1250,29 @@ class OperationsProposalController extends Controller {
 
         $proposal->resource_data = json_encode($payload, JSON_UNESCAPED_UNICODE);
         if ($status === 'approved' && $appliedRow !== null && $updateResourceId && !empty($keyColumns)) {
-            $proposal->resource_id = $this->buildCompositeId($keyColumns, $appliedRow);
+            $proposal->resource_id = $this->buildCompositeId($keyColumns, $appliedRow, $proposal->resource);
         }
         $proposal->save();
     }
 
-    protected function buildCompositeId(array $keyColumns, array $row): string {
+    /**
+     * 核准／落帳時用的 `_._` 位置式主鍵字串。
+     *
+     * 格式刻意維持位置式（不換成 CompositePrimaryKey::buildStoredResourceId() 的 query-string）：
+     * 代碼表的查閱連結會把它塞進 codes 編輯頁的 path，而 CodesController::buildNamedConditionsFromId()
+     * 只認**純數字**主鍵值，含文字主鍵的代碼表換格式後會從「查得到」變成「查不到」。
+     *
+     * 但欄序必須對齊 CompositePrimaryKey::SCHEMAS：位置式在解析端（parseStoredResourceId()）
+     * 是按 SCHEMAS 欄序還原，而 $keyColumns 來自提案的 __key_columns（人物子資源取自 handler
+     * 的 keyColumns()、代碼表取自 CodesController::getKeyColumns()），兩者不保證同序。
+     * 錯位不會報錯，只會**靜默指到別的資料列**——所以有 schema 且欄位集合相同時一律照 schema 排。
+     */
+    protected function buildCompositeId(array $keyColumns, array $row, ?string $table = null): string {
         if (empty($keyColumns)) {
             return '';
         }
+
+        $keyColumns = $this->alignKeyColumnsToSchema($keyColumns, $table);
 
         $parts = [];
         foreach ($keyColumns as $column) {
@@ -1265,6 +1280,32 @@ class OperationsProposalController extends Controller {
         }
 
         return implode('_._', $parts);
+    }
+
+    /**
+     * 把 __key_columns 重排成 CompositePrimaryKey::SCHEMAS 的欄序。
+     * 沒有 schema、或欄位集合對不上（歷史 4-key ALTNAME 等）時原樣回傳——
+     * 這種情況下重排只是換一種錯法，不如維持既有行為。
+     *
+     * @param array<int,string> $keyColumns
+     * @return array<int,string>
+     */
+    protected function alignKeyColumnsToSchema(array $keyColumns, ?string $table): array {
+        if ($table === null || trim($table) === '') {
+            return $keyColumns;
+        }
+
+        $schema = CompositePrimaryKey::getSchema($table);
+        if (!is_array($schema) || $schema === []) {
+            return $keyColumns;
+        }
+
+        $given = array_values(array_filter($keyColumns, 'is_string'));
+        if (count($given) !== count($schema) || array_diff($given, $schema) !== [] || array_diff($schema, $given) !== []) {
+            return $keyColumns;
+        }
+
+        return $schema;
     }
 
     protected function assignAutoKeyIfNeeded(string $table, array $keyColumns, array $data): array {

--- a/app/Services/PersonBrowserService.php
+++ b/app/Services/PersonBrowserService.php
@@ -649,8 +649,13 @@ class PersonBrowserService {
                 'ALTNAME_DATA.c_source',
                 'ALTNAME_DATA.c_pages',
                 'ALTNAME_DATA.c_notes',
+                // 出處以書名顯示（與 AltnameEditor 的 c_source label 同源）；c_source 的哨兵 0
+                // 在 TEXT_CODES 沒有對應列，leftJoin 自然落空、不需另外過濾。
+                'TC.c_title_chn AS source_title_chn',
+                'TC.c_title AS source_title',
             ])
             ->leftJoin('ALTNAME_CODES AS ATC', 'ATC.c_name_type_code', '=', 'ALTNAME_DATA.c_alt_name_type_code')
+            ->leftJoin('TEXT_CODES AS TC', 'TC.c_textid', '=', 'ALTNAME_DATA.c_source')
             ->where('ALTNAME_DATA.c_personid', $personId)
             ->orderBy('ALTNAME_DATA.c_alt_name_type_code')
             ->get();
@@ -670,6 +675,8 @@ class PersonBrowserService {
                 'type_label_chn' => $r->c_name_type_desc_chn,
                 'type_label' => $r->c_name_type_desc,
                 'source_id' => $r->c_source,
+                'source_title_chn' => $r->source_title_chn,
+                'source_title' => $r->source_title,
                 'pages' => $r->c_pages,
                 'notes' => $r->c_notes,
             ])->values()->all(),

--- a/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
+++ b/resources/js/inertia/components/PersonBrowser/tabs/AltNamesTab.tsx
@@ -14,6 +14,16 @@ import { useTranslation } from '../../../hooks/useTranslation';
 import { Button } from '../../ui/Button';
 import { ConfirmDialog } from '../../ui/ConfirmDialog';
 
+/**
+ * 出處顯示：優先書名（中／英），沒有對應 TEXT_CODES 列時退回 `#id`，
+ * 哨兵 0 與 null 一律視為「未填」。
+ */
+function formatSourceLabel(item: AltNameItem): string | null {
+    const label = formatBilingualLabel(item.source_title_chn, item.source_title);
+    if (label) return label;
+    return item.source_id ? `#${item.source_id}` : null;
+}
+
 interface AltNameItem {
     pk: {
         c_personid: number;
@@ -27,6 +37,8 @@ interface AltNameItem {
     type_label_chn: string | null;
     type_label: string | null;
     source_id: number | null;
+    source_title_chn: string | null;
+    source_title: string | null;
     pages: string | null;
     notes: string | null;
 }
@@ -131,6 +143,11 @@ export default function AltNamesTab({
                     { header: tb('altname_pinyin_label'), render: (item) => item.name },
                     { header: tb('altname_chinese'), render: (item) => item.name_chn },
                     { header: t('alt_name_type'), render: (item) => formatBilingualLabel(item.type_label_chn, item.type_label) },
+                    // 出處／頁碼／備註：AltnameMutationHandler 的 allowedFields 允許提案修改，
+                    // 卻只在編輯器裡看得到——列表不顯示會讓使用者以為沒存進去。
+                    { header: tb('source_field'), render: (item) => formatSourceLabel(item) },
+                    { header: tb('pages_entries'), render: (item) => item.pages },
+                    { header: tb('notes_field'), render: (item) => (item.notes ? <div style={notesCellStyle}>{item.notes}</div> : null) },
                 ]}
                 actions={(canEdit || canPropose) ? (item) => (useReactEditor ? (
                     <span style={actionCellStyle}>
@@ -164,6 +181,13 @@ export default function AltNamesTab({
         </div>
     );
 }
+
+// 備註可能很長：限寬並保留換行，避免把整張表撐爆（外層 SubresourceTable 已有橫向捲動）。
+const notesCellStyle: React.CSSProperties = {
+    maxWidth: 360,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+};
 
 const containerStyle: React.CSSProperties = {
     display: 'flex',

--- a/tests/Feature/OperationsProposalResourceLinkTest.php
+++ b/tests/Feature/OperationsProposalResourceLinkTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 操作紀錄「資源」連結：提案的 resource_id 是**提案完成後**的主鍵，先於現實寫入，
+ * 直接拿去開 edit-v2 會 404（編輯器以主鍵查不到列就 abort(404)）。
+ *
+ * 這是所有複合主鍵子資源共通的缺口，不限別名：
+ * - create 提案核准前那一列不存在；
+ * - update 提案只要改到任一主鍵成員（文本型如 ALTNAME_DATA.c_alt_name_chn，
+ *   或代碼型如 BIOG_ADDR_DATA.c_addr_type）就是尚不存在的新鍵；
+ * - delete 提案核准後舊鍵那一列已被刪除。
+ *
+ * @see \App\Http\Controllers\OperationsController::resolveLinkResourceId()
+ */
+class OperationsProposalResourceLinkTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $compiledViewPath = sys_get_temp_dir() . '/cbdb-test-views-op-proposal-links';
+        if (!is_dir($compiledViewPath)) {
+            mkdir($compiledViewPath, 0777, true);
+        }
+        config(['view.compiled' => $compiledViewPath]);
+        config(['migration_flags.pages.basicinformation.altname' => 'new']);
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('confirmation_token')->nullable();
+            $table->tinyInteger('is_active')->default(0);
+            $table->tinyInteger('is_admin')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id')->default(0);
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type')->default(0);
+            $table->string('resource')->nullable();
+            $table->string('resource_id')->nullable();
+            $table->text('resource_data')->nullable();
+            $table->text('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('BIOG_MAIN', function ($table) {
+            $table->integer('c_personid')->primary();
+            $table->string('c_name')->nullable();
+            $table->string('c_name_chn')->nullable();
+        });
+
+        DB::table('BIOG_MAIN')->insert([
+            'c_personid' => 85303, 'c_name' => 'Hong Ping', 'c_name_chn' => '洪枰',
+        ]);
+    }
+
+    private function admin(): User {
+        return User::forceCreate([
+            'name' => 'Admin', 'email' => 'op-link@example.com', 'password' => bcrypt('x'),
+            'confirmation_token' => 't', 'is_active' => 1, 'is_admin' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    /** @param array<string,mixed> $attributes */
+    private function proposal(User $admin, int $opType, string $resourceId, array $payload, array $original = []): Operation {
+        return Operation::forceCreate([
+            'user_id' => $admin->id,
+            'c_personid' => 85303,
+            'op_type' => $opType,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => $resourceId,
+            'resource_data' => json_encode($payload, JSON_UNESCAPED_UNICODE),
+            'resource_original' => $original === [] ? null : json_encode($original, JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+    }
+
+    /** @return array<string,mixed> */
+    private function altnamePayload(string $name, string $reviewStatus = 'pending'): array {
+        return [
+            'c_personid' => 85303,
+            'c_alt_name_chn' => $name,
+            'c_alt_name_type_code' => 5,
+            '__review_status' => $reviewStatus,
+            '__key_columns' => ['c_personid', 'c_alt_name_chn', 'c_alt_name_type_code'],
+            '__proposal_meta' => ['action' => 'create', 'submitted_by' => 'Someone'],
+        ];
+    }
+
+    #[Test]
+    public function pending_create_proposal_gets_no_resource_link(): void {
+        $admin = $this->admin();
+        $this->proposal(
+            $admin,
+            Operation::TYPE_PROPOSAL_CREATE,
+            'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E4%95%AC&c_alt_name_type_code=5',
+            $this->altnamePayload('雪䕬')
+        );
+
+        $this->actingAs($admin)
+            ->get(route('app.operations.index', ['proposals_only' => 1]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Admin/Operations/Index')
+                ->where('lists.0.op_type', Operation::TYPE_PROPOSAL_CREATE)
+                // 那一列還沒建立，任何 edit-v2 連結都必然 404 ⇒ 不出連結。
+                ->where('lists.0.resource_link', null)
+                // 但描述仍要顯示提案的主鍵，審核者才看得出提案內容。
+                ->where('lists.0.resource_description', "c_personid：85303\nc_alt_name_chn：雪䕬\nc_alt_name_type_code：5"));
+    }
+
+    #[Test]
+    public function pending_update_proposal_that_changes_the_pk_links_to_the_original_row(): void {
+        $admin = $this->admin();
+        // 提案：把既有的「雪蔃」改成「雪䕬」。c_alt_name_chn 是主鍵成員 ⇒ resource_id 是新鍵。
+        $this->proposal(
+            $admin,
+            Operation::TYPE_PROPOSAL_UPDATE,
+            'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E4%95%AC&c_alt_name_type_code=5',
+            $this->altnamePayload('雪䕬'),
+            ['c_personid' => 85303, 'c_alt_name_chn' => '雪蔃', 'c_alt_name_type_code' => 5]
+        );
+
+        $this->actingAs($admin)
+            ->get(route('app.operations.index', ['proposals_only' => 1]))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+                $this->assertIsString($link);
+                $this->assertStringStartsWith('/app/basicinformation/85303/altnames/edit-v2?', $link);
+                // 指向現存那一列（雪蔃），不是提案後才會存在的新鍵（雪䕬）。
+                $this->assertStringContainsString(rawurlencode('雪蔃'), $link);
+                $this->assertStringNotContainsString(rawurlencode('雪䕬'), $link);
+            });
+    }
+
+    #[Test]
+    public function approved_update_proposal_links_to_the_new_pk(): void {
+        $admin = $this->admin();
+        $this->proposal(
+            $admin,
+            Operation::TYPE_PROPOSAL_UPDATE,
+            'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E4%95%AC&c_alt_name_type_code=5',
+            $this->altnamePayload('雪䕬', 'approved'),
+            ['c_personid' => 85303, 'c_alt_name_chn' => '雪蔃', 'c_alt_name_type_code' => 5]
+        );
+
+        $this->actingAs($admin)
+            ->get(route('app.operations.index', ['proposals_only' => 1]))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+                $this->assertIsString($link);
+                // 已核准 ⇒ 新鍵就是現況。
+                $this->assertStringContainsString(rawurlencode('雪䕬'), $link);
+            });
+    }
+
+    #[Test]
+    public function approved_delete_proposal_gets_no_resource_link(): void {
+        $admin = $this->admin();
+        $this->proposal(
+            $admin,
+            Operation::TYPE_PROPOSAL_DELETE,
+            'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E4%95%AC&c_alt_name_type_code=5',
+            $this->altnamePayload('雪䕬', 'approved'),
+            ['c_personid' => 85303, 'c_alt_name_chn' => '雪䕬', 'c_alt_name_type_code' => 5]
+        );
+
+        // delete 提案（op_type 10）不進 proposals_only 清單（那裡只收 8／9），走一般操作紀錄清單。
+        $this->actingAs($admin)
+            ->get(route('app.operations.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('lists.0.resource_link', null));
+    }
+
+    #[Test]
+    public function pending_delete_proposal_still_links_to_the_row_being_deleted(): void {
+        $admin = $this->admin();
+        $this->proposal(
+            $admin,
+            Operation::TYPE_PROPOSAL_DELETE,
+            'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E4%95%AC&c_alt_name_type_code=5',
+            $this->altnamePayload('雪䕬'),
+            ['c_personid' => 85303, 'c_alt_name_chn' => '雪䕬', 'c_alt_name_type_code' => 5]
+        );
+
+        $this->actingAs($admin)
+            ->get(route('app.operations.index'))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+                $this->assertIsString($link);
+                $this->assertStringContainsString(rawurlencode('雪䕬'), $link);
+            });
+    }
+
+    #[Test]
+    public function direct_update_link_is_unchanged(): void {
+        $admin = $this->admin();
+        Operation::forceCreate([
+            'user_id' => $admin->id,
+            'c_personid' => 85303,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'ALTNAME_DATA',
+            'resource_id' => 'c_personid=85303&c_alt_name_chn=%E9%9B%AA%E8%94%83&c_alt_name_type_code=5',
+            'resource_data' => json_encode(['c_alt_name_chn' => '雪蔃'], JSON_UNESCAPED_UNICODE),
+            'resource_original' => json_encode(['c_alt_name_chn' => '雪强'], JSON_UNESCAPED_UNICODE),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('app.operations.index'))
+            ->assertOk()
+            ->assertInertia(function (Assert $page) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+                $this->assertIsString($link);
+                $this->assertStringContainsString(rawurlencode('雪蔃'), $link);
+            });
+    }
+}

--- a/tests/Feature/PersonBrowserTest.php
+++ b/tests/Feature/PersonBrowserTest.php
@@ -654,7 +654,8 @@ class PersonBrowserTest extends TestCase {
 
         DB::table('ALTNAME_DATA')->insert([
             ['c_personid' => 1, 'c_sequence' => 1, 'c_alt_name_chn' => '太白', 'c_alt_name' => 'Taibai', 'c_alt_name_type_code' => 4, 'c_source' => null, 'c_pages' => null, 'c_notes' => null],
-            ['c_personid' => 1, 'c_sequence' => 2, 'c_alt_name_chn' => '青蓮居士', 'c_alt_name' => 'Qinglian Jushi', 'c_alt_name_type_code' => 5, 'c_source' => null, 'c_pages' => null, 'c_notes' => null],
+            // 出處／頁碼／備註在這一列填滿，釘住 alt_names 分頁確實把「提案可改欄位」送到前端。
+            ['c_personid' => 1, 'c_sequence' => 2, 'c_alt_name_chn' => '青蓮居士', 'c_alt_name' => 'Qinglian Jushi', 'c_alt_name_type_code' => 5, 'c_source' => 1, 'c_pages' => '卷一', 'c_notes' => '測試備註'],
             ['c_personid' => 3, 'c_sequence' => 1, 'c_alt_name_chn' => '子瞻', 'c_alt_name' => 'Zizhan', 'c_alt_name_type_code' => 4, 'c_source' => null, 'c_pages' => null, 'c_notes' => null],
             ['c_personid' => 3, 'c_sequence' => 2, 'c_alt_name_chn' => '東坡居士', 'c_alt_name' => 'Dongpo Jushi', 'c_alt_name_type_code' => 5, 'c_source' => null, 'c_pages' => null, 'c_notes' => null],
         ]);
@@ -1149,6 +1150,28 @@ class PersonBrowserTest extends TestCase {
         $this->assertCount(2, $response->json('items'));
         $response->assertJsonPath('items.0.type_label_chn', '字');
         $response->assertJsonPath('items.0.type_label', 'Zi');
+    }
+
+    /**
+     * 出處／頁碼／備註同樣是 AltnameMutationHandler 允許提案修改的欄位，必須送到前端
+     * （以前撈了卻沒進 UI，看起來像「沒存進去」）。出處以 TEXT_CODES 書名顯示。
+     */
+    #[Test]
+    public function test_tab_alt_names_exposes_source_pages_and_notes(): void {
+        $response = $this->actingAs($this->user)
+            ->getJson(route('app.person-browser.tab', ['personId' => 1, 'tabKey' => 'alt_names']));
+
+        $response->assertOk();
+        $response->assertJsonPath('items.1.name_chn', '青蓮居士');
+        $response->assertJsonPath('items.1.source_id', 1);
+        $response->assertJsonPath('items.1.source_title_chn', '新唐書');
+        $response->assertJsonPath('items.1.source_title', 'New Tang Book');
+        $response->assertJsonPath('items.1.pages', '卷一');
+        $response->assertJsonPath('items.1.notes', '測試備註');
+
+        // 沒有出處的列不可因 leftJoin 落空而多出／少掉欄位。
+        $response->assertJsonPath('items.0.source_title_chn', null);
+        $response->assertJsonPath('items.0.notes', null);
     }
 
     #[Test]


### PR DESCRIPTION
## 起因

回報：`/app/operations?proposals_only=1` 裡明明有這筆別名提案，但點「資源」連結直接 404 ——

```
/app/basicinformation/85303/altnames/edit-v2?c_personid=85303&c_alt_name_chn=雪䕬&c_alt_name_type_code=5
```

排查後發現是兩件互相獨立的事，各一個 commit。

## 1. 修正操作紀錄「資源」連結對提案一律 404

`operations.resource_id` 存的是**提案完成後**的主鍵，是先於現實寫進去的：

- **create 提案**：核准前那一列根本不存在；
- **update 提案**：只要改到任一主鍵成員就是尚不存在的新鍵——不只 `ALTNAME_DATA.c_alt_name_chn`、`ASSOC_DATA.c_text_title`、`BIOG_SOURCE_DATA.c_pages` 這三個文本型，`BIOG_ADDR_DATA.c_addr_type`、`KIN_DATA.c_kin_code`、`BIOG_TEXT_DATA.c_role_id` 這些代碼型主鍵成員也都在各自 handler 的 `allowedFields()` 裡；
- **delete 提案**：核准後舊鍵那一列已被刪除。

`OperationsController::serializeOperationRow()` 的守衛原本只擋 `op_type = 4`，於是提案列照樣產出連結，而 `appAltnameEditV2()` 之流以主鍵查不到列就 `abort(404)`。**這是全部 12 張複合主鍵人物子資源共通的缺口，不限別名。**

修法是新增 `resolveLinkResourceId()`，把「連結該指向哪一列」與「這筆操作記錄的是什麼」分開：

| op_type | 未核准 | 已核准 |
|---|---|---|
| 8 提案新增 | 不出連結 | `resource_id`（已指向實際建立的列） |
| 9 提案修改 | 改用 `resource_original` 的主鍵 | `resource_id`（新鍵即現況） |
| 10 提案刪除 | `resource_id`（列還在） | 不出連結 |

未核准的 update 改以 original 定位，與核准路徑 `OperationsProposalController::applyViaMutationHandler()`（一律以 original 定位目標列）是同一套語義。

同時修掉兩個併發缺口（都是寫測試才跑出來的）：

- **codes 回退分支**：`ALTNAME_DATA` 同時也在 `config('codes.tables')` 裡，主連結被擋掉後會落到 `elseif ($isCodeResource …)`，換一條路徑產出 `/app/codes/ALTNAME_DATA/…/edit` 撞同一個 404。
- **`resolveAffectedPeopleResourceTargets()`**（KIN/ASSOC 的 per-person 連結）：提案沒有 `audit_logs`，會落到 `resource_id` 回退分支；而已核准的刪除提案有 audit 卻沒有列，`$allowEditLink` 原本只擋 `TYPE_DELETE = 4`。

另外把 `OperationsProposalController::buildCompositeId()` 的 `_._` 位置式主鍵改成先對齊 `CompositePrimaryKey::SCHEMAS` 欄序：解析端 `parseStoredResourceId()` 是按 SCHEMAS 還原，而寫入端的 `__key_columns` 欄序不保證相同，錯位不會報錯、只會**靜默指到別的資料列**。格式**刻意不換**成 query-string——`CodesController::buildNamedConditionsFromId()` 只認純數字主鍵值，換了會讓含文字主鍵的代碼表從「查得到」變「查不到」。

新增 `tests/Feature/OperationsProposalResourceLinkTest.php`（6 個案例）釘住上表。

## 2. 別名分頁補上出處／頁碼／備註欄

排查途中發現的另一件事：`PersonBrowserService::tabAltNames()` 本來就把 `c_source`／`c_pages`／`c_notes` 撈出來、序列化進 props，`AltNamesTab` 卻只渲染 序號／別名(拼音)／別名(中)／類型 四欄——是**送到前端就被丟掉的死負載**。這三欄都在 `AltnameMutationHandler::allowedFields()` 裡、可經提案修改，列表看不到會讓使用者以為「沒存進去」。

（已驗證寫入端沒問題：propose → approve 的 create 與 update 兩條路徑，`c_notes` 落庫值都正確。）

- `tabAltNames()` `leftJoin TEXT_CODES` 補出處書名，與 `AltnameEditor` 的 `c_source` label 同源；`c_source` 的哨兵 0 在 `TEXT_CODES` 沒有對應列，leftJoin 自然落空、不需另外過濾。
- 出處優先顯示書名（中／英）、查不到退回 `#id`；備註限寬 360px 並保留換行（`SubresourceTable` 外層已有橫向捲動）。
- 表頭沿用編輯器同一組 i18n key（`biogmains.source_field`／`pages_entries`／`notes_field`），列表欄名與編輯器欄位標籤字面一致，不需新增翻譯。

**注意**：其餘 11 個分頁有同樣的「撈了不顯示」問題（`notes` 在 12 個分頁全都沒渲染），本 PR 只處理別名，其餘另案。

## 驗證

- `./vendor/bin/phpunit` 全量 **2994 tests / 15861 assertions 綠**
- `./vendor/bin/php-cs-fixer fix` 0 fixed
- `npm run build` 綠、`tsc --noEmit` 與 base 同為 21 個既有錯誤（無新增）

> 小提醒：`node_modules` 裡的 `@tanstack/react-table` 若還是 8.21.3（`package.json`／lockfile 已是 9.1.2，dependabot #2adc213f 之後未重裝），`npm run build` 會因 `DataTable.tsx` 用 v9 API 而失敗。跑一次 `npm ci` 即可，與本 PR 無關。

## 後續（不在本 PR）

`AltnameCreateHandler`／`AltnameMutationHandler` 的 `allowedFields()` 裡有四個**幻影欄位**：`c_alt_name_pinyin`／`2`／`3`／`c_alt_name_role`。migration 從未建立（baseline `import_cbdb_schema.php` 的 `ALTNAME_DATA` 就是 12 欄），prod 也查不到。白名單放行 → SQL 層才炸，實測是 **500 而非 422**，而 `API.md:960` 仍把它們列為對外 update 白名單。測試之所以一直綠，是因為合成表自己把這四欄建了出來。另開 issue 處理。
