### PR TITLE
v2 API 補上行政類別代碼（ADMIN_CAT_CODES）的新增，update 白名單擴到整列

### DIFF
--- a/API.md
+++ b/API.md
@@ -463,13 +463,13 @@ CBDB 子資源表幾乎都是複合主鍵，且不使用 Eloquent 主鍵行為�
 | sources | **create／update 只接受 `sources`**；delete 另接受 source, biog_source_data | BIOG_SOURCE_DATA | ✔ | ✔ | ✔ |
 | merged-person | merged_person, merged_person_data, mergedperson | MERGED_PERSON_DATA | ✔ | ✘ | ✔ |
 | 可修改的代碼表（nianhao、office_codes、dynasties…） | 見〈代碼表與複合實體寫入〉 | 各代碼表 | ✘（501） | ✔ | ✘（501） |
-| 可新增的代碼表（text-codes、char-variant-map、addr-codes、addr-belongs-data） | 逐操作不同，見〈代碼表與複合實體寫入〉 | TEXT_CODES、char_variant_map、ADDR_CODES、ADDR_BELONGS_DATA | 僅 direct | ✔ | ✘（403，已停用） |
+| 可新增的代碼表（text-codes、char-variant-map、addr-codes、addr-belongs-data、admin-cat-codes） | 逐操作不同，見〈代碼表與複合實體寫入〉 | TEXT_CODES、char_variant_map、ADDR_CODES、ADDR_BELONGS_DATA、ADMIN_CAT_CODES | 僅 direct | ✔ | ✘（403，已停用） |
 | office、social-institution、text-entity（複合實體聚合） | 見〈代碼表與複合實體寫入〉 | 多表聚合 | ✔ | ✔ | ✔ |
 
 - 表中 `✔` 表示 `direct` 與 `proposal` 兩種模式都支援。
 - 人物主檔（basicinformation）的 `create` 與 `delete` **不支援 proposal**，會回 501 `mode: ["proposal_not_supported"]`；`update` 則兩種模式都支援。
 - 人物主檔的 `delete` 是**軟刪除**：把 `c_name_chn` 改為 `<待删除>`（UPDATE，不是真的 DELETE，也不觸發外鍵連鎖），並記一筆 `op_type=4` 的 operation。
-- 代碼表分兩組：**只能改**的一組（`config/code_table_mutations.php`，如 nianhao、office_codes、dynasties、choronym_codes、ganzhi_codes 等）送 `create`／`delete` 會回 501；**可新增**的一組是 `TEXT_CODES`、`char_variant_map`、`ADDR_CODES` 與 `ADDR_BELONGS_DATA`（`config/code_table_writes.php`）。代碼表的 `delete` 一律不開放——受支援的四張表回 **403**（防止級聯刪除人物資料），其餘代碼表回 501。
+- 代碼表分兩組：**只能改**的一組（`config/code_table_mutations.php`，如 nianhao、office_codes、dynasties、choronym_codes、ganzhi_codes 等）送 `create`／`delete` 會回 501；**可新增**的一組是 `TEXT_CODES`、`char_variant_map`、`ADDR_CODES`、`ADDR_BELONGS_DATA` 與 `ADMIN_CAT_CODES`（`config/code_table_writes.php`）。代碼表的 `delete` 一律不開放——受支援的五張表回 **403**（防止級聯刪除人物資料），其餘代碼表回 501。
 - 不支援的 `resource` / `mode` / `operation` 組合一律回 **501**：`{"ok":false,"message":"目前尚未支援此變更模式","errors":{"resource":"...","mode":"...","operation":"..."}}`。
 
 各資源的欄位白名單、必填規則與範例見〈各資源欄位參考〉。
@@ -1397,7 +1397,7 @@ Authorization: Bearer <token>
 | ganzhi_codes | ganzhi | GANZHI_CODES | c_ganzhi_code | c_ganzhi_py |
 | social_institution_name_codes | — | SOCIAL_INSTITUTION_NAME_CODES | c_inst_name_code | c_inst_name_py |
 | social_institution_types | — | SOCIAL_INSTITUTION_TYPES | c_inst_type_code | c_inst_type_py |
-| admin_cat_codes | admin_cat | ADMIN_CAT_CODES | c_admin_cat_code | c_admin_cat_py |
+| admin_cat_codes | admin_cat, admin-cat-codes, admin-cat | ADMIN_CAT_CODES | c_admin_cat_code | c_admin_cat_py, c_admin_cat_hz, c_admin_cat_trans, c_notes |
 | addr_codes | addr-codes, addrcodes | ADDR_CODES | c_addr_id | c_name, c_name_chn, c_alt_names, c_firstyear, c_lastyear, c_admin_type, c_admin_cat_code, x_coord, y_coord, CHGIS_PT_ID, c_notes |
 | addr_belongs_data | addr-belongs-data, addr_belongs, addr-belongs | ADDR_BELONGS_DATA | c_addr_id, c_belongs_to, c_firstyear, c_lastyear | c_source, c_pages, c_notes |
 | char_variant_map | char-variant-map, charvariantmap | char_variant_map | id | c_variant_char, c_reference_char, c_strict_excluded, c_notes |
@@ -1411,11 +1411,11 @@ Authorization: Bearer <token>
   - 可為 null 的數值欄送空字串 `""` 等於**清空（寫入 null）**，不是寫 0。
   - 整數欄另有**值域檢查**（依該欄實際型別，如 smallint 是 -32768～32767），超出回 422 `<欄名> 必須在 <min> 與 <max> 之間`。同理由：非 strict sql_mode 下 MariaDB 會把 40000 靜默截斷成 32767，回 200 但年份是錯的。
   - 超出 PHP 整數精度的數字字串回 422 `<欄名> 整數值超出可表示範圍`（`(int)` 會飽和成最大值，讓值域檢查誤判為「剛好在範圍內」）。`bigint` 欄不做值域檢查，只做這條溢位檢查。
-  - **不受 255 上限**：`ADDR_CODES.c_notes`（實際型別是 longtext）。13.2 的 create 另有 `TEXT_CODES.c_notes`——該欄只能新增時寫，不在本節的 update 白名單內。
+  - **不受 255 上限**：`ADDR_CODES.c_notes`、`ADMIN_CAT_CODES.c_notes`（實際型別是 longtext）。13.2 的 create 另有 `TEXT_CODES.c_notes`——該欄只能新增時寫，不在本節的 update 白名單內。
   - **整數欄也收「小數部分為 0 的浮點數」**（`1200.0` → `1200`）：不少 JSON 序列化器就是這樣送整數的。真的帶小數時回 422，不會靜默截斷。create 與 update 兩端一致。
   - **文字欄收到 JSON 數字時，只有 `create` 會轉成字串**（`"c_pages": 12` → `"12"`，等同資料庫原本的隱式轉型）；`update` 一律回 422。這是刻意的不對稱：create 在加上型別校驗之前完全沒有檢查，改判 422 會打斷既有客戶端；update 從第一天就要求字串。**要送 update 請自己加引號。**
   - **不可為 `null`**：資料庫 NOT NULL 的欄，訊息 `<欄名> 不可為空`。數值型的（`ADDR_CODES.c_admin_cat_code`、`char_variant_map.c_strict_excluded`）連空字串也拒絕，整個不送則吃資料庫預設值；文字型的（`TEXT_BIBLCAT_CODES.c_text_cat_pinyin`、`GANZHI_CODES.c_ganzhi_py`、`SOCIAL_INSTITUTION_NAME_CODES.c_inst_name_py`、`char_variant_map.c_variant_char`／`c_reference_char`）**允許送空字串**——那些欄是 `NOT NULL DEFAULT ''`，`''` 就是它們清空的合法寫法。
-- 純拼音欄位在保存時會**靜默**把 `v` 正規化為 `ü`（只轉「`l`／`n` 之後、且後面不接 `a`／`i`／`o`／`u`」的 `v`，例如 `lv`→`lü`、`nv`→`nü`）。可能含西文的混合欄不做這個轉換——注意這是**逐表逐欄**登記的，同一個欄名在不同表可能不同：`ETHNICITY_TRIBE_CODES.c_name` 與 `TEXT_CODES.c_title` 會轉，`ADDR_CODES.c_name`、`DYNASTIES.c_dynasty`、`CHORONYM_CODES.c_choronym_desc`、`ETHNICITY_TRIBE_CODES.c_romanized` 不轉。
+- 純拼音欄位在保存時會**靜默**把 `v` 正規化為 `ü`（`create` 與 `update` 兩端一致）（只轉「`l`／`n` 之後、且後面不接 `a`／`i`／`o`／`u`」的 `v`，例如 `lv`→`lü`、`nv`→`nü`）。可能含西文的混合欄不做這個轉換——注意這是**逐表逐欄**登記的，同一個欄名在不同表可能不同：`ETHNICITY_TRIBE_CODES.c_name` 與 `TEXT_CODES.c_title` 會轉，`ADDR_CODES.c_name`、`DYNASTIES.c_dynasty`、`CHORONYM_CODES.c_choronym_desc`、`ETHNICITY_TRIBE_CODES.c_romanized` 不轉。
 - **`v→ü` 正規化發生在「有沒有變更」的判斷之前**：若庫內已是 `lü` 而你送 `lv`，兩者正規化後相同，會得到 422 `changes: no_effective_changes`。這不是 bug。
 - 改後的值與其他列的唯一鍵衝突 → 409 `changes: conflict`。
 - 外鍵欄指向不存在的列 → 422 `changes: ["foreign_key_violation"]`（`ADDR_CODES.c_admin_cat_code` → `ADMIN_CAT_CODES`、`ADDR_BELONGS_DATA.c_source` → `TEXT_CODES`）。NOT NULL 欄仍被寫成空 → 422 `changes: ["not_null_violation"]`（正常情況下會先被上面的欄位級規則擋在 `<欄名> 不可為空`）。
@@ -1426,7 +1426,7 @@ Authorization: Bearer <token>
 
 ### 13.2 可新增的代碼表（只支援 `create`、只支援 `direct`）
 
-目前開放新增的有四張表：
+目前開放新增的有五張表：
 
 > **與 13.4 的 `text-entity` 聚合並存**：`TEXT_CODES` 兩條寫入路徑都在役——本節的裸表 create 是「就這一列、就這些欄」的機器化寫入（S5 起同樣會做異體字落地替換）；聚合資源另外處理拼音派生、書名字形／標點正規化與 `TEXT_INSTANCE_DATA` 版本列。要建立一筆語義完整的文獻，用 13.4；只補一列原始資料，用本節。
 
@@ -1436,6 +1436,7 @@ Authorization: Bearer <token>
 | char-variant-map | char_variant_map, charvariantmap | char_variant_map | id（可自動配發） | c_variant_char, c_reference_char, c_strict_excluded, c_notes |
 | addr-codes | addr_codes, addrcodes | ADDR_CODES | c_addr_id（可自動配發） | c_name, c_name_chn, c_alt_names, c_firstyear, c_lastyear, c_admin_type, c_admin_cat_code, x_coord, y_coord, CHGIS_PT_ID, c_notes |
 | addr-belongs-data | addr_belongs_data, addr_belongs, addr-belongs | ADDR_BELONGS_DATA | c_addr_id, c_belongs_to, c_firstyear, c_lastyear（**四欄都必填、不配發**） | c_source, c_pages, c_notes |
+| admin-cat-codes | admin_cat_codes, admin-cat, admin_cat | ADMIN_CAT_CODES | c_admin_cat_code（可自動配發） | c_admin_cat_py, c_admin_cat_hz, c_admin_cat_trans, c_notes |
 
 - 主鍵可放在 `target.pk` 或 `changes`；**單一主鍵的表在兩處都沒給值時，由伺服器以 `max(主鍵)+1` 自動配發**。但 `target` 這個鍵本身仍必須存在——請送 `"target": {"pk": {}}`，完全省略會被控制器層 422 擋下。
 - **複合主鍵的表（`addr-belongs-data`）沒有自動配發**：四個主鍵欄一個都不能少，缺哪一欄就回 422 `target.pk.<欄名>: ["required"]`。
@@ -1446,9 +1447,10 @@ Authorization: Bearer <token>
 - 欄位型別／長度／NOT NULL 的校驗規則與 13.1 完全相同（同一份登記、同一套判定），唯一的差異是文字欄收到 JSON 數字時 create 會轉成字串、update 會 422（見 13.1 的說明）。
 - **外鍵指向不存在的列 → 422 `changes: ["foreign_key_violation"]`**（例如 `addr-belongs-data` 的 `c_belongs_to` 上級地名尚未建立、或 `c_source` 指向不存在的 `TEXT_CODES.c_textid`）。先建父列再建子列。
 - 只支援 `mode=direct`；送 `mode=proposal` 會得到 **501**（找不到 handler），不是 403。注意這與 13.1 的 `update` 不對稱：**代碼表可以提案修改、但不能提案新增**，眾包帳號只能改不能增。
-- 回應：`result.pk`、`result.status: "created"`、`result.operation_id`、`result.row`；系統會蓋 `c_created_by`／`c_created_date`。
+- 回應：`result.pk`、`result.status: "created"`、`result.operation_id`、`result.row`；**表有稽核欄時**系統會蓋 `c_created_by`／`c_created_date`。多數代碼表（含 `ADMIN_CAT_CODES`）沒有那組欄位，此時不蓋——操作者與時間仍完整記在 `operations` 與 `audit_log`。
 - 可以放進 `batch_mutate` 一起送。
-- **本節這四張表沒有 `/api/v2/read` 定義**（代碼表中只有 `nianhao` 有）：新增後要拿到伺服器配發的主鍵，直接看回應的 `result.pk` 與 `result.row`（整列都在裡面）。
+- **本節這五張表沒有 `/api/v2/read` 定義**（代碼表中只有 `nianhao` 有）：新增後要拿到伺服器配發的主鍵，直接看回應的 `result.pk` 與 `result.row`（整列都在裡面）。
+- **新增前請自行查重**：本節的表都沒有「同名就重用」的邏輯，也沒有 read 端點可查——`ADMIN_CAT_CODES.c_admin_cat_hz` 之類的名稱欄**沒有唯一鍵**（現庫本來就有同名的類別），送兩次就是兩列。批次匯入前請先用 `/codes` 或 Query Playground 把既有代碼查出來，否則 `ADDR_CODES.c_admin_cat_code` 會分散指向兩個同義類別。
 - **地名相關**：`ADDRESSES` 是由 `ADDR_CODES` + `ADDR_BELONGS_DATA` 派生的反正規化快取表，只由 `php artisan cbdb:regenerate-addresses-table` 重建。經本 API 新增的地名，在重建之前不會出現在依賴該快取的功能（官職地點自動填表、朝代同名地消歧、部分自然語言查詢）。批次匯入地名後請安排重建。
 - `TEXT_CODES` 的新增與修改是**兩份不同的定義**，別名清單不對稱：`create` 接受 `text-codes`／`text_codes`／`textcodes`，而 `update` **只接受 `text_codes`**（送 `text-codes` 做 update 會 501）。最保險是 create 用 `text-codes`、update 用 `text_codes`。
 
@@ -1456,7 +1458,7 @@ Authorization: Bearer <token>
 
 代碼表被大量人物資料以外鍵引用，刪一列可能影響數萬筆記錄且難以乾淨復原，因此刪除**已停用**：
 
-- 上述四張支援寫入的表、且 `mode=direct` → **403**（`代碼表刪除已停用（防止級聯刪除人物資料）`）
+- 上述五張支援寫入的表、且 `mode=direct` → **403**（`代碼表刪除已停用（防止級聯刪除人物資料）`）
 - 其他代碼表，或 `mode=proposal` → **501**（找不到對應 handler）
 
 ### 13.4 複合實體聚合：office、social-institution 與 text-entity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## 2026-09
 
+### v2 API 補上行政類別代碼（ADMIN_CAT_CODES）的新增，並把 update 白名單擴到整列
+
+- **回報**：「只能 update `c_admin_cat_py`；沒有 create」。要建一個新的行政類別（州／府／縣…）只能走 `/codes` UI；機器化匯入地名時就卡在這裡——`ADDR_CODES.c_admin_cat_code` 帶外鍵，引用不存在的類別會被擋下，而 API 又建不出新類別。
+- **新增能力**：`admin-cat-codes` 支援 `/api/v2/create`（主鍵可自動配發或指定），update 白名單從 `c_admin_cat_py` 一欄擴到 `c_admin_cat_py`／`c_admin_cat_hz`／`c_admin_cat_trans`／`c_notes` 四欄。既有的 §D-6 行為不變：`c_admin_cat_py` 仍是 Tier 1（保存時後端靜默 v→ü），另外三欄不是拼音欄、兩個 tier 都不列（列進 tier2 會讓 `/codes` 編輯器對漢字名與註記也彈 ü 轉換視窗）。`c_notes` 是 longtext，登記進 `long_text_fields` 以免被 255 上限誤擋。
+- **沒有補稽核欄，這是刻意的**：本表（以及多數代碼表）沒有 `c_created_by`／`c_modified_*` 那組欄位。v2 的每一次寫入都已經在 `operations` 與 `audit_log` 留下操作者與時間，補欄只會讓 `/codes` 列表多出四個永遠是空的欄。`CodeTableCreateHandler` 上一個 commit 起就是按實際欄位蓋章，所以缺欄不會再像 `ADDR_CODES` 那樣直接 500——測試裡有一支專門把「沒有稽核欄也要能新增」釘住。
+- **刪除維持停用**（403）：本表被 `ADDR_CODES.c_admin_cat_code` 與 `ADMIN_CAT_CODE_TYPE_REL` 以外鍵引用，與其他代碼表一致。
+- **順帶修掉一個既有的兩端不一致**：`CodeTableCreateHandler` 從來沒有做 §D-6 的 Tier 1 拼音 v→ü 歸一化，於是同一個 `lv` 走 `/api/v2/create` 存 `lv`、走 `/api/v2/mutate` 或 `/codes` 存 `lü`——同一欄兩種寫法，而 §D-6 的承諾是「保存時一律歸一」。現在 create 端也做，Tier 定義仍只有一份（`config/code_table_mutations.php`），create 端按表名去查、不複製第二份清單。連帶修好 `TEXT_CODES.c_title`（同樣是 Tier 1 且開放新增）。
+- **兩份 config 的別名一致性也機械化**：`CodeTableWriteConfigDriftTest` 新增兩條——同一張表在兩份 config 的別名集合必須相等（`TEXT_CODES` 的不對稱是歷史遺留且已對外文件化，登記為例外），且每個 `resource` 正規名必須在自己的 `aliases` 內。漏掉的症狀是「某個拼法新增成功、修改卻 501」，錯誤訊息看起來像是表名寫錯。
+- **測試**：`ApiV2MutateAdminCatCodesTest`（10 案例：無稽核欄的自動配發、顯式主鍵與 409、smallint 主鍵值域、update 四欄對稱、longtext 註記不被 255 擋、Tier 1 拼音在 update 與 create 兩端都轉、中文欄落地替換並回 notices、刪除 403、未啟用帳號 403＋提案新增 501）。兩份 config 的白名單一致性由既有的 `CodeTableWriteConfigDriftTest` 自動把關。
+
 ### v2 API 補上地名表寫入：ADDR_CODES 可新增、可整列修改，ADDR_BELONGS_DATA 從無到有
 
 - **回報**：「API 無法新增地名表記錄」。查證屬實，而且不只一層：`ADDR_CODES` 只登錄在 `config/code_table_mutations.php`（純 update）、白名單只有 `c_name` 一欄，沒有任何新增入口；`ADDR_BELONGS_DATA`（地名隸屬關係）連 update 都沒有。就算當時把 `ADDR_CODES` 登進 `config/code_table_writes.php` 也照樣失敗——`CodeTableCreateHandler` 經 `ToolsRepository::timestamp()` 無條件寫 `c_created_by`／`c_created_date`，而這張表從建表起就沒有那 4 欄，會直接以「Unknown column」炸掉；而且 create handler 當時只認單一主鍵，`ADDR_BELONGS_DATA` 的四欄複合主鍵根本進不來。

--- a/app/Services/Mutations/CodeTableCreateHandler.php
+++ b/app/Services/Mutations/CodeTableCreateHandler.php
@@ -8,6 +8,7 @@ use App\Repositories\ToolsRepository;
 use App\Services\AuditLogService;
 use App\Support\CodeTableFieldValidator;
 use App\Support\CompositePrimaryKey;
+use App\Support\PinyinUmlaut;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -180,6 +181,13 @@ class CodeTableCreateHandler extends AbstractMutationHandler {
             return $this->errorResponse('參數校驗失敗', 422, $validationErrors);
         }
 
+        // §D-6 保存止血：Tier 1 拼音欄的 v→ü 靜默歸一化。**create 端原本沒有這一步**，
+        // 於是同一個 `lv` 走 /api/v2/create 存 `lv`、走 /api/v2/mutate 或 /codes 存 `lü`
+        // ——同一欄兩種寫法，而 §D-6 的承諾是「保存時一律歸一」。Tier 定義只有一份
+        // （config/code_table_mutations.php），這裡按表名去查，不在本檔複製一份 tier 清單。
+        // 順序比照 update 端：歸一化在落地替換之前。
+        $row = PinyinUmlaut::normalizeFields($row, $this->tier1FieldsFor($table));
+
         // 異體字落地替換（型別驅動）。掛在白名單化之後、落庫（與 ToolsRepository::timestamp()
         // 蓋稽核欄）之前；稽核欄本來就在排除清單裡。char_variant_map 自身在 EXCLUDED_TABLES
         // （替換等於自我吞噬），所以對照表的維護不會被自己改寫。
@@ -295,6 +303,26 @@ class CodeTableCreateHandler extends AbstractMutationHandler {
                 'row' => $insertedArray,
             ],
         ]));
+    }
+
+    /**
+     * 該表的 §D-6 Tier 1 拼音欄（純拼音、無西文，保存時靜默 v→ü）。
+     *
+     * Tier 的定義只存在於 `config/code_table_mutations.php`（update 端的 config）；
+     * 這裡按**表名**去查而不是在 code_table_writes 複製一份，否則兩份 tier 清單一定會漂移
+     * ——而漂移的症狀是「同一個值在新增與修改後落庫成不同字形」，最難查的那一類。
+     * 沒登錄在那份 config 的表（純新增表）回空陣列＝不做歸一。
+     *
+     * @return array<int,string>
+     */
+    protected function tier1FieldsFor(string $table): array {
+        foreach ((array) config('code_table_mutations.tables', []) as $definition) {
+            if (($definition['table'] ?? null) === $table) {
+                return (array) ($definition['tier1_fields'] ?? []);
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/config/code_table_mutations.php
+++ b/config/code_table_mutations.php
@@ -160,12 +160,18 @@ return [
         [
             'resource' => 'admin_cat_codes',
             'table' => 'ADMIN_CAT_CODES',
-            'aliases' => ['admin_cat_codes', 'admin_cat'],
+            'aliases' => ['admin_cat_codes', 'admin_cat', 'admin-cat-codes', 'admin-cat'],
             'display_name' => '行政類別代碼',
             'key_columns' => ['c_admin_cat_code'],
-            'allowed_fields' => ['c_admin_cat_py'],
+            // 本表可經 /api/v2/create 新增（config/code_table_writes.php），所以 update 端
+            // 收得下同一組欄位——只開拼音欄會讓「新增時填得進去、之後改不了」
+            // （CodeTableWriteConfigDriftTest 會機械檢查兩端一致）。
+            'allowed_fields' => ['c_admin_cat_py', 'c_admin_cat_hz', 'c_admin_cat_trans', 'c_notes'],
             'tier1_fields' => ['c_admin_cat_py'],
+            // c_admin_cat_hz 是漢字、c_admin_cat_trans 是英譯、c_notes 是註記，
+            // 都不是拼音欄，兩個 tier 都不列（列進 tier2 會讓 /codes 編輯器對它們彈 ü 轉換視窗）。
             'tier2_fields' => [],
+            'long_text_fields' => ['c_notes'],
         ],
         [
             'resource' => 'addr_codes',

--- a/config/code_table_writes.php
+++ b/config/code_table_writes.php
@@ -84,6 +84,25 @@ return [
             // 但送 null／空字串是明確的錯誤，要在 422 就擋下。
             'not_null_fields' => ['c_admin_cat_code'],
         ],
+        // 行政類別代碼（州／府／縣…）。原本只能 update 拼音欄、沒有新增入口，
+        // 於是要建一個新的行政類別只能走 /codes UI（機器化匯入地名時卡在這裡）。
+        // 被 ADDR_CODES.c_admin_cat_code 與 ADMIN_CAT_CODE_TYPE_REL 以外鍵引用，
+        // 所以刪除仍然停用（與其他代碼表一致）。
+        'ADMIN_CAT_CODES' => [
+            'resource' => 'admin-cat-codes',
+            'aliases' => ['admin-cat-codes', 'admin_cat_codes', 'admin-cat', 'admin_cat'],
+            'table' => 'ADMIN_CAT_CODES',
+            'display_name' => '行政類別代碼',
+            'key_columns' => ['c_admin_cat_code'],
+            'auto_assign_id' => true,
+            'allowed_fields' => ['c_admin_cat_py', 'c_admin_cat_hz', 'c_admin_cat_trans', 'c_notes'],
+            'long_text_fields' => ['c_notes'],
+            // 本表沒有 c_created_by／c_modified_* 那組稽核欄，**刻意不補**：v2 的每一次寫入
+            // 都已經在 operations 與 audit_log 留下操作者與時間，補欄只會讓 /codes 列表多出
+            // 四個永遠是空的欄。CodeTableCreateHandler 按實際欄位蓋章，缺欄不會 500
+            // （ADDR_CODES 當年就是因為缺欄而必然新增失敗，那張表選擇補欄是因為它已經有
+            // 姊妹表 ADDR_BELONGS_DATA 帶著同一組欄位、補齊才一致）。
+        ],
         // 地名隸屬關係：四欄複合主鍵（地名、上級地名、起訖年）全部由呼叫端給定——
         // 沒有 auto_assign 的餘地，也不該有：換上級或換年段就是另一筆記錄。
         'ADDR_BELONGS_DATA' => [

--- a/tests/Feature/ApiV2MutateAdminCatCodesTest.php
+++ b/tests/Feature/ApiV2MutateAdminCatCodesTest.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Operation;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * 行政類別代碼（ADMIN_CAT_CODES）的 v2 mutation API。
+ *
+ * 回報：「只能 update c_admin_cat_py；沒有 create」。要建一個新的行政類別只能走
+ * /codes UI，機器化匯入地名時就卡在這裡（`ADDR_CODES.c_admin_cat_code` 帶外鍵，
+ * 引用不存在的類別會被擋下）。
+ *
+ * 本表**沒有** c_created_by／c_modified_by 那組稽核欄（多數代碼表都沒有）。這是刻意
+ * 不補的：v2 的每一次寫入都已經在 `operations` 與 `audit_log` 留下操作者與時間，補欄
+ * 只會讓 /codes 列表多出四個永遠是空的欄。下面有一支測試把「沒有稽核欄也要能新增」
+ * 釘住——`CodeTableCreateHandler` 按實際欄位蓋章，這條路徑不能因為缺欄而 500。
+ */
+class ApiV2MutateAdminCatCodesTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        config()->set('app.env', 'testing');
+        $this->app['env'] = 'testing';
+        config()->set('prometheus.enabled', false);
+        config()->set('prometheus.storage_adapter', 'memory');
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createSupportTables();
+        $this->createAdminCatCodes();
+    }
+
+    protected function tearDown(): void {
+        foreach (['ADMIN_CAT_CODES', 'char_variant_map', 'audit_log', 'operations', 'users'] as $t) {
+            Schema::dropIfExists($t);
+        }
+        parent::tearDown();
+    }
+
+    protected function createSupportTables(): void {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
+            $table->string('confirmation_token')->nullable();
+            $table->integer('is_active')->default(0);
+            $table->integer('is_admin')->default(0);
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('operations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->nullable();
+            $table->integer('c_personid')->default(0);
+            $table->integer('op_type');
+            $table->string('resource');
+            $table->string('resource_id')->nullable();
+            $table->longText('resource_data')->nullable();
+            $table->longText('resource_original')->nullable();
+            $table->integer('crowdsourcing_status')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('audit_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->dateTime('occurred_at');
+            $table->dateTime('created_at');
+            $table->string('table_name', 64);
+            $table->string('operation', 16);
+            $table->string('actor_type', 32);
+            $table->string('actor_id', 128);
+            $table->string('operation_id', 64);
+            $table->text('row_pk');
+            $table->string('row_pk_text', 512)->nullable();
+            $table->longText('old_data')->nullable();
+            $table->longText('new_data')->nullable();
+        });
+    }
+
+    /** 只有需要驗落地替換的案例才建（其餘案例刻意不建，確認缺表時不會炸）。 */
+    protected function createCharVariantMap(): void {
+        Schema::create('char_variant_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('c_variant_char', 10)->unique();
+            $table->string('c_reference_char', 10);
+            $table->tinyInteger('c_strict_excluded')->default(0);
+            $table->string('c_notes')->nullable();
+            $table->timestamps();
+        });
+
+        DB::table('char_variant_map')->insert([
+            ['c_variant_char' => '淸', 'c_reference_char' => '清', 'c_strict_excluded' => 0],
+        ]);
+    }
+
+    /** 型別比照 prod，且**刻意不加**稽核欄（prod 就是沒有）。 */
+    protected function createAdminCatCodes(): void {
+        DB::statement('CREATE TABLE "ADMIN_CAT_CODES" (
+            "c_admin_cat_code" smallint NOT NULL PRIMARY KEY,
+            "c_admin_cat_py" varchar(255) NULL,
+            "c_admin_cat_hz" varchar(255) NULL,
+            "c_admin_cat_trans" varchar(255) NULL,
+            "c_notes" longtext NULL
+        )');
+    }
+
+    protected function makeUser(int $status = User::STATUS_ACTIVE, int $role = User::ROLE_REGULAR, string $email = 'admincat@example.com'): User {
+        return User::forceCreate([
+            'name' => '行政類別編輯者',
+            'email' => $email,
+            'confirmation_token' => 'token-admincat',
+            'is_active' => $status,
+            'is_admin' => $role,
+        ]);
+    }
+
+    #[Test]
+    public function testCreateAutoAssignsIdOnTableWithoutAuditColumns(): void {
+        $this->actingAs($this->makeUser(email: 'admincat-create@example.com'));
+        DB::table('ADMIN_CAT_CODES')->insert(['c_admin_cat_code' => 40, 'c_admin_cat_py' => 'zhou', 'c_admin_cat_hz' => '州']);
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => []],
+            'changes' => [
+                'c_admin_cat_py' => 'xian',
+                'c_admin_cat_hz' => '縣',
+                'c_admin_cat_trans' => 'county',
+                'c_notes' => '測試用類別',
+            ],
+        ])->assertOk()->assertJson([
+            'ok' => true,
+            'resource' => 'admin-cat-codes',
+            'operation' => 'create',
+            'result' => ['pk' => ['c_admin_cat_code' => 41], 'status' => 'created'],
+        ]);
+
+        $this->assertDatabaseHas('ADMIN_CAT_CODES', [
+            'c_admin_cat_code' => 41,
+            'c_admin_cat_py' => 'xian',
+            'c_admin_cat_hz' => '縣',
+            'c_admin_cat_trans' => 'county',
+        ]);
+        $this->assertDatabaseHas('audit_log', ['table_name' => 'ADMIN_CAT_CODES', 'operation' => 'INSERT']);
+        $this->assertDatabaseHas('operations', ['resource' => 'ADMIN_CAT_CODES', 'op_type' => Operation::TYPE_CREATE]);
+    }
+
+    #[Test]
+    public function testCreateWithExplicitIdAndDuplicateConflict(): void {
+        $this->actingAs($this->makeUser(email: 'admincat-explicit@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 900]],
+            'changes' => ['c_admin_cat_hz' => '鎮'],
+        ])->assertOk()->assertJson(['result' => ['pk' => ['c_admin_cat_code' => 900]]]);
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 900]],
+            'changes' => ['c_admin_cat_hz' => '重複'],
+        ])->assertStatus(409);
+
+        $this->assertSame(1, DB::table('ADMIN_CAT_CODES')->count());
+    }
+
+    #[Test]
+    public function testCreateRejectsOutOfRangeSmallintId(): void {
+        // c_admin_cat_code 是 smallint：非 strict 的 MariaDB 會把 40000 截斷成 32767，
+        // 那一列就被建在呼叫端沒有指定的鍵上。
+        $this->actingAs($this->makeUser(email: 'admincat-range@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 40000]],
+            'changes' => ['c_admin_cat_hz' => '太大'],
+        ])->assertStatus(422)
+            ->assertJsonFragment(['target.pk.c_admin_cat_code' => ['out_of_range:-32768..32767']]);
+
+        $this->assertSame(0, DB::table('ADMIN_CAT_CODES')->count());
+    }
+
+    #[Test]
+    public function testUpdateAcceptsEveryCreatableField(): void {
+        // 迴歸：白名單原本只有 c_admin_cat_py——漢字名、英譯、註記新增時填得進去、
+        // 之後改不了。
+        $this->actingAs($this->makeUser(email: 'admincat-update@example.com'));
+        DB::table('ADMIN_CAT_CODES')->insert(['c_admin_cat_code' => 50, 'c_admin_cat_py' => 'old']);
+
+        $changes = [
+            'c_admin_cat_py' => 'fu',
+            'c_admin_cat_hz' => '府',
+            'c_admin_cat_trans' => 'prefecture',
+            'c_notes' => '註記',
+        ];
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'admin_cat_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_admin_cat_code' => 50]],
+            'changes' => $changes,
+        ])->assertOk();
+
+        $this->assertDatabaseHas('ADMIN_CAT_CODES', ['c_admin_cat_code' => 50] + $changes);
+    }
+
+    #[Test]
+    public function testLongNotesAreNotRejectedByThe255Cap(): void {
+        // c_notes 是 longtext；沒登記 long_text_fields 的話會被基底的 255 上限誤擋。
+        $this->actingAs($this->makeUser(email: 'admincat-notes@example.com'));
+        DB::table('ADMIN_CAT_CODES')->insert(['c_admin_cat_code' => 51, 'c_admin_cat_py' => 'x']);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'admin_cat_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_admin_cat_code' => 51]],
+            'changes' => ['c_notes' => str_repeat('註', 600)],
+        ])->assertOk();
+
+        $this->assertSame(600, mb_strlen((string) DB::table('ADMIN_CAT_CODES')->where('c_admin_cat_code', 51)->value('c_notes')));
+    }
+
+    #[Test]
+    public function testPinyinTier1StillNormalizesVToUmlaut(): void {
+        // 擴大白名單不可影響既有的 §D-6 行為：c_admin_cat_py 仍是 Tier 1（後端靜默轉）。
+        $this->actingAs($this->makeUser(email: 'admincat-tier1@example.com'));
+        DB::table('ADMIN_CAT_CODES')->insert(['c_admin_cat_code' => 52, 'c_admin_cat_hz' => '呂']);
+
+        $this->postJson('/api/v2/mutate', [
+            'resource' => 'admin_cat_codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'operation' => 'update',
+            'target' => ['pk' => ['c_admin_cat_code' => 52]],
+            'changes' => ['c_admin_cat_py' => 'lv'],
+        ])->assertOk();
+
+        $this->assertSame('lü', DB::table('ADMIN_CAT_CODES')->where('c_admin_cat_code', 52)->value('c_admin_cat_py'));
+    }
+
+    #[Test]
+    public function testCreateAlsoNormalizesTier1PinyinLikeUpdateDoes(): void {
+        // 迴歸：create 端原本**沒有** §D-6 的 v→ü 歸一化，於是同一個 `lv` 走
+        // /api/v2/create 存 lv、走 /api/v2/mutate 或 /codes 存 lü——同一欄兩種寫法。
+        // Tier 定義只有一份（config/code_table_mutations.php），create 端按表名去查。
+        $this->actingAs($this->makeUser(email: 'admincat-create-tier1@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 600]],
+            'changes' => ['c_admin_cat_py' => 'lv', 'c_admin_cat_hz' => '呂'],
+        ])->assertOk();
+
+        $this->assertSame('lü', DB::table('ADMIN_CAT_CODES')->where('c_admin_cat_code', 600)->value('c_admin_cat_py'));
+
+        // 非 Tier 1 的欄位不轉（c_admin_cat_trans 是英譯，可能含西文）
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 601]],
+            'changes' => ['c_admin_cat_trans' => 'Lvov'],
+        ])->assertOk();
+
+        $this->assertSame('Lvov', DB::table('ADMIN_CAT_CODES')->where('c_admin_cat_code', 601)->value('c_admin_cat_trans'));
+    }
+
+    #[Test]
+    public function testChineseColumnIsVariantReplacedWithNotice(): void {
+        // c_admin_cat_hz 是新開放的中文欄，必須經落地替換（AGENTS §1.3），
+        // 且替換發生了要讓使用者知道。它只用於顯示、不是 label→code 查表鍵，
+        // 所以替換不會打斷任何關聯（本表的 join 走數值 c_admin_cat_code）。
+        $this->createCharVariantMap();
+        $this->actingAs($this->makeUser(email: 'admincat-variant@example.com'));
+
+        $response = $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 700]],
+            'changes' => ['c_admin_cat_hz' => '淸州', 'c_notes' => '淸代設置'],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('ADMIN_CAT_CODES', ['c_admin_cat_code' => 700, 'c_admin_cat_hz' => '清州', 'c_notes' => '清代設置']);
+        $this->assertNotEmpty($response->json('notices'), '替換發生了卻沒有回 notices（AGENTS §1.3）');
+    }
+
+    #[Test]
+    public function testDeleteStaysDisabled(): void {
+        // 本表被 ADDR_CODES.c_admin_cat_code 與 ADMIN_CAT_CODE_TYPE_REL 以外鍵引用，
+        // 刪除維持全面停用。
+        $this->actingAs($this->makeUser(User::STATUS_ACTIVE, User::ROLE_SUPER_ADMIN, 'admincat-delete@example.com'));
+        DB::table('ADMIN_CAT_CODES')->insert(['c_admin_cat_code' => 53, 'c_admin_cat_py' => 'x']);
+
+        $this->postJson('/api/v2/delete', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => ['c_admin_cat_code' => 53]],
+        ])->assertStatus(403);
+
+        $this->assertDatabaseHas('ADMIN_CAT_CODES', ['c_admin_cat_code' => 53]);
+    }
+
+    #[Test]
+    public function testCreateForbiddenForInactiveUserAndProposalUnsupported(): void {
+        $this->actingAs($this->makeUser(User::STATUS_INACTIVE, User::ROLE_REGULAR, 'admincat-inactive@example.com'));
+
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'direct',
+            'target' => ['pk' => []],
+            'changes' => ['c_admin_cat_hz' => '不可'],
+        ])->assertStatus(403);
+
+        // 代碼表可以提案修改、但不能提案新增（create 只支援 direct）→ 501 找不到 handler
+        $this->actingAs($this->makeUser(User::STATUS_ACTIVE, User::ROLE_CROWDSOURCING, 'admincat-crowd@example.com'));
+        $this->postJson('/api/v2/create', [
+            'resource' => 'admin-cat-codes',
+            'person_id' => 0,
+            'mode' => 'proposal',
+            'target' => ['pk' => []],
+            'changes' => ['c_admin_cat_hz' => '提案'],
+        ])->assertStatus(501);
+
+        $this->assertSame(0, DB::table('ADMIN_CAT_CODES')->count());
+    }
+}

--- a/tests/Feature/CodeTableWriteConfigDriftTest.php
+++ b/tests/Feature/CodeTableWriteConfigDriftTest.php
@@ -80,6 +80,74 @@ class CodeTableWriteConfigDriftTest extends TestCase {
         );
     }
 
+    /**
+     * 兩份 config 的別名清單**刻意**不對稱的表：表 => 理由。
+     * 完整比對：不在這裡、兩邊別名集合又不相等的表一律判紅。
+     */
+    private const ALIASES_MAY_DIFFER = [
+        // 歷史遺留且已對外文件化（API.md 13.2 最後一條）：create 接受
+        // text-codes／text_codes／textcodes，update 只接受 text_codes。
+        // 改動會打斷既有客戶端，故維持並登記在此。
+        'TEXT_CODES' => 'create 與 update 別名刻意不對稱，已在 API.md 13.2 明文說明',
+    ];
+
+    #[Test]
+    public function aliases_agree_between_both_configs_for_shared_tables(): void {
+        // 症狀很難查：某個拼法「新增成功、修改卻 501」——呼叫端會以為是自己弄錯表名。
+        $writes = $this->byTable(config('code_table_writes.tables', []));
+        $updates = $this->byTable(config('code_table_mutations.tables', []));
+
+        $mismatched = [];
+        foreach (array_intersect(array_keys($writes), array_keys($updates)) as $table) {
+            if (isset(self::ALIASES_MAY_DIFFER[$table])) {
+                continue;
+            }
+
+            $createAliases = array_values((array) ($writes[$table]['aliases'] ?? []));
+            $updateAliases = array_values((array) ($updates[$table]['aliases'] ?? []));
+            sort($createAliases);
+            sort($updateAliases);
+
+            if ($createAliases !== $updateAliases) {
+                $mismatched[$table] = [
+                    'create_only' => array_values(array_diff($createAliases, $updateAliases)),
+                    'update_only' => array_values(array_diff($updateAliases, $createAliases)),
+                ];
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $mismatched,
+            "同一張表的 create 與 update 別名清單不一致：
+"
+                . json_encode($mismatched, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                . "
+只有一邊認得的拼法會讓呼叫端拿到 501（找不到 handler），而錯誤訊息看起來像是表名寫錯。"
+                . '刻意的差異請登記進 ALIASES_MAY_DIFFER 並寫理由。'
+        );
+    }
+
+    #[Test]
+    public function every_configured_resource_name_is_one_of_its_own_aliases(): void {
+        // resource 是回應與提案 meta 用的正規名；不在自己的 aliases 裡的話，
+        // 呼叫端照回應的 resource 值回送會 501。
+        $problems = [];
+        foreach ([
+            'code_table_writes' => config('code_table_writes.tables', []),
+            'code_table_mutations' => config('code_table_mutations.tables', []),
+        ] as $configName => $definitions) {
+            foreach ($definitions as $def) {
+                if (!in_array($def['resource'] ?? '', (array) ($def['aliases'] ?? []), true)) {
+                    $problems[] = $configName . ': ' . ($def['table'] ?? '?') . ' 的 resource「' . ($def['resource'] ?? '') . '」不在自己的 aliases 內';
+                }
+            }
+        }
+
+        $this->assertSame([], $problems, implode("
+", $problems));
+    }
+
     #[Test]
     public function type_registries_agree_between_both_configs_for_shared_tables(): void {
         $writes = $this->byTable(config('code_table_writes.tables', []));


### PR DESCRIPTION
## 問題

回報：「`ADMIN_CAT_CODES` ⚠️ 只能 update `c_admin_cat_py`；沒有 create」。

要建一個新的行政類別（州／府／縣…）只能走 `/codes` UI。機器化匯入地名時就卡在這裡——`ADDR_CODES.c_admin_cat_code` 帶外鍵，引用不存在的類別會被擋下，而 API 又建不出新類別。

## 新增能力

- `admin-cat-codes` 支援 `/api/v2/create`（主鍵可自動配發或指定）。
- update 白名單從 `c_admin_cat_py` 一欄擴到 `c_admin_cat_py`／`c_admin_cat_hz`／`c_admin_cat_trans`／`c_notes`（兩端對稱由 `CodeTableWriteConfigDriftTest` 機械把關）。
- 既有 §D-6 行為不變：`c_admin_cat_py` 仍是 Tier 1，另外三欄不是拼音欄、兩個 tier 都不列（列進 tier2 會讓 `/codes` 編輯器對漢字名與註記也彈 ü 轉換視窗）。
- `c_notes` 是 longtext，登記進 `long_text_fields` 以免被 255 上限誤擋。
- 刪除維持停用（403）：本表被 `ADDR_CODES.c_admin_cat_code` 與 `ADMIN_CAT_CODE_TYPE_REL` 以外鍵引用。

## 刻意不補稽核欄

本表（以及多數代碼表）沒有 `c_created_by`／`c_modified_*` 那組欄位。v2 的每一次寫入都已經在 `operations` 與 `audit_log` 留下操作者與時間，補欄只會讓 `/codes` 列表多出四個永遠是空的欄。handler 按實際欄位蓋章，所以缺欄不會像 `ADDR_CODES` 那樣直接 500——測試有一支專門把「沒有稽核欄也要能新增」釘住。理由也寫在 config 旁邊，免得下一個登錄新表的人重新推導一次。

## 順帶修掉一個既有的兩端不一致

`CodeTableCreateHandler` 從來沒有做 §D-6 的 Tier 1 拼音 `v→ü` 歸一化，於是同一個 `lv` 走 `/api/v2/create` 存 `lv`、走 `/api/v2/mutate` 或 `/codes` 存 `lü`——同一欄兩種寫法，而 §D-6 的承諾是「保存時一律歸一」。

現在 create 端也做。Tier 定義仍只有一份（`config/code_table_mutations.php`），create 端按表名去查、**不**複製第二份清單（兩份 tier 清單一定會漂移，而漂移的症狀正是「同一個值在新增與修改後落庫成不同字形」）。連帶修好 `TEXT_CODES.c_title`（同樣是 Tier 1 且開放新增）。

## 別名一致性也機械化

`CodeTableWriteConfigDriftTest` 新增兩條：

1. 同一張表在兩份 config 的**別名集合必須相等**（`TEXT_CODES` 的不對稱是歷史遺留且已在 API.md 明文說明，登記為例外）。
2. 每個 `resource` 正規名必須在自己的 `aliases` 內。

漏掉的症狀是「某個拼法新增成功、修改卻 501」，而錯誤訊息看起來像是表名寫錯。

## 文檔

`API.md` 另補一條批次匯入須知：本節的表都沒有「同名就重用」的邏輯、也沒有 read 端點可查，而 `c_admin_cat_hz` 之類的名稱欄**沒有唯一鍵**（現庫本來就有同名類別），送兩次就是兩列，之後 `ADDR_CODES.c_admin_cat_code` 會分散指向兩個同義類別。

## 測試

`ApiV2MutateAdminCatCodesTest`（10 案例：無稽核欄的自動配發、顯式主鍵與 409、smallint 主鍵值域、update 四欄對稱、longtext 註記不被 255 擋、Tier 1 拼音在 update 與 create 兩端都轉、中文欄落地替換並回 `notices`、刪除 403、未啟用帳號 403 ＋ 提案新增 501）＋ `CodeTableWriteConfigDriftTest` 增 2。

全套 **3105 綠**；`php-cs-fixer`（清 cache + dist config）0 檔待修。

Review：review agent 一輪（僅 minor，全部已處理）＋ codex 一輪（no blocking findings）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 汇总

在保持各代码表 API 的验证、规范化、审计和配置行为一致的同时，为管理类代码（ADMIN_CAT_CODES）启用完整的 v2 写入支持。

新功能：
- 支持通过 v2 API 创建 ADMIN_CAT_CODES，并支持自动生成或显式指定主键。
- 扩展 ADMIN_CAT_CODES 更新功能，支持音译、中文名称、翻译和备注字段。

错误修复：
- 对创建操作统一应用 Tier 1 拼音 v→ü 规范化，包括 TEXT_CODES 标题。
- 允许 ADMIN_CAT_CODES 使用较长备注，不再应用默认的 255 个字符限制。

增强功能：
- 通过漂移测试确保代码表别名与创建/更新白名单的一致性。
- 支持向缺少审计列的代码表写入，同时保留操作和审计日志跟踪。

文档：
- 记录 ADMIN_CAT_CODES 的创建、扩展更新支持、禁用删除、审计列行为以及重复项检查要求。

测试：
- 为 ADMIN_CAT_CODES 的创建、更新、验证、规范化、变体替换、授权和删除行为增加全面的 API 覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable complete v2 write support for administrative category codes while keeping validation, normalization, auditing, and configuration behavior consistent across code-table APIs.

New Features:
- Enable v2 API creation of ADMIN_CAT_CODES with automatic or explicit primary keys.
- Expand ADMIN_CAT_CODES updates to cover transliteration, Chinese name, translation, and notes fields.

Bug Fixes:
- Apply consistent Tier 1 pinyin v→ü normalization to create operations, including TEXT_CODES titles.
- Allow long ADMIN_CAT_CODES notes without applying the default 255-character limit.

Enhancements:
- Make code-table alias and create/update whitelist consistency enforceable through drift tests.
- Support writes to code tables that lack audit columns while retaining operation and audit-log tracking.

Documentation:
- Document ADMIN_CAT_CODES creation, expanded update support, disabled deletion, audit-column behavior, and duplicate-check requirements.

Tests:
- Add comprehensive API coverage for ADMIN_CAT_CODES creation, updates, validation, normalization, variant replacement, authorization, and deletion behavior.

</details>