### PR TITLE
修 /app/operations 的「查閱」連結指向已封寫代碼表，點進去必吃唯讀警告

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## 2026-09
 
+### 修 /app/operations 的「查閱」連結指向已封寫的代碼表，點進去必吃唯讀警告
+
+- **症狀**：`https://input.cbdb.fas.harvard.edu/app/operations` 上，凡是 `OFFICE_CODES`、`SOCIAL_INSTITUTION_CODES`／`NAME_CODES`／`ADDR` 這幾張表的操作紀錄，按「查閱」都會被導到 `/app/codes/{表}/{id}/edit`，然後吃到「該代碼表為只讀，禁止編輯。」再被彈回列表頁。使用者從操作紀錄根本走不到那筆資料。
+- **成因**：#1174（`0e8c4334`）把官職實體推進到 step 4 時，把 `OFFICE_CODES` 加進 `CodesController::$readOnlyTables`（`ca601b0d` 之後改由 `config/entity_aggregates.php` 的 `closed_code_tables` 推導），寫入入口收歸 `/app/office`、`/app/social-institution`。**但只改了守衛、沒改任何連結出口**——`OperationsController::serializeOperationRow()` 仍無條件呼叫 `code_table_edit_url()`，而它只做 codes flag 的新舊分流、不知道有「封寫」這回事。封寫判定與連結解析分兩處推導，是這個 bug 的全部成因。
+- **為什麼測試沒抓到**：`OperationsIndexLinksTest::test_code_resource_link_generation_logic` 拿 `OFFICE_CODES` 當樣本，把 `/app/codes/OFFICE_CODES/803819/edit` **釘成期望值**。它只斷言 helper 產出的字串、從不驗證那個 URL 打不打得開，所以測試不但沒抓到，還在替一條死連結背書。
+- **修法**：新增 `app/Support/EntityAggregateRegistry.php` 作為 `config/entity_aggregates.php` 的唯一查詢介面，**封寫判定與連結解析同源**——`CodesController::isReadOnlyTable()` 改為委派過來，`OperationsController` 則在該表被封寫時改指實體聚合編輯頁（config 新增 `edit_route`）。日後任何新的封寫只要登記進 `closed_code_tables`，守衛與連結就同步生效，不會再出現只能撞牆的連結。
+- **識別鍵解析採三級優先序**，因為 operations 的 `resource_id` 有多種歷史格式（本機全量 76 列實測）：具名 query-string（`buildStoredResourceId()`）→ 呼叫端從 `resource_data`／`resource_original` 取的識別欄 → 單鍵表位置式的第一段。位置式排最後是因為它只是推測：codes UI 的 `buildCompositeId()` 會濾掉空值段，缺識別鍵時 `{c_office_id}_._{c_dy}` 會塌成單獨的朝代碼。**壞掉的正是封寫前由 codes UI 寫入的那批**（`SOCIAL_INSTITUTION_CODES` 存成裸值 `3983`、`ADDR` 存成 `3983-5348`，欄序來自 `$tablePrimaryKeyOverrides`，與 `CompositePrimaryKey::SCHEMAS` 不同源），少了 payload 那一級等於沒修到票上說的情境。
+- **解不出就不出連結，不猜**：`SOCIAL_INSTITUTION_NAME_CODES` 的名稱碼跨機構共用（`resolveNameCode()` 同名複用既有碼），`resource_id` 與 payload 都不含 `c_inst_code`——導向一個**存在但錯誤**的機構，比沒有連結糟得多。同一次機構新增／改名一定會伴隨一筆 `SOCIAL_INSTITUTION_CODES` 的 operation，那筆有連結。
+- **連結要看權限**：`/operations` 是公開頁，但實體編輯頁一律 `abort(403)`（泛用 codes 編輯頁沒有授權閘門）。不看權限就改指，等於發一條必然 403 的連結給訪客——按鈕文案還是「查閱」。各實體要求的能力**不一致**（office 是 `canPropose()`、social-institution 與 text-entity 是 `canWriteDirectly()`），故由 config 的 `form_capability` 宣告、不寫死。
+- **防復發**：新增 `tests/Unit/EntityAggregateRegistryTest.php`（16 案例）兩條 fail-closed 不變量——(1) `CodesController::isReadOnlyTable()` 與 Registry 逐表一致，不得各自再抄一份 config 迴圈；(2) 每張被封寫的表要嘛 `resource_id` 解得出識別鍵，要嘛**逐筆登記**進 `UNRESOLVABLE_FROM_RESOURCE_ID` 並寫明呼叫端補不補得到，多一個少一個都紅。另釘住 `edit_route` 必須存在且是單一 `{id}` 參數（`route()` 不驗證 `whereNumber`，參數名不符會拋 `UrlGenerationException` 把整頁打成 500）、無表被兩實體認領。`OperationsIndexLinksTest` 新增 9 條端到端案例：office 案例**把連結真的打開來驗**（`assertInertia` 拿 `resource_link`，再 GET 它斷言渲染出 `Office/Edit`）——只斷言字串形狀正是當初沒抓到這個 bug 的原因；其餘覆蓋機構 payload 補救、名稱碼無連結、未封寫表不得被改指、訪客不得拿到必然 403 的連結，用眾包帳號釘住 `form_capability` 的 propose／write 差異（那是唯一能分辨兩者的身分——少了它，config 三個值互換都不會有測試變紅），以及**未核准的更新提案必須指向現存的那一列而非提案想改成的新鍵**（`resolveLinkResourceId()` 對這種 operation 刻意回原列主鍵，payload 補救若照一般順序先讀 `resource_data` 就會與它自相矛盾）。同時把上述那條替死連結背書的舊測試改用未封寫的表，並加一條「樣本表被封寫了就紅」的自我檢查。
+- **順帶收斂**：`Navigation::entityNavItem()` 與 `EntityAggregateDefinitionRegistry::boot()` 原本直接 `foreach config('entity_aggregates.entities', [])`——`config()` 的預設值只在 key **不存在**時生效，被設成 null／字串時仍會原樣回傳並 fatal，而側欄是每一頁都渲染的（等於整站 500）。兩處一併改走 Registry 的防禦性讀取。
+- **範圍**：只處理**有實體頁可去**的封寫表。`DYNASTIES`／`GANZHI_CODES`／`CBDB__NAME_FTS` 唯讀是終態、沒有替代入口，連結行為維持現狀。舊 Blade 版 `/operations` 未動（React 版已上線；該路徑同樣的連結問題留在原地）。`TEXT_CODES` 目前刻意「暫不封寫」，連結維持走泛用 codes 頁。
+
 ### 人物主檔 create 補齊生卒年月日六欄，並加上 create／update 對稱守衛
 
 （上一輪 `b1f4bf44` 把這 6 欄判為「擴張對外 API 契約、留待產品決定」而未動；本輪經裁定補齊。）

--- a/app/Http/Controllers/CodesController.php
+++ b/app/Http/Controllers/CodesController.php
@@ -10,6 +10,7 @@ use App\Services\AuditLogService;
 use App\Services\CharVariantMapService;
 use App\Support\ColumnFilterExpression;
 use App\Support\ColumnFilterParseException;
+use App\Support\EntityAggregateRegistry;
 use App\Support\PinyinUmlaut;
 use App\Support\VariantEquivalentLookup;
 use App\Support\VariantReplaceScope;
@@ -68,6 +69,9 @@ class CodesController extends Controller {
         'CBDB__NAME_FTS',
         'DYNASTIES',
         'GANZHI_CODES',
+        // 這三張表的共同點是**沒有替代寫入入口**（派生索引／全域字典），唯讀是終態，
+        // 所以也不會有「連結該改指哪裡」的問題——EntityAggregateRegistry 不管它們。
+        //
         // 被實體聚合認領的下層表（OFFICE_CODES、SOCIAL_INSTITUTION_* 等）不列在此——
         // 由 config/entity_aggregates.php 的 closed_code_tables 推導（見 isReadOnlyTable()）：
         // 實體上線即自動封寫，回退＝改 config。裸表 proposal 一併封閉為實體級提案（§4.5）
@@ -2372,13 +2376,11 @@ class CodesController extends Controller {
 
         // 實體聚合認領的下層表一律唯讀（docs/ENTITY_AGGREGATE_ARCHITECTURE.md §4.4／§6.5）：
         // 寫入路徑由實體頁（/app/office、/app/social-institution…）獨佔，讀取／匯出開放。
-        foreach (config('entity_aggregates.entities', []) as $entity) {
-            if (in_array($upper, array_map('strtoupper', $entity['closed_code_tables'] ?? []), true)) {
-                return true;
-            }
-        }
-
-        return false;
+        //
+        // 判定**必須**委派給 EntityAggregateRegistry，不可在此另抄一份 config 迴圈：
+        // 這道守衛與「封寫表的編輯連結該指向哪」是同一個問題的兩面，#1174 當初只改了守衛、
+        // 沒改連結，才留下 /app/operations 點「查閱」必吃唯讀警告的死連結。一份推導才不會再漂移。
+        return EntityAggregateRegistry::isClosedByEntity($upper);
     }
 
     /**

--- a/app/Http/Controllers/OperationsController.php
+++ b/app/Http/Controllers/OperationsController.php
@@ -11,6 +11,7 @@ use App\Repositories\OperationRepository;
 use App\Services\CharVariantMapService;
 use App\Support\BasicInformationHistory;
 use App\Support\CompositePrimaryKey;
+use App\Support\EntityAggregateRegistry;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -870,9 +871,12 @@ class OperationsController extends Controller {
         } elseif ($isCodeResource && $opType !== 4 && $linkResourceId !== null) {
             // 同樣用 $linkResourceId：ALTNAME_DATA 這類「既是人物子資源、也在 codes.tables 裡」的表，
             // 提案在上面的分支被擋掉後會落到這裡，若沿用 $rawResourceId 等於換一條路徑撞同一個 404。
-            $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($resourceName, $linkResourceId);
-            // flag-aware：codes flag=new 時開 React 版編輯頁，不要從 React 操作紀錄掉回舊 Blade 頁。
-            $resourceLink = code_table_edit_url($resourceName, $codeRouteId);
+            $resourceLink = $this->codeResourceLink(
+                $resourceName,
+                $linkResourceId,
+                is_array($resourceDataParsed) ? $resourceDataParsed : null,
+                $item
+            );
         }
 
         // 每位受影響人物附上編輯連結與資源描述。
@@ -1155,6 +1159,89 @@ class OperationsController extends Controller {
         }
 
         return CompositePrimaryKey::buildStoredResourceId($originalPk);
+    }
+
+    /**
+     * 代碼表資源的「查閱」連結。
+     *
+     * 已被實體聚合封寫的下層表（OFFICE_CODES、SOCIAL_INSTITUTION_*）**不能**再指向泛用
+     * codes 編輯頁：那條路徑早在 #1174 就被 `CodesController::isReadOnlyTable()` 擋死，
+     * 點進去只會吃到「該代碼表為只讀，禁止編輯。」再被彈回列表。封寫時只改了守衛、沒改
+     * 這個連結出口，就是這個 bug 的全部成因。
+     *
+     * 三種結果：
+     *  - 未封寫的表：維持原本 flag-aware 的 codes 編輯頁連結。
+     *  - 已封寫且使用者打得開實體表單：改指實體聚合編輯頁。
+     *  - 已封寫但打不開（訪客／權限不足），或識別鍵無從定位：不出連結。前端會顯示
+     *    「無資源頁面」，比一條必然 403／必然撞牆的連結誠實。
+     *
+     * @param array<string, mixed>|null $payload 已解碼的 resource_data
+     */
+    protected function codeResourceLink(string $resource, string $linkResourceId, ?array $payload, $item): ?string {
+        if (EntityAggregateRegistry::isClosedByEntity($resource)) {
+            if (!EntityAggregateRegistry::canReachEditForm($resource)) {
+                return null;
+            }
+
+            return EntityAggregateRegistry::editUrl(
+                $resource,
+                $linkResourceId,
+                $this->entityPkFromOperationPayload($resource, $payload, $item)
+            );
+        }
+
+        // flag-aware：codes flag=new 時開 React 版編輯頁，不要從 React 操作紀錄掉回舊 Blade 頁。
+        $codeRouteId = CompositePrimaryKey::normalizeSingleKeyResourceIdForCodeRoute($resource, $linkResourceId);
+
+        return code_table_edit_url($resource, $codeRouteId);
+    }
+
+    /**
+     * 從該筆 operation 的快照取實體識別鍵（resource_id 解不出來時的補救）。
+     *
+     * 為什麼非有不可：codes UI 封寫前寫進 operations 的 resource_id 用的是
+     * `CodesController::buildCompositeId()` 的位置式格式，欄序來自
+     * `$tablePrimaryKeyOverrides`，與 `CompositePrimaryKey::SCHEMAS` 不同源——
+     * SOCIAL_INSTITUTION_CODES 存成裸值 `3983`、SOCIAL_INSTITUTION_ADDR 存成 `3983-5348`，
+     * 兩者都解不出 `c_inst_code`。而**壞掉的連結正是這批**（封寫後由實體頁寫入的那些
+     * 反而解得出來），所以少了這一步等於沒修到票上說的情境。
+     *
+     * 一般情況先看 resource_data 再看 resource_original：update 的 `$data` 只有被改的欄、
+     * 未必含主鍵，但 `$original` 是完整原始列。
+     *
+     * **未核准的更新提案例外，只看 resource_original**：`resolveLinkResourceId()` 對這種
+     * operation 刻意回「原列」的主鍵（提案還沒套用，新鍵在現實中不存在）。若這裡照一般順序
+     * 先讀 resource_data，就會拿到提案「想改成」的識別鍵——例如一筆把 c_inst_code 從 3983
+     * 改成 5000 的待審提案，連結會指向 5000，而現存的列其實還是 3983。那與同一段程式碼
+     * 上游的定位語義自相矛盾，且送出去的是一條 404。
+     *
+     * 兩邊都沒有就回 null——例如 SOCIAL_INSTITUTION_NAME_CODES 的快照只有
+     * (c_inst_name_code, c_inst_name_hz, c_inst_name_py)，而名稱碼跨機構共用、本來就不唯一
+     * 決定一個機構，猜一個送使用者過去比不出連結糟得多。
+     *
+     * @param array<string, mixed>|null $payload 已解碼的 resource_data
+     */
+    protected function entityPkFromOperationPayload(string $resource, ?array $payload, $item): ?string {
+        $entity = EntityAggregateRegistry::entityForClosedTable($resource);
+        $pkColumn = (string) ($entity['pk'] ?? '');
+        if ($pkColumn === '') {
+            return null;
+        }
+
+        $original = json_decode((string) ($item->resource_original ?? ''), true);
+        $original = is_array($original) ? $original : null;
+
+        $pendingProposalUpdate = (int) ($item->op_type ?? 0) === Operation::TYPE_PROPOSAL_UPDATE
+            && (string) ($payload['__review_status'] ?? 'pending') !== 'approved';
+        $sources = $pendingProposalUpdate ? [$original] : [$payload, $original];
+
+        foreach ($sources as $source) {
+            if (is_array($source) && isset($source[$pkColumn]) && is_scalar($source[$pkColumn])) {
+                return (string) $source[$pkColumn];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Http/Controllers/TextEntityController.php
+++ b/app/Http/Controllers/TextEntityController.php
@@ -18,7 +18,8 @@ use Inertia\Inertia;
  * 故此 controller 不自帶寫入路徑。
  *
  * 這是「上層聚合入口」：把 TEXT_CODES ＋ TEXT_INSTANCE_DATA（版本層級）當作單一文獻實體
- * 管理，有別於 /app/codes/TEXT_CODES 的裸單表 CRUD（已封寫）。實體識別＝c_textid 單鍵。
+ * 管理，有別於 /app/codes/TEXT_CODES 的裸單表 CRUD（**尚未**封寫——見 config/entity_aggregates.php
+ * 的 closed_code_tables 註解：parity 補齊前兩條路徑刻意並存）。實體識別＝c_textid 單鍵。
  *
  * 列表與 Office／SocialInstitution EntityController 同構（EntityTableBrowser 描述子驅動），
  * 另加聚合特有的版本數與子文獻數（c_source 自引用樹）計算欄。

--- a/app/Services/Mutations/EntityAggregate/EntityAggregateDefinitionRegistry.php
+++ b/app/Services/Mutations/EntityAggregate/EntityAggregateDefinitionRegistry.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Mutations\EntityAggregate;
 
+use App\Support\EntityAggregateRegistry;
 use Illuminate\Contracts\Container\Container;
 
 /**
@@ -25,7 +26,8 @@ class EntityAggregateDefinitionRegistry {
             return;
         }
 
-        foreach (config('entity_aggregates.entities', []) as $entity) {
+        // 註冊表讀取一律經 EntityAggregateRegistry::entities()（防 config 被設成非陣列）。
+        foreach (EntityAggregateRegistry::entities() as $entity) {
             $class = $entity['definition'] ?? null;
             if (!$class) {
                 continue;

--- a/app/Support/EntityAggregateRegistry.php
+++ b/app/Support/EntityAggregateRegistry.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * config/entity_aggregates.php 的唯一查詢介面：封寫判定 + 封寫表的編輯連結解析。
+ *
+ * 為什麼把這兩件事放在同一個類：#1174／ca601b0d 把 OFFICE_CODES、SOCIAL_INSTITUTION_*
+ * 這些下層表在泛用 /codes 介面封寫（寫入入口收歸實體聚合頁），但只改了守衛、沒改任何
+ * 連結出口——/app/operations 的「查閱」仍寫死指向 /app/codes/{table}/{id}/edit，
+ * 使用者點進去只會吃到「該代碼表為只讀，禁止編輯。」再被彈回列表。**封寫與連結解析
+ * 分兩處推導，就是那個 bug 的成因**；分開再修一次只會把病灶換個位置重種。
+ *
+ * 因此 CodesController::isReadOnlyTable() 也委派到這裡（見該方法），日後任何新的封寫
+ * 只要登記進 closed_code_tables，守衛與連結就同步生效。
+ *
+ * 範圍僅限**有實體頁可去**的表。沒有替代入口的唯讀表（DYNASTIES、GANZHI_CODES、
+ * CBDB__NAME_FTS）不歸本類管，仍由 CodesController 自己的清單處理、行為不變。
+ *
+ * 設計參考 docs/ENTITY_AGGREGATE_ARCHITECTURE.md §4.4／§6.5。
+ */
+class EntityAggregateRegistry {
+    /**
+     * 註冊表內容（防禦性讀取）。
+     *
+     * config() 的預設值只在 key **不存在**時生效；key 存在但被設成 null／字串時仍會原樣
+     * 回傳，直接 foreach 會拋 ErrorException 把整頁打成 500。這裡一律收斂成陣列。
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function entities(): array {
+        $entities = config('entity_aggregates.entities');
+        if (!is_array($entities)) {
+            return [];
+        }
+
+        return array_values(array_filter($entities, 'is_array'));
+    }
+
+    /**
+     * 取得「認領並封寫」該表的實體聚合設定；不是被封寫的下層表則回 null。
+     *
+     * @return array<string, mixed>|null config/entity_aggregates.php 的單一實體項
+     */
+    public static function entityForClosedTable(string $table): ?array {
+        $upper = strtoupper($table);
+
+        foreach (self::entities() as $entity) {
+            if (in_array($upper, self::closedTablesOf($entity), true)) {
+                return $entity;
+            }
+        }
+
+        return null;
+    }
+
+    /** 該表是否已被某個實體聚合封寫（＝泛用 codes 編輯頁對它是死路）。 */
+    public static function isClosedByEntity(string $table): bool {
+        return self::entityForClosedTable($table) !== null;
+    }
+
+    /**
+     * 單一實體項認領封寫的表名（一律大寫）。
+     *
+     * @param array<string, mixed> $entity
+     * @return array<int, string>
+     */
+    public static function closedTablesOf(array $entity): array {
+        $closed = $entity['closed_code_tables'] ?? [];
+        if (!is_array($closed)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            fn ($t) => strtoupper((string) $t),
+            array_filter($closed, 'is_scalar')
+        ));
+    }
+
+    /**
+     * 目前使用者能不能真的打開該封寫表所屬實體的編輯表單。
+     *
+     * 為什麼需要這道檢查：實體編輯頁**一律 abort(403)**，而泛用 codes 編輯頁沒有授權閘門
+     * （唯讀表只是 flash 警告後 redirect）。連結若不看權限就改指實體頁，訪客與眾包帳號按
+     * 「查閱」會從「警告＋回列表」變成硬 403——按鈕文案是「查閱」，語義上更不該。
+     *
+     * 各實體要求的能力**不一致**，所以由 config 的 form_capability 宣告、不可寫死：
+     * office 的 `ensureCanReachForm()` 是 `canPropose()`，social-institution 與 text-entity
+     * 的 `ensureWrite()` 是 `canWriteDirectly()`。未宣告時取較嚴的 write（fail-closed）。
+     */
+    public static function canReachEditForm(string $table): bool {
+        $entity = self::entityForClosedTable($table);
+        $user = Auth::user();
+        if ($entity === null || $user === null) {
+            return false;
+        }
+
+        return match ((string) ($entity['form_capability'] ?? 'write')) {
+            'propose' => $user->canPropose(),
+            default => $user->canWriteDirectly(),
+        };
+    }
+
+    /**
+     * 被封寫的下層表 → 其實體聚合編輯頁 URL；無法定位就回 null。
+     *
+     * 「寧可不出連結，也不要送使用者去撞牆」是這裡的取捨基準：導向一個**存在但錯誤**的
+     * 實體，比沒有連結糟得多。
+     *
+     * ⚠️ **呼叫端一律要準備好 $fallbackEntityPk**。operations 裡的 resource_id 有多種歷史
+     * 格式（見下面兩個 entityPkFrom*ResourceId()），單靠 resource_id 只解得出其中一部分——
+     * 本機實測 76 列封寫表 operations，只有 OFFICE_CODES 全數可解，
+     * SOCIAL_INSTITUTION_CODES／ADDR 一列都解不出。把 fallback 當成選配就會靜默少一批連結。
+     *
+     * @param string          $table            下層代碼表名
+     * @param string          $storedResourceId operations.resource_id 原值
+     * @param int|string|null $fallbackEntityPk 呼叫端另行解析出的實體識別鍵（見上）
+     */
+    public static function editUrl(string $table, string $storedResourceId, $fallbackEntityPk = null): ?string {
+        $entity = self::entityForClosedTable($table);
+        if ($entity === null) {
+            return null;
+        }
+
+        $editRoute = (string) ($entity['edit_route'] ?? '');
+        $route = $editRoute === '' ? null : Route::getRoutes()->getByName($editRoute);
+        // 參數名不是 {id} 時 route() 會拋 UrlGenerationException，把整頁打成 500——
+        // 與本類「解不出就回 null」的契約相反。config 漂移由單元測試擋，這裡是執行期兜底。
+        if ($route === null || $route->parameterNames() !== ['id']) {
+            return null;
+        }
+
+        // 三級優先序，**刻意**把呼叫端的 payload 值排在位置式解析之前：
+        //  1. 具名格式——欄名齊全，最可靠。
+        //  2. 呼叫端從 operation payload 取的識別欄——欄名明確，只是不在 resource_id 裡。
+        //  3. 單鍵表的位置式第一段——只是「約定俗成第一段是識別鍵」的推測，可能落空：
+        //     codes UI 的 buildCompositeId() 會把值為空的段整段濾掉，所以缺識別鍵時
+        //     `{c_office_id}_._{c_dy}` 會塌成單獨的朝代碼，被這一級誤解成官職 id。
+        //     排在 payload 之後，就只在真的沒有更好來源時才用。
+        $id = self::entityPkFromNamedResourceId($table, $storedResourceId, $entity)
+            ?? self::normalizePkValue($fallbackEntityPk)
+            ?? self::entityPkFromPositionalResourceId($table, $storedResourceId, $entity);
+        if ($id === null) {
+            return null;
+        }
+
+        return route($editRoute, ['id' => $id], false);
+    }
+
+    /**
+     * 來源 1（最可靠）：`buildStoredResourceId()` 的具名 query-string 格式。
+     *
+     * 欄名必須完整覆蓋該表 schema 才算數，另外比對分隔符數量，擋掉
+     * `c_inst_code=88&c_inst_name_code=4021&c_inst_code=999` 這種同名參數覆蓋
+     * （`CodesController::buildNamedConditionsFromId()` 已有同一道檢查）。
+     *
+     * @param array<string, mixed>|null $entity
+     */
+    protected static function entityPkFromNamedResourceId(string $table, string $storedResourceId, ?array $entity = null): ?string {
+        [$pkColumn, $resourceId, $upper, $schema] = self::parseContext($table, $storedResourceId, $entity);
+        if ($schema === null) {
+            return null;
+        }
+        if (!str_contains($resourceId, '=') || str_contains($resourceId, '_._')) {
+            return null;
+        }
+
+        $arity = count($schema);
+        if (substr_count($resourceId, '&') !== $arity - 1 || substr_count($resourceId, '=') !== $arity) {
+            return null;
+        }
+
+        $parsed = CompositePrimaryKey::parseStoredResourceId($resourceId, $upper);
+
+        return (is_array($parsed) && array_key_exists($pkColumn, $parsed))
+            ? self::normalizePkValue($parsed[$pkColumn])
+            : null;
+    }
+
+    /**
+     * 來源 3（最不可靠，僅在沒有更好來源時用）：單鍵表位置式 id 的第一段。
+     *
+     * 涵蓋 OFFICE_CODES 的裸值 `12304`，以及 `getKeyColumns()` 找不到 PK 而回退成「前兩欄」
+     * 時產生的 `2318_._15`＝`{c_office_id}_._{c_dy}`（生產資料裡確實存在，本機 19 列中有 5 列）。
+     *
+     * **這一級是推測，不是解析**：安全性來自「`c_office_id` 恰好是該表第一欄」，不是 arity。
+     * 同一個回退欄序下，若 payload 缺識別鍵，`buildCompositeId()` 的 `array_filter` 會把
+     * 空的那段整段濾掉，`{c_office_id}_._{c_dy}` 就塌成單獨的朝代碼，被這裡誤解成官職 id。
+     * 所以 `editUrl()` 把它排在呼叫端 payload 值**之後**。
+     *
+     * 為什麼不乾脆信 `parseStoredResourceId()` 的位置式回退：它的欄序來自
+     * `CompositePrimaryKey::SCHEMAS`，與 codes UI 寫 operations 時用的
+     * `CodesController::$tablePrimaryKeyOverrides` **本來就不同源**——
+     * SOCIAL_INSTITUTION_CODES 在前者是 2 欄、後者只有 `['c_inst_code']`，
+     * SOCIAL_INSTITUTION_ADDR 是 6 欄對 2 欄。今天兩表的實際段數都**少於** SCHEMAS 欄數
+     * （`3983`、`3983-5348`），位置式分支會直接失敗、不至於出錯；但只要有人往
+     * `$tablePrimaryKeyOverrides` 補一欄湊足段數，`4021_._88` 就會被當成
+     * `(c_inst_code=4021, c_inst_name_code=88)`，把使用者導向另一個**真實存在**的機構。
+     *
+     * @param array<string, mixed>|null $entity
+     */
+    protected static function entityPkFromPositionalResourceId(string $table, string $storedResourceId, ?array $entity = null): ?string {
+        [$pkColumn, $resourceId, , $schema] = self::parseContext($table, $storedResourceId, $entity);
+        if ($schema === null || count($schema) !== 1 || $schema[0] !== $pkColumn) {
+            return null;
+        }
+
+        return self::normalizePkValue(explode('_._', $resourceId, 2)[0]);
+    }
+
+    /**
+     * 兩種解析共用的前置資料；任一必要條件不成立時 schema 回 null。
+     *
+     * @param array<string, mixed>|null $entity
+     * @return array{0: string, 1: string, 2: string, 3: array<int, string>|null}
+     */
+    protected static function parseContext(string $table, string $storedResourceId, ?array $entity): array {
+        $upper = strtoupper($table);
+        $resourceId = trim($storedResourceId);
+        $entity ??= self::entityForClosedTable($upper);
+        $pkColumn = (string) ($entity['pk'] ?? '');
+
+        if ($entity === null || $pkColumn === '' || $resourceId === '') {
+            return [$pkColumn, $resourceId, $upper, null];
+        }
+
+        $schema = CompositePrimaryKey::getSchema(CompositePrimaryKey::getResourceIdSchemaTable($upper));
+
+        return [$pkColumn, $resourceId, $upper, (is_array($schema) && $schema !== []) ? array_values($schema) : null];
+    }
+
+    /**
+     * 識別鍵值正規化：**白名單**——必須是十進位整數，其餘一律視為無效。
+     *
+     * 目前三個實體的識別鍵都是整數代理鍵（c_office_id／c_inst_code／c_textid），三條
+     * edit_route 也都掛了 `->whereNumber('id')`。但 Laravel 的 `route()` **不驗證** where
+     * 約束，任何值都會照樣被拼進路徑——黑名單擋不完（`..`、`a/b`、`1#frag` 都能組出
+     * 一條被注入路徑的 URL），所以這裡用白名單。
+     *
+     * 日後若出現非整數識別鍵的實體，正確做法是由 config 宣告該實體的鍵形，
+     * 而不是回頭把這裡放寬成黑名單。
+     *
+     * @param mixed $value
+     */
+    protected static function normalizePkValue($value): ?string {
+        if ($value === null || !is_scalar($value) || is_bool($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        // 不接受前導零：`0012304` 在資料庫的數值親和性下仍查得到，但會產出一條長相怪異、
+        // 與正規連結不一致的 URL。識別鍵的正規形只有一種。
+        return preg_match('/\A(?:0|[1-9][0-9]*)\z/', $value) === 1 ? $value : null;
+    }
+}

--- a/app/Support/Navigation.php
+++ b/app/Support/Navigation.php
@@ -361,7 +361,10 @@ class Navigation {
      * @return array<string, mixed>
      */
     protected static function entityNavItem(string $table, string $fallbackKey, string $fallbackLabel, string $fallbackIcon): array {
-        foreach (config('entity_aggregates.entities', []) as $entity) {
+        // 走 EntityAggregateRegistry::entities() 而非直接 config()：config 的預設值只在 key
+        // 不存在時生效，key 被設成 null／字串時直接 foreach 會 fatal——側欄是每一頁都渲染的，
+        // 那等於整站 500。
+        foreach (EntityAggregateRegistry::entities() as $entity) {
             $nav = $entity['nav'] ?? null;
             if (!$nav || strtoupper((string) ($nav['table'] ?? '')) !== strtoupper($table)) {
                 continue;

--- a/config/entity_aggregates.php
+++ b/config/entity_aggregates.php
@@ -7,6 +7,9 @@
  * 作為橫向接線的單一真源，驅動：
  *  - codes UI 封寫：closed_code_tables 內的表在 CodesController 一律唯讀
  *    （寫入路徑由實體頁獨佔；讀取／匯出開放）。回退＝移除該表或整個實體項。
+ *  - 封寫表的編輯連結改指：operations 等處指向被封寫下層表的連結，改導向該實體的
+ *    edit_route（App\Support\EntityAggregateRegistry）。封寫與連結解析同源，不會再出現
+ *    「點進去只吃到唯讀警告」的死連結。
  *  - 側欄節點：Navigation 依 nav 設定把對應 codes 子表節點改指實體聚合頁。
  *
  * 領域邏輯（派生、去重、護欄、校驗）不進 config——留在各實體的
@@ -21,10 +24,20 @@ return [
             // 通用 mutation handler 依此分派（EntityAggregate*Handler → definition）。
             'definition' => \App\Services\Mutations\EntityAggregate\OfficeAggregateDefinition::class,
             'pk' => 'c_office_id',
+            // 實體聚合編輯頁路由：封寫下層表後，operations 等處的「查閱」連結改指這裡
+            // （EntityAggregateRegistry::editUrl()）。不由 resource 推導——text-entity 的
+            // resource 與路由前綴刻意不同名。
+            'edit_route' => 'app.office.edit',
+            // 該實體的編輯表單需要什麼能力（'propose'＝canPropose、'write'＝canWriteDirectly）。
+            // 必須與該實體 Controller 的守衛一致，否則連結解析會發出一條必然 403 的連結。
+            // office 是 OfficeEntityController::ensureCanReachForm()＝canPropose；
+            // social-institution／text-entity 是 ensureWrite()＝canWriteDirectly。
+            'form_capability' => 'propose',
             // 聚合認領的下層表（文件化用；封寫範圍以 closed_code_tables 為準——
             // 僅列 codes UI 實際可瀏覽的表）。
             'tables' => ['OFFICE_CODES', 'OFFICE_CODE_TYPE_REL'],
             'closed_code_tables' => ['OFFICE_CODES'],
+            // nav 是**列表頁**節點設定（側欄），與上面的 edit_route 各司其職。
             'nav' => [
                 'key' => 'office-codes',
                 'label' => 'codes.office_codes',
@@ -39,6 +52,8 @@ return [
             'service' => \App\Services\Import\SocialInstituteImportService::class,
             'definition' => \App\Services\Mutations\EntityAggregate\SocialInstitutionAggregateDefinition::class,
             'pk' => 'c_inst_code',
+            'edit_route' => 'app.social-institution.edit',
+            'form_capability' => 'write',
             'tables' => ['SOCIAL_INSTITUTION_NAME_CODES', 'SOCIAL_INSTITUTION_CODES', 'SOCIAL_INSTITUTION_ADDR'],
             'closed_code_tables' => ['SOCIAL_INSTITUTION_CODES', 'SOCIAL_INSTITUTION_NAME_CODES', 'SOCIAL_INSTITUTION_ADDR'],
             'nav' => [
@@ -57,6 +72,8 @@ return [
             'service' => \App\Services\Import\TextImportService::class,
             'definition' => \App\Services\Mutations\EntityAggregate\TextAggregateDefinition::class,
             'pk' => 'c_textid',
+            'edit_route' => 'app.text.edit',
+            'form_capability' => 'write',
             'tables' => ['TEXT_CODES', 'TEXT_INSTANCE_DATA'],
             // step 4（下層直寫封閉）整體暫緩，兩條裸表路徑都仍在役：
             //  - codes UI：裸表編輯頁尚有實體頁未對齊的功能（TEXT_CODES 編輯頁的作者列表

--- a/docs/ENTITY_AGGREGATE_ARCHITECTURE.md
+++ b/docs/ENTITY_AGGREGATE_ARCHITECTURE.md
@@ -167,10 +167,26 @@ filter／sort／guard 機制，封閉永遠是「認領下層表＋換側欄＋�
 據此抽出五件套，後續實體不再整套重寫：
 
 1. **實體註冊表 `config/entity_aggregates.php`（單一真源）**：每個聚合聲明
-   resource／Service／`definition`／識別鍵／認領表／`closed_code_tables`／側欄 nav。往下推導：
+   resource／Service／`definition`／識別鍵／認領表／`closed_code_tables`／`edit_route`／
+   `form_capability`／側欄 nav。往下推導：
    - codes UI 封寫：`CodesController::isReadOnlyTable()` 對 `closed_code_tables` 內
      的表一律唯讀——**實體上線即自動封寫，不再手維護清單**；回退＝改 config。
-   - 側欄節點：`Navigation::entityNavItem()` 依 nav 設定把裸表節點改指實體頁。
+     判定本身委派給 `App\Support\EntityAggregateRegistry::isClosedByEntity()`。
+   - **封寫表的編輯連結改指**：指向被封寫下層表的「查閱／編輯」連結（`/app/operations`）
+     改導向該實體的 `edit_route`，由 `EntityAggregateRegistry::editUrl()` 解析。
+     **封寫與連結解析必須同源**——#1174 只改了守衛、沒改連結出口，於是每一條
+     `/app/codes/{封寫表}/{id}/edit` 都變成「點進去吃唯讀警告、再被彈回列表」的死連結。
+     **呼叫端一律要準備好 fallback 識別鍵**：operations 的 `resource_id` 有多種歷史格式
+     （具名 query-string、裸值、`_._`、`-`），解析採三級優先序——具名格式 → 呼叫端從
+     `resource_data`／`resource_original` 取的識別欄 → 單鍵表位置式的第一段。位置式那級
+     只是推測（缺識別鍵時 `{c_office_id}_._{c_dy}` 會塌成單獨的朝代碼），所以排在 payload 之後。
+     兩邊都取不到（如 `SOCIAL_INSTITUTION_NAME_CODES`——名稱碼跨機構共用、payload 也不含
+     `c_inst_code`）就不出連結，**不猜**：導向一個存在但錯誤的實體，比沒有連結糟得多。
+     **連結也要看權限**：`/operations` 是公開頁，實體編輯頁卻一律 `abort(403)`，所以由
+     `form_capability` 宣告該實體表單需要的能力（office＝`canPropose`、其餘＝`canWriteDirectly`），
+     打不開就不出連結，不要發一條必然 403 的「查閱」。
+   - 側欄節點：`Navigation::entityNavItem()` 依 nav 設定把裸表節點改指實體頁
+     （`nav.route` 是**列表頁**路由，與 `edit_route` 各司其職）。
    - mutation 分派：`EntityAggregateDefinitionRegistry` 依 `definition` 建 resource 索引。
 2. **`EntityAggregateService` 介面**＋Service 共用基元（`SharesImportHelpers`）：
    `allocateNextId()`（lockForUpdate max+1）、`countReferences()`（護欄計數）、
@@ -246,7 +262,9 @@ direct 與 proposal 天然對等（§7 原則），不必每實體各接一遍�
 
 ## 8. 相關文件與程式碼
 
-- `config/entity_aggregates.php`（實體註冊表：封寫／側欄接線的單一真源，§6.5）
+- `config/entity_aggregates.php`（實體註冊表：封寫／連結／側欄接線的單一真源，§6.5）
+- `app/Support/EntityAggregateRegistry.php`＋`tests/Unit/EntityAggregateRegistryTest.php`（註冊表查詢介面：封寫判定與封寫表的編輯連結解析，§6.5）
+- `app/Http/Controllers/OperationsController.php`＋`tests/Feature/OperationsIndexLinksTest.php`（操作紀錄的「查閱」連結：封寫表改指實體編輯頁，§6.5）
 - `app/Services/Import/EntityAggregateService.php`（聚合根介面）
 - `app/Services/Mutations/EntityAggregate*Handler.php`＋`EntityAggregate/`（通用 mutation handler、definition 契約與分派 registry，§6.5）
 - `app/Services/Import/Concerns/SharesImportHelpers.php`（配號／護欄計數／集合對賬／審計基元）

--- a/tests/Feature/OperationsIndexLinksTest.php
+++ b/tests/Feature/OperationsIndexLinksTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\Operation;
 use App\Models\User;
+use App\Support\EntityAggregateRegistry;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -98,6 +100,65 @@ class OperationsIndexLinksTest extends TestCase {
             $table->integer('c_assoc_first_year')->nullable();
         });
 
+        // 被實體聚合封寫的下層表：泛用 codes 編輯頁對它們是死路，連結必須改指實體頁。
+        // 建到「實體編輯頁真的能渲染」的程度，才能斷言連結不只形狀對、而是真的打得開。
+        Schema::create('OFFICE_CODES', function ($table) {
+            $table->integer('c_office_id')->primary();
+            $table->string('c_office_chn')->nullable();
+            $table->string('c_office_chn_alt')->nullable();
+            $table->string('c_office_trans')->nullable();
+            $table->string('c_office_trans_alt')->nullable();
+            $table->string('c_office_pinyin')->nullable();
+            $table->string('c_office_pinyin_alt')->nullable();
+            $table->integer('c_dy')->nullable();
+            $table->integer('c_source')->nullable();
+            $table->string('c_pages')->nullable();
+            $table->text('c_notes')->nullable();
+        });
+
+        Schema::create('OFFICE_CODE_TYPE_REL', function ($table) {
+            $table->integer('c_office_id');
+            $table->integer('c_office_tree_id');
+            $table->primary(['c_office_id', 'c_office_tree_id']);
+        });
+
+        Schema::create('OFFICE_TYPE_TREE', function ($table) {
+            $table->integer('c_office_type_node_id')->primary();
+            $table->string('c_office_type_desc_chn')->nullable();
+        });
+
+        Schema::create('DYNASTIES', function ($table) {
+            $table->integer('c_dy')->primary();
+            $table->string('c_dynasty_chn')->nullable();
+        });
+
+        Schema::create('TEXT_CODES', function ($table) {
+            $table->integer('c_textid')->primary();
+            $table->string('c_title')->nullable();
+        });
+
+        Schema::create('SOCIAL_INSTITUTION_CODES', function ($table) {
+            $table->integer('c_inst_code');
+            $table->integer('c_inst_name_code');
+            $table->integer('c_inst_type_code')->nullable();
+            $table->primary(['c_inst_code', 'c_inst_name_code']);
+        });
+
+        Schema::create('SOCIAL_INSTITUTION_NAME_CODES', function ($table) {
+            $table->integer('c_inst_name_code')->primary();
+            $table->string('c_inst_name_hz')->nullable();
+            $table->string('c_inst_name_py')->nullable();
+        });
+
+        Schema::create('SOCIAL_INSTITUTION_ADDR', function ($table) {
+            $table->integer('c_inst_addr_id');
+            $table->integer('c_inst_addr_type_code');
+            $table->integer('c_inst_code');
+            $table->integer('c_inst_name_code');
+            $table->float('inst_xcoord')->nullable();
+            $table->float('inst_ycoord')->nullable();
+        });
+
         Schema::create('audit_log', function ($table) {
             $table->bigIncrements('id');
             $table->dateTime('occurred_at');
@@ -156,6 +217,18 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertSee('(本修改不涉及人物)');
     }
 
+    /**
+     * codes 編輯頁連結的 flag-aware 行為。
+     *
+     * ⚠️ 這條測試原本拿 `OFFICE_CODES` 當樣本，把 `/app/codes/OFFICE_CODES/803819/edit`
+     * 釘成期望值——但那張表早在 #1174 就被封寫，那個 URL 點進去只會吃到「該代碼表為只讀」
+     * 再被彈回列表。也就是說，測試在替一條死連結背書，而且因為它只斷言 helper 產出的**字串**、
+     * 從不驗證那個 URL 打不打得開，所以修了 controller 也不會變紅。這正是那個 bug 活了兩個月
+     * 沒被發現的原因之一。
+     *
+     * 現在改用**未封寫**的表測 flag-aware（那才是這條測試真正的主題）；封寫表的連結行為
+     * 由下面的 test_closed_* 系列負責，其中 office 兩條是真的把連結打開來驗。
+     */
     #[Test]
     public function test_code_resource_link_generation_logic() {
         // 测试 codes 表配置是否正确
@@ -169,24 +242,26 @@ class OperationsIndexLinksTest extends TestCase {
         $this->assertTrue(in_array('ADDR_CODES', $codeTables));
         $this->assertTrue(in_array('ALTNAME_DATA', $codeTables));
 
-        // 验证链接生成逻辑
+        // 验证链接生成逻辑（用未封寫的 ADDR_CODES，封寫表不該再走這條路徑）
         $resourceId = '803819';
-        $resource = 'OFFICE_CODES';
+        $resource = 'ADDR_CODES';
         $isCodeResource = in_array(strtoupper($resource), $codeTables);
 
         $this->assertTrue($isCodeResource);
+        $this->assertFalse(
+            EntityAggregateRegistry::isClosedByEntity($resource),
+            '樣本表被封寫了：這條測試會再次替一條死連結背書，請換一張未封寫的表'
+        );
 
-        // 验证可以生成正确的路由。React 操作紀錄實際用的是 flag-aware 的 code_table_edit_url()，
-        // 這裡兩個方向都釘住，避免這條測試繼續斷言與production相反的東西。
         config(['migration_flags.pages.codes' => 'new']);
         $this->assertEquals(
-            '/app/codes/OFFICE_CODES/803819/edit',
+            '/app/codes/ADDR_CODES/803819/edit',
             code_table_edit_url($resource, $resourceId)
         );
 
         config(['migration_flags.pages.codes' => 'old']);
         $this->assertEquals(
-            '/codes/OFFICE_CODES/803819/edit',
+            '/codes/ADDR_CODES/803819/edit',
             code_table_edit_url($resource, $resourceId)
         );
     }
@@ -864,5 +939,326 @@ class OperationsIndexLinksTest extends TestCase {
         $response->assertDontSee('/app/basicinformation/101/kinship/edit-v2?c_personid=101&amp;c_kin_id=202&amp;c_kin_code=1', false);
         $response->assertDontSee('/app/basicinformation/202/kinship/edit-v2?c_personid=202&amp;c_kin_id=101&amp;c_kin_code=3', false);
         $response->assertSee('無資源頁面');
+    }
+
+    // =====================================================================
+    // 被實體聚合封寫的下層表：連結必須改指實體編輯頁
+    //
+    // #1174／ca601b0d 把 OFFICE_CODES、SOCIAL_INSTITUTION_* 在泛用 /codes 介面封寫，
+    // 寫入收歸實體頁，但沒有動這裡的連結出口，於是每一條「查閱」都變成
+    // 「點進去吃唯讀警告、再被彈回列表」。
+    //
+    // 兩條 office 案例**把連結打開來驗**（拿到 resource_link 後再 GET 它，斷言渲染出
+    // Office/Edit）——只斷言字串形狀正是當初沒抓到這個 bug 的原因。其餘案例驗的是解析與
+    // 授權結果本身（機構要靠 payload 補、名稱碼不得亂猜、提案要指向現存的列、訪客不得拿到
+    // 必然 403 的連結）；`test_unclosed_code_tables_keep_using_the_generic_codes_editor`
+    // 是**回歸護欄**——它在修復前後都該是綠的，作用是擋住「改指改過頭」。
+    // =====================================================================
+
+    /**
+     * 已啟用帳號。$role 用 User::ROLE_*——`canWriteDirectly()` 判的是 is_admin 是否等於
+     * ROLE_CROWDSOURCING(2)，寫成 0／1 的布林旗標只會得到「一般使用者」而測不到眾包帳號。
+     *
+     * @return \App\Models\User
+     */
+    private function activeUser(string $email, int $role = User::ROLE_EXPERT) {
+        return User::forceCreate([
+            'name' => 'Test User',
+            'email' => $email,
+            'password' => bcrypt('password'),
+            'confirmation_token' => 'test-token',
+            'is_active' => 1,
+            'is_admin' => $role,
+        ]);
+    }
+
+    /**
+     * 讀 /app/operations 第一列的 resource_link（提案要帶 proposals_only=1 才會列出）。
+     *
+     * $user 為 null 代表**訪客**：必須顯式登出，否則同一測試裡先前的 actingAs() 會延續下來，
+     * 「訪客」那次請求會靜默變成第二次登入請求，斷言就什麼都沒驗到。
+     */
+    private function firstResourceLink($user = null, string $query = ''): ?string {
+        $link = null;
+        if ($user === null) {
+            Auth::logout();
+        }
+        $request = $user ? $this->actingAs($user) : $this;
+        $request->get('/app/operations' . $query)
+            ->assertOk()
+            ->assertInertia(function ($page) use (&$link) {
+                $link = $page->toArray()['props']['lists'][0]['resource_link'];
+            });
+
+        return $link;
+    }
+
+    #[Test]
+    public function test_closed_office_code_link_opens_the_entity_editor_instead_of_the_read_only_codes_page(): void {
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('office-entity-link@example.com');
+
+        \DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 12304, 'c_office_chn' => '知州', 'c_office_pinyin' => 'zhi zhou',
+            'c_dy' => 15, 'c_source' => null,
+        ]);
+        \DB::table('OFFICE_CODE_TYPE_REL')->insert(['c_office_id' => 12304, 'c_office_tree_id' => 7]);
+        \DB::table('OFFICE_TYPE_TREE')->insert(['c_office_type_node_id' => 7, 'c_office_type_desc_chn' => '地方官']);
+        \DB::table('DYNASTIES')->insert(['c_dy' => 15, 'c_dynasty_chn' => '宋']);
+
+        // 封寫前 codes UI 寫進去的裸值格式——線上壞掉的正是這批。
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'OFFICE_CODES',
+            'resource_id' => '12304',
+            'resource_data' => json_encode(['c_office_id' => 12304, 'c_office_chn' => '知州']),
+            'resource_original' => json_encode(['c_office_id' => 12304, 'c_office_chn' => '知洲']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $link = $this->firstResourceLink($user);
+
+        $this->assertSame('/app/office/12304/edit', $link);
+        $this->assertStringNotContainsString(
+            '/codes/OFFICE_CODES/',
+            (string) $link,
+            '仍指向已封寫的泛用 codes 編輯頁——那條路徑點進去只會吃到唯讀警告'
+        );
+
+        // 連結的另一半：它必須真的打得開，而不是被重導並 flash 唯讀警告。
+        $this->actingAs($user)->get($link)
+            ->assertOk()
+            ->assertSessionMissing('flash_notification')
+            ->assertInertia(fn ($page) => $page
+                ->component('Office/Edit')
+                ->where('office.office_id', 12304));
+    }
+
+    #[Test]
+    public function test_closed_office_code_link_handles_the_legacy_two_segment_resource_id(): void {
+        // getKeyColumns() 取不到 PK 時會回退成「前兩欄」，寫出 `{c_office_id}_._{c_dy}`。
+        // 這個形狀在生產 operations 裡確實存在，不能漏。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('office-legacy-id@example.com');
+
+        \DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 2318, 'c_office_chn' => '通判', 'c_office_pinyin' => 'tong pan', 'c_dy' => 15,
+        ]);
+        \DB::table('DYNASTIES')->insert(['c_dy' => 15, 'c_dynasty_chn' => '宋']);
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'OFFICE_CODES',
+            'resource_id' => '2318_._15',
+            'resource_data' => json_encode(['c_office_chn' => '通判']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $link = $this->firstResourceLink($user);
+        $this->assertSame('/app/office/2318/edit', $link);
+        // 同樣把連結打開來驗：形狀對不代表打得開。
+        $this->actingAs($user)->get($link)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('Office/Edit')->where('office.office_id', 2318));
+    }
+
+    #[Test]
+    public function test_pending_update_proposal_links_to_the_row_that_exists_now_not_the_proposed_key(): void {
+        // resolveLinkResourceId() 對未核准的更新提案刻意回「原列」的主鍵——提案還沒套用，
+        // 新鍵在現實中不存在。payload fallback 若照一般順序先讀 resource_data，就會拿到
+        // 提案「想改成」的識別鍵，連結指向一個不存在的機構（404），與上游定位語義自相矛盾。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('inst-pending-proposal@example.com');
+
+        $operation = Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_PROPOSAL_UPDATE,
+            'resource' => 'SOCIAL_INSTITUTION_CODES',
+            'resource_id' => '5000',
+            'resource_data' => json_encode([
+                'c_inst_code' => 5000, 'c_inst_name_code' => 5348,
+                '__key_columns' => ['c_inst_code'], '__review_status' => 'pending',
+            ]),
+            'resource_original' => json_encode(['c_inst_code' => 3983, 'c_inst_name_code' => 5348]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertSame('/app/social-institution/3983/edit', $this->firstResourceLink($user, '?proposals_only=1'));
+
+        // 核准後（提案已套用）才該指向新鍵。
+        Operation::whereKey($operation->id)->update([
+            'resource_data' => json_encode([
+                'c_inst_code' => 5000, 'c_inst_name_code' => 5348,
+                '__key_columns' => ['c_inst_code'], '__review_status' => 'approved',
+            ]),
+        ]);
+        $this->assertSame('/app/social-institution/5000/edit', $this->firstResourceLink($user, '?proposals_only=1'));
+    }
+
+    #[Test]
+    public function test_closed_social_institution_link_falls_back_to_the_operation_payload(): void {
+        // SOCIAL_INSTITUTION_CODES 的 resource_id 是 codes UI 寫的裸值（欄序來自
+        // $tablePrimaryKeyOverrides，與 CompositePrimaryKey::SCHEMAS 不同源），
+        // 單靠它解不出 c_inst_code——必須從 operation 快照補，否則這批列會靜默沒有連結。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('inst-entity-link@example.com');
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'SOCIAL_INSTITUTION_CODES',
+            'resource_id' => '3983',
+            // update 的 resource_data 只有被改的欄、未必含主鍵；c_inst_code 在 original 裡。
+            'resource_data' => json_encode(['c_inst_type_code' => 4]),
+            'resource_original' => json_encode(['c_inst_code' => 3983, 'c_inst_name_code' => 5348, 'c_inst_type_code' => 3]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertSame('/app/social-institution/3983/edit', $this->firstResourceLink($user));
+    }
+
+    #[Test]
+    public function test_closed_social_institution_addr_link_falls_back_to_the_operation_payload(): void {
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('inst-addr-link@example.com');
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_CREATE,
+            'resource' => 'SOCIAL_INSTITUTION_ADDR',
+            // 生產中的形狀是 `-` 連接的 {c_inst_code}-{c_inst_addr_id}，六欄 schema 解不開。
+            'resource_id' => '3983-5348',
+            'resource_data' => json_encode([
+                'c_inst_addr_id' => 5348, 'c_inst_addr_type_code' => 1, 'c_inst_code' => 3983,
+                'c_inst_name_code' => 5348, 'inst_xcoord' => 120.5, 'inst_ycoord' => 30.25,
+            ]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertSame('/app/social-institution/3983/edit', $this->firstResourceLink($user));
+    }
+
+    #[Test]
+    public function test_name_codes_operation_gets_no_link_because_the_name_code_is_shared(): void {
+        // 名稱碼跨機構共用（resolveNameCode() 同名複用），resource_id 與 payload 都沒有
+        // c_inst_code——猜一個機構送使用者過去，比不出連結糟得多。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('inst-name-link@example.com');
+
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_CREATE,
+            'resource' => 'SOCIAL_INSTITUTION_NAME_CODES',
+            'resource_id' => '2619',
+            'resource_data' => json_encode([
+                'c_inst_name_code' => 2619, 'c_inst_name_hz' => '佑聖寺', 'c_inst_name_py' => 'you sheng si',
+            ]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertNull($this->firstResourceLink($user));
+    }
+
+    #[Test]
+    public function test_closed_code_link_is_withheld_from_viewers_who_cannot_open_the_entity_form(): void {
+        // /operations 是公開頁，但實體編輯頁一律 abort(403)（泛用 codes 編輯頁沒有閘門）。
+        // 不看權限就改指，等於發一條必然 403 的連結給訪客——按鈕文案還是「查閱」。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('office-guest-link@example.com');
+
+        \DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 12304, 'c_office_chn' => '知州', 'c_office_pinyin' => 'zhi zhou', 'c_dy' => 15,
+        ]);
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'OFFICE_CODES',
+            'resource_id' => '12304',
+            'resource_data' => json_encode(['c_office_id' => 12304]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        // 訪客：不出連結。
+        $this->assertNull($this->firstResourceLink());
+        // 且確認前提為真——訪客直接開實體編輯頁確實會 403。
+        $this->get('/app/office/12304/edit')->assertForbidden();
+
+        // 已啟用帳號：出連結。
+        $this->assertSame('/app/office/12304/edit', $this->firstResourceLink($user));
+    }
+
+    #[Test]
+    public function test_link_authorization_follows_each_entity_declared_form_capability(): void {
+        // 各實體的表單守衛**不一致**：office 是 canPropose()、social-institution 是
+        // canWriteDirectly()。眾包帳號兩者相異（canPropose 真、canWriteDirectly 假），
+        // 是唯一能分辨這個差異的身分——沒有這條，config 的三個 form_capability 值互換
+        // 都不會有任何測試變紅，那段「不可寫死」的論證就沒有把關。
+        config(['migration_flags.pages.codes' => 'new']);
+        $crowdsourcer = $this->activeUser('capability-crowdsourcing@example.com', User::ROLE_CROWDSOURCING);
+        $this->assertTrue($crowdsourcer->canPropose());
+        $this->assertFalse($crowdsourcer->canWriteDirectly());
+
+        \DB::table('OFFICE_CODES')->insert([
+            'c_office_id' => 12304, 'c_office_chn' => '知州', 'c_office_pinyin' => 'zhi zhou', 'c_dy' => 15,
+        ]);
+        $office = Operation::create([
+            'user_id' => $crowdsourcer->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'OFFICE_CODES',
+            'resource_id' => '12304',
+            'resource_data' => json_encode(['c_office_id' => 12304]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        // office：form_capability=propose ⇒ 眾包帳號拿得到連結，且真的打得開。
+        $link = $this->firstResourceLink($crowdsourcer);
+        $this->assertSame('/app/office/12304/edit', $link);
+        $this->actingAs($crowdsourcer)->get($link)->assertOk();
+
+        // social-institution：form_capability=write ⇒ 同一個帳號拿不到連結，
+        // 因為 /app/social-institution/{id}/edit 對它就是 403。
+        $office->delete();
+        Operation::create([
+            'user_id' => $crowdsourcer->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'SOCIAL_INSTITUTION_CODES',
+            'resource_id' => '3983',
+            'resource_data' => json_encode(['c_inst_code' => 3983]),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertNull($this->firstResourceLink($crowdsourcer));
+        $this->actingAs($crowdsourcer)->get('/app/social-institution/3983/edit')->assertForbidden();
+    }
+
+    #[Test]
+    public function test_unclosed_code_tables_keep_using_the_generic_codes_editor(): void {
+        // 只有被封寫的表改指實體頁；其餘一律維持原本 flag-aware 的 codes 連結。
+        config(['migration_flags.pages.codes' => 'new']);
+        $user = $this->activeUser('nianhao-unclosed@example.com');
+
+        \DB::table('NIAN_HAO')->insert(['c_nianhao_id' => 464, 'c_nianhao_chn' => '測試年號']);
+        Operation::create([
+            'user_id' => $user->id,
+            'c_personid' => 0,
+            'op_type' => Operation::TYPE_UPDATE,
+            'resource' => 'NIAN_HAO',
+            'resource_id' => 'c_nianhao_id=464',
+            'resource_data' => json_encode(['c_nianhao_id' => 464, 'c_nianhao_chn' => '測試年號']),
+            'crowdsourcing_status' => 0,
+        ]);
+
+        $this->assertSame('/app/codes/NIAN_HAO/464/edit', $this->firstResourceLink($user));
     }
 }

--- a/tests/Unit/EntityAggregateRegistryTest.php
+++ b/tests/Unit/EntityAggregateRegistryTest.php
@@ -1,0 +1,470 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\CodesController;
+use App\Support\CompositePrimaryKey;
+use App\Support\EntityAggregateRegistry;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * config/entity_aggregates.php 的封寫判定與連結解析（App\Support\EntityAggregateRegistry）。
+ *
+ * 這支測試存在的理由：#1174／ca601b0d 封寫 OFFICE_CODES 等表時只動了 CodesController 的
+ * 唯讀守衛，沒有動任何連結出口，於是 /app/operations 的「查閱」全變成「點進去吃唯讀警告、
+ * 再被彈回列表」的死連結——而當時的測試只斷言 URL 字串長什麼樣，沒有人斷言那個 URL 到底
+ * 能不能用（tests/Feature/OperationsIndexLinksTest.php 甚至把壞掉的 URL 釘成期望值）。
+ *
+ * 所以這裡刻意不只測「函式回傳什麼」，而是把兩個**不變量**釘成 fail-closed 的把關：
+ *  1. 封寫判定只有一份推導（CodesController 委派過來，不得自己再抄一份）。
+ *  2. 每張被封寫的表，要嘛 resource_id 就解得出實體識別鍵，要嘛必須登記進
+ *     UNRESOLVABLE_FROM_RESOURCE_ID 並說明理由——不允許靜默少一條連結。
+ */
+class EntityAggregateRegistryTest extends TestCase {
+    /**
+     * 被封寫、但**主鍵 schema 不含實體識別鍵**的表：resource_id 本身無從定位實體。
+     *
+     * 登記在此**不代表**呼叫端補得到——是否補得到取決於該表的 operation payload 有沒有
+     * 帶到識別欄，兩種情況都可能，理由必須逐筆寫清楚：
+     *  - 補得到：呼叫端（OperationsController）從 resource_data／resource_original 取識別欄。
+     *  - 補不到：連結就是不存在，這是**正確**結果，不要為了「讓每列都有連結」去猜。
+     *
+     * 新封寫一張表時，要嘛它的 schema 解得出識別鍵，要嘛被迫來這裡登記並交代屬於哪一種——
+     * 兩者皆非就會紅，不會靜默變成「沒有連結」。
+     *
+     * @var array<string, string>
+     */
+    private const UNRESOLVABLE_FROM_RESOURCE_ID = [
+        // 主鍵只有 c_inst_name_code，而名稱碼是**跨機構共用**的
+        // （SocialInstituteImportService::resolveNameCode() 同名複用既有碼），
+        // 所以名稱碼根本不唯一決定一個 c_inst_code。而且該表的 operation payload
+        // 只有 (c_inst_name_code, c_inst_name_hz, c_inst_name_py)，呼叫端也補不到——
+        // 這類 operation 沒有實體連結是正確的終態，不是待補的缺口。
+        // （同一次機構新增／改名一定會伴隨一筆 SOCIAL_INSTITUTION_CODES 的 operation，
+        // 那筆有連結，使用者不會被卡住。）
+        'SOCIAL_INSTITUTION_NAME_CODES' => '名稱碼跨機構共用；resource_id 與 payload 都無 c_inst_code，補不到＝正確無連結',
+    ];
+
+    /** 唯讀但**沒有實體頁可去**的表：不歸 Registry 管，連結行為維持現狀。 */
+    private const NO_ENTITY_PAGE = [
+        'CBDB__NAME_FTS',
+        'DYNASTIES',
+        'GANZHI_CODES',
+    ];
+
+    // ---------------------------------------------------------------------
+    // 不變量一：封寫判定只有一份推導
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function test_codes_controller_read_only_guard_agrees_with_the_registry(): void {
+        $isReadOnly = new ReflectionMethod(CodesController::class, 'isReadOnlyTable');
+        $isReadOnly->setAccessible(true);
+        $controller = app(CodesController::class);
+
+        foreach (self::allClosedTables() as $table) {
+            $this->assertTrue(
+                $isReadOnly->invoke($controller, $table),
+                "{$table} 已登記封寫，CodesController 卻仍放行——守衛與連結解析漂移了"
+            );
+        }
+
+        foreach (self::NO_ENTITY_PAGE as $table) {
+            $this->assertTrue(
+                $isReadOnly->invoke($controller, $table),
+                "{$table} 應維持唯讀"
+            );
+            $this->assertFalse(
+                EntityAggregateRegistry::isClosedByEntity($table),
+                "{$table} 沒有實體頁，不該被 Registry 認領（否則連結會被導去不存在的頁）"
+            );
+        }
+
+        // 未封寫的表不得被誤判為唯讀。
+        // TEXT_CODES 是**刻意**的過渡狀態（config 註解說明 parity 補齊後就會封寫）；
+        // 屆時這裡與 test_unclosed_and_unknown_tables_are_not_claimed 要一起翻面，
+        // 那不是 bug，是預期中的下一步。
+        foreach (['ADDR_CODES', 'NIAN_HAO', 'OFFICE_CODE_TYPE_REL', 'TEXT_CODES'] as $table) {
+            $this->assertFalse(
+                $isReadOnly->invoke($controller, $table),
+                "{$table} 目前未登記封寫，不該被判為唯讀（若剛把它加進 closed_code_tables，"
+                . '這條與 test_unclosed_and_unknown_tables_are_not_claimed 要一併更新）'
+            );
+        }
+    }
+
+    #[Test]
+    public function test_no_table_is_claimed_by_two_entities(): void {
+        $all = [];
+        foreach (EntityAggregateRegistry::entities() as $entity) {
+            foreach (EntityAggregateRegistry::closedTablesOf($entity) as $table) {
+                $all[] = $table;
+            }
+        }
+
+        $this->assertSame(
+            array_values(array_unique($all)),
+            $all,
+            '同一張表被兩個實體認領：連結解析會靜默選中第一個實體'
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // 不變量二：封寫 ⇒ 連結解得出（否則必須登記例外）
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function test_every_registered_entity_declares_a_usable_edit_route(): void {
+        $entities = EntityAggregateRegistry::entities();
+        $this->assertNotEmpty($entities, 'entity_aggregates 註冊表不應為空');
+
+        foreach ($entities as $entity) {
+            $resource = (string) ($entity['resource'] ?? '(unnamed)');
+
+            $this->assertNotEmpty(
+                $entity['pk'] ?? null,
+                "實體 {$resource} 未宣告 pk，連結解析無從取得識別鍵"
+            );
+
+            $editRoute = (string) ($entity['edit_route'] ?? '');
+            $this->assertNotSame('', $editRoute, "實體 {$resource} 未宣告 edit_route");
+
+            $route = Route::getRoutes()->getByName($editRoute);
+            $this->assertNotNull(
+                $route,
+                "實體 {$resource} 的 edit_route（{$editRoute}）不存在——封寫後連結會靜默消失"
+            );
+            // 參數名寫死在 editUrl() 的 ['id' => …]；若哪天路由改成 {office}，
+            // route() 不會報錯，只會把 id 掛成 query string，連結靜默壞掉。
+            $this->assertSame(
+                ['id'],
+                $route->parameterNames(),
+                "實體 {$resource} 的 edit_route 必須是單一 {id} 參數"
+            );
+        }
+    }
+
+    #[Test]
+    public function test_every_closed_table_either_resolves_or_is_registered_as_unresolvable(): void {
+        $unresolvable = [];
+
+        foreach (EntityAggregateRegistry::entities() as $entity) {
+            $pkColumn = (string) ($entity['pk'] ?? '');
+            foreach (EntityAggregateRegistry::closedTablesOf($entity) as $table) {
+                $schema = CompositePrimaryKey::getSchema(
+                    CompositePrimaryKey::getResourceIdSchemaTable($table)
+                );
+                $this->assertIsArray(
+                    $schema,
+                    "{$table} 已封寫卻不在 CompositePrimaryKey::SCHEMAS 裡，resource_id 永遠解不開"
+                );
+
+                if (!in_array($pkColumn, $schema, true)) {
+                    $unresolvable[] = $table;
+
+                    continue;
+                }
+
+                // schema 含識別鍵 ⇒ 具名格式的 resource_id 必須解得出實體編輯連結。
+                $pk = [];
+                foreach ($schema as $i => $column) {
+                    $pk[$column] = $column === $pkColumn ? 4242 : ($i + 1);
+                }
+                $this->assertSame(
+                    "/{$this->routePrefix($entity)}/4242/edit",
+                    EntityAggregateRegistry::editUrl($table, CompositePrimaryKey::buildStoredResourceId($pk)),
+                    "{$table} 已封寫且 schema 含 {$pkColumn}，連結卻解不出來"
+                );
+            }
+        }
+
+        sort($unresolvable);
+        $expected = array_keys(self::UNRESOLVABLE_FROM_RESOURCE_ID);
+        sort($expected);
+        $this->assertSame(
+            $expected,
+            $unresolvable,
+            'UNRESOLVABLE_FROM_RESOURCE_ID 清冊與實際情況不符：'
+            . '新封寫的表若無法由 resource_id 定位實體，必須登記進清冊並寫明'
+            . '呼叫端補不補得到識別鍵（補不到就是正確的無連結，不要用猜的補上）'
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // 連結解析行為
+    // ---------------------------------------------------------------------
+
+    #[Test]
+    public function test_office_codes_resolves_from_every_real_stored_id_format(): void {
+        $this->assertTrue(EntityAggregateRegistry::isClosedByEntity('OFFICE_CODES'));
+
+        // 具名格式（實體頁 SharesImportHelpers::recordOp() 寫入）。
+        $this->assertSame(
+            '/app/office/12304/edit',
+            EntityAggregateRegistry::editUrl('OFFICE_CODES', CompositePrimaryKey::buildStoredResourceId(['c_office_id' => 12304]))
+        );
+
+        // 裸值格式（封寫前 codes UI 的 buildCompositeId() 寫入）——線上壞掉的正是這批。
+        $this->assertSame('/app/office/803811/edit', EntityAggregateRegistry::editUrl('OFFICE_CODES', '803811'));
+
+        // `{c_office_id}_._{c_dy}`：getKeyColumns() 取不到 PK 而回退成「前兩欄」時的產物，
+        // 生產 operations 裡確實存在（本機 19 列 OFFICE_CODES 中有 5 列是這個形狀）。
+        // 單鍵表的識別鍵必為第一段，所以取 `_._` 之前即可。
+        $this->assertSame('/app/office/2318/edit', EntityAggregateRegistry::editUrl('OFFICE_CODES', '2318_._15'));
+
+        // 表名大小寫不敏感。
+        $this->assertSame('/app/office/7/edit', EntityAggregateRegistry::editUrl('office_codes', '7'));
+    }
+
+    #[Test]
+    public function test_composite_key_closed_table_extracts_entity_pk_not_the_whole_key(): void {
+        // SOCIAL_INSTITUTION_CODES 主鍵是 (c_inst_code, c_inst_name_code)，
+        // 實體識別鍵只有 c_inst_code——取錯欄位會導向另一個真實存在的機構。
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_inst_code' => 88,
+            'c_inst_name_code' => 4021,
+        ]);
+
+        $this->assertSame(
+            '/app/social-institution/88/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_CODES', $resourceId)
+        );
+    }
+
+    #[Test]
+    public function test_addr_closed_table_extracts_entity_pk_from_six_column_key(): void {
+        $resourceId = CompositePrimaryKey::buildStoredResourceId([
+            'c_inst_addr_id' => 3,
+            'c_inst_addr_type_code' => 1,
+            'c_inst_code' => 88,
+            'c_inst_name_code' => 4021,
+            'inst_xcoord' => 120.5,
+            'inst_ycoord' => 30.25,
+        ]);
+
+        $this->assertSame(
+            '/app/social-institution/88/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_ADDR', $resourceId)
+        );
+    }
+
+    #[Test]
+    public function test_positional_resource_ids_of_multi_column_tables_are_refused(): void {
+        // codes UI 的 buildCompositeId() 欄序來自 $tablePrimaryKeyOverrides，與
+        // CompositePrimaryKey::SCHEMAS 不同源（前者 SOCIAL_INSTITUTION_CODES 只有 1 欄、
+        // ADDR 2 欄；後者 2 欄與 6 欄）。硬信位置式切分會把名稱碼當成機構碼，
+        // 導向另一個**真實存在**的機構——那比沒有連結糟得多。
+        //
+        // 前兩個是**生產 operations 裡真實存在**的形狀（本機各 21／19 列）：機構碼裸值、
+        // 以及 `-` 連接的 `{c_inst_code}-{c_inst_addr_id}`。這兩批一律要靠呼叫端補識別鍵，
+        // 這條斷言就是釘住「Registry 自己解不出來」這件事，讓呼叫端不能不補。
+        $this->assertNull(EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_CODES', '3983'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_ADDR', '3983-5348'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_CODES', '4021_._88'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_ADDR', '88_._3'));
+
+        // 但呼叫端從 payload 取到 c_inst_code 時就能補起來。
+        $this->assertSame(
+            '/app/social-institution/3983/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_CODES', '3983', 3983)
+        );
+        $this->assertSame(
+            '/app/social-institution/3983/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_ADDR', '3983-5348', 3983)
+        );
+    }
+
+    #[Test]
+    public function test_duplicate_query_parameters_cannot_override_the_entity_pk(): void {
+        // parse_str() 後者覆蓋前者；不比對分隔符數量的話，'…&c_inst_code=999'
+        // 會把使用者送去 999 號機構。
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', 'c_office_id=12&c_office_id=999'));
+        $this->assertNull(EntityAggregateRegistry::editUrl(
+            'SOCIAL_INSTITUTION_CODES',
+            'c_inst_code=88&c_inst_name_code=4021&c_inst_code=999'
+        ));
+    }
+
+    #[Test]
+    public function test_caller_payload_fallback_outranks_positional_guessing(): void {
+        // 三級優先序：具名格式 → 呼叫端 payload → 單鍵位置式。
+        //
+        // 位置式那級只是「約定第一段是識別鍵」的推測，會落空：codes UI 的
+        // buildCompositeId() 把空值的段整段濾掉，所以 `{c_office_id}_._{c_dy}` 在缺識別鍵時
+        // 會塌成單獨的朝代碼（`15`），被位置式誤解成官職 15。payload 值有明確欄名、更可靠，
+        // 必須贏過它——否則使用者會被送到一個真實存在但不相干的官職。
+        $this->assertSame(
+            '/app/office/2318/edit',
+            EntityAggregateRegistry::editUrl('OFFICE_CODES', '15', 2318)
+        );
+
+        // 但具名格式仍然贏過 payload（欄名齊全，最可靠）。
+        $this->assertSame(
+            '/app/office/12304/edit',
+            EntityAggregateRegistry::editUrl(
+                'OFFICE_CODES',
+                CompositePrimaryKey::buildStoredResourceId(['c_office_id' => 12304]),
+                99999
+            )
+        );
+
+        // 沒有 payload 時，位置式仍是最後的可用來源（不要因為它不可靠就整個拿掉）。
+        $this->assertSame('/app/office/2318/edit', EntityAggregateRegistry::editUrl('OFFICE_CODES', '2318_._15'));
+    }
+
+    #[Test]
+    public function test_fallback_entity_pk_is_used_only_when_resource_id_cannot_supply_it(): void {
+        $nameCodeId = CompositePrimaryKey::buildStoredResourceId(['c_inst_name_code' => 4021]);
+        $this->assertNull(EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_NAME_CODES', $nameCodeId));
+        $this->assertSame(
+            '/app/social-institution/88/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_NAME_CODES', $nameCodeId, 88)
+        );
+
+        // resource_id 本身就帶得出識別鍵時，fallback 不得覆蓋它。
+        $instCodeId = CompositePrimaryKey::buildStoredResourceId([
+            'c_inst_code' => 88,
+            'c_inst_name_code' => 4021,
+        ]);
+        $this->assertSame(
+            '/app/social-institution/88/edit',
+            EntityAggregateRegistry::editUrl('SOCIAL_INSTITUTION_CODES', $instCodeId, 99999)
+        );
+    }
+
+    #[Test]
+    public function test_unclosed_and_unknown_tables_are_not_claimed(): void {
+        // TEXT_CODES 目前刻意「暫不封寫」（config 的 closed_code_tables 為空）——連結必須
+        // 維持走泛用 codes 頁，不可提前改指實體頁。
+        // 封寫 TEXT_CODES／TEXT_INSTANCE_DATA 時，這兩條斷言要一併翻面（連同 §4.4 的
+        // parity 清單與 tests/Feature/TextEntityIndexTest 的「暫不封寫」斷言）。
+        $this->assertFalse(EntityAggregateRegistry::isClosedByEntity('TEXT_CODES'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('TEXT_CODES', 'c_textid=123'));
+
+        // OFFICE_CODE_TYPE_REL 被 office 聚合認領（tables）但未封寫（closed_code_tables），
+        // 連結同樣維持現狀。
+        $this->assertFalse(EntityAggregateRegistry::isClosedByEntity('OFFICE_CODE_TYPE_REL'));
+
+        $this->assertFalse(EntityAggregateRegistry::isClosedByEntity('ADDR_CODES'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('ADDR_CODES', 'c_addr_id=1'));
+
+        // 沒有實體頁的唯讀表不在本類處理範圍內，維持既有行為。
+        foreach (self::NO_ENTITY_PAGE as $table) {
+            $this->assertNull(EntityAggregateRegistry::editUrl($table, 'c_dy=15'));
+        }
+    }
+
+    #[Test]
+    public function test_non_numeric_and_unusable_ids_never_produce_a_link(): void {
+        // 識別鍵是整數代理鍵；route() 不驗證 whereNumber，所以白名單擋在這裡，
+        // 否則會組出被注入路徑的 URL。
+        foreach (['', '   ', 'NULL', 'c_office_id=NULL', 'c_bogus=5', 'abc', '..', '1/../../admin', 'a/b', '1#frag', '-1', '1.5'] as $bad) {
+            $this->assertNull(
+                EntityAggregateRegistry::editUrl('OFFICE_CODES', $bad),
+                "resource_id 「{$bad}」不該產生連結"
+            );
+        }
+
+        // fallback 走同一道白名單。
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '', '../admin'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '', true));
+    }
+
+    #[Test]
+    public function test_missing_or_unregistered_edit_route_yields_no_link(): void {
+        config(['entity_aggregates.entities' => [[
+            'resource' => 'office',
+            'pk' => 'c_office_id',
+            'edit_route' => 'app.office.not-a-real-route',
+            'closed_code_tables' => ['OFFICE_CODES'],
+        ]]]);
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+
+        config(['entity_aggregates.entities' => [[
+            'resource' => 'office',
+            'pk' => 'c_office_id',
+            'closed_code_tables' => ['OFFICE_CODES'],
+        ]]]);
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+
+        // 有路由但缺 pk。
+        config(['entity_aggregates.entities' => [[
+            'resource' => 'office',
+            'edit_route' => 'app.office.edit',
+            'closed_code_tables' => ['OFFICE_CODES'],
+        ]]]);
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+    }
+
+    #[Test]
+    public function test_edit_route_with_a_different_parameter_name_yields_no_link_instead_of_throwing(): void {
+        // route() 對名稱不符的參數不會報錯——它會把 id 掛成 query string；而**缺**必要參數
+        // 則直接拋 UrlGenerationException，把 /app/operations 整頁打成 500。
+        // 本類的契約是「解不出就回 null」，所以執行期也要兜底，不能只靠單元測試擋 config 漂移。
+        Route::get('test-only/entity/{office}/edit', fn () => '')->name('test-only.entity.edit');
+        // 沒有這行，getByName() 會回 null，測試就只是在重測「路由不存在」那條分支：
+        // RouteCollection::add() 在 ->name() 被呼叫前就跑完 addLookups()，名稱查找表
+        // 只在 app boot 時 refresh 一次。
+        Route::getRoutes()->refreshNameLookups();
+        $this->assertNotNull(
+            Route::getRoutes()->getByName('test-only.entity.edit'),
+            '測試前提不成立：路由沒註冊進名稱查找表，下面的斷言會走錯分支'
+        );
+
+        config(['entity_aggregates.entities' => [[
+            'resource' => 'office',
+            'pk' => 'c_office_id',
+            'edit_route' => 'test-only.entity.edit',
+            'closed_code_tables' => ['OFFICE_CODES'],
+        ]]]);
+
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+    }
+
+    #[Test]
+    public function test_malformed_registry_does_not_blow_up(): void {
+        // config(key, []) 的預設值只在 key **不存在**時生效；key 存在但為 null 仍回 null，
+        // 直接 foreach 會把 /app/operations 整頁打成 500。
+        foreach ([null, 'oops', 42] as $broken) {
+            config(['entity_aggregates.entities' => $broken]);
+            $this->assertSame([], EntityAggregateRegistry::entities());
+            $this->assertFalse(EntityAggregateRegistry::isClosedByEntity('OFFICE_CODES'));
+            $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+        }
+
+        config(['entity_aggregates.entities' => [
+            'not-an-array',
+            ['resource' => 'x', 'closed_code_tables' => 'not-an-array'],
+            ['resource' => 'y'],
+            ['resource' => 'z', 'closed_code_tables' => [['nested']]],
+        ]]);
+        $this->assertFalse(EntityAggregateRegistry::isClosedByEntity('OFFICE_CODES'));
+        $this->assertNull(EntityAggregateRegistry::editUrl('OFFICE_CODES', '12304'));
+    }
+
+    /**
+     * 全部已封寫的表（跨實體攤平）。
+     *
+     * @return array<int, string>
+     */
+    private static function allClosedTables(): array {
+        $tables = [];
+        foreach (EntityAggregateRegistry::entities() as $entity) {
+            foreach (EntityAggregateRegistry::closedTablesOf($entity) as $table) {
+                $tables[] = $table;
+            }
+        }
+
+        return $tables;
+    }
+
+    /** 由 edit_route 推出該實體頁的 URL 前綴（測試自用，不進生產程式碼）。 */
+    private function routePrefix(array $entity): string {
+        $uri = Route::getRoutes()->getByName($entity['edit_route'])->uri();
+
+        return substr($uri, 0, strpos($uri, '/{'));
+    }
+}


### PR DESCRIPTION
## 症狀

`https://input.cbdb.fas.harvard.edu/app/operations` 上，凡是 `OFFICE_CODES`、`SOCIAL_INSTITUTION_CODES`／`NAME_CODES`／`ADDR` 這幾張表的操作紀錄，按「查閱」都會被導到 `/app/codes/{表}/{id}/edit`，然後吃到「該代碼表為只讀，禁止編輯。」再被彈回列表頁。使用者從操作紀錄根本走不到那筆資料。

## 成因

#1174（`0e8c4334`）把官職實體推進到 step 4 時，把 `OFFICE_CODES` 加進 `CodesController::$readOnlyTables`（`ca601b0d` 之後改由 `config/entity_aggregates.php` 的 `closed_code_tables` 推導），寫入入口收歸 `/app/office`、`/app/social-institution`。

**但只改了守衛、沒改任何連結出口**——`OperationsController::serializeOperationRow()` 仍無條件呼叫 `code_table_edit_url()`，而它只做 codes flag 的新舊分流、不知道有「封寫」這回事。封寫判定與連結解析分兩處推導，是這個 bug 的全部成因。

## 為什麼測試沒抓到

`OperationsIndexLinksTest::test_code_resource_link_generation_logic` 拿 `OFFICE_CODES` 當樣本，把 `/app/codes/OFFICE_CODES/803819/edit` **釘成期望值**。它只斷言 helper 產出的字串、從不驗證那個 URL 打不打得開，所以測試不但沒抓到，還在替一條死連結背書。

## 修法

新增 `app/Support/EntityAggregateRegistry.php` 作為 `config/entity_aggregates.php` 的唯一查詢介面，**讓封寫判定與連結解析同源**：

- `CodesController::isReadOnlyTable()` 改為委派過來，不再自己抄一份 config 迴圈
- `OperationsController` 在該表被封寫時改指實體聚合編輯頁（config 新增 `edit_route`）
- 日後任何新的封寫只要登記進 `closed_code_tables`，守衛與連結就同步生效

**識別鍵三級優先序**（本機全量 76 列 operations 實測）：具名 query-string → 呼叫端從 `resource_data`／`resource_original` 取的識別欄 → 單鍵表位置式的第一段。位置式排最後是因為它只是推測（`buildCompositeId()` 會濾掉空值段，缺識別鍵時 `{c_office_id}_._{c_dy}` 會塌成單獨的朝代碼）。**壞掉的正是封寫前由 codes UI 寫入的那批**（`SOCIAL_INSTITUTION_CODES` 存成裸值 `3983`、`ADDR` 存成 `3983-5348`，欄序來自 `$tablePrimaryKeyOverrides`，與 `CompositePrimaryKey::SCHEMAS` 不同源），少了 payload 那一級等於沒修到票上說的情境。

**未核准的更新提案只讀 `resource_original`**：`resolveLinkResourceId()` 對這種 operation 刻意回「原列」主鍵（提案還沒套用，新鍵在現實中不存在）；payload 若照一般順序先讀 `resource_data`，會指向提案「想改成」的鍵——不是 404 就是導向另一個真實存在的實體。

**解不出就不出連結，不猜**：`SOCIAL_INSTITUTION_NAME_CODES` 的名稱碼跨機構共用（`resolveNameCode()` 同名複用既有碼），`resource_id` 與 payload 都不含 `c_inst_code`。同一次機構新增／改名一定會伴隨一筆 `SOCIAL_INSTITUTION_CODES` 的 operation，那筆有連結。

**連結要看權限**：`/operations` 是公開頁，但實體編輯頁一律 `abort(403)`（泛用 codes 編輯頁沒有授權閘門）。不看權限就改指，等於發一條必然 403 的連結給訪客——按鈕文案還是「查閱」。各實體要求的能力**不一致**（office 是 `canPropose()`、social-institution 與 text-entity 是 `canWriteDirectly()`），故由 config 的 `form_capability` 宣告、不寫死。

## 防復發

- **`tests/Unit/EntityAggregateRegistryTest.php`**（16 案例）兩條 fail-closed 不變量：
  1. `CodesController::isReadOnlyTable()` 與 Registry 逐表一致，不得各自再抄一份 config 迴圈
  2. 每張被封寫的表要嘛 `resource_id` 解得出識別鍵，要嘛**逐筆登記**進 `UNRESOLVABLE_FROM_RESOURCE_ID` 並寫明呼叫端補不補得到，多一個少一個都紅

  另釘住 `edit_route` 必須存在且是單一 `{id}` 參數（`route()` 不驗證 `whereNumber`，參數名不符會拋 `UrlGenerationException` 把整頁打成 500）、無表被兩實體認領、config 被設成非陣列時不得 fatal。

- **`tests/Feature/OperationsIndexLinksTest.php`** 新增 9 案例：office 案例**把連結真的打開來驗**（`assertInertia` 拿 `resource_link`，再 GET 它斷言渲染出 `Office/Edit`）；其餘覆蓋機構 payload 補救、名稱碼無連結、提案指向現存的列、訪客不得拿到必然 403 的連結，以及用眾包帳號釘住 `form_capability` 的 propose／write 差異——那是唯一能分辨兩者的身分，少了它 config 三個值互換都不會有任何測試變紅。其中 `test_unclosed_code_tables_keep_using_the_generic_codes_editor` 是**回歸護欄**，修復前後都該綠（擋「改指改過頭」）。同時把上述那條替死連結背書的舊測試改用未封寫的表，並加一條「樣本表被封寫了就紅」的自我檢查。

## 順帶收斂

`Navigation::entityNavItem()` 與 `EntityAggregateDefinitionRegistry::boot()` 原本直接 `foreach config('entity_aggregates.entities', [])`——`config()` 的預設值只在 key **不存在**時生效，被設成 null／字串時仍會原樣回傳並 fatal，而側欄是每一頁都渲染的（等於整站 500）。兩處一併改走 Registry 的防禦性讀取。另修正 `TextEntityController` 說 `TEXT_CODES`「已封寫」的過時註解（實際仍刻意未封寫）。

## 範圍

只處理**有實體頁可去**的封寫表。`DYNASTIES`／`GANZHI_CODES`／`CBDB__NAME_FTS` 唯讀是終態、沒有替代入口，連結行為維持現狀。`TEXT_CODES` 目前刻意「暫不封寫」，連結維持走泛用 codes 頁。舊 Blade 版 `/operations` 未動（React 版已上線）。

## 本次刻意不做、建議另開票的既有問題

1. **`CodesController::ensureProposalEditable()` 缺 `isReadOnlyTable()` 檢查**（`CodesController.php:2974`）：封寫表上的舊 pending 提案仍可被提案者改寫並寫進 `operations`，與「裸表 proposal 一併封閉為實體級提案」不一致。這是 #1174 封寫沒收乾淨的地方，但它不造成本 PR 的症狀（提案編輯會成功、不是死連結），且封鎖它是行為變更。
2. **`urls.edit_proposal`／`urls.cancel_proposal` 非 flag-aware**（`OperationsController.php:1042`／`1094`）：對代碼表一律吐舊 Blade 路由，即使 `app.codes.proposals.*` 已存在也不分流，會把 React 頁的使用者掉回舊 Blade。

## 驗證

- `./vendor/bin/phpunit`：**3032 tests OK**
- `./vendor/bin/php-cs-fixer fix`：0 需修正
- 無前端改動（`resources/js/**` 未動），毋須 `npm run build`
- 無路由／請求回應／授權契約／錯誤碼／resource 別名變更，毋須同步 `API.md` 與 OpenAPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

让操作记录中的封写代码表查阅链接安全地指向对应实体页，并以实体注册表统一相关规则。

Bug Fixes:
- 修正操作记录中指向已封写代码表的查阅链接，改为导向可用的实体编辑页，避免用户遭遇只读警告或无效页面。

Enhancements:
- 新增实体聚合注册接口，统一封写判定、编辑链接解析与表单权限判断。
- 支持多种历史操作资源识别格式及快照补救，无法可靠定位或用户无权限时不生成链接。
- 强化实体聚合配置与导航、定义注册的防御性读取，避免异常配置导致页面错误。

Documentation:
- 更新实体聚合架构文档，说明封写表链接、权限与注册表配置。

Tests:
- 新增注册表与操作记录链接测试，涵盖实体页可用性、识别键解析、提案状态、权限及未封写表回归行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

讓操作紀錄中的封寫代碼表查閱連結安全地指向對應實體頁，並以實體註冊表統一相關規則。

Bug Fixes:
- 修正操作紀錄中指向已封寫代碼表的查閱連結，改為導向可用的實體編輯頁，避免使用者遭遇唯讀警告或無效頁面。

Enhancements:
- 新增實體聚合註冊介面，統一封寫判定、編輯連結解析與表單權限判斷。
- 支援多種歷史操作資源識別格式及快照補救，無法可靠定位或使用者無權限時不產生連結。
- 強化實體聚合設定與導航、定義註冊的防禦性讀取，避免異常設定造成頁面錯誤。

Documentation:
- 更新實體聚合架構文件，說明封寫表連結、權限與註冊表設定。

Tests:
- 新增註冊表與操作紀錄連結測試，涵蓋實體頁可用性、識別鍵解析、提案狀態、權限及未封寫表回歸行為。

</details>